### PR TITLE
Fix remaining build issues

### DIFF
--- a/.github/workflows/javascript.yml
+++ b/.github/workflows/javascript.yml
@@ -12,24 +12,21 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
+        with:
+          submodules: recursive
       - uses: actions/setup-node@v3
         with:
           node-version: 16.15
-          registry-url: https://npm.pkg.github.com/
       - name: Use SSH deploy key
         uses: webfactory/ssh-agent@v0.5.4
         with:
           ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
       - name: Install dependencies
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.GH_PACKAGES_TOKEN }}
         run: npm ci
       - name: Package version check
         run: npm ls
       - name: Code format check
         run: npm run format:check
-      - name: Checkout submodules
-        run: git submodule set-url theme https://github.com/tradingstrategy-ai/theme.git
       - name: Setup submodules
         run: bash scripts/build-deps.sh
       - name: Run Cypress

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,12 +7,10 @@
     "": {
       "name": "frontend",
       "version": "0.0.1",
-      "hasInstallScript": true,
       "dependencies": {
         "@fontsource/fira-mono": "^4.2.2",
         "@lukeed/uuid": "^2.0.0",
         "@metamask/detect-provider": "^1.2.0",
-        "@tradingstrategy-ai/trade-executor-frontend": "^0.1.1",
         "@tryghost/content-api": "^1.5.13",
         "cheerio": "^1.0.0-rc.10",
         "cookie": "^0.4.1",
@@ -3595,20 +3593,6 @@
         "node": ">= 6"
       }
     },
