### PR TITLE
implement Google SiteLinks search box

### DIFF
--- a/cypress/integration/home.spec.js
+++ b/cypress/integration/home.spec.js
@@ -32,7 +32,7 @@ describe('Traging strategy Home', () => {
         cy.wait("@about");
     });
 
-    it('Use can navigate the site from home page', () => {
+    it('User can navigate the site from home page', () => {
         cy.intercept('/').as("home");
         cy.intercept('/community').as("community");
         cy.intercept('/about').as("about");
@@ -47,5 +47,12 @@ describe('Traging strategy Home', () => {
         cy.location('pathname').should('eq', '/about');
         cy.go('back');
         cy.wait("@home")
-      });
-})
+    });
+
+    it('should include Google Sitelinks search box metadata', () => {
+        cy.get('head > script[type="application/ld+json"]')
+            .invoke('html')
+            .then(JSON.parse)
+            .should('have.nested.property', 'potentialAction.@type', 'SearchAction');
+    });
+});

--- a/src/lib/helpers/googleMeta.ts
+++ b/src/lib/helpers/googleMeta.ts
@@ -1,3 +1,21 @@
+/**
+ * Google Search metadata to provide enhanced search results:
+ * https://developers.google.com/search/docs/advanced/structured-data/search-gallery
+ */
+
+// Utility function for generating metadata script tag
+function generateScriptTag(metadata) {
+  return `<script type="application/ld+json">${JSON.stringify(metadata)}</script>`;
+}
+
+
+/**
+ * Google Article – enhanced search results for blog posts:
+ * https://developers.google.com/search/docs/advanced/structured-data/article
+ *
+ * The generated <script> tag should included in the <head> of all blog posts
+ * as raw @html
+ */
 interface Post {
   title: string,
   author: string,
@@ -18,5 +36,33 @@ export function serializePost(postData: Post) {
       "dateModified": postData.updated_at,
     }
 
-    return `<script type="application/ld+json">${JSON.stringify(metadata, null, 2)}</script>`
+    return generateScriptTag(metadata);
+}
+
+
+/**
+ * Sitelinks Search Box – for including an embedded search box in search results:
+ * https://developers.google.com/search/docs/advanced/structured-data/sitelinks-searchbox
+ *
+ * The generated <script> tag should included in the <head> of the home page
+ * (only) as raw @html
+ */
+export function sitelinksSearchBox() {
+  const url = "https://tradingstrategy.ai/";
+
+  const metadata = {
+    "@context": "https://schema.org",
+    "@type": "WebSite",
+    "url": url,
+    "potentialAction": {
+      "@type": "SearchAction",
+      "target": {
+        "@type": "EntryPoint",
+        "urlTemplate": `${url}search?q={search_term_string}`
+      },
+      "query-input": "required name=search_term_string"
+    }
+  };
+
+  return generateScriptTag(metadata);
 }

--- a/src/routes/index.svelte
+++ b/src/routes/index.svelte
@@ -51,7 +51,8 @@
 	import PoolPreviewEthLisbon from '$lib/pool/PoolPreviewEthLisbon.svelte';
 	import TopMomentum from '$lib/content/TopMomentum.svelte';
 	import ImpressiveNumbers from "$lib/content/ImpressiveNumbers.svelte";
-  import BlogPreviewCard from "$lib/blog/BlogPreviewCard.svelte"
+	import BlogPreviewCard from "$lib/blog/BlogPreviewCard.svelte";
+	import { sitelinksSearchBox } from '$lib/helpers/googleMeta';
 
 	export let topMomentum;
 	export let impressiveNumbers;
@@ -61,8 +62,8 @@
 <svelte:head>
 	<title>Trading Strategy - Algorithmic trading strategy protocol</title>
 	<meta name="description" content="DeFi market data and systematic trading">
+	{@html sitelinksSearchBox()}
 </svelte:head>
-
 
 <main>
 	<section class="card-home card-jumbo">


### PR DESCRIPTION
Added Google [Sitelinks search box](https://developers.google.com/search/docs/advanced/structured-data/sitelinks-searchbox) metadata to home page.

I tested this using `nginx` and Google's [Rich Results Test](https://search.google.com/test/rich-results) utility – the metadata appears to be recognized correctly.

Added a Cypress test.

closes #29
