### PR TITLE
add node-adapter wrapper for malformed URIs

### DIFF
--- a/server.js
+++ b/server.js
@@ -1,0 +1,27 @@
+/**
+ * Wrapper service to check for malformed URIs before passing requests to
+ * `node-adapter` handler.
+ * 
+ * After running `SSR=true npm run build`, start this service with:
+ * `node server.js`
+ */
+import { createServer } from 'http';
+import { handler } from './build/handler.js';
+
+const port = process.env.FRONTEND_PORT || 3000;
+
+const server = createServer((req, res) => {
+  try {
+    decodeURI(req.url);
+  } catch (e) {
+    const invalidUriPath = `/invalid${encodeURI(req.url)}`;
+    console.log(`URIError: can't decode ${req.url}; forwarding to ${invalidUriPath}`);
+    req.url = invalidUriPath;
+  } finally {
+    handler(req, res);
+  }
+});
+
+server.listen(port, () => {
+  console.log(`Listening on port: ${port}`);
+});

--- a/src/routes/invalid/[...path].svelte
+++ b/src/routes/invalid/[...path].svelte
@@ -1,0 +1,12 @@
+<!--
+Special route for handling invalid URI requests. See `/server.js`
+-->
+<script context="module" lang="ts">
+  /** @type {import('@sveltejs/kit').Load} */
+  export function load({ params }) {
+    return {
+      status: 400,
+      error: new Error(`Bad request - malformed URI: /${params.path}`)
+    };
+  }
+</script>


### PR DESCRIPTION
Wrapper service to handle malformed URIs.

## Testing usage

Run this locally:

```bash
SSR=true npm run build
node server.js
```

then try testing
http://localhost:3000/%CD%EA%D5%FB.rar

## Prod usage

We've had other exceptions cause fatal errors on the `node` service (e.g., `fetch` DNS errors). We can't anticipate ahead-of-time all the unhandled exceptions that cause `node-adapter` to explode. Recommendation: wrap the `node` command in a simple supervisor to restart on exit, such as:

```bash
while true; do
  node server.js
  sleep 1
done
```

We could add some error output to this so it's easier to track down in the logs.

## Follow up

I still need to submit a GH issue to the SvelteKit project (will do so Thursday).

fixes #102