### PR TITLE
Remove the horizontal scroll showing in datatable sometimes

### DIFF
--- a/src/lib/datatable/datatable.svelte
+++ b/src/lib/datatable/datatable.svelte
@@ -93,7 +93,7 @@
 
 <div class="datatables-wrapper">
 	<div class="table-responsive">
-		<table bind:this={el} class={"table table-datatable " + extraClass} style={loaded ? "display: table" : "display: none"} data-cy={dataCy || 'exchange-table'}>
+		<table bind:this={el} class={"table table-datatable " + extraClass} style={loaded ? "display: table; width: 100%;" : "display: none"} data-cy={dataCy || 'exchange-table'}>
 			<thead>
 				<tr>
 					{#each columns as column}


### PR DESCRIPTION
Remove this annoying horizontal scroll for good: 
![image](https://user-images.githubusercontent.com/1258431/157134574-7578f044-9715-4aa2-8263-85529234d8a9.png)