### PR TITLE
fix issues with ChartIQ quote feed

### DIFF
--- a/src/lib/chart/ChartIQ.svelte
+++ b/src/lib/chart/ChartIQ.svelte
@@ -95,6 +95,9 @@ chartiq dependency.
       dontRoll: true
     });
 
+    // display X-Axis time markers in UTC
+    chartEngine.setTimeZone(null, 'UTC');
+
     // attach custom studies - e.g., volume, liquidity bar charts
     for (const study of studies) {
       CIQ.Studies.addStudy(chartEngine, study);

--- a/src/lib/chart/quoteFeed.ts
+++ b/src/lib/chart/quoteFeed.ts
@@ -18,7 +18,7 @@ function dateUrlParam(date: Date): string {
 
 function fieldMapper({ ts, o, h, l, c, v, ...restParams }) {
   return {
-    Date: ts,
+    DT: `${ts}Z`,
     Open: o,
     High: h,
     Low: l,

--- a/src/lib/chart/quoteFeed.ts
+++ b/src/lib/chart/quoteFeed.ts
@@ -5,6 +5,8 @@
 import { backendUrl } from '$lib/config';
 import { feedParamsToTimeBucket } from '$lib/chart/timeBucketConverters';
 
+const maxTicks = 2000;
+
 const endpoints = {
   price: 'candles',
   liquidity: 'xyliquidity'
@@ -26,33 +28,47 @@ function fieldMapper({ ts, o, h, l, c, v, ...restParams }) {
   };
 }
 
-async function fetchData(url, symbol, startDate, endDate, params) {
-  const urlParams = new URLSearchParams({
-    pair_id: symbol,
-    time_bucket: feedParamsToTimeBucket(params.period, params.interval),
-    start: dateUrlParam(startDate),
-    end: dateUrlParam(endDate)
-  });
-
-  const response = await fetch(`${url}?${urlParams}`);
-  const quotes = await response.json();
-
-  return quotes.map(fieldMapper);
-}
-
 export default function(type: 'price' | 'liquidity') {
-  const url = `${backendUrl}/${endpoints[type]}`;
+  const baseUrl = `${backendUrl}/${endpoints[type]}`;
+  const lastRequest = {
+    price: null,
+    liquidity: null
+  };
+
+  async function fetchData(symbol, startDate, endDate, params) {
+    const urlParams = new URLSearchParams({
+      pair_id: symbol,
+      time_bucket: feedParamsToTimeBucket(params.period, params.interval),
+      start: dateUrlParam(startDate),
+      end: dateUrlParam(endDate)
+    });
+
+    const queryString = `?${urlParams}`;
+
+    // Prevent infinite request loops: if request is identical to last request,
+    // instruct ChartIQ to check for older data. See:
+    // https://documentation.chartiq.com/tutorial-DataIntegrationQuoteFeeds.html#toc6__anchor
+    if (lastRequest[type] === queryString) {
+      return [{ DT: startDate - (endDate - startDate) }];
+    }
+
+    lastRequest[type] = queryString;
+    const response = await fetch(baseUrl + queryString);
+    const quotes = await response.json();
+
+    return quotes.map(fieldMapper);
+  }
 
   async function fetchInitialData(symbol, startDate, endDate, params, callback) {
-    const quotes = await fetchData(url, symbol, startDate, endDate, params);
+    const quotes = await fetchData(symbol, startDate, endDate, params);
     callback({ quotes });
   }
 
   async function fetchPaginationData(symbol, startDate, endDate, params, callback) {
-    const quotes = await fetchData(url, symbol, startDate, endDate, params);
-    const moreAvailable = quotes.length > 0;
+    const quotes = await fetchData(symbol, startDate, endDate, params);
+    const moreAvailable = dateUrlParam(startDate) > params.chart.firstTradeDate;
     callback({ quotes, moreAvailable });
   }
 
-  return { fetchInitialData, fetchPaginationData };
+  return { fetchInitialData, fetchPaginationData, maxTicks };
 }

--- a/src/routes/trading-view/[chain]/[exchange]/[pair]/_ChartSection.svelte
+++ b/src/routes/trading-view/[chain]/[exchange]/[pair]/_ChartSection.svelte
@@ -73,9 +73,9 @@ for the same hovered date. Also displays a time-bucket selector.
         studies={['Liquidity AR']}
         linker={chartLinker}
     >
-        <div slot="hud-row-2" class="hud-row" let:active let:formatForHud>
-            <dl class="vol-added"><dt>Vol Added</dt><dd>{formatForHud(active.av)}</dd></dl>
-            <dl class="vol-removed"><dt>Vol Removed</dt><dd>{formatForHud(active.rv)}</dd></dl>
+        <div slot="hud-row-2" class="hud-row" let:activeTick let:formatForHud>
+            <dl class="vol-added"><dt>Vol Added</dt><dd>{formatForHud(activeTick.av)}</dd></dl>
+            <dl class="vol-removed"><dt>Vol Removed</dt><dd>{formatForHud(activeTick.rv)}</dd></dl>
         </div>
     </ChartIQ>
 </div>

--- a/src/routes/trading-view/[chain]/[exchange]/[pair]/_ChartSection.svelte
+++ b/src/routes/trading-view/[chain]/[exchange]/[pair]/_ChartSection.svelte
@@ -1,16 +1,33 @@
+<!--
+@component
+Displays trading pair price/volume and liquidity charts. The two charts are
+linked so they scroll/zoom together and display crosshairs and HUD data
+for the same hovered date. Also displays a time-bucket selector.
+
+#### Usage:
+```tsx
+  <ChartSection
+    pairId={12345}
+    pairSymbol={"ELON-ETH"}
+    firstTradeDate={"2020-01-02T00:00"}
+  />
+```
+-->
 <script lang="ts">
   import { page } from '$app/stores';
+  import type { TimeBucket } from '$lib/chart/timeBucketConverters';
   import TimeBucketSelector from '$lib/chart/TimeBucketSelector.svelte';
   import ChartIQ from '$lib/chart/ChartIQ.svelte';
   import quoteFeed from '$lib/chart/quoteFeed';
   import ChartLinker from '$lib/chart/ChartLinker';
 
-  export let pairSymbol;
-  export let pairId;
+  export let pairSymbol: string;
+  export let pairId: number | string;
+  export let firstTradeDate: string;
 
   const chartLinker = new ChartLinker();
 
-  $: timeBucket = $page.url.hash.slice(1) || '4h';
+  $: timeBucket = (($page.url.hash.slice(1) || '4h') as TimeBucket);
 </script>
 
 <div class="chart-header">
@@ -32,6 +49,7 @@
         feed={quoteFeed('price')}
         {pairId}
         {timeBucket}
+        {firstTradeDate}
         studies={['Volume Underlay']}
         linker={chartLinker}
     />
@@ -51,6 +69,7 @@
         feed={quoteFeed('liquidity')}
         {pairId}
         {timeBucket}
+        {firstTradeDate}
         studies={['Liquidity AR']}
         linker={chartLinker}
     >

--- a/src/routes/trading-view/[chain]/[exchange]/[pair]/index.svelte
+++ b/src/routes/trading-view/[chain]/[exchange]/[pair]/index.svelte
@@ -204,7 +204,11 @@ Render the pair trading page
         </div>
     </div>
 
-    <ChartSection pairId={summary.pair_id} pairSymbol={summary.pair_symbol} />
+    <ChartSection
+        pairId={summary.pair_id}
+        pairSymbol={summary.pair_symbol}
+        firstTradeDate={details.first_trade_at}
+    />
 
     <h2>Time period summary</h2>
 


### PR DESCRIPTION
- tell ChartIQ to cleanup gaps
- use pair's first trade date to determine when no more data available
- prevent infinite request loops (abort duplicate requests)
- limit max ticks requested to 2000

fixes #96