### PR TITLE
Import trade-executor-frontend via npm

### DIFF
--- a/.env
+++ b/.env
@@ -8,4 +8,4 @@ VITE_PUBLIC_TYPESENSE_API_KEY=G26ReHm1VZwTpKye2w4P5hZkmQghb6i9
 # VITE_PUBLIC_CHAINS_UNDER_MAINTENANCE={ "binance": "BNB Chain" }
 
 # See trade-executor-frontend for configuration
-VITE_PUBLIC_STRATEGIES=[{"id":"pancake_8h_momentum","name":"Data collection test for PancakeSwap","url":"https://t-100.tradingstrategy.ai"}]
+VITE_PUBLIC_STRATEGIES=[{"id":"pancake_8h_momentum","name":"Pancake 8h tick momentum","url":"https://t-100.tradingstrategy.ai"},{"id":"quickswap-momentum","name":"QuickSwap momentum","url":"https://robocop.tradingstrategy.ai"}]

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .DS_Store
 node_modules
+/trade-executor-frontend
 /.svelte-kit
 /package
 .idea

--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,2 @@
 engine-strict=true
+@tradingstrategy-ai:registry=https://npm.pkg.github.com

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,10 +7,12 @@
     "": {
       "name": "frontend",
       "version": "0.0.1",
+      "hasInstallScript": true,
       "dependencies": {
         "@fontsource/fira-mono": "^4.2.2",
         "@lukeed/uuid": "^2.0.0",
         "@metamask/detect-provider": "^1.2.0",
+        "@tradingstrategy-ai/trade-executor-frontend": "^0.1.0",
         "@tryghost/content-api": "^1.5.13",
         "cheerio": "^1.0.0-rc.10",
         "cookie": "^0.4.1",
@@ -21,7 +23,6 @@
         "svelte-spinner": "^2.0.2",
         "svelte-tradingview-widget": "^2.3.0",
         "sveltestrap": "^4.2.1",
-        "trade-executor-frontend": "file:../trade-executor-frontend/package",
         "ts-custom-error": "^3.2.0",
         "typesense": "^1.2.1",
         "web3": "^1.6.0"
@@ -76,6 +77,7 @@
     "../trade-executor-frontend/package": {
       "name": "@tradingstrategy-ai/trade-executor-frontend",
       "version": "0.0.1",
+      "extraneous": true,
       "dependencies": {
         "@fontsource/fira-mono": "^4.5.0",
         "@lukeed/uuid": "^2.0.0",
@@ -3556,6 +3558,20 @@
         "node": ">= 6"
       }
     },
+    "node_modules/@tradingstrategy-ai/trade-executor-frontend": {
+      "version": "0.1.0",
+      "resolved": "https://npm.pkg.github.com/download/@tradingstrategy-ai/trade-executor-frontend/0.1.0/057d8f0d5a6b208974c682977dbeab8965883c50f0e9f63b9e284c8bbc4cdf3a",
+      "integrity": "sha512-FCW/J1KZlNLAqx+8IrEHYehXjsz8qVtgiLwuraKhm6cGaPfATdSpUNw+qs3f+AnBNjKSETMSTq6G9phOpHuoVA==",
+      "dependencies": {
+        "@fontsource/fira-mono": "^4.5.0",
+        "@lukeed/uuid": "^2.0.0",
+        "assert-ts": "^0.3.4",
+        "cookie": "^0.4.1",
+        "gridjs": "^5.0.2",
+        "gridjs-svelte": "^2.1.1",
+        "svelte-spinner": "^2.0.2"
+      }
+    },
     "node_modules/@tryghost/content-api": {
       "version": "1.5.13",
       "resolved": "https://registry.npmjs.org/@tryghost/content-api/-/content-api-1.5.13.tgz",
@@ -4323,8 +4339,7 @@
     "node_modules/assert-ts": {
       "version": "0.3.4",
       "resolved": "https://registry.npmjs.org/assert-ts/-/assert-ts-0.3.4.tgz",
-      "integrity": "sha512-CQtNOdOCzzZfE3TF9a1vFTcz4ZfJYM6iHoWYCkpFY3wdk6CkFvevuLwpOFVL/KMJ9vCNIbeidWH5uo/Y8sLVWg==",
-      "dev": true
+      "integrity": "sha512-CQtNOdOCzzZfE3TF9a1vFTcz4ZfJYM6iHoWYCkpFY3wdk6CkFvevuLwpOFVL/KMJ9vCNIbeidWH5uo/Y8sLVWg=="
     },
     "node_modules/assign-symbols": {
       "version": "1.0.0",
@@ -8938,7 +8953,6 @@
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/gridjs/-/gridjs-5.0.2.tgz",
       "integrity": "sha512-7EaMc4/IhqRcSbdOYvHOlHETciWmbbhMU6rDr2e0UfzIXSkb7X3Lhf9+bGv+v4JaWnJW5GBillgIIHrAvIIoFg==",
-      "dev": true,
       "dependencies": {
         "preact": "^10.5.12",
         "tslib": "^2.0.1"
@@ -8948,7 +8962,6 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/gridjs-svelte/-/gridjs-svelte-2.1.1.tgz",
       "integrity": "sha512-tYkgdqNKSnfmAYYc8EP4axn/Xlugp7VLwAlpNkP4SBLHHYD/ejD2DJ+FMatDNqcJ1Z1kuMnJWO+VBcAOirEByw==",
-      "dev": true,
       "peerDependencies": {
         "gridjs": ">=5.0.0",
         "svelte": ">=3.30.0"
@@ -13756,7 +13769,6 @@
       "version": "10.7.1",
       "resolved": "https://registry.npmjs.org/preact/-/preact-10.7.1.tgz",
       "integrity": "sha512-MufnRFz39aIhs9AMFisonjzTud1PK1bY+jcJLo6m2T9Uh8AqjD77w11eAAawmjUogoGOnipECq7e/1RClIKsxg==",
-      "dev": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/preact"
@@ -16618,10 +16630,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/trade-executor-frontend": {
-      "resolved": "../trade-executor-frontend/package",
-      "link": true
     },
     "node_modules/ts-custom-error": {
       "version": "3.2.0",
@@ -20730,6 +20738,20 @@
       "integrity": "sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==",
       "dev": true
     },
+    "@tradingstrategy-ai/trade-executor-frontend": {
+      "version": "0.1.0",
+      "resolved": "https://npm.pkg.github.com/download/@tradingstrategy-ai/trade-executor-frontend/0.1.0/057d8f0d5a6b208974c682977dbeab8965883c50f0e9f63b9e284c8bbc4cdf3a",
+      "integrity": "sha512-FCW/J1KZlNLAqx+8IrEHYehXjsz8qVtgiLwuraKhm6cGaPfATdSpUNw+qs3f+AnBNjKSETMSTq6G9phOpHuoVA==",
+      "requires": {
+        "@fontsource/fira-mono": "^4.5.0",
+        "@lukeed/uuid": "^2.0.0",
+        "assert-ts": "^0.3.4",
+        "cookie": "^0.4.1",
+        "gridjs": "^5.0.2",
+        "gridjs-svelte": "^2.1.1",
+        "svelte-spinner": "^2.0.2"
+      }
+    },
     "@tryghost/content-api": {
       "version": "1.5.13",
       "resolved": "https://registry.npmjs.org/@tryghost/content-api/-/content-api-1.5.13.tgz",
@@ -21322,8 +21344,7 @@
     "assert-ts": {
       "version": "0.3.4",
       "resolved": "https://registry.npmjs.org/assert-ts/-/assert-ts-0.3.4.tgz",
-      "integrity": "sha512-CQtNOdOCzzZfE3TF9a1vFTcz4ZfJYM6iHoWYCkpFY3wdk6CkFvevuLwpOFVL/KMJ9vCNIbeidWH5uo/Y8sLVWg==",
-      "dev": true
+      "integrity": "sha512-CQtNOdOCzzZfE3TF9a1vFTcz4ZfJYM6iHoWYCkpFY3wdk6CkFvevuLwpOFVL/KMJ9vCNIbeidWH5uo/Y8sLVWg=="
     },
     "assign-symbols": {
       "version": "1.0.0",
@@ -24942,7 +24963,6 @@
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/gridjs/-/gridjs-5.0.2.tgz",
       "integrity": "sha512-7EaMc4/IhqRcSbdOYvHOlHETciWmbbhMU6rDr2e0UfzIXSkb7X3Lhf9+bGv+v4JaWnJW5GBillgIIHrAvIIoFg==",
-      "dev": true,
       "requires": {
         "preact": "^10.5.12",
         "tslib": "^2.0.1"
@@ -24952,7 +24972,6 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/gridjs-svelte/-/gridjs-svelte-2.1.1.tgz",
       "integrity": "sha512-tYkgdqNKSnfmAYYc8EP4axn/Xlugp7VLwAlpNkP4SBLHHYD/ejD2DJ+FMatDNqcJ1Z1kuMnJWO+VBcAOirEByw==",
-      "dev": true,
       "requires": {}
     },
     "growly": {
@@ -28569,8 +28588,7 @@
     "preact": {
       "version": "10.7.1",
       "resolved": "https://registry.npmjs.org/preact/-/preact-10.7.1.tgz",
-      "integrity": "sha512-MufnRFz39aIhs9AMFisonjzTud1PK1bY+jcJLo6m2T9Uh8AqjD77w11eAAawmjUogoGOnipECq7e/1RClIKsxg==",
-      "dev": true
+      "integrity": "sha512-MufnRFz39aIhs9AMFisonjzTud1PK1bY+jcJLo6m2T9Uh8AqjD77w11eAAawmjUogoGOnipECq7e/1RClIKsxg=="
     },
     "prelude-ls": {
       "version": "1.2.1",
@@ -30768,36 +30786,6 @@
       "dev": true,
       "requires": {
         "punycode": "^2.1.1"
-      }
-    },
-    "trade-executor-frontend": {
-      "version": "file:../trade-executor-frontend/package",
-      "requires": {
-        "@fontsource/fira-mono": "^4.5.0",
-        "@lukeed/uuid": "^2.0.0",
-        "@playwright/test": "^1.20.0",
-        "@sveltejs/adapter-auto": "next",
-        "@sveltejs/kit": "next",
-        "@types/cookie": "^0.4.1",
-        "@typescript-eslint/eslint-plugin": "^5.10.1",
-        "@typescript-eslint/parser": "^5.10.1",
-        "assert-ts": "^0.3.4",
-        "cookie": "^0.4.1",
-        "eslint": "^7.32.0",
-        "eslint-config-prettier": "^8.3.0",
-        "eslint-plugin-svelte3": "^3.2.1",
-        "gridjs": "^5.0.2",
-        "gridjs-svelte": "^2.1.1",
-        "prettier": "^2.5.1",
-        "prettier-plugin-svelte": "^2.5.0",
-        "svelte": "^3.46.0",
-        "svelte-check": "^2.2.6",
-        "svelte-preprocess": "^4.10.1",
-        "svelte-simple-datatables": "^0.2.3",
-        "svelte-spinner": "^2.0.2",
-        "svelte2tsx": "^0.5.9",
-        "tslib": "^2.3.1",
-        "typescript": "~4.6.2"
       }
     },
     "ts-custom-error": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "svelte-spinner": "^2.0.2",
         "svelte-tradingview-widget": "^2.3.0",
         "sveltestrap": "^4.2.1",
+        "trade-executor-frontend": "file:../trade-executor-frontend/package",
         "ts-custom-error": "^3.2.0",
         "typesense": "^1.2.1",
         "web3": "^1.6.0"
@@ -70,6 +71,39 @@
       },
       "optionalDependencies": {
         "chartiq": "github:tradingstrategy-ai/chartiq-dist"
+      }
+    },
+    "../trade-executor-frontend/package": {
+      "name": "@tradingstrategy-ai/trade-executor-frontend",
+      "version": "0.0.1",
+      "dependencies": {
+        "@fontsource/fira-mono": "^4.5.0",
+        "@lukeed/uuid": "^2.0.0",
+        "assert-ts": "^0.3.4",
+        "cookie": "^0.4.1",
+        "gridjs": "^5.0.2",
+        "gridjs-svelte": "^2.1.1",
+        "svelte-spinner": "^2.0.2"
+      },
+      "devDependencies": {
+        "@playwright/test": "^1.20.0",
+        "@sveltejs/adapter-auto": "next",
+        "@sveltejs/kit": "next",
+        "@types/cookie": "^0.4.1",
+        "@typescript-eslint/eslint-plugin": "^5.10.1",
+        "@typescript-eslint/parser": "^5.10.1",
+        "eslint": "^7.32.0",
+        "eslint-config-prettier": "^8.3.0",
+        "eslint-plugin-svelte3": "^3.2.1",
+        "prettier": "^2.5.1",
+        "prettier-plugin-svelte": "^2.5.0",
+        "svelte": "^3.46.0",
+        "svelte-check": "^2.2.6",
+        "svelte-preprocess": "^4.10.1",
+        "svelte-simple-datatables": "^0.2.3",
+        "svelte2tsx": "^0.5.9",
+        "tslib": "^2.3.1",
+        "typescript": "~4.6.2"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -16585,6 +16619,10 @@
         "node": ">=8"
       }
     },
+    "node_modules/trade-executor-frontend": {
+      "resolved": "../trade-executor-frontend/package",
+      "link": true
+    },
     "node_modules/ts-custom-error": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/ts-custom-error/-/ts-custom-error-3.2.0.tgz",
@@ -30730,6 +30768,36 @@
       "dev": true,
       "requires": {
         "punycode": "^2.1.1"
+      }
+    },
+    "trade-executor-frontend": {
+      "version": "file:../trade-executor-frontend/package",
+      "requires": {
+        "@fontsource/fira-mono": "^4.5.0",
+        "@lukeed/uuid": "^2.0.0",
+        "@playwright/test": "^1.20.0",
+        "@sveltejs/adapter-auto": "next",
+        "@sveltejs/kit": "next",
+        "@types/cookie": "^0.4.1",
+        "@typescript-eslint/eslint-plugin": "^5.10.1",
+        "@typescript-eslint/parser": "^5.10.1",
+        "assert-ts": "^0.3.4",
+        "cookie": "^0.4.1",
+        "eslint": "^7.32.0",
+        "eslint-config-prettier": "^8.3.0",
+        "eslint-plugin-svelte3": "^3.2.1",
+        "gridjs": "^5.0.2",
+        "gridjs-svelte": "^2.1.1",
+        "prettier": "^2.5.1",
+        "prettier-plugin-svelte": "^2.5.0",
+        "svelte": "^3.46.0",
+        "svelte-check": "^2.2.6",
+        "svelte-preprocess": "^4.10.1",
+        "svelte-simple-datatables": "^0.2.3",
+        "svelte-spinner": "^2.0.2",
+        "svelte2tsx": "^0.5.9",
+        "tslib": "^2.3.1",
+        "typescript": "~4.6.2"
       }
     },
     "ts-custom-error": {

--- a/package.json
+++ b/package.json
@@ -101,6 +101,7 @@
     "svelte-spinner": "^2.0.2",
     "svelte-tradingview-widget": "^2.3.0",
     "sveltestrap": "^4.2.1",
+    "trade-executor-frontend": "file:../trade-executor-frontend/package",
     "ts-custom-error": "^3.2.0",
     "typesense": "^1.2.1",
     "web3": "^1.6.0"

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "test": "node --experimental-vm-modules node_modules/jest/bin/jest.js",
     "test:watch": "npm test -- --watch",
     "ssr:node": "svelte-kit build",
-    "prepare": "svelte-kit sync"
+    "prepare": "svelte-kit sync",
+    "postinstall": "cp -R node_modules/@tradingstrategy-ai/trade-executor-frontend ."
   },
   "engines": {
     "node": "^16.15.0"
@@ -91,6 +92,7 @@
     "@fontsource/fira-mono": "^4.2.2",
     "@lukeed/uuid": "^2.0.0",
     "@metamask/detect-provider": "^1.2.0",
+    "@tradingstrategy-ai/trade-executor-frontend": "^0.1.0",
     "@tryghost/content-api": "^1.5.13",
     "cheerio": "^1.0.0-rc.10",
     "cookie": "^0.4.1",
@@ -101,7 +103,6 @@
     "svelte-spinner": "^2.0.2",
     "svelte-tradingview-widget": "^2.3.0",
     "sveltestrap": "^4.2.1",
-    "trade-executor-frontend": "file:../trade-executor-frontend/package",
     "ts-custom-error": "^3.2.0",
     "typesense": "^1.2.1",
     "web3": "^1.6.0"

--- a/src/routes/strategy/[strategy_id]/__layout.svelte
+++ b/src/routes/strategy/[strategy_id]/__layout.svelte
@@ -10,9 +10,7 @@
 	import { onMount } from 'svelte';
 
 	import { loadStrategyById } from 'trade-executor-frontend/state/store';
-	import StrategyHeader from 'trade-executor-frontend/strategy/StrategyHeader.svelte';
-	import StrategyLoadIndicator from 'trade-executor-frontend/strategy/StrategyLoadIndicator.svelte';
-	import StrategyMenu from 'trade-executor-frontend/strategy/StrategyMenu.svelte';
+	import { StrategyHeader, StrategyLoadIndicator, StrategyMenu } from 'trade-executor-frontend';
 
 	const strategyId = $page.params.strategy_id;
 

--- a/src/routes/strategy/[strategy_id]/closed-positions/[position_id]/index.svelte
+++ b/src/routes/strategy/[strategy_id]/closed-positions/[position_id]/index.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import PositionDetailsPage from 'trade-executor-frontend/strategy/PositionDetailsPage.svelte';
+	import { PositionDetailsPage } from 'trade-executor-frontend';
 	import { PositionKind } from 'trade-executor-frontend/state/interface';
 </script>
 

--- a/src/routes/strategy/[strategy_id]/closed-positions/[position_id]/trade-[trade_id].svelte
+++ b/src/routes/strategy/[strategy_id]/closed-positions/[position_id]/trade-[trade_id].svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import TradeDetailsPage from 'trade-executor-frontend/strategy/TradeDetailsPage.svelte';
+	import { TradeDetailsPage } from 'trade-executor-frontend';
 	import { PositionKind } from 'trade-executor-frontend/state/interface';
 </script>
 

--- a/src/routes/strategy/[strategy_id]/closed-positions/index.svelte
+++ b/src/routes/strategy/[strategy_id]/closed-positions/index.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { portfolio, stats } from 'trade-executor-frontend/state/store';
-	import PositionList from 'trade-executor-frontend/strategy/PositionList.svelte';
+	import { PositionList } from 'trade-executor-frontend';
 
 	$: closedPositions = $portfolio?.closed_positions;
 </script>

--- a/src/routes/strategy/[strategy_id]/frozen-positions/[position_id]/index.svelte
+++ b/src/routes/strategy/[strategy_id]/frozen-positions/[position_id]/index.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import PositionDetailsPage from 'trade-executor-frontend/strategy/PositionDetailsPage.svelte';
+	import { PositionDetailsPage } from 'trade-executor-frontend';
 	import { PositionKind } from 'trade-executor-frontend/state/interface';
 </script>
 

--- a/src/routes/strategy/[strategy_id]/frozen-positions/[position_id]/trade-[trade_id].svelte
+++ b/src/routes/strategy/[strategy_id]/frozen-positions/[position_id]/trade-[trade_id].svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import TradeDetailsPage from 'trade-executor-frontend/strategy/TradeDetailsPage.svelte';
+	import { TradeDetailsPage } from 'trade-executor-frontend';
 	import { PositionKind } from 'trade-executor-frontend/state/interface';
 </script>
 

--- a/src/routes/strategy/[strategy_id]/frozen-positions/index.svelte
+++ b/src/routes/strategy/[strategy_id]/frozen-positions/index.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { portfolio, stats } from 'trade-executor-frontend/state/store';
-	import PositionList from 'trade-executor-frontend/strategy/PositionList.svelte';
+	import { PositionList } from 'trade-executor-frontend';
 
 	$: frozenPositions = $portfolio?.frozen_positions;
 </script>

--- a/src/routes/strategy/[strategy_id]/index.svelte
+++ b/src/routes/strategy/[strategy_id]/index.svelte
@@ -1,5 +1,5 @@
 <script context="module">
-	import StrategyOverviewPage from 'trade-executor-frontend/strategy/StrategyOverviewPage.svelte';
+	import { StrategyOverviewPage } from 'trade-executor-frontend';
 	import { getConfiguredStrategyById } from 'trade-executor-frontend/strategy/configuration';
 	import { getStrategyMetadata } from 'trade-executor-frontend/strategy/metadata';
 

--- a/src/routes/strategy/[strategy_id]/open-positions/[position_id]/index.svelte
+++ b/src/routes/strategy/[strategy_id]/open-positions/[position_id]/index.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import PositionDetailsPage from 'trade-executor-frontend/strategy/PositionDetailsPage.svelte';
+	import { PositionDetailsPage } from 'trade-executor-frontend';
 	import { PositionKind } from 'trade-executor-frontend/state/interface';
 </script>
 

--- a/src/routes/strategy/[strategy_id]/open-positions/[position_id]/trade-[trade_id].svelte
+++ b/src/routes/strategy/[strategy_id]/open-positions/[position_id]/trade-[trade_id].svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import TradeDetailsPage from 'trade-executor-frontend/strategy/TradeDetailsPage.svelte';
+	import { TradeDetailsPage } from 'trade-executor-frontend';
 	import { PositionKind } from 'trade-executor-frontend/state/interface';
 </script>
 

--- a/src/routes/strategy/[strategy_id]/open-positions/index.svelte
+++ b/src/routes/strategy/[strategy_id]/open-positions/index.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { portfolio, stats } from 'trade-executor-frontend/state/store';
-	import PositionList from 'trade-executor-frontend/strategy/PositionList.svelte';
+	import { PositionList } from 'trade-executor-frontend';
 
 	$: openPositions = $portfolio?.open_positions;
 </script>

--- a/src/routes/strategy/__layout.svelte
+++ b/src/routes/strategy/__layout.svelte
@@ -1,5 +1,5 @@
 <script>
-	import Breadcrumb from 'trade-executor-frontend/header/Breadcrumb.svelte';
+	import { Breadcrumb } from 'trade-executor-frontend';
 </script>
 
 <div class="container">

--- a/src/routes/strategy/index.svelte
+++ b/src/routes/strategy/index.svelte
@@ -14,7 +14,7 @@
 </script>
 
 <script>
-	import StrategySummaryPage from 'trade-executor-frontend/strategy/StrategySummaryPage.svelte';
+	import { StrategySummaryPage } from 'trade-executor-frontend';
 
 	export let strategies;
 </script>

--- a/svelte.config.js
+++ b/svelte.config.js
@@ -9,6 +9,7 @@
  */
 import preprocess from 'svelte-preprocess';
 import node from '@sveltejs/adapter-node';
+import path from 'path';
 
 let config;
 
@@ -96,6 +97,12 @@ config.kit.vite = {
 			output: {
 				manualChunks: undefined
 			}
+		}
+	},
+
+	resolve: {
+		alias: {
+			'trade-executor-frontend': path.resolve('./trade-executor-frontend')
 		}
 	}
 };

--- a/svelte.config.js
+++ b/svelte.config.js
@@ -9,7 +9,6 @@
  */
 import preprocess from 'svelte-preprocess';
 import node from '@sveltejs/adapter-node';
-import path from 'path';
 
 let config;
 
@@ -97,13 +96,6 @@ config.kit.vite = {
 			output: {
 				manualChunks: undefined
 			}
-		}
-	},
-
-	// Dropping in the executor frontend
-	resolve: {
-		alias: {
-			'trade-executor-frontend': path.resolve('../trade-executor-frontend/src/lib')
 		}
 	}
 };


### PR DESCRIPTION
This PR updates `frontend` to import `trade-executor-strategy` via an NPM module (published to the GH registry).

**NOTE:** this PR should be merged _before_ https://github.com/tradingstrategy-ai/trade-executor-frontend/pull/1. See note on that PR.

closes #94 