-    "node_modules/@tradingstrategy-ai/trade-executor-frontend": {
-      "version": "0.1.1",
-      "resolved": "https://npm.pkg.github.com/download/@tradingstrategy-ai/trade-executor-frontend/0.1.1/4457d567f7018b51d5568426c30023b9c98e2f5a9c6c87bf7bae5afd31973578",
-      "integrity": "sha512-I36PmtgjthZ5nZyQZCk2EWfY8njbc3p7Fyk6Bv2onGfWCrlKOLiO9ECza9GvVAm0k/TKs/nTG+upMKHbs9mc5Q==",
-      "dependencies": {
-        "@fontsource/fira-mono": "^4.5.0",
-        "@lukeed/uuid": "^2.0.0",
-        "assert-ts": "^0.3.4",
-        "cookie": "^0.4.1",
-        "gridjs": "^5.0.2",
-        "gridjs-svelte": "^2.1.1",
-        "svelte-spinner": "^2.0.2"
-      }
-    },
     "node_modules/@tryghost/content-api": {
       "version": "1.5.13",
       "resolved": "https://registry.npmjs.org/@tryghost/content-api/-/content-api-1.5.13.tgz",
@@ -4376,7 +4360,8 @@
     "node_modules/assert-ts": {
       "version": "0.3.4",
       "resolved": "https://registry.npmjs.org/assert-ts/-/assert-ts-0.3.4.tgz",
-      "integrity": "sha512-CQtNOdOCzzZfE3TF9a1vFTcz4ZfJYM6iHoWYCkpFY3wdk6CkFvevuLwpOFVL/KMJ9vCNIbeidWH5uo/Y8sLVWg=="
+      "integrity": "sha512-CQtNOdOCzzZfE3TF9a1vFTcz4ZfJYM6iHoWYCkpFY3wdk6CkFvevuLwpOFVL/KMJ9vCNIbeidWH5uo/Y8sLVWg==",
+      "dev": true
     },
     "node_modules/assign-symbols": {
       "version": "1.0.0",
@@ -8990,6 +8975,7 @@
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/gridjs/-/gridjs-5.0.2.tgz",
       "integrity": "sha512-7EaMc4/IhqRcSbdOYvHOlHETciWmbbhMU6rDr2e0UfzIXSkb7X3Lhf9+bGv+v4JaWnJW5GBillgIIHrAvIIoFg==",
+      "dev": true,
       "dependencies": {
         "preact": "^10.5.12",
         "tslib": "^2.0.1"
@@ -8999,6 +8985,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/gridjs-svelte/-/gridjs-svelte-2.1.1.tgz",
       "integrity": "sha512-tYkgdqNKSnfmAYYc8EP4axn/Xlugp7VLwAlpNkP4SBLHHYD/ejD2DJ+FMatDNqcJ1Z1kuMnJWO+VBcAOirEByw==",
+      "dev": true,
       "peerDependencies": {
         "gridjs": ">=5.0.0",
         "svelte": ">=3.30.0"
@@ -13806,6 +13793,7 @@
       "version": "10.7.1",
       "resolved": "https://registry.npmjs.org/preact/-/preact-10.7.1.tgz",
       "integrity": "sha512-MufnRFz39aIhs9AMFisonjzTud1PK1bY+jcJLo6m2T9Uh8AqjD77w11eAAawmjUogoGOnipECq7e/1RClIKsxg==",
+      "dev": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/preact"
@@ -20804,20 +20792,6 @@
       "integrity": "sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==",
       "dev": true
     },
-    "@tradingstrategy-ai/trade-executor-frontend": {
-      "version": "0.1.1",
-      "resolved": "https://npm.pkg.github.com/download/@tradingstrategy-ai/trade-executor-frontend/0.1.1/4457d567f7018b51d5568426c30023b9c98e2f5a9c6c87bf7bae5afd31973578",
-      "integrity": "sha512-I36PmtgjthZ5nZyQZCk2EWfY8njbc3p7Fyk6Bv2onGfWCrlKOLiO9ECza9GvVAm0k/TKs/nTG+upMKHbs9mc5Q==",
-      "requires": {
-        "@fontsource/fira-mono": "^4.5.0",
-        "@lukeed/uuid": "^2.0.0",
-        "assert-ts": "^0.3.4",
-        "cookie": "^0.4.1",
-        "gridjs": "^5.0.2",
-        "gridjs-svelte": "^2.1.1",
-        "svelte-spinner": "^2.0.2"
-      }
-    },
     "@tryghost/content-api": {
       "version": "1.5.13",
       "resolved": "https://registry.npmjs.org/@tryghost/content-api/-/content-api-1.5.13.tgz",
@@ -21410,7 +21384,8 @@
     "assert-ts": {
       "version": "0.3.4",
       "resolved": "https://registry.npmjs.org/assert-ts/-/assert-ts-0.3.4.tgz",
-      "integrity": "sha512-CQtNOdOCzzZfE3TF9a1vFTcz4ZfJYM6iHoWYCkpFY3wdk6CkFvevuLwpOFVL/KMJ9vCNIbeidWH5uo/Y8sLVWg=="
+      "integrity": "sha512-CQtNOdOCzzZfE3TF9a1vFTcz4ZfJYM6iHoWYCkpFY3wdk6CkFvevuLwpOFVL/KMJ9vCNIbeidWH5uo/Y8sLVWg==",
+      "dev": true
     },
     "assign-symbols": {
       "version": "1.0.0",
@@ -25029,6 +25004,7 @@
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/gridjs/-/gridjs-5.0.2.tgz",
       "integrity": "sha512-7EaMc4/IhqRcSbdOYvHOlHETciWmbbhMU6rDr2e0UfzIXSkb7X3Lhf9+bGv+v4JaWnJW5GBillgIIHrAvIIoFg==",
+      "dev": true,
       "requires": {
         "preact": "^10.5.12",
         "tslib": "^2.0.1"
@@ -25038,6 +25014,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/gridjs-svelte/-/gridjs-svelte-2.1.1.tgz",
       "integrity": "sha512-tYkgdqNKSnfmAYYc8EP4axn/Xlugp7VLwAlpNkP4SBLHHYD/ejD2DJ+FMatDNqcJ1Z1kuMnJWO+VBcAOirEByw==",
+      "dev": true,
       "requires": {}
     },
     "growly": {
@@ -28654,7 +28631,8 @@
     "preact": {
       "version": "10.7.1",
       "resolved": "https://registry.npmjs.org/preact/-/preact-10.7.1.tgz",
-      "integrity": "sha512-MufnRFz39aIhs9AMFisonjzTud1PK1bY+jcJLo6m2T9Uh8AqjD77w11eAAawmjUogoGOnipECq7e/1RClIKsxg=="
+      "integrity": "sha512-MufnRFz39aIhs9AMFisonjzTud1PK1bY+jcJLo6m2T9Uh8AqjD77w11eAAawmjUogoGOnipECq7e/1RClIKsxg==",
+      "dev": true
     },
     "prelude-ls": {
       "version": "1.2.1",

--- a/scripts/build-deps.sh
+++ b/scripts/build-deps.sh
@@ -13,7 +13,7 @@ fi
 
 
 # Create the Bootstrap precompiled CSS bundle
-(cd deps/theme && npm install && npx gulp build:dist)
+(cd deps/theme && npm ci && npx gulp build:dist)
 
 
 # Needed to correctly build the executor frontend.
@@ -24,5 +24,5 @@ if [ -z "VITE_PUBLIC_STRATEGIES" ]; then
 fi
 
 # Package trade-executor-frontend for SvelteKit
-(cd deps/trade-executor-frontend && npm run build)
+(cd deps/trade-executor-frontend && npm ci)
 

--- a/scripts/update-and-restart-production.sh
+++ b/scripts/update-and-restart-production.sh
@@ -34,7 +34,7 @@ npm ci
 
 # Creates build/server.js
 echo "Building frontend"
-node_modules/.bin/svelte-kit build
+npm run build
 
 # Start SvelteKit node-adapter at port 3000
 node scripts/server.js


### PR DESCRIPTION
I noticed a few outstanding issues on `master` with the submodules approach to `trade-executor-frontend`:
* preferable to use `npm ci` vs `npm install` when building for prod
* with a clean checkout, the last command in `build-deps.sh` was failing for me (`npm run build`) – it turns out you need to install dependencies there after all (so that the `prepare` command can run successfully). Using `npm ci` seems to work correctly
* the GH action was failing – needed some updates based on the new approach
