### PR TITLE
Advanced Search UI

### DIFF
--- a/src/lib/header/Navbar.svelte
+++ b/src/lib/header/Navbar.svelte
@@ -5,11 +5,14 @@
 
 -->
 <script lang="ts">
-  import Search from '../search/Search.svelte';
-  import logo from '../../lib/assets/logo-two-lines-new-no-text.svg';
+  import { page } from '$app/stores';
+  import Search from '$lib/search/Search.svelte';
+  import logo from '$lib/assets/logo-two-lines-new-no-text.svg';
   import twitter from './twitter.svg';
   import telegram from './telegram.svg';
   import discord from './discord.svg';
+
+  $: showSearch = $page.url.pathname !== '/search';
 
   let isOpen = false;
 
@@ -86,10 +89,12 @@
         </ul>
       </div>
 
-      <!-- Search box -->
-      <form class="form-inline flex-grow-1 d-flex flex-row-reverse">
-        <Search />
-      </form>
+      <!-- Search box (NOT shown on full search page) -->
+      {#if showSearch}
+        <form class="form-inline flex-grow-1 d-flex flex-row-reverse">
+          <Search />
+        </form>
+      {/if}
 
       <!-- Right - social icons/links (desktop) -->
       <div class="collapse navbar-collapse flex-grow-0">

--- a/src/lib/search/ResultLineItem.svelte
+++ b/src/lib/search/ResultLineItem.svelte
@@ -19,7 +19,7 @@
   on:pointerdown
 >
   <div class="type badge-{type}">{label}</div>
-  <div class="description flex-grow-1">{description}</div>
+  <div class="desc flex-grow-1">{description}</div>
   {#if price_change_24h !== undefined}
     <div class="price-change {priceChangeClass}">{getPriceChangePct()}%</div>
   {/if}
@@ -28,7 +28,7 @@
 <style>
   li {
     border: none;
-    font-size: 0.9rem;
+    font-size: 0.875rem;
     font-weight: normal;
     line-height: 1.25;
     gap: 1em;
@@ -49,7 +49,7 @@
     line-height: 1.75;
   }
 
-  .description {
+  .desc {
     display: -webkit-box;
     -webkit-line-clamp: 2;
     -webkit-box-orient: vertical;

--- a/src/lib/search/ResultLineItem.svelte
+++ b/src/lib/search/ResultLineItem.svelte
@@ -1,7 +1,26 @@
+<!--
+@component
+**ResultLineItem** displays a single `tradingEntity` search result line item.
+Used for showing simple search results from top-nav.
+- `document` object comes from `$tradingEntity.hits`
+- `selected` is used for styling the currently selected result item
+- forwards native `mouseenter` and `pointerdown` events
+
+#### Usage:
+```tsx
+  <ResultLineItem {document} selected={true}
+    on:mouseenter={handleMouseEnter} on:mouseenter={handlePointerDown} />
+```
+-->
 <script lang="ts">
   import { determinePriceChangeClass } from "$lib/helpers/price";
 
-  export let document, selected;
+  /**
+   * document returned by Typesense `tradingEntity` search hits
+   * see (Trading Entities Collection)[https://github.com/tradingstrategy-ai/search/blob/main/docs/trading-entities.md]
+   */
+  export let document
+  export let selected = false;
 
   const { description, type, price_change_24h } = document;
   const label = type === "exchange" ? "DEX" : type;

--- a/src/lib/search/ResultLineItem.svelte
+++ b/src/lib/search/ResultLineItem.svelte
@@ -6,10 +6,10 @@
   const { description, type, price_change_24h } = document;
   const label = type === "exchange" ? "DEX" : type;
   const priceChangeClass = determinePriceChangeClass(price_change_24h);
-
-  function getPriceChangePct() {
-    return Math.abs(price_change_24h * 100).toFixed(1);
-  }
+  const priceChangePct = Math.abs(price_change_24h).toLocaleString("en-US", {
+    style: "percent",
+    minimumFractionDigits: 1
+  });
 </script>
 
 <li
@@ -21,7 +21,7 @@
   <div class="type badge-{type}">{label}</div>
   <div class="desc flex-grow-1">{description}</div>
   {#if price_change_24h !== undefined}
-    <div class="price-change {priceChangeClass}">{getPriceChangePct()}%</div>
+    <div class="price-change {priceChangeClass}">{priceChangePct}</div>
   {/if}
 </li>
 

--- a/src/lib/search/ResultLineItem.svelte
+++ b/src/lib/search/ResultLineItem.svelte
@@ -1,25 +1,27 @@
 <!--
 @component
-**ResultLineItem** displays a single `tradingEntity` search result line item.
-Used for showing simple search results from top-nav.
-- `document` object comes from `$tradingEntity.hits`
-- `selected` is used for styling the currently selected result item
-- forwards native `mouseenter` and `pointerdown` events
+Used for simple search results from top-nav; displays a single
+`$tradingEntity.hits` search result line item.
 
 #### Usage:
 ```tsx
-  <ResultLineItem {document} selected={true}
-    on:mouseenter={handleMouseEnter} on:mouseenter={handlePointerDown} />
+  <ResultLineItem
+    {document}
+    selected={true}
+    on:mouseenter={handleMouseEnter}
+    on:mouseenter={handlePointerDown}
+  />
 ```
 -->
 <script lang="ts">
   import { determinePriceChangeClass } from "$lib/helpers/price";
 
   /**
-   * document returned by Typesense `tradingEntity` search hits
-   * see (Trading Entities Collection)[https://github.com/tradingstrategy-ai/search/blob/main/docs/trading-entities.md]
+   * object returned by Typesense `tradingEntity` search hits; see:
+   * https://github.com/tradingstrategy-ai/search/blob/main/docs/trading-entities.md
    */
   export let document
+
   export let selected = false;
 
   const { description, type, price_change_24h } = document;

--- a/src/lib/search/Search.svelte
+++ b/src/lib/search/Search.svelte
@@ -81,7 +81,7 @@ Display site-wide search box for use in top-nav.
                     />
                 {/each}
                 <li class="show-all list-group-item" on:pointerdown={() => goto(`/search?q=${q}`)}>
-                    Show more | advanced options
+                    Show all results | advanced options
                 </li>
             </ListGroup>
         </div>

--- a/src/lib/search/Search.svelte
+++ b/src/lib/search/Search.svelte
@@ -39,7 +39,7 @@
 
   function gotoEntity({ url_path, description }) {
     if (url_path) {
-      goto (url_path.replace(/^\/+/g, "/"));
+      goto (url_path);
     } else {
       console.log(`GOTO ${description}`);
     }
@@ -69,7 +69,7 @@
                       on:pointerdown={() => gotoEntity(document)}
                     />
                 {/each}
-                <li class="show-all list-group-item" on:pointerdown={goto(`/search?q=${q}`)}>
+                <li class="show-all list-group-item" on:pointerdown={() => goto(`/search?q=${q}`)}>
                     Show all results
                 </li>
             </ListGroup>

--- a/src/lib/search/Search.svelte
+++ b/src/lib/search/Search.svelte
@@ -1,3 +1,14 @@
+<!--
+@component
+**Search** generates a site-wide search box for use in top-nav.
+- used for limited inline results; advanced search available through `/search` page
+- uses (tradingstrategy/search)[https://github.com/tradingstrategy-ai/search] backend
+
+#### Usage:
+```tsx
+<Search />
+```
+-->
 <script lang="ts">
   import { goto } from "$app/navigation";
   import tradingEntities from "./trading-entities";

--- a/src/lib/search/Search.svelte
+++ b/src/lib/search/Search.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { goto } from "$app/navigation";
   import tradingEntities from "./trading-entities";
-  import { Fade, ListGroup, ListGroupItem } from "sveltestrap";
+  import { Fade, ListGroup } from "sveltestrap";
   import ResultLineItem from "./ResultLineItem.svelte";
 
   let q = "";
@@ -47,33 +47,34 @@
 </script>
 
 <div class="search">
-  <input
-    type="search"
-    data-cy="search"
-    placeholder="search"
-    autocapitalize="none"
-    spellcheck="false"
-    bind:value={q}
-    on:focus={() => hasFocus = true}
-    on:blur={() => hasFocus = false}
-    on:keydown={handleKeydown}
-  />
-  <Fade isOpen={hasFocus && q}>
-    <div class="card bg-primary shadow-soft border-light">
-      <ListGroup flush>
-        {#each $tradingEntities.hits as { document }, index (document.id)}
-          <ResultLineItem
-            {document}
-            selected={index === selectedIndex}
-            on:mouseenter={() => selectedIndex = index}
-            on:pointerdown={() => gotoEntity(document)}
-          />
-        {:else}
-          <ListGroupItem>Search exchanges, tokens and pairs</ListGroupItem>
-        {/each}
-      </ListGroup>
-    </div>
-  </Fade>
+    <input
+      type="search"
+      data-cy="search"
+      placeholder="search"
+      autocapitalize="none"
+      spellcheck="false"
+      bind:value={q}
+      on:focus={() => hasFocus = true}
+      on:blur={() => hasFocus = false}
+      on:keydown={handleKeydown}
+    />
+    <Fade isOpen={hasFocus && q}>
+        <div class="card bg-primary shadow-soft border-light">
+            <ListGroup flush>
+                {#each $tradingEntities.hits as { document }, index (document.id)}
+                    <ResultLineItem
+                      {document}
+                      selected={index === selectedIndex}
+                      on:mouseenter={() => selectedIndex = index}
+                      on:pointerdown={() => gotoEntity(document)}
+                    />
+                {/each}
+                <li class="show-all list-group-item" on:pointerdown={goto(`/search?q=${q}`)}>
+                    Show all results
+                </li>
+            </ListGroup>
+        </div>
+    </Fade>
 </div>
 
 <style>
@@ -116,6 +117,21 @@
     right: 0;
     width: 450px;
     margin-top: 5px;
+  }
+
+  .show-all {
+    background-color: #d4cdc8;
+    cursor: pointer;
+    text-align: center;
+    padding: 0.5em;
+    font-size: 0.75rem;
+    font-weight: 500;
+    text-transform: uppercase;
+    letter-spacing: 1px;
+  }
+
+  .show-all:hover {
+    filter: brightness(0.9);
   }
 
   @media (max-width: 768px) {

--- a/src/lib/search/Search.svelte
+++ b/src/lib/search/Search.svelte
@@ -81,7 +81,7 @@ Display site-wide search box for use in top-nav.
                     />
                 {/each}
                 <li class="show-all list-group-item" on:pointerdown={() => goto(`/search?q=${q}`)}>
-                    Show all results
+                    Show more | advanced options
                 </li>
             </ListGroup>
         </div>

--- a/src/lib/search/Search.svelte
+++ b/src/lib/search/Search.svelte
@@ -1,6 +1,6 @@
 <!--
 @component
-**Search** generates a site-wide search box for use in top-nav.
+Display site-wide search box for use in top-nav.
 - used for limited inline results; advanced search available through `/search` page
 - uses (tradingstrategy/search)[https://github.com/tradingstrategy-ai/search] backend
 

--- a/src/lib/search/Search.svelte
+++ b/src/lib/search/Search.svelte
@@ -4,15 +4,19 @@
   import { Fade, ListGroup, ListGroupItem } from "sveltestrap";
   import ResultLineItem from "./ResultLineItem.svelte";
 
-  let value = "";
+  let q = "";
   let hasFocus = false;
   let selectedIndex = 0;
   let resultCount = 0;
 
-  $: tradingEntities.search(value);
+  $: tradingEntities.search({
+    q,
+    sort_by: ["type_rank:asc", "_text_match:desc", "volume_24h:desc"],
+    group_by: ["type"]
+  });
 
   $: {
-    resultCount = $tradingEntities.length;
+    resultCount = $tradingEntities.hits.length;
     selectedIndex = Math.min(selectedIndex, Math.max(resultCount - 1, 0));
   }
 
@@ -25,7 +29,7 @@
         selectedIndex = (selectedIndex + resultCount - 1) % resultCount;
         break;
       case "Enter":
-        gotoEntity($tradingEntities[selectedIndex].document);
+        gotoEntity($tradingEntities.hits[selectedIndex].document);
         break;
       default:
         return;
@@ -49,15 +53,15 @@
     placeholder="search"
     autocapitalize="none"
     spellcheck="false"
-    bind:value
+    bind:value={q}
     on:focus={() => hasFocus = true}
     on:blur={() => hasFocus = false}
     on:keydown={handleKeydown}
   />
-  <Fade isOpen={hasFocus && value}>
+  <Fade isOpen={hasFocus && q}>
     <div class="card bg-primary shadow-soft border-light">
       <ListGroup flush>
-        {#each $tradingEntities as { document }, index (document.id)}
+        {#each $tradingEntities.hits as { document }, index (document.id)}
           <ResultLineItem
             {document}
             selected={index === selectedIndex}

--- a/src/lib/search/Search.svelte
+++ b/src/lib/search/Search.svelte
@@ -91,6 +91,7 @@
     padding: 0 1ex 0 2em;
     border: 2px solid #44476a;
     border-radius: 16px;
+    outline: none;
     background: rgba(255, 255, 255, 0.5) url("/images/search.svg") 1ex 55%/14px no-repeat;
     font-size: 0.8rem;
     color: #44476a;
@@ -98,7 +99,6 @@
 
   input:focus {
     background-color: rgba(255, 255, 255, 0.75);
-    outline: none;
     box-shadow: 0 0 10px #44476a55;
   }
 

--- a/src/lib/search/trading-entities.ts
+++ b/src/lib/search/trading-entities.ts
@@ -32,6 +32,7 @@ let lastSearchIndex = 0;
 interface SearchOptions {
   q: string;
   facet_by?: Array<string>;
+  filter_by?: Array<string>;
   group_by?: Array<string>;
   sort_by?: Array<string>;
 }
@@ -39,7 +40,9 @@ interface SearchOptions {
 function typesenseOptions(options: SearchOptions) {
   const mergedOptions = {...defaultOptions, ...options };
   for (const key in mergedOptions) {
-    if (mergedOptions[key] instanceof Array) {
+    if (key === "filter_by") {
+      mergedOptions[key] = mergedOptions[key].join(" && ");
+    } else if (mergedOptions[key] instanceof Array) {
       mergedOptions[key] = mergedOptions[key].toString();
     }
   }

--- a/src/lib/search/trading-entities.ts
+++ b/src/lib/search/trading-entities.ts
@@ -3,39 +3,65 @@
  * the Typesense `trading-entities` collection.
  *
  * usage:
- *   tradingEntities.search('foo')        // search the collection
+ *   tradingEntities.search({ q: "foo" }) // search the collection
  *   tradingEntities.subscribe(callback)  // receive updated search results
  *   $tradingEntities                     // within a component - Svelte's reactive store sugar
  */
 import { writable } from "svelte/store";
 import searchClient from "./client";
 
-const searchOptions = {
-  query_by: "name,token_tickers,token_names,smart_contract_addresses",
-  sort_by: "type_rank:asc,_text_match:desc,volume_24h:desc",
-  group_by: "type"
+const defaultOptions = {
+  query_by: ["description", "token_tickers", "token_names" ,"smart_contract_addresses"],
+  sort_by: ["type_rank:asc", "_text_match:desc", "volume_24h:desc"],
+  highlight_full_fields: "description",
+  highlight_start_tag: "<em>",
+  highlight_end_tag: "</em>"
 };
 
 const collection = searchClient?.collections("trading-entities").documents();
 
-const { subscribe, set } = writable([]);
-let lastQuery: string;
+const { subscribe, set } = writable({
+  hits: [],
+  facets: [],
+  count: null,
+  total: null
+});
 
-async function search(query: string): Promise<void> {
+let lastSearchIndex = 0;
+
+interface SearchOptions {
+  q: string;
+  facet_by?: Array<string>;
+  group_by?: Array<string>;
+  sort_by?: Array<string>;
+}
+
+function typesenseOptions(options: SearchOptions) {
+  const mergedOptions = {...defaultOptions, ...options };
+  for (const key in mergedOptions) {
+    if (mergedOptions[key] instanceof Array) {
+      mergedOptions[key] = mergedOptions[key].toString();
+    }
+  }
+  return mergedOptions;
+}
+
+async function search(options: SearchOptions): Promise<void> {
   if (!collection) return;
 
-  const q = lastQuery = query.trim();
-
-  if (q === "") {
-    set([]);
-    return;
-  }
+  const searchIndex = ++lastSearchIndex;
 
   try {
-    const response = await collection.search({ q, ...searchOptions });
+    const response = await collection.search(typesenseOptions(options), {});
     // prevent race conditions - only update store if this was the last query
-    if (q === lastQuery) {
-      set(response.grouped_hits.flatMap((group) => group.hits));
+    if (searchIndex === lastSearchIndex) {
+      const hits = response.hits || response.grouped_hits.flatMap((group) => group.hits);
+      set({
+        hits,
+        facets: response.facet_counts,
+        count: response.found,
+        total: response.out_of
+      });
     }
   } catch (error) {
     console.error(error);

--- a/src/lib/search/trading-entities.ts
+++ b/src/lib/search/trading-entities.ts
@@ -27,7 +27,7 @@ const { subscribe, set } = writable({
   total: null
 });
 
-let lastSearchIndex = 0;
+let lastSearchJSON;
 
 interface SearchOptions {
   q: string;
@@ -52,12 +52,17 @@ function typesenseOptions(options: SearchOptions) {
 async function search(options: SearchOptions): Promise<void> {
   if (!collection) return;
 
-  const searchIndex = ++lastSearchIndex;
+  const searchJSON = JSON.stringify(options);
+  if (searchJSON === lastSearchJSON) {
+    return;
+  } else {
+    lastSearchJSON = searchJSON;
+  }
 
   try {
     const response = await collection.search(typesenseOptions(options), {});
     // prevent race conditions - only update store if this was the last query
-    if (searchIndex === lastSearchIndex) {
+    if (searchJSON === lastSearchJSON) {
       const hits = response.hits || response.grouped_hits.flatMap((group) => group.hits);
       set({
         hits,

--- a/src/lib/search/trading-entities.ts
+++ b/src/lib/search/trading-entities.ts
@@ -35,6 +35,7 @@ interface SearchOptions {
   filter_by?: Array<string>;
   group_by?: Array<string>;
   sort_by?: Array<string>;
+  per_page?: number;
 }
 
 function typesenseOptions(options: SearchOptions) {

--- a/src/lib/search/trading-entities.ts
+++ b/src/lib/search/trading-entities.ts
@@ -12,7 +12,7 @@ import searchClient from "./client";
 
 const defaultOptions = {
   query_by: ["description", "token_tickers", "token_names" ,"smart_contract_addresses"],
-  sort_by: ["type_rank:asc", "_text_match:desc", "volume_24h:desc"],
+  sort_by: [],
   highlight_full_fields: "description",
   highlight_start_tag: "<em>",
   highlight_end_tag: "</em>"

--- a/src/lib/search/trading-entities.ts
+++ b/src/lib/search/trading-entities.ts
@@ -11,7 +11,7 @@ import { writable } from "svelte/store";
 import searchClient from "./client";
 
 const defaultOptions = {
-  query_by: ["description", "token_tickers", "token_names" ,"smart_contract_addresses"],
+  query_by: ["description", "token_tickers", "token_names", "smart_contract_addresses"],
   sort_by: [],
   highlight_full_fields: "description",
   highlight_start_tag: "<em>",

--- a/src/routes/search.svelte
+++ b/src/routes/search.svelte
@@ -1,0 +1,36 @@
+<script lang="ts">
+
+</script>
+
+<svelte:head>
+    <title>Search</title>
+    <meta name="description" content="Search Trading Entities">
+</svelte:head>
+
+<main>
+    <section>
+        <div class="container">
+            <div class="row">
+                <div class="col-md-3">
+                    <h1>Search</h1>
+                </div>
+                <div class="col-md-9 col-sm-12">
+                  <h2>Search Box goes here</h2>
+                </div>
+              </div>
+
+              <div class="row">
+                <div class="col-md-3">
+                    <h2>Filters</h2>
+                </div>
+                <div class="col-md-9 col-sm-12">
+                  <h2>Search Results</h2>
+                </div>
+              </div>
+          </div>
+    </section>
+</main>
+
+<style>
+
+</style>

--- a/src/routes/search.svelte
+++ b/src/routes/search.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-
+  let value="";
 </script>
 
 <svelte:head>
@@ -14,23 +14,51 @@
                 <div class="col-md-3">
                     <h1>Search</h1>
                 </div>
-                <div class="col-md-9 col-sm-12">
-                  <h2>Search Box goes here</h2>
+                <div class="col-md-9 col-sm-12 d-flex align-items-center">
+                    <input
+                      type="search"
+                      data-cy="search"
+                      placeholder="search"
+                      autocapitalize="none"
+                      spellcheck="false"
+                      bind:value
+                    />
                 </div>
-              </div>
+            </div>
 
-              <div class="row">
-                <div class="col-md-3">
-                    <h2>Filters</h2>
-                </div>
-                <div class="col-md-9 col-sm-12">
-                  <h2>Search Results</h2>
-                </div>
+            <div class="row">
+              <div class="col-md-3">
+                  <h2>Filters</h2>
               </div>
-          </div>
+              <div class="col-md-9 col-sm-12">
+                <h2>Search Results</h2>
+              </div>
+            </div>
+        </div>
     </section>
 </main>
 
 <style>
+  input {
+    flex: 1;
+    height: 40px;
+    width: 100%;
+    max-width: 500px;
+    padding: 0 1ex 0 2em;
+    border: 2px solid #44476a;
+    border-radius: 20px;
+    outline: none;
+    background: rgba(255, 255, 255, 0.5) url("/images/search.svg") 1ex 55%/16px no-repeat;
+    font-size: 1rem;
+    color: #44476a;
+  }
 
+  input:focus {
+    background-color: rgba(255, 255, 255, 0.75);
+    box-shadow: 0 0 10px #44476a55;
+  }
+
+  input::placeholder {
+    color: #44476a80;
+  }
 </style>

--- a/src/routes/search/_FacetFilter.svelte
+++ b/src/routes/search/_FacetFilter.svelte
@@ -1,12 +1,16 @@
 <script lang="ts">
+	import { createEventDispatcher } from 'svelte';
   import Filter from "./_Filter.svelte";
-
+  
   export let fieldName, options;
-  export let filter = null;
+  export let selected = [];
 
-  let selected = [];
+  const dispatch = createEventDispatcher();
+  $: dispatch("change", { fieldName, filter: getFilter(selected) });
 
-  $: filter = selected.length ? `${fieldName}:=[${selected}]` : null;
+  function getFilter(values) {
+    return values.length ? `${fieldName}:=[${values}]` : null;
+  }
 </script>
 
 <Filter bind:selected {fieldName} {options} />

--- a/src/routes/search/_FacetFilter.svelte
+++ b/src/routes/search/_FacetFilter.svelte
@@ -1,9 +1,26 @@
+<!--
+@component
+**FacetFilter** extends the standard **Filter** component by dispatching a `filter`
+string that can be used for filtering facet-based fields in Typesense searches.
+- `options` must include a `value` prop; may include `label` and `count`
+- selected values are assigned to the `selected` array
+- the generated `filter` string is dispatched `on:change`
+
+#### Usage:
+```tsx
+  <Filter bind:selected fieldName="product_types"
+    options={[{ value: "shoes" }]}
+    on:change={({ fieldName, filter }) => ... )}
+  />
+```
+-->
 <script lang="ts">
 	import { createEventDispatcher } from 'svelte';
-  import Filter from "./_Filter.svelte";
-  
-  export let fieldName, options;
-  export let selected = [];
+  import Filter, { FilterOption } from "./_Filter.svelte";
+
+  export let fieldName: string;
+  export let options: FilterOption[];
+  export let selected: string[] = [];
 
   const dispatch = createEventDispatcher();
   $: dispatch("change", { fieldName, filter: getFilter(selected) });

--- a/src/routes/search/_FacetFilter.svelte
+++ b/src/routes/search/_FacetFilter.svelte
@@ -1,16 +1,15 @@
 <!--
 @component
-**FacetFilter** extends the standard **Filter** component by dispatching a `filter`
-string that can be used for filtering facet-based fields in Typesense searches.
-- `options` must include a `value` prop; may include `label` and `count`
-- selected values are assigned to the `selected` array
-- the generated `filter` string is dispatched `on:change`
+Display filter options for facet-based search fields; dispatches valid Typesense
+filter on:change.
 
 #### Usage:
 ```tsx
-  <Filter bind:selected fieldName="product_types"
-    options={[{ value: "shoes" }]}
-    on:change={({ fieldName, filter }) => ... )}
+  <Filter
+    bind:selected
+    fieldName="facet_search_field"
+    options={[option1, option2]}
+    on:change={({ fieldName, filter }) => setFilter(filter) )}
   />
 ```
 -->

--- a/src/routes/search/_FacetFilter.svelte
+++ b/src/routes/search/_FacetFilter.svelte
@@ -1,4 +1,4 @@
-<script>
+<script lang="ts">
   import Filter from "./_Filter.svelte";
 
   export let fieldName, options;

--- a/src/routes/search/_FacetFilter.svelte
+++ b/src/routes/search/_FacetFilter.svelte
@@ -1,5 +1,8 @@
 <script>
-  export let title, options, group;
+  export let title, options, filter;
+  let selected = [];
+
+  $: filter = selected.length ? `${title}:=[${selected}]` : null;
 </script>
 
 <h2>{title}</h2>
@@ -7,7 +10,7 @@
     {#each options as { value, count } (value)}
         {#if value}
             <label>
-              <input type="checkbox" bind:group {value} />
+              <input type="checkbox" bind:group={selected} {value} />
               <div class="value">{value}</div>
               <div class="count">{count.toLocaleString('en')}</div>
             </label>

--- a/src/routes/search/_FacetFilter.svelte
+++ b/src/routes/search/_FacetFilter.svelte
@@ -1,11 +1,11 @@
 <script>
-  export let title, options, filter;
+  export let fieldName, options, filter;
   let selected = [];
 
-  $: filter = selected.length ? `${title}:=[${selected}]` : null;
+  $: filter = selected.length ? `${fieldName}:=[${selected}]` : null;
 </script>
 
-<h2>{title}</h2>
+<h2>{fieldName}</h2>
 <div class="option-group">
     {#each options as { value, count } (value)}
         {#if value}

--- a/src/routes/search/_FacetFilter.svelte
+++ b/src/routes/search/_FacetFilter.svelte
@@ -1,54 +1,12 @@
 <script>
-  export let fieldName, options, filter;
+  import Filter from "./_Filter.svelte";
+
+  export let fieldName, options;
+  export let filter = null;
+
   let selected = [];
 
   $: filter = selected.length ? `${fieldName}:=[${selected}]` : null;
 </script>
 
-<h2>{fieldName}</h2>
-<div class="option-group">
-    {#each options as { value, count } (value)}
-        {#if value}
-            <label>
-              <input type="checkbox" bind:group={selected} {value} />
-              <div class="value">{value}</div>
-              <div class="count">{count.toLocaleString('en')}</div>
-            </label>
-        {/if}
-    {/each}
-</div>
-
-<style>
-  h2 {
-    font-size: 1rem;
-    text-transform: capitalize;
-  }
-
-  .option-group {
-    margin-bottom: 1.25em;
-    max-width: 200px;
-  }
-
-  label {
-    display: flex;
-    justify-content: left;
-    align-items: center;
-    gap: 1ex;
-    line-height: 1.2;
-  }
-
-  .value {
-    flex: 1;
-    overflow: hidden;
-    text-transform: capitalize;
-  }
-
-  .count {
-    padding: 0px 4px;
-    border-radius: 4px;
-    font-size: 0.75rem;
-    line-height: 1.4;
-    font-weight: 400;
-    background-color: #99999988;
-  }
-</style>
+<Filter bind:selected {fieldName} {options} />

--- a/src/routes/search/_FacetFilter.svelte
+++ b/src/routes/search/_FacetFilter.svelte
@@ -1,0 +1,51 @@
+<script>
+  export let title, options, group;
+</script>
+
+<h2>{title}</h2>
+<div class="option-group">
+    {#each options as { value, count } (value)}
+        {#if value}
+            <label>
+              <input type="checkbox" bind:group {value} />
+              <div class="value">{value}</div>
+              <div class="count">{count.toLocaleString('en')}</div>
+            </label>
+        {/if}
+    {/each}
+</div>
+
+<style>
+  h2 {
+    font-size: 1rem;
+    text-transform: capitalize;
+  }
+
+  .option-group {
+    margin-bottom: 1.25em;
+    max-width: 200px;
+  }
+
+  label {
+    display: flex;
+    justify-content: left;
+    align-items: center;
+    gap: 1ex;
+    line-height: 1.2;
+  }
+
+  .value {
+    flex: 1;
+    overflow: hidden;
+    text-transform: capitalize;
+  }
+
+  .count {
+    padding: 0px 4px;
+    border-radius: 4px;
+    font-size: 0.75rem;
+    line-height: 1.4;
+    font-weight: 400;
+    background-color: #99999988;
+  }
+</style>

--- a/src/routes/search/_Filter.svelte
+++ b/src/routes/search/_Filter.svelte
@@ -1,0 +1,54 @@
+<script>
+  export let fieldName, options;
+  export let selected = [];
+</script>
+
+<h2>{fieldName.replace(/_/g, " ")}</h2>
+<div class="option-group">
+    {#each options as { label, value, count } (value)}
+        {#if value}
+            <label>
+                <input type="checkbox" bind:group={selected} {value} />
+                <div class="label">{label || value}</div>
+                {#if count}
+                    <div class="count">{count.toLocaleString('en')}</div>
+                {/if}
+            </label>
+        {/if}
+    {/each}
+</div>
+
+<style>
+  h2 {
+    font-size: 1rem;
+    text-transform: capitalize;
+  }
+
+  .option-group {
+    margin-bottom: 1.25em;
+    max-width: 200px;
+  }
+
+  label {
+    display: flex;
+    justify-content: left;
+    align-items: center;
+    gap: 1ex;
+    line-height: 1.2;
+  }
+
+  .label {
+    flex: 1;
+    overflow: hidden;
+    text-transform: capitalize;
+  }
+
+  .count {
+    padding: 0px 4px;
+    border-radius: 4px;
+    font-size: 0.75rem;
+    line-height: 1.4;
+    font-weight: 400;
+    background-color: #99999988;
+  }
+</style>

--- a/src/routes/search/_Filter.svelte
+++ b/src/routes/search/_Filter.svelte
@@ -1,12 +1,14 @@
 <!--
 @component
-**Filter** displays a set of checkboxes for filtering search queries.
-- `options` must include a `value` prop; may include `label` and `count`
-- selected values are assigned to the `selected` array
+Display filter options as checkboxes search queries.
 
 #### Usage:
 ```tsx
-  <Filter bind:selected fieldName="product_types" options={[{ value: "shoes" }]} />
+  <Filter
+    bind:selected
+    fieldName="search_field_1"
+    options={[option1, option2]}
+  />
 ```
 -->
 <script context="module" lang="ts">

--- a/src/routes/search/_Filter.svelte
+++ b/src/routes/search/_Filter.svelte
@@ -1,4 +1,4 @@
-<script>
+<script lang="ts">
   export let fieldName, options;
   export let selected = [];
 </script>

--- a/src/routes/search/_Filter.svelte
+++ b/src/routes/search/_Filter.svelte
@@ -1,6 +1,26 @@
+<!--
+@component
+**Filter** displays a set of checkboxes for filtering search queries.
+- `options` must include a `value` prop; may include `label` and `count`
+- selected values are assigned to the `selected` array
+
+#### Usage:
+```tsx
+  <Filter bind:selected fieldName="product_types" options={[{ value: "shoes" }]} />
+```
+-->
+<script context="module" lang="ts">
+  export interface FilterOption {
+    value: string;
+    label?: string;
+    count?: number;
+  }
+</script>
+
 <script lang="ts">
-  export let fieldName, options;
-  export let selected = [];
+  export let fieldName: string;
+  export let options: FilterOption[];
+  export let selected: string[] = [];
 </script>
 
 <h2>{fieldName.replace(/_/g, " ")}</h2>

--- a/src/routes/search/_RangeFilter.svelte
+++ b/src/routes/search/_RangeFilter.svelte
@@ -1,20 +1,17 @@
 <!--
 @component
-**RangeFilter** extends the standard **Filter** component by dispatching a `filter`
-string that can be used for filtering numeric fields in Typesense searches.
-- `breakpoints` should be an array of numbers in ascending or descending order;
-±`Infinity` can be included at start/end to search all values greater/lesser
-- `formatter` (optional) formats values in auto-generated labels
-- `labels` (optional) array of labels - overrides auto-generated labels
-- selected values are assigned to the `selected` array
-- the generated `filter` string is dispatched `on:change`.
+Displays filter options for numeric filter search fields; generates options
+based on breakpoints; generates valid Typesense filter on:change.
 
 #### Usage:
 ```tsx
-  <Filter bind:selected fieldName="price"
+  <Filter
+    bind:selected
+    fieldName="numeric_search_field"
     breakpoints={[0, 100, 1000, 10000, Infinity]}
-    formatter={formatDollar} labels={['free',,,'expensive']}
-    on:change={({ fieldName, filter }) => ... )}
+    formatter={formatFunction}
+    labels={[label1, label2, ...]}
+    on:change={({ fieldName, filter }) => setFilter(filter) )}
   />
 ```
 -->
@@ -23,12 +20,16 @@ string that can be used for filtering numeric fields in Typesense searches.
   import Filter from "./_Filter.svelte";
 
   export let fieldName: string;
-  export let breakpoints: number[];
   export let selected: [number, number][] = [];
-  export let labels: string[] = [];
 
-  // default formatter returns value unchanged
-  export let formatter = (n: number) => n;
+  /** array of numbers in ascending or descending order */
+  export let breakpoints: number[];
+
+  /** formats values in auto-generated labels; default: `toLocaleString("en")` */
+  export let formatter = (n: number) => n.toLocaleString("en");
+
+  /** override auto-generated labels */
+  export let labels: string[] = [];
 
   const dispatch = createEventDispatcher();  
   $: dispatch("change", { fieldName, filter: getFilter(selected) });

--- a/src/routes/search/_RangeFilter.svelte
+++ b/src/routes/search/_RangeFilter.svelte
@@ -5,6 +5,7 @@
   export let fieldName, breakpoints;
   export let selected = [];
   export let formatter = (val) => val; // default formatter returns value unchanged
+  export let labels = [];
 
   const dispatch = createEventDispatcher();  
   $: dispatch("change", { fieldName, filter: getFilter(selected) });
@@ -12,11 +13,12 @@
   const options = [];
   for (let i = 0; i < breakpoints.length - 1; i++) {
     const value = breakpoints.slice(i, i + 2);
-    const label = getLabel(value);
+    const label = labels[i] || getLabel(value);
     options.push({ label, value });
   }
 
-  function getLabel([ min, max ]) {
+  function getLabel(range) {
+    const [ min, max ] = range.sort();
     if (Number.isFinite(min) && Number.isFinite(max)) {
       return `${formatter(min)} - ${formatter(max)}`;
     } else if (Number.isFinite(min)) {

--- a/src/routes/search/_RangeFilter.svelte
+++ b/src/routes/search/_RangeFilter.svelte
@@ -1,4 +1,4 @@
-<script>
+<script lang="ts">
   import Filter from "./_Filter.svelte";
 
   export let fieldName, breakpoints;

--- a/src/routes/search/_RangeFilter.svelte
+++ b/src/routes/search/_RangeFilter.svelte
@@ -1,5 +1,8 @@
 <script>
-  export let fieldName, breakpoints, filter;
+  import Filter from "./_Filter.svelte";
+
+  export let fieldName, breakpoints;
+  export let filter = null;
 
   // default formatter returns value unchanged
   export let formatter = (val) => val;
@@ -10,7 +13,9 @@
 
   const options = [];
   for (let i = 0; i < breakpoints.length - 1; i++) {
-    options.push(breakpoints.slice(i, i + 2));
+    const value = breakpoints.slice(i, i + 2);
+    const label = getLabel(value);
+    options.push({ label, value });
   }
 
   function getLabel([ min, max ]) {
@@ -35,39 +40,4 @@
   }
 </script>
 
-<h2>{fieldName.replace(/_/g, " ")}</h2>
-<div class="option-group">
-    {#each options as option, idx (idx)}
-        <label>
-          <input type="checkbox" bind:group={selected} value={option} />
-          <div class="value">{getLabel(option)}</div>
-        </label>
-    {/each}
-</div>
-
-
-<style>
-  h2 {
-    font-size: 1rem;
-    text-transform: capitalize;
-  }
-
-  .option-group {
-    margin-bottom: 1.25em;
-    max-width: 200px;
-  }
-
-  label {
-    display: flex;
-    justify-content: left;
-    align-items: center;
-    gap: 1ex;
-    line-height: 1.2;
-  }
-
-  .value {
-    flex: 1;
-    overflow: hidden;
-    text-transform: capitalize;
-  }
-</style>
+<Filter bind:selected {fieldName} {options} />

--- a/src/routes/search/_RangeFilter.svelte
+++ b/src/routes/search/_RangeFilter.svelte
@@ -1,11 +1,34 @@
+<!--
+@component
+**RangeFilter** extends the standard **Filter** component by dispatching a `filter`
+string that can be used for filtering numeric fields in Typesense searches.
+- `breakpoints` should be an array of numbers in ascending or descending order;
+±`Infinity` can be included at start/end to search all values greater/lesser
+- `formatter` (optional) formats values in auto-generated labels
+- `labels` (optional) array of labels - overrides auto-generated labels
+- selected values are assigned to the `selected` array
+- the generated `filter` string is dispatched `on:change`.
+
+#### Usage:
+```tsx
+  <Filter bind:selected fieldName="price"
+    breakpoints={[0, 100, 1000, 10000, Infinity]}
+    formatter={formatDollar} labels={['free',,,'expensive']}
+    on:change={({ fieldName, filter }) => ... )}
+  />
+```
+-->
 <script lang="ts">
 	import { createEventDispatcher } from 'svelte';
   import Filter from "./_Filter.svelte";
 
-  export let fieldName, breakpoints;
-  export let selected = [];
-  export let formatter = (val) => val; // default formatter returns value unchanged
-  export let labels = [];
+  export let fieldName: string;
+  export let breakpoints: number[];
+  export let selected: [number, number][] = [];
+  export let labels: string[] = [];
+
+  // default formatter returns value unchanged
+  export let formatter = (n: number) => n;
 
   const dispatch = createEventDispatcher();  
   $: dispatch("change", { fieldName, filter: getFilter(selected) });

--- a/src/routes/search/_RangeFilter.svelte
+++ b/src/routes/search/_RangeFilter.svelte
@@ -1,0 +1,73 @@
+<script>
+  export let fieldName, breakpoints, filter;
+
+  // default formatter returns value unchanged
+  export let formatter = (val) => val;
+
+  let selected = [];
+
+  $: filter = getFilter(selected.flat());
+
+  const options = [];
+  for (let i = 0; i < breakpoints.length - 1; i++) {
+    options.push(breakpoints.slice(i, i + 2));
+  }
+
+  function getLabel([ min, max ]) {
+    if (Number.isFinite(min) && Number.isFinite(max)) {
+      return `${formatter(min)} - ${formatter(max)}`;
+    } else if (Number.isFinite(min)) {
+      return `> ${formatter(min)}`;
+    } else if (Number.isFinite(max)) {
+      return `< ${formatter(max)}`;
+    }
+  }
+
+  function getFilter(values) {
+    if (values.length > 0) {
+      const min = Math.min(...values);
+      const max = Math.max(...values);
+      const filters = [];
+      if (Number.isFinite(min)) filters.push(`${fieldName}:>=${min}`);
+      if (Number.isFinite(max)) filters.push(`${fieldName}:<${max}`);
+      return filters.join(" && ");
+    }
+  }
+</script>
+
+<h2>{fieldName.replace(/_/g, " ")}</h2>
+<div class="option-group">
+    {#each options as option, idx (idx)}
+        <label>
+          <input type="checkbox" bind:group={selected} value={option} />
+          <div class="value">{getLabel(option)}</div>
+        </label>
+    {/each}
+</div>
+
+
+<style>
+  h2 {
+    font-size: 1rem;
+    text-transform: capitalize;
+  }
+
+  .option-group {
+    margin-bottom: 1.25em;
+    max-width: 200px;
+  }
+
+  label {
+    display: flex;
+    justify-content: left;
+    align-items: center;
+    gap: 1ex;
+    line-height: 1.2;
+  }
+
+  .value {
+    flex: 1;
+    overflow: hidden;
+    text-transform: capitalize;
+  }
+</style>

--- a/src/routes/search/_RangeFilter.svelte
+++ b/src/routes/search/_RangeFilter.svelte
@@ -1,15 +1,13 @@
 <script lang="ts">
+	import { createEventDispatcher } from 'svelte';
   import Filter from "./_Filter.svelte";
 
   export let fieldName, breakpoints;
-  export let filter = null;
+  export let selected = [];
+  export let formatter = (val) => val; // default formatter returns value unchanged
 
-  // default formatter returns value unchanged
-  export let formatter = (val) => val;
-
-  let selected = [];
-
-  $: filter = getFilter(selected.flat());
+  const dispatch = createEventDispatcher();  
+  $: dispatch("change", { fieldName, filter: getFilter(selected) });
 
   const options = [];
   for (let i = 0; i < breakpoints.length - 1; i++) {
@@ -29,9 +27,10 @@
   }
 
   function getFilter(values) {
-    if (values.length > 0) {
-      const min = Math.min(...values);
-      const max = Math.max(...values);
+    const allValues = values.flat();
+    if (allValues.length > 0) {
+      const min = Math.min(...allValues);
+      const max = Math.max(...allValues);
       const filters = [];
       if (Number.isFinite(min)) filters.push(`${fieldName}:>=${min}`);
       if (Number.isFinite(max)) filters.push(`${fieldName}:<${max}`);

--- a/src/routes/search/_ResultLineItem.svelte
+++ b/src/routes/search/_ResultLineItem.svelte
@@ -1,13 +1,56 @@
 <script>
+  import { determinePriceChangeClass } from "$lib/helpers/price";
+
   export let document;
 
-  const { description, type } = document;
+  const { description, type, price_usd_latest, price_change_24h, liquidity, volume_24h } = document;
   const label = type === "exchange" ? "DEX" : type;
+  const isPair = type === "pair";
+  const priceChangeClass = determinePriceChangeClass(price_change_24h);
+
+  // TODO: refactor to helper
+  function getPriceChangePct() {
+    return Math.abs(price_change_24h).toLocaleString("en-US", {
+      style: "percent",
+      minimumFractionDigits: 1
+    });
+  }
+
+  // TODO: refactor to helper
+  function USD(value) {
+    return (price_usd_latest || 0).toLocaleString('en-US', {
+      style: "currency",
+      currency: "USD"
+    });
+  }
 </script>
 
 <li class="list-group-item d-flex align-items-center">
-  <div class="type badge-{type}">{label}</div>
-  <div class="desc flex-grow-1">{description}</div>
+    <div class="type badge-{type}">{label}</div>
+    <div class="flex-grow-1">
+
+      <div class="d-flex flex-grow-1">
+        <div class="desc flex-grow-1">{description}</div>
+        {#if isPair}
+            <div class="price {priceChangeClass}">{USD(price_usd_latest)}</div>
+        {/if}
+      </div>
+      {#if isPair}
+          <div class="details d-flex flex-grow-1">
+              <div>
+                <dt>volume 24h:</dt>
+                <dd>{USD(volume_24h)}</dd>
+              </div>
+              <div>
+                <dt>liquidity:</dt>
+                <dd>{USD(liquidity)}</dd>
+              </div>
+              <div class="price-change">
+                <dd class="{priceChangeClass}">{getPriceChangePct()}</dd>
+              </div>
+          </div>
+      {/if}
+    </div>
 </li>
 
 <style>
@@ -39,5 +82,45 @@
     -webkit-line-clamp: 2;
     -webkit-box-orient: vertical;
     overflow: hidden;
+  }
+
+  .details {
+    justify-content: space-between;
+    margin-top: 1ex;
+    font-size: 0.75rem;
+  }
+
+  .details div {
+    width: 12em;
+  }
+
+  .details div.price-change {
+    width: 5em;
+    text-align: right;
+  }
+
+  .details dt {
+    display: inline;
+    font-weight: 300;
+    color: #777777;
+  }
+
+  .details dd {
+    display: inline;
+    font-weight: 500;
+  }
+
+  .price-change dd::after {
+    content: "~";
+    display: inline-block;
+    width: 1.25em;
+  }
+
+  dd.price-change-red::after {
+    content: "▼";
+  }
+
+  dd.price-change-green::after {
+    content: "▲";
   }
 </style>

--- a/src/routes/search/_ResultLineItem.svelte
+++ b/src/routes/search/_ResultLineItem.svelte
@@ -1,7 +1,7 @@
 <!--
 @component
-**ResultLineItem** displays a single `tradingEntity` search result line item.
-Used for showing advanced search results.
+Used for advanced search results; displays a single `$tradingEntity.hits`
+search result line item.
 
 #### Usage:
 ```tsx
@@ -14,8 +14,8 @@ Used for showing advanced search results.
   import { goto } from "$app/navigation";
 
   /**
-   * document returned by Typesense `tradingEntity` search hits
-   * see (Trading Entities Collection)[https://github.com/tradingstrategy-ai/search/blob/main/docs/trading-entities.md]
+   * object returned by Typesense `tradingEntity` search hits; see:
+   * https://github.com/tradingstrategy-ai/search/blob/main/docs/trading-entities.md
    */
   export let document;
 

--- a/src/routes/search/_ResultLineItem.svelte
+++ b/src/routes/search/_ResultLineItem.svelte
@@ -59,7 +59,7 @@
     flex: 0 0 4.6em;
     border-radius: 6px;
     color: white;
-    font-size: 0.875em;
+    font-size: 0.8em;
     font-weight: 600;
     text-align: center;
     line-height: 1.85;

--- a/src/routes/search/_ResultLineItem.svelte
+++ b/src/routes/search/_ResultLineItem.svelte
@@ -11,14 +11,6 @@
   const label = type === "exchange" ? "DEX" : type;
   const isPair = type === "pair";
   const priceChangeClass = determinePriceChangeClass(price_change_24h);
-
-  // TODO: refactor to helper
-  function getPriceChangePct() {
-    return Math.abs(price_change_24h).toLocaleString("en-US", {
-      style: "percent",
-      minimumFractionDigits: 1
-    });
-  }
 </script>
 
 <li class="list-group-item d-flex align-items-center" on:click={() => goto(url_path)}>

--- a/src/routes/search/_ResultLineItem.svelte
+++ b/src/routes/search/_ResultLineItem.svelte
@@ -1,4 +1,4 @@
-<script>
+<script lang="ts">
   import { determinePriceChangeClass } from "$lib/helpers/price";
   import { formatDollar, formatPriceChange } from "$lib/helpers/formatters";
 

--- a/src/routes/search/_ResultLineItem.svelte
+++ b/src/routes/search/_ResultLineItem.svelte
@@ -1,0 +1,43 @@
+<script>
+  export let document;
+
+  const { description, type } = document;
+  const label = type === "exchange" ? "DEX" : type;
+</script>
+
+<li class="list-group-item d-flex align-items-center">
+  <div class="type badge-{type}">{label}</div>
+  <div class="desc flex-grow-1">{description}</div>
+</li>
+
+<style>
+  li {
+    max-width: 600px;
+    margin-bottom: 0.65em;
+    padding: 20px 30px;
+    border: 1px solid #ccbbab;
+    border-radius: 8px;
+    background-color: #fff8f2;
+    font-weight: normal;
+    line-height: 1.25;
+    gap: 1em;
+    cursor: pointer;
+  }
+
+  .type {
+    flex: 0 0 64px;
+    border-radius: 6px;
+    color: white;
+    font-size: 0.875rem;
+    font-weight: 600;
+    text-align: center;
+    line-height: 1.85;
+  }
+
+  .desc {
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+  }
+</style>

--- a/src/routes/search/_ResultLineItem.svelte
+++ b/src/routes/search/_ResultLineItem.svelte
@@ -1,8 +1,22 @@
+<!--
+@component
+**ResultLineItem** displays a single `tradingEntity` search result line item.
+Used for showing advanced search results.
+
+#### Usage:
+```tsx
+  <ResultLineItem {document} />
+```
+-->
 <script lang="ts">
   import { determinePriceChangeClass } from "$lib/helpers/price";
   import { formatDollar, formatPriceChange } from "$lib/helpers/formatters";
   import { goto } from "$app/navigation";
 
+  /**
+   * document returned by Typesense `tradingEntity` search hits
+   * see (Trading Entities Collection)[https://github.com/tradingstrategy-ai/search/blob/main/docs/trading-entities.md]
+   */
   export let document;
 
   const {

--- a/src/routes/search/_ResultLineItem.svelte
+++ b/src/routes/search/_ResultLineItem.svelte
@@ -61,10 +61,10 @@
   }
 
   .type {
-    flex: 0 0 64px;
+    flex: 0 0 4.6em;
     border-radius: 6px;
     color: white;
-    font-size: 0.875rem;
+    font-size: 0.875em;
     font-weight: 600;
     text-align: center;
     line-height: 1.85;
@@ -101,5 +101,25 @@
   .details dd {
     display: inline;
     font-weight: 500;
+  }
+
+  @media (max-width: 576px) {
+    li {
+      margin: -1px 0 0 0;
+      padding: 15px;
+      font-size: 0.875rem;
+      border-left: none;
+      border-right: none;
+      /* override bootstrap border radiuses - requires corner-specific properties */
+      border-top-left-radius: 0;
+      border-top-right-radius: 0;
+      border-bottom-left-radius: 0;
+      border-bottom-right-radius: 0;
+    }
+
+    .details div,
+    .details div.price-change {
+      width: auto;
+    }
   }
 </style>

--- a/src/routes/search/_ResultLineItem.svelte
+++ b/src/routes/search/_ResultLineItem.svelte
@@ -1,5 +1,6 @@
 <script>
   import { determinePriceChangeClass } from "$lib/helpers/price";
+  import { formatDollar, formatPriceChange } from "$lib/helpers/formatters";
 
   export let document;
 
@@ -15,14 +16,6 @@
       minimumFractionDigits: 1
     });
   }
-
-  // TODO: refactor to helper
-  function USD(value) {
-    return (price_usd_latest || 0).toLocaleString('en-US', {
-      style: "currency",
-      currency: "USD"
-    });
-  }
 </script>
 
 <li class="list-group-item d-flex align-items-center">
@@ -32,21 +25,21 @@
       <div class="d-flex flex-grow-1">
         <div class="desc flex-grow-1">{description}</div>
         {#if isPair}
-            <div class="price {priceChangeClass}">{USD(price_usd_latest)}</div>
+            <div class="price {priceChangeClass}">{formatDollar(price_usd_latest)}</div>
         {/if}
       </div>
       {#if isPair}
           <div class="details d-flex flex-grow-1">
               <div>
                 <dt>volume 24h:</dt>
-                <dd>{USD(volume_24h)}</dd>
+                <dd>{formatDollar(volume_24h)}</dd>
               </div>
               <div>
                 <dt>liquidity:</dt>
-                <dd>{USD(liquidity)}</dd>
+                <dd>{formatDollar(liquidity)}</dd>
               </div>
               <div class="price-change">
-                <dd class="{priceChangeClass}">{getPriceChangePct()}</dd>
+                <dd class="{priceChangeClass}">{formatPriceChange(price_change_24h)}</dd>
               </div>
           </div>
       {/if}
@@ -108,19 +101,5 @@
   .details dd {
     display: inline;
     font-weight: 500;
-  }
-
-  .price-change dd::after {
-    content: "~";
-    display: inline-block;
-    width: 1.25em;
-  }
-
-  dd.price-change-red::after {
-    content: "▼";
-  }
-
-  dd.price-change-green::after {
-    content: "▲";
   }
 </style>

--- a/src/routes/search/_ResultLineItem.svelte
+++ b/src/routes/search/_ResultLineItem.svelte
@@ -1,10 +1,13 @@
 <script lang="ts">
   import { determinePriceChangeClass } from "$lib/helpers/price";
   import { formatDollar, formatPriceChange } from "$lib/helpers/formatters";
+  import { goto } from "$app/navigation";
 
   export let document;
 
-  const { description, type, price_usd_latest, price_change_24h, liquidity, volume_24h } = document;
+  const {
+    description, type, price_usd_latest, price_change_24h, liquidity, volume_24h, url_path
+  } = document;
   const label = type === "exchange" ? "DEX" : type;
   const isPair = type === "pair";
   const priceChangeClass = determinePriceChangeClass(price_change_24h);
@@ -18,7 +21,7 @@
   }
 </script>
 
-<li class="list-group-item d-flex align-items-center">
+<li class="list-group-item d-flex align-items-center" on:click={() => goto(url_path)}>
     <div class="type badge-{type}">{label}</div>
     <div class="flex-grow-1">
 

--- a/src/routes/search/_SortSelect.svelte
+++ b/src/routes/search/_SortSelect.svelte
@@ -1,10 +1,7 @@
 <!--
 @component
-**SortSelect** is a custom drop-down component used for selecting from a
-pre-defined set of sort options. Used for advanced searches.
-- `value` should be bound (as with a native `<select>`)
-- passes through `class` prop
-- dispatches `on:change` event with the selcted option
+Used for advanced searches; custom drop-down component for selecting from a
+pre-defined set of sort options.
 
 #### Usage:
 ```tsx
@@ -15,6 +12,7 @@ pre-defined set of sort options. Used for advanced searches.
 	import { createEventDispatcher, onMount } from 'svelte';
 
   export let value = "default";
+
   let className = "";
   export { className as class };
 

--- a/src/routes/search/_SortSelect.svelte
+++ b/src/routes/search/_SortSelect.svelte
@@ -1,0 +1,97 @@
+<script lang="ts">
+  export let sort_by;
+
+  const options = [
+    {
+      shortLabel: "text match",
+      longLabel: "text match",
+      direction: "desc",
+      value: ["_text_match:desc", "volume_24h:desc"]
+    },
+    {
+      shortLabel: "volume",
+      longLabel: "volume (high to low)",
+      direction: "desc",
+      value: ["volume_24h:desc", "_text_match:desc"]
+    },
+    {
+      shortLabel: "liquidity",
+      longLabel: "liquidity (high to low)",
+      direction: "desc",
+      value: ["liquidity:desc", "_text_match:desc"]
+    },
+    {
+      shortLabel: "price change",
+      longLabel: "price change (high to low)",
+      direction: "desc",
+      value: ["price_change_24h:desc", "_text_match:desc"]
+    },
+    {
+      shortLabel: "price change",
+      longLabel: "price change (low to high)",
+      direction: "asc",
+      value: ["price_change_24h:asc", "_text_match:desc"]
+    }
+  ];
+
+  let selected = options[0];
+  $: sort_by = selected.value;
+</script>
+
+<div class={selected.direction}>
+    <label for="sort-select">{selected.shortLabel}</label>
+    <select id="sort-select" bind:value={selected}>
+        {#each options as option, idx (idx)}
+            <option value={option}>
+                {option.longLabel}
+            </option>
+        {/each}
+    </select>
+</div>
+
+<style>
+  div {
+    position: relative;
+    width: 8em;
+    height: 100%;
+  }
+
+  div > * {
+    position: absolute;
+    width: 100%;
+    top: 50%;
+    transform: translate(0, -50%);
+  }
+
+  label {
+    font-size: 1rem;
+    font-weight: 500;
+    color: #44476a;
+  }
+
+  label::before {
+    content: "▾";
+    display: inline-block;
+    font-size: 1.25rem;
+    line-height: 1rem;
+    margin-right: 0.6ex;
+  }
+
+  .asc label::before {
+    transform: rotate(180deg) translate(0, -0.4ex);
+  }
+
+  select {
+    overflow: hidden;
+    appearance: none;
+    -webkit-appearance: none;
+    background: none;
+    color: transparent;
+    border: none;
+    outline: none;
+  }
+
+  option {
+    color: initial;
+  }
+</style>

--- a/src/routes/search/_SortSelect.svelte
+++ b/src/routes/search/_SortSelect.svelte
@@ -1,3 +1,16 @@
+<!--
+@component
+**SortSelect** is a custom drop-down component used for selecting from a
+pre-defined set of sort options. Used for advanced searches.
+- `value` should be bound (as with a native `<select>`)
+- passes through `class` prop
+- dispatches `on:change` event with the selcted option
+
+#### Usage:
+```tsx
+  <SortSelect bind:value on:change={handleChange} />
+```
+-->
 <script lang="ts">
 	import { createEventDispatcher, onMount } from 'svelte';
 

--- a/src/routes/search/_SortSelect.svelte
+++ b/src/routes/search/_SortSelect.svelte
@@ -1,48 +1,56 @@
 <script lang="ts">
-  export let sort_by;
+	import { createEventDispatcher, onMount } from 'svelte';
 
-  const options = [
-    {
+  export let value = 'default';
+
+  const dispatch = createEventDispatcher();
+
+  function dispatchChange() {
+    dispatch("change", options[value]);
+  }
+
+  // this is needed to ensure the sort_by value is set on initial load
+  onMount(dispatchChange);
+
+  const options = {
+    default: {
       shortLabel: "text match",
       longLabel: "text match",
       direction: "desc",
-      value: ["_text_match:desc", "volume_24h:desc"]
+      sort_by: ["_text_match:desc", "volume_24h:desc"]
     },
-    {
+    volume: {
       shortLabel: "volume",
       longLabel: "volume (high to low)",
       direction: "desc",
-      value: ["volume_24h:desc", "_text_match:desc"]
+      sort_by: ["volume_24h:desc", "_text_match:desc"]
     },
-    {
+    liquidity: {
       shortLabel: "liquidity",
       longLabel: "liquidity (high to low)",
       direction: "desc",
-      value: ["liquidity:desc", "_text_match:desc"]
+      sort_by: ["liquidity:desc", "_text_match:desc"]
     },
-    {
+    priceChangeDesc: {
       shortLabel: "price change",
       longLabel: "price change (high to low)",
       direction: "desc",
-      value: ["price_change_24h:desc", "_text_match:desc"]
+      sort_by: ["price_change_24h:desc", "_text_match:desc"]
     },
-    {
+    priceChangeAsc: {
       shortLabel: "price change",
       longLabel: "price change (low to high)",
       direction: "asc",
-      value: ["price_change_24h:asc", "_text_match:desc"]
+      sort_by: ["price_change_24h:asc", "_text_match:desc"]
     }
-  ];
-
-  let selected = options[0];
-  $: sort_by = selected.value;
+  };
 </script>
 
-<div class={selected.direction}>
-    <label for="sort-select">{selected.shortLabel}</label>
-    <select id="sort-select" bind:value={selected}>
-        {#each options as option, idx (idx)}
-            <option value={option}>
+<div class={options[value].direction}>
+    <label for="sort-select">{options[value].shortLabel}</label>
+    <select id="sort-select" bind:value on:change={dispatchChange}>
+        {#each Object.entries(options) as [key, option] (key)}
+            <option value={key}>
                 {option.longLabel}
             </option>
         {/each}
@@ -53,7 +61,6 @@
   div {
     position: relative;
     width: 8em;
-    height: 100%;
   }
 
   div > * {

--- a/src/routes/search/_SortSelect.svelte
+++ b/src/routes/search/_SortSelect.svelte
@@ -11,10 +11,10 @@ pre-defined set of sort options.
 <script context="module" lang="ts">
   export const sortOptions = {
     default: {
-      shortLabel: "text match",
-      longLabel: "text match",
+      shortLabel: "relevance",
+      longLabel: "relevance (text match, volume)",
       direction: "desc",
-      value: ["_text_match:desc", "volume_24h:desc"]
+      value: ["_text_match:desc", "volume_24h:desc", "liquidity:desc"]
     },
 
     volume: {

--- a/src/routes/search/_SortSelect.svelte
+++ b/src/routes/search/_SortSelect.svelte
@@ -5,64 +5,59 @@ pre-defined set of sort options.
 
 #### Usage:
 ```tsx
-  <SortSelect bind:value on:change={handleChange} />
+  <SortSelect bind:value />
 ```
 -->
-<script lang="ts">
-	import { createEventDispatcher, onMount } from 'svelte';
-
-  export let value = "default";
-
-  let className = "";
-  export { className as class };
-
-  const dispatch = createEventDispatcher();
-
-  function dispatchChange() {
-    dispatch("change", options[value]);
-  }
-
-  // this is needed to ensure the sort_by value is set on initial load
-  onMount(dispatchChange);
-
-  const options = {
+<script context="module" lang="ts">
+  export const sortOptions = {
     default: {
       shortLabel: "text match",
       longLabel: "text match",
       direction: "desc",
-      sort_by: ["_text_match:desc", "volume_24h:desc"]
+      value: ["_text_match:desc", "volume_24h:desc"]
     },
+
     volume: {
       shortLabel: "volume",
       longLabel: "volume (high to low)",
       direction: "desc",
-      sort_by: ["volume_24h:desc", "_text_match:desc"]
+      value: ["volume_24h:desc", "_text_match:desc"]
     },
+
     liquidity: {
       shortLabel: "liquidity",
       longLabel: "liquidity (high to low)",
       direction: "desc",
-      sort_by: ["liquidity:desc", "_text_match:desc"]
+      value: ["liquidity:desc", "_text_match:desc"]
     },
+
     priceChangeDesc: {
       shortLabel: "price change",
       longLabel: "price change (high to low)",
       direction: "desc",
-      sort_by: ["price_change_24h:desc", "_text_match:desc"]
+      value: ["price_change_24h:desc", "_text_match:desc"]
     },
+
     priceChangeAsc: {
       shortLabel: "price change",
       longLabel: "price change (low to high)",
       direction: "asc",
-      sort_by: ["price_change_24h:asc", "_text_match:desc"]
+      value: ["price_change_24h:asc", "_text_match:desc"]
     }
   };
 </script>
 
-<div class="{className} {options[value].direction}">
-    <label for="sort-select">{options[value].shortLabel}</label>
-    <select id="sort-select" bind:value on:change={dispatchChange}>
-        {#each Object.entries(options) as [key, option] (key)}
+<script lang="ts">
+  export let value = "default";
+
+  let className = "";
+  export { className as class };
+</script>
+
+<div class="{className} {sortOptions[value].direction}">
+    <label for="sort-select">{sortOptions[value].shortLabel}</label>
+    <select id="sort-select" bind:value>
+        {#each Object.entries(sortOptions) as [key, option] (key)}
             <option value={key}>
                 {option.longLabel}
             </option>

--- a/src/routes/search/_SortSelect.svelte
+++ b/src/routes/search/_SortSelect.svelte
@@ -12,16 +12,9 @@ pre-defined set of sort options.
   export const sortOptions = {
     default: {
       shortLabel: "relevance",
-      longLabel: "relevance (text match, volume)",
+      longLabel: "relevance (text match, liquidity)",
       direction: "desc",
-      value: ["_text_match:desc", "volume_24h:desc", "liquidity:desc"]
-    },
-
-    volume: {
-      shortLabel: "volume",
-      longLabel: "volume (high to low)",
-      direction: "desc",
-      value: ["volume_24h:desc", "_text_match:desc"]
+      value: ["_text_match:desc", "liquidity:desc", "volume_24h:desc"]
     },
 
     liquidity: {
@@ -29,6 +22,13 @@ pre-defined set of sort options.
       longLabel: "liquidity (high to low)",
       direction: "desc",
       value: ["liquidity:desc", "_text_match:desc"]
+    },
+
+    volume: {
+      shortLabel: "volume",
+      longLabel: "volume (high to low)",
+      direction: "desc",
+      value: ["volume_24h:desc", "_text_match:desc"]
     },
 
     priceChangeDesc: {

--- a/src/routes/search/_SortSelect.svelte
+++ b/src/routes/search/_SortSelect.svelte
@@ -1,7 +1,9 @@
 <script lang="ts">
 	import { createEventDispatcher, onMount } from 'svelte';
 
-  export let value = 'default';
+  export let value = "default";
+  let className = "";
+  export { className as class };
 
   const dispatch = createEventDispatcher();
 
@@ -46,7 +48,7 @@
   };
 </script>
 
-<div class={options[value].direction}>
+<div class="{className} {options[value].direction}">
     <label for="sort-select">{options[value].shortLabel}</label>
     <select id="sort-select" bind:value on:change={dispatchChange}>
         {#each Object.entries(options) as [key, option] (key)}
@@ -60,7 +62,7 @@
 <style>
   div {
     position: relative;
-    width: 8em;
+    width: 7em;
   }
 
   div > * {
@@ -71,17 +73,17 @@
   }
 
   label {
-    font-size: 1rem;
     font-weight: 500;
     color: #44476a;
+    white-space: nowrap;
   }
 
   label::before {
     content: "▾";
     display: inline-block;
-    font-size: 1.25rem;
-    line-height: 1rem;
-    margin-right: 0.6ex;
+    font-size: 1.25em;
+    line-height: 1;
+    margin-right: 0.5ex;
   }
 
   .asc label::before {

--- a/src/routes/search/index.svelte
+++ b/src/routes/search/index.svelte
@@ -1,3 +1,9 @@
+<!--
+Advanced Search page
+- uses (tradingstrategy/search)[https://github.com/tradingstrategy-ai/search] backend
+- auto-populates search box with `q` query param if supplied
+- returns first 200 matching results (future: pagination or infinite scroll)
+-->
 <script lang="ts">
   import { page } from "$app/stores";
   import { formatDollar } from "$lib/helpers/formatters";

--- a/src/routes/search/index.svelte
+++ b/src/routes/search/index.svelte
@@ -3,9 +3,12 @@
   import { ListGroup } from "sveltestrap";
   import ResultLineItem from "./_ResultLineItem.svelte";
 
-  let value="";
+  let q = "";
 
-  $: tradingEntities.search(value);
+  $: tradingEntities.search({
+    q,
+    facet_by: ["type", "blockchain", "exchange"]
+  });
 </script>
 
 <svelte:head>
@@ -27,7 +30,7 @@
                       placeholder="search"
                       autocapitalize="none"
                       spellcheck="false"
-                      bind:value
+                      bind:value={q}
                     />
                 </div>
             </div>
@@ -38,7 +41,7 @@
               </div>
               <div class="col-md-9 col-sm-12">
                   <ListGroup>
-                      {#each $tradingEntities as { document }, index (document.id)}
+                      {#each $tradingEntities.hits as { document }, index (document.id)}
                           <ResultLineItem {document} />
                       {/each}
                   </ListGroup>

--- a/src/routes/search/index.svelte
+++ b/src/routes/search/index.svelte
@@ -102,15 +102,15 @@
                           <RangeFilter
                             bind:selected={filters['volume_24h']}
                             fieldName="volume_24h"
-                            breakpoints={[0, 100, 1000, 10000, Infinity]}
-                            formatter={formatDollar}
+                            breakpoints={[0, 50_000, 1_000_000, Infinity]}
+                            formatter={(v) => formatDollar(v, 0, 0)}
                             on:change={handleFilterChange}
                           />
                           <RangeFilter
                             bind:selected={filters['liquidity']}
                             fieldName="liquidity"
-                            breakpoints={[0, 100, 1000, 10000, Infinity]}
-                            formatter={formatDollar}
+                            breakpoints={[0, 500_000, 5_000_000, Infinity]}
+                            formatter={(v) => formatDollar(v, 0, 0)}
                             on:change={handleFilterChange}
                           />
                           <RangeFilter

--- a/src/routes/search/index.svelte
+++ b/src/routes/search/index.svelte
@@ -1,10 +1,11 @@
 <script lang="ts">
+  import { page } from "$app/stores";
   import tradingEntities from "$lib/search/trading-entities";
   import { ListGroup } from "sveltestrap";
   import FacetFilter from "./_FacetFilter.svelte";
   import ResultLineItem from "./_ResultLineItem.svelte";
 
-  let q = "";
+  let q = $page.url.searchParams.get('q') || "";
 
   let filters = {
     type: [],

--- a/src/routes/search/index.svelte
+++ b/src/routes/search/index.svelte
@@ -1,13 +1,31 @@
 <script lang="ts">
   import tradingEntities from "$lib/search/trading-entities";
   import { ListGroup } from "sveltestrap";
+  import FacetFilter from "./_FacetFilter.svelte";
   import ResultLineItem from "./_ResultLineItem.svelte";
 
   let q = "";
 
+  let filters = {
+    type: [],
+    blockchain: [],
+    exchange: []
+  };
+
+  function getFilterBy(filters) {
+    const filterBy = [];
+    Object.entries(filters).forEach(([key, value]) => {
+      if (value.length > 0) {
+        filterBy.push(`${key}:=[${value}]`)
+      }
+    });
+    return filterBy;
+  }
+
   $: tradingEntities.search({
     q,
-    facet_by: ["type", "blockchain", "exchange"]
+    facet_by: ["type", "blockchain", "exchange"],
+    filter_by: getFilterBy(filters)
   });
 </script>
 
@@ -36,8 +54,14 @@
             </div>
 
             <div class="row mt-1">
-              <div class="col-md-3">
-                  <h2>Filters</h2>
+              <div class="filters col-md-3">
+                  {#each $tradingEntities.facets as { field_name, counts } (field_name)}
+                    <FacetFilter
+                      bind:group={filters[field_name]}
+                      title={field_name}
+                      options={counts}
+                    />
+                  {/each}
               </div>
               <div class="col-md-9 col-sm-12">
                   <ListGroup>

--- a/src/routes/search/index.svelte
+++ b/src/routes/search/index.svelte
@@ -16,6 +16,7 @@
   const facet_by = ["type", "blockchain", "exchange"];
 
   $: filter_by = Object.values(filterVals).filter((v) => v);
+  $: hasSearch = filter_by.length > 0 || q.trim().length > 0;
   $: tradingEntities.search({ q, facet_by, filter_by, sort_by });
 
   function handleFilterChange({ detail }) {
@@ -119,14 +120,14 @@
                   </div>
               </div>
               <div class="results col-md-9 col-sm-12">
-                  {#if /^\s*$/.test(q)}
-                      <div>Search exchanges, tokens and trading pairs.</div>
-                  {:else}
+                  {#if hasSearch}
                       <ListGroup>
                           {#each $tradingEntities.hits as { document }, index (document.id)}
                               <ResultLineItem {document} />
                           {/each}
                       </ListGroup>
+                  {:else}
+                      <div>Search exchanges, tokens and trading pairs.</div>
                   {/if}
               </div>
             </div>

--- a/src/routes/search/index.svelte
+++ b/src/routes/search/index.svelte
@@ -29,11 +29,11 @@
 <main>
     <section>
         <div class="container">
-            <div class="row">
-                <div class="col-md-3">
+            <div class="row my-3 my-md-0">
+                <div class="col-md-3 d-none d-md-block">
                     <h1>Search</h1>
                 </div>
-                <div class="search-box col-md-9 col-sm-12 d-flex align-items-center">
+                <div class="search-box col-md-9 d-flex align-items-center">
                     <input
                       type="search"
                       data-cy="search"
@@ -48,33 +48,39 @@
 
             <div class="row mt-1">
               <div class="filters col-md-3">
-                  {#each $tradingEntities.facets as { field_name, counts } (field_name)}
-                    <FacetFilter
-                      bind:filter={filters[field_name]}
-                      fieldName={field_name}
-                      options={counts}
-                    />
-                  {/each}
-                  <RangeFilter
-                    bind:filter={filters['volume_24h']}
-                    fieldName="volume_24h"
-                    breakpoints={[0, 100, 1000, 10000, Infinity]}
-                    formatter={formatDollar}
-                  />
-                  <RangeFilter
-                    bind:filter={filters['liquidity']}
-                    fieldName="liquidity"
-                    breakpoints={[0, 100, 1000, 10000, Infinity]}
-                    formatter={formatDollar}
-                  />
-                  <RangeFilter
-                    bind:filter={filters['price_change_24h']}
-                    fieldName="price_change_24h"
-                    breakpoints={[-Infinity, -0.01, -0.0001, 0.0001, 0.01, Infinity]}
-                    formatter={(v) => v.toLocaleString("en", { style: "percent",  minimumFractionDigits: 1 })}
-                  />
+                  <div class="row">
+                      <div class="col-6 col-md-12">
+                          {#each $tradingEntities.facets as { field_name, counts } (field_name)}
+                            <FacetFilter
+                              bind:filter={filters[field_name]}
+                              fieldName={field_name}
+                              options={counts}
+                            />
+                          {/each}
+                      </div>
+                      <div class="col-6 col-md-12">
+                          <RangeFilter
+                            bind:filter={filters['volume_24h']}
+                            fieldName="volume_24h"
+                            breakpoints={[0, 100, 1000, 10000, Infinity]}
+                            formatter={formatDollar}
+                          />
+                          <RangeFilter
+                            bind:filter={filters['liquidity']}
+                            fieldName="liquidity"
+                            breakpoints={[0, 100, 1000, 10000, Infinity]}
+                            formatter={formatDollar}
+                          />
+                          <RangeFilter
+                            bind:filter={filters['price_change_24h']}
+                            fieldName="price_change_24h"
+                            breakpoints={[-Infinity, -0.01, -0.0001, 0.0001, 0.01, Infinity]}
+                            formatter={(v) => v.toLocaleString("en", { style: "percent",  minimumFractionDigits: 1 })}
+                          />
+                      </div>
+                  </div>
               </div>
-              <div class="col-md-9 col-sm-12">
+              <div class="results col-md-9 col-sm-12">
                   {#if /^\s*$/.test(q)}
                       <div>Search exchanges, tokens and trading pairs.</div>
                   {:else}
@@ -116,5 +122,11 @@
 
   input::placeholder {
     color: #44476a80;
+  }
+
+  @media (max-width: 576px) {
+    .results {
+      padding: 0;
+    }
   }
 </style>

--- a/src/routes/search/index.svelte
+++ b/src/routes/search/index.svelte
@@ -9,7 +9,7 @@ Advanced Search page
   import { formatDollar } from "$lib/helpers/formatters";
   import tradingEntities from "$lib/search/trading-entities";
   import { ListGroup } from "sveltestrap";
-  import SortSelect from "./_SortSelect.svelte";
+  import SortSelect, { sortOptions } from "./_SortSelect.svelte";
   import FacetFilter from "./_FacetFilter.svelte";
   import RangeFilter from "./_RangeFilter.svelte";
   import ResultLineItem from "./_ResultLineItem.svelte";
@@ -18,16 +18,17 @@ Advanced Search page
 
   let isOpen = true;
   let filters = {}, filterVals = {}, filter_by = [];
-  let sortOption = "default", sort_by = [];
-
-  const searchDefaults = {
-    facet_by: ["type", "blockchain", "exchange"],
-    per_page: 200
-  };
+  let sortOption = "default"
 
   $: filter_by = Object.values(filterVals).filter((v) => v);
   $: hasSearch = filter_by.length > 0 || q.trim().length > 0;
-  $: tradingEntities.search({ q, filter_by, sort_by, ...searchDefaults });
+  $: tradingEntities.search({
+    q,
+    filter_by,
+    sort_by: sortOptions[sortOption].value,
+    facet_by: ["type", "blockchain", "exchange"],
+    per_page: 200
+  });
 
   function handleFilterChange({ detail }) {
     filterVals[detail.fieldName] = detail.filter;
@@ -62,11 +63,7 @@ Advanced Search page
                       bind:value={q}
                       on:focus={() => isOpen = true}
                     />
-                    <SortSelect
-                      class="d-none d-md-block"
-                      bind:value={sortOption}
-                      on:change={(e) => ({sort_by} = e.detail)}
-                    />
+                    <SortSelect class="d-none d-md-block" bind:value={sortOption} />
                     <button
                       class:isOpen
                       class="close-filters d-md-none"
@@ -87,10 +84,7 @@ Advanced Search page
                       </div>
                       <div class="col-6 d-md-none d-flex align-items-center">
                           <h2>Sort by:</h2>
-                          <SortSelect
-                            bind:value={sortOption}
-                            on:change={(e) => ({sort_by} = e.detail)}
-                          />
+                          <SortSelect bind:value={sortOption} />
                       </div>
                   </div>
                   <div class="row">

--- a/src/routes/search/index.svelte
+++ b/src/routes/search/index.svelte
@@ -1,5 +1,11 @@
 <script lang="ts">
+  import tradingEntities from "$lib/search/trading-entities";
+  import { ListGroup } from "sveltestrap";
+  import ResultLineItem from "./_ResultLineItem.svelte";
+
   let value="";
+
+  $: tradingEntities.search(value);
 </script>
 
 <svelte:head>
@@ -26,12 +32,16 @@
                 </div>
             </div>
 
-            <div class="row">
+            <div class="row mt-1">
               <div class="col-md-3">
                   <h2>Filters</h2>
               </div>
               <div class="col-md-9 col-sm-12">
-                <h2>Search Results</h2>
+                  <ListGroup>
+                      {#each $tradingEntities as { document }, index (document.id)}
+                          <ResultLineItem {document} />
+                      {/each}
+                  </ListGroup>
               </div>
             </div>
         </div>

--- a/src/routes/search/index.svelte
+++ b/src/routes/search/index.svelte
@@ -13,11 +13,15 @@
   let isOpen = true;
   let filters = {}, filterVals = {}, filter_by = [];
   let sortOption = "default", sort_by = [];
-  const facet_by = ["type", "blockchain", "exchange"];
+
+  const searchDefaults = {
+    facet_by: ["type", "blockchain", "exchange"],
+    per_page: 200
+  };
 
   $: filter_by = Object.values(filterVals).filter((v) => v);
   $: hasSearch = filter_by.length > 0 || q.trim().length > 0;
-  $: tradingEntities.search({ q, facet_by, filter_by, sort_by });
+  $: tradingEntities.search({ q, filter_by, sort_by, ...searchDefaults });
 
   function handleFilterChange({ detail }) {
     filterVals[detail.fieldName] = detail.filter;

--- a/src/routes/search/index.svelte
+++ b/src/routes/search/index.svelte
@@ -1,22 +1,20 @@
 <script lang="ts">
   import { page } from "$app/stores";
+  import { formatDollar } from "$lib/helpers/formatters";
   import tradingEntities from "$lib/search/trading-entities";
   import { ListGroup } from "sveltestrap";
   import FacetFilter from "./_FacetFilter.svelte";
+  import RangeFilter from "./_RangeFilter.svelte";
   import ResultLineItem from "./_ResultLineItem.svelte";
 
   let q = $page.url.searchParams.get('q') || "";
 
-  let filters = {
-    type: [],
-    blockchain: [],
-    exchange: []
-  };
+  let filters = {};
 
   $: tradingEntities.search({
     q,
     facet_by: ["type", "blockchain", "exchange"],
-    filter_by: Object.values(filters).filter((v) => v),
+    filter_by: Object.values(filters).filter((v) => v), // refactor "filter filter" into tradingEntities
     sort_by: ["_text_match:desc", "volume_24h:desc"]
   });
 </script>
@@ -50,10 +48,28 @@
                   {#each $tradingEntities.facets as { field_name, counts } (field_name)}
                     <FacetFilter
                       bind:filter={filters[field_name]}
-                      title={field_name}
+                      fieldName={field_name}
                       options={counts}
                     />
                   {/each}
+                  <RangeFilter
+                    bind:filter={filters['volume_24h']}
+                    fieldName="volume_24h"
+                    breakpoints={[0, 100, 1000, 10000, Infinity]}
+                    formatter={formatDollar}
+                  />
+                  <RangeFilter
+                    bind:filter={filters['liquidity']}
+                    fieldName="liquidity"
+                    breakpoints={[0, 100, 1000, 10000, Infinity]}
+                    formatter={formatDollar}
+                  />
+                  <RangeFilter
+                    bind:filter={filters['price_change_24h']}
+                    fieldName="price_change_24h"
+                    breakpoints={[-Infinity, -0.01, -0.0001, 0.0001, 0.01, Infinity]}
+                    formatter={(v) => v.toLocaleString("en", { style: "percent",  minimumFractionDigits: 1 })}
+                  />
               </div>
               <div class="col-md-9 col-sm-12">
                   {#if /^\s*$/.test(q)}

--- a/src/routes/search/index.svelte
+++ b/src/routes/search/index.svelte
@@ -25,7 +25,8 @@
   $: tradingEntities.search({
     q,
     facet_by: ["type", "blockchain", "exchange"],
-    filter_by: getFilterBy(filters)
+    filter_by: getFilterBy(filters),
+    sort_by: ["_text_match:desc", "volume_24h:desc"]
   });
 </script>
 

--- a/src/routes/search/index.svelte
+++ b/src/routes/search/index.svelte
@@ -10,16 +10,23 @@
 
   let q = $page.url.searchParams.get('q') || "";
 
-  let filters = {};
-  let sortOption, sort_by;
   let isOpen = true;
+  let filters = {}, filterVals = {}, filter_by = [];
+  let sortOption = "default", sort_by = [];
+  const facet_by = ["type", "blockchain", "exchange"];
 
-  $: tradingEntities.search({
-    q,
-    facet_by: ["type", "blockchain", "exchange"],
-    filter_by: Object.values(filters).filter((v) => v), // refactor "filter filter" into tradingEntities
-    sort_by
-  });
+  $: filter_by = Object.values(filterVals).filter((v) => v);
+  $: tradingEntities.search({ q, facet_by, filter_by, sort_by });
+
+  function handleFilterChange({ detail }) {
+    filterVals[detail.fieldName] = detail.filter;
+  }
+
+  function clearAllFilters() {
+    for (const name in filters) {
+      filters[name] = [];
+    }
+  }
 </script>
 
 <svelte:head>
@@ -59,8 +66,15 @@
 
             <div class="row mt-1">
               <div class:isOpen class="filters col-md-3">
-                  <div class="row d-md-none">
-                      <div class="col d-flex align-items-center mb-3">
+                  <div class="row  mb-3">
+                      <div class="col-6 col-md-12">
+                          <button
+                            class="clear-filters"
+                            disabled={filter_by.length === 0}
+                            on:click={clearAllFilters}
+                          >× clear all filters</button>
+                      </div>
+                      <div class="col-6 d-md-none d-flex align-items-center">
                           <h2>Sort by:</h2>
                           <SortSelect
                             bind:value={sortOption}
@@ -72,30 +86,34 @@
                       <div class="col-6 col-md-12">
                           {#each $tradingEntities.facets as { field_name, counts } (field_name)}
                             <FacetFilter
-                              bind:filter={filters[field_name]}
+                              bind:selected={filters[field_name]}
                               fieldName={field_name}
                               options={counts}
+                              on:change={handleFilterChange}
                             />
                           {/each}
                       </div>
                       <div class="col-6 col-md-12">
                           <RangeFilter
-                            bind:filter={filters['volume_24h']}
+                            bind:selected={filters['volume_24h']}
                             fieldName="volume_24h"
                             breakpoints={[0, 100, 1000, 10000, Infinity]}
                             formatter={formatDollar}
+                            on:change={handleFilterChange}
                           />
                           <RangeFilter
-                            bind:filter={filters['liquidity']}
+                            bind:selected={filters['liquidity']}
                             fieldName="liquidity"
                             breakpoints={[0, 100, 1000, 10000, Infinity]}
                             formatter={formatDollar}
+                            on:change={handleFilterChange}
                           />
                           <RangeFilter
-                            bind:filter={filters['price_change_24h']}
+                            bind:selected={filters['price_change_24h']}
                             fieldName="price_change_24h"
                             breakpoints={[-Infinity, -0.01, -0.0001, 0.0001, 0.01, Infinity]}
                             formatter={(v) => v.toLocaleString("en", { style: "percent",  minimumFractionDigits: 1 })}
+                            on:change={handleFilterChange}
                           />
                       </div>
                   </div>
@@ -163,6 +181,27 @@
     opacity: 0.8;
   }
 
+  button.clear-filters {
+    border: none;
+    background-color: transparent;
+    padding: 0;
+    font-size: 0.875rem;
+    font-weight: 500;
+    color: var(--link-underline);
+    cursor: pointer;
+  }
+
+  button.clear-filters:hover {
+    border-bottom: 1px solid var(--link-underline);
+  }
+
+  button.clear-filters:disabled {
+    color: black;
+    border-color: transparent;
+    opacity: 0.5;
+    text-decoration: none;
+    cursor: default;
+  }
 
   @media (max-width: 768px) {
     .filters, .close-filters {

--- a/src/routes/search/index.svelte
+++ b/src/routes/search/index.svelte
@@ -12,6 +12,7 @@
 
   let filters = {};
   let sortOption, sort_by;
+  let isOpen = true;
 
   $: tradingEntities.search({
     q,
@@ -41,13 +42,32 @@
                       autocapitalize="none"
                       spellcheck="false"
                       bind:value={q}
+                      on:focus={() => isOpen = true}
                     />
-                    <SortSelect bind:value={sortOption} on:change={(e) => ({sort_by} = e.detail)} />
+                    <SortSelect
+                      class="d-none d-md-block"
+                      bind:value={sortOption}
+                      on:change={(e) => ({sort_by} = e.detail)}
+                    />
+                    <button
+                      class:isOpen
+                      class="close-filters d-md-none"
+                      on:click={() => isOpen = false}
+                    >Done</button>
                 </div>
             </div>
 
             <div class="row mt-1">
-              <div class="filters col-md-3">
+              <div class:isOpen class="filters col-md-3">
+                  <div class="row d-md-none">
+                      <div class="col d-flex align-items-center mb-3">
+                          <h2>Sort by:</h2>
+                          <SortSelect
+                            bind:value={sortOption}
+                            on:change={(e) => ({sort_by} = e.detail)}
+                          />
+                      </div>
+                  </div>
                   <div class="row">
                       <div class="col-6 col-md-12">
                           {#each $tradingEntities.facets as { field_name, counts } (field_name)}
@@ -99,13 +119,19 @@
 <style>
   .search-box {
     gap: 1em;
+    max-width: 630px;
+  }
+
+  h2 {
+    font-size: 1rem;
+    margin: 0 1ex 0 0;
+    white-space: nowrap;
   }
 
   input {
     flex: 1;
     height: 40px;
     width: 100%;
-    max-width: 500px;
     padding: 0 1ex 0 2em;
     border: 2px solid #44476a;
     border-radius: 20px;
@@ -122,6 +148,30 @@
 
   input::placeholder {
     color: #44476a80;
+  }
+
+  button.close-filters {
+    background-color: #44476a;
+    border: none;
+    border-radius: 1em;
+    height: 100%;
+    padding: 0 1em;
+    font-weight: 600;
+    font-size: 0.75rem;
+    color: white;
+    text-transform: uppercase;
+    opacity: 0.8;
+  }
+
+
+  @media (max-width: 768px) {
+    .filters, .close-filters {
+      display: none;
+    }
+
+    .isOpen {
+      display: block;
+    }
   }
 
   @media (max-width: 576px) {

--- a/src/routes/search/index.svelte
+++ b/src/routes/search/index.svelte
@@ -102,22 +102,22 @@
                           <RangeFilter
                             bind:selected={filters['volume_24h']}
                             fieldName="volume_24h"
-                            breakpoints={[0, 50_000, 1_000_000, Infinity]}
+                            breakpoints={[Infinity, 1_000_000, 50_000, 0]}
                             formatter={(v) => formatDollar(v, 0, 0)}
                             on:change={handleFilterChange}
                           />
                           <RangeFilter
                             bind:selected={filters['liquidity']}
                             fieldName="liquidity"
-                            breakpoints={[0, 500_000, 5_000_000, Infinity]}
+                            breakpoints={[Infinity, 5_000_000, 500_000, 0]}
                             formatter={(v) => formatDollar(v, 0, 0)}
                             on:change={handleFilterChange}
                           />
                           <RangeFilter
                             bind:selected={filters['price_change_24h']}
                             fieldName="price_change_24h"
-                            breakpoints={[-Infinity, -0.01, -0.0001, 0.0001, 0.01, Infinity]}
-                            formatter={(v) => v.toLocaleString("en", { style: "percent",  minimumFractionDigits: 1 })}
+                            breakpoints={[Infinity, 0.01, 0.0001, -0.0001, -0.01, -Infinity]}
+                            labels={["▲ > 1%", "△ 0.01% - 1%", "⬦ 0% ± 0.01%", "▽ 0.01% - 1%", "▼ > 1%"]}
                             on:change={handleFilterChange}
                           />
                       </div>

--- a/src/routes/search/index.svelte
+++ b/src/routes/search/index.svelte
@@ -11,7 +11,7 @@
   let q = $page.url.searchParams.get('q') || "";
 
   let filters = {};
-  let sort_by;
+  let sortOption, sort_by;
 
   $: tradingEntities.search({
     q,
@@ -42,7 +42,7 @@
                       spellcheck="false"
                       bind:value={q}
                     />
-                    <SortSelect bind:sort_by />
+                    <SortSelect bind:value={sortOption} on:change={(e) => ({sort_by} = e.detail)} />
                 </div>
             </div>
 

--- a/src/routes/search/index.svelte
+++ b/src/routes/search/index.svelte
@@ -65,11 +65,15 @@
                   {/each}
               </div>
               <div class="col-md-9 col-sm-12">
-                  <ListGroup>
-                      {#each $tradingEntities.hits as { document }, index (document.id)}
-                          <ResultLineItem {document} />
-                      {/each}
-                  </ListGroup>
+                  {#if /^\s*$/.test(q)}
+                      <div>Search exchanges, tokens and trading pairs.</div>
+                  {:else}
+                      <ListGroup>
+                          {#each $tradingEntities.hits as { document }, index (document.id)}
+                              <ResultLineItem {document} />
+                          {/each}
+                      </ListGroup>
+                  {/if}
               </div>
             </div>
         </div>

--- a/src/routes/search/index.svelte
+++ b/src/routes/search/index.svelte
@@ -3,6 +3,7 @@
   import { formatDollar } from "$lib/helpers/formatters";
   import tradingEntities from "$lib/search/trading-entities";
   import { ListGroup } from "sveltestrap";
+  import SortSelect from "./_SortSelect.svelte";
   import FacetFilter from "./_FacetFilter.svelte";
   import RangeFilter from "./_RangeFilter.svelte";
   import ResultLineItem from "./_ResultLineItem.svelte";
@@ -10,12 +11,13 @@
   let q = $page.url.searchParams.get('q') || "";
 
   let filters = {};
+  let sort_by;
 
   $: tradingEntities.search({
     q,
     facet_by: ["type", "blockchain", "exchange"],
     filter_by: Object.values(filters).filter((v) => v), // refactor "filter filter" into tradingEntities
-    sort_by: ["_text_match:desc", "volume_24h:desc"]
+    sort_by
   });
 </script>
 
@@ -31,7 +33,7 @@
                 <div class="col-md-3">
                     <h1>Search</h1>
                 </div>
-                <div class="col-md-9 col-sm-12 d-flex align-items-center">
+                <div class="search-box col-md-9 col-sm-12 d-flex align-items-center">
                     <input
                       type="search"
                       data-cy="search"
@@ -40,6 +42,7 @@
                       spellcheck="false"
                       bind:value={q}
                     />
+                    <SortSelect bind:sort_by />
                 </div>
             </div>
 
@@ -88,6 +91,10 @@
 </main>
 
 <style>
+  .search-box {
+    gap: 1em;
+  }
+
   input {
     flex: 1;
     height: 40px;

--- a/src/routes/search/index.svelte
+++ b/src/routes/search/index.svelte
@@ -13,20 +13,10 @@
     exchange: []
   };
 
-  function getFilterBy(filters) {
-    const filterBy = [];
-    Object.entries(filters).forEach(([key, value]) => {
-      if (value.length > 0) {
-        filterBy.push(`${key}:=[${value}]`)
-      }
-    });
-    return filterBy;
-  }
-
   $: tradingEntities.search({
     q,
     facet_by: ["type", "blockchain", "exchange"],
-    filter_by: getFilterBy(filters),
+    filter_by: Object.values(filters).filter((v) => v),
     sort_by: ["_text_match:desc", "volume_24h:desc"]
   });
 </script>
@@ -59,7 +49,7 @@
               <div class="filters col-md-3">
                   {#each $tradingEntities.facets as { field_name, counts } (field_name)}
                     <FacetFilter
-                      bind:group={filters[field_name]}
+                      bind:filter={filters[field_name]}
                       title={field_name}
                       options={counts}
                     />


### PR DESCRIPTION
## Summary

This PR builds on top of #11 with an advanced search page:
* provides a variety of filter and sort options
* displays additional data for each row (price, liquidity, volume)
* shows up to 200 matching results

## Dependencies

This PR depends on #11, which depends on #13.

## Status

I believe this is in good shape to merge. Let me know if you have any questions or feedback on code / user experience.

### Completed

* hide nav search bar on search page
* pass nav-based search query into advanced search
* search page layout (responsive)
* facet-based filters (type, blockchain, exchange)
* numeric range-based filters (volume, liquidity, price change %)
* sort-by options
* clear search options control(s)
* show up to 200 results

