### PR TITLE
fix dev-specific typescript import error

### DIFF
--- a/src/routes/search/_FacetFilter.svelte
+++ b/src/routes/search/_FacetFilter.svelte
@@ -15,7 +15,8 @@ filter on:change.
 -->
 <script lang="ts">
 	import { createEventDispatcher } from 'svelte';
-  import Filter, { FilterOption } from "./_Filter.svelte";
+  import Filter from "./_Filter.svelte";
+  import type { FilterOption } from "./_Filter.svelte";
 
   export let fieldName: string;
   export let options: FilterOption[];


### PR DESCRIPTION
update ts import syntax – fixes error on `/search` page in dev (apparently introduced with recent lib upgrades)