### PR TITLE
Fix page load progress bar

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "cookie": "^0.4.1",
         "ethers": "^5.6.4",
         "gulp": "^4.0.2",
+        "svelte-fsm": "^1.1.2",
         "svelte-inview": "^3.0.0",
         "svelte-spinner": "^2.0.2",
         "svelte-tradingview-widget": "^2.3.0",
@@ -16014,6 +16015,15 @@
         "node": ">=8"
       }
     },
+    "node_modules/svelte-fsm": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/svelte-fsm/-/svelte-fsm-1.1.2.tgz",
+      "integrity": "sha512-lGeuhELDkQC5WK4+MHJtdigXCqwsYMR1euyRTacDCwtbORzEy5ovivTY3Mnd5bM7H+huO3nKjNjdPvDLcLn3pQ==",
+      "engines": {
+        "node": ">=14.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
     "node_modules/svelte-highlight": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/svelte-highlight/-/svelte-highlight-5.1.2.tgz",
@@ -30304,6 +30314,11 @@
           }
         }
       }
+    },
+    "svelte-fsm": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/svelte-fsm/-/svelte-fsm-1.1.2.tgz",
+      "integrity": "sha512-lGeuhELDkQC5WK4+MHJtdigXCqwsYMR1euyRTacDCwtbORzEy5ovivTY3Mnd5bM7H+huO3nKjNjdPvDLcLn3pQ=="
     },
     "svelte-highlight": {
       "version": "5.1.2",

--- a/package.json
+++ b/package.json
@@ -94,6 +94,7 @@
     "cookie": "^0.4.1",
     "ethers": "^5.6.4",
     "gulp": "^4.0.2",
+    "svelte-fsm": "^1.1.2",
     "svelte-inview": "^3.0.0",
     "svelte-spinner": "^2.0.2",
     "svelte-tradingview-widget": "^2.3.0",

--- a/src/routes/slow-load.svelte
+++ b/src/routes/slow-load.svelte
@@ -1,27 +1,32 @@
-<script context="module">
-    /**
-     * A test endpoint for the page load progress bar.
-     *
-     */
-	export async function load({ }) {
-		// Sleep for 2 seconds
-		const sleep = new Promise((resolve) => setTimeout(resolve, 4000));
-		await sleep;
-		return {};
+<!--
+A test endpoint for the page load progress bar. Page load is delayed 2 seconds
+by default. Increment the `?page=n` param to delay by n * 2 seconds.
+-->
+<script context="module" lang="ts">
+	export async function load({ url }) {
+		const page = parseInt(url.searchParams.get('page')) || 1;
+		await new Promise((resolve) => setTimeout(resolve, page * 2000));
+		return { props: { page } };
 	}
+</script>
+
+<script lang="ts">
+	export let page: number;
 </script>
 
 <div class="container">
 	<div class="content">
-		<h1>You're on Page 1.</h1>
+		<h1>You're on Page {page}.</h1>
 		<p>
-			In this page's <code>load</code> function, we waited for two seconds to mimick a real-world API
-			call before rendering. You can go back to the home page, which should load instantaneously because
-			it doesn't do much server side. Page 2, however, will have a longer delay of 5 seconds.
+			In this page's <code>load</code> function, we waited for {page * 2}
+			seconds to mimick a real-world API call before rendering. You can go
+			back to the home page, which should load instantaneously because it
+			doesn't do much server side. Page 2 (and beyond) will have a longer
+			delay of {(page + 1) * 2} seconds.
 		</p>
 		<div class="links">
 			<a href="/">Home</a>
-			<a href="/page-2">Page 2</a>
+			<a href="?page={page + 1}">Page {page + 1}</a>
 		</div>
 	</div>
 </div>


### PR DESCRIPTION
- use navigating store instead of outdated nav events
- use html5 semantic <progress> element
- use svelte-fsm for deterministic state management
- improve /slow-load test page

fixes #87
