### PR TITLE
upgrade chartiq from 8.6.0-dev to 8.7.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -71,7 +71,7 @@
         "node": "^16.15.0"
       },
       "optionalDependencies": {
-        "chartiq": "github:tradingstrategy-ai/chartiq-dist"
+        "chartiq": "github:tradingstrategy-ai/chartiq-dist#v8.7.0"
       }
     },
     "../trade-executor-frontend/package": {
@@ -5243,8 +5243,8 @@
       }
     },
     "node_modules/chartiq": {
-      "version": "8.6.0",
-      "resolved": "git+ssh://git@github.com/tradingstrategy-ai/chartiq-dist.git#d1aca4f0a0b3c52eb88d0e584912c8e07a05d7b4",
+      "version": "8.7.0",
+      "resolved": "git+ssh://git@github.com/tradingstrategy-ai/chartiq-dist.git#0ae7aa5ec5de02d66eaca3421df817e982eaa7db",
       "license": "https://cosaic.io/developer-license-agreement/",
       "optional": true
     },
@@ -21983,8 +21983,8 @@
       "dev": true
     },
     "chartiq": {
-      "version": "git+ssh://git@github.com/tradingstrategy-ai/chartiq-dist.git#d1aca4f0a0b3c52eb88d0e584912c8e07a05d7b4",
-      "from": "chartiq@github:tradingstrategy-ai/chartiq-dist",
+      "version": "git+ssh://git@github.com/tradingstrategy-ai/chartiq-dist.git#0ae7aa5ec5de02d66eaca3421df817e982eaa7db",
+      "from": "chartiq@github:tradingstrategy-ai/chartiq-dist#v8.7.0",
       "optional": true
     },
     "chokidar": {

--- a/package.json
+++ b/package.json
@@ -108,6 +108,6 @@
     "web3": "^1.6.0"
   },
   "optionalDependencies": {
-    "chartiq": "github:tradingstrategy-ai/chartiq-dist"
+    "chartiq": "github:tradingstrategy-ai/chartiq-dist#v8.7.0"
   }
 }


### PR DESCRIPTION
Upgrade to `8.7.0` does not cause any issues. Tested locally, including with a UTC+ timezone 🙃.

**NOTE:** this needs to be merged and deployed before 08.07.2022 (our old `v8.6.0-dev` license expires on that date).

Test locally with:
```shell
TS_PUBLIC_FRONTEND_VERSION_TAG=pr-135 docker-compose up -d
```

closes #131 