### PR TITLE
Tweak price change filter labels

### DIFF
--- a/src/routes/search/_FacetFilter.svelte
+++ b/src/routes/search/_FacetFilter.svelte
@@ -5,9 +5,9 @@ filter on:change.
 
 #### Usage:
 ```tsx
-  <Filter
+  <FacetFilter
     bind:selected
-    fieldName="facet_search_field"
+    fieldName="facet_field"
     options={[option1, option2]}
     on:change={({ fieldName, filter }) => setFilter(filter) )}
   />

--- a/src/routes/search/_NumericFilter.svelte
+++ b/src/routes/search/_NumericFilter.svelte
@@ -1,0 +1,37 @@
+<!--
+@component
+Displays filter options for numeric filter search fields; dispatches valid
+Typesense filter on:change.
+
+#### Usage:
+```tsx
+  <NumericFilter
+    bind:selected
+    fieldName="numeric_field"
+    filters={[filter1, filter2, ...]}
+    labels={[label1, label2, ...]}
+    on:change={({ fieldName, filter }) => setFilter(filter) )}
+  />
+```
+-->
+<script lang="ts">
+  import { createEventDispatcher } from 'svelte';
+  import Filter from "./_Filter.svelte";
+
+  export let fieldName: string;
+  export let selected: string[] = [];
+  export let filters: string[] = [];
+  export let labels: string[] = [];
+
+  const options = filters.map((filter, idx) => {
+    return {
+      label: labels[idx],
+      value: `${fieldName}:${filters[idx]}`
+    };
+  });
+
+  const dispatch = createEventDispatcher();  
+  $: dispatch("change", { fieldName, filter: selected.join(" && ") });
+</script>
+
+<Filter bind:selected {fieldName} {options} />

--- a/src/routes/search/_RangeFilter.svelte
+++ b/src/routes/search/_RangeFilter.svelte
@@ -1,13 +1,13 @@
 <!--
 @component
-Displays filter options for numeric filter search fields; generates options
-based on breakpoints; generates valid Typesense filter on:change.
+Displays filter options as ranges for numeric filter search fields; generates
+range options based on breakpoints; dispatches valid Typesense filter on:change.
 
 #### Usage:
 ```tsx
-  <Filter
+  <RangeFilter
     bind:selected
-    fieldName="numeric_search_field"
+    fieldName="range_field"
     breakpoints={[0, 100, 1000, 10000, Infinity]}
     formatter={formatFunction}
     labels={[label1, label2, ...]}

--- a/src/routes/search/index.svelte
+++ b/src/routes/search/index.svelte
@@ -12,6 +12,7 @@ Advanced Search page
   import SortSelect, { sortOptions } from "./_SortSelect.svelte";
   import FacetFilter from "./_FacetFilter.svelte";
   import RangeFilter from "./_RangeFilter.svelte";
+  import NumericFilter from "./_NumericFilter.svelte";
   import ResultLineItem from "./_ResultLineItem.svelte";
 
   let q = $page.url.searchParams.get('q') || "";
@@ -115,11 +116,11 @@ Advanced Search page
                             formatter={(v) => formatDollar(v, 0, 0)}
                             on:change={handleFilterChange}
                           />
-                          <RangeFilter
+                          <NumericFilter
                             bind:selected={filters['price_change_24h']}
                             fieldName="price_change_24h"
-                            breakpoints={[Infinity, 0.01, 0.0001, -0.0001, -0.01, -Infinity]}
-                            labels={["▲ > 1%", "△ 0.01% - 1%", "⬦ 0% ± 0.01%", "▽ 0.01% - 1%", "▼ > 1%"]}
+                            filters={[">0.05", ">0", "<0", "<-0.05"]}
+                            labels={["▲ Up > 5%", "△ Up", "▽ Down", "▼ Down > 5%"]}
                             on:change={handleFilterChange}
                           />
                       </div>


### PR DESCRIPTION
Modified the breakpoints per the issue (5%).

I went with shorter labels so they don't wrap at lower breakpoints. Also… I wasn't sure if you wanted to keep the "neutral" option. Current state:

- [ ] ▲ Up > 5%
- [ ] △ Up
- [ ] ⬦ Neutral ±0.01%
- [ ] ▽ Down
- [ ] ▼ Down > 5%

Let me know if you prefer the longer labels (will wrap at some screen widths) and/or if you want to drop "neutral".

fixes #18