### PR TITLE
Escape & in rss

### DIFF
--- a/src/routes/blog/rss.xml.ts
+++ b/src/routes/blog/rss.xml.ts
@@ -24,13 +24,16 @@ const render = (posts) => `<?xml version="1.0" encoding="UTF-8" ?>
 <description>Algorithmic trading protocol for decentralised markets</description>
 ${posts
   .map(
-    (post) => `<item>
-                  <guid>https://tradingstrategy.ai/blog/${post.slug}</guid>
-                  <title>${post.title}</title>
-                  <link>https://tradingstrategy.ai/blog/${post.slug}</link>
-                  <description>${post.custom_excerpt}</description>
-                  <pubDate>${new Date(post.published_at).toUTCString()}</pubDate>
-              </item>`
+    (post) => {
+      const excerpt = post.custom_excerpt.replace('&', '&amp;')
+      return `<item>
+        <guid>https://tradingstrategy.ai/blog/${post.slug}</guid>
+        <title>${post.title}</title>
+        <link>https://tradingstrategy.ai/blog/${post.slug}</link>
+        <description>${excerpt}</description>
+        <pubDate>${new Date(post.published_at).toUTCString()}</pubDate>
+      </item>`
+    }
   )
   .join('')}
 </channel>


### PR DESCRIPTION
Not sure if there's  a better way to escape "&" in rss,  I just replace & to &amp since rss doesn't like "&" 

![image](https://user-images.githubusercontent.com/3521485/169919630-1b628841-0654-463d-93e6-29b6d2e7d183.png)
