### PR TITLE
fix 4h candles chart rendering bug

### DIFF
--- a/src/lib/chart/quoteFeed.ts
+++ b/src/lib/chart/quoteFeed.ts
@@ -2,7 +2,7 @@
  * ChartIQ quote feed adapter for Trading Strategy candle and liquidity data.
  * See: https://documentation.chartiq.com/tutorial-DataIntegrationQuoteFeeds.html
  */
-import { feedParamsToTimeBucket } from '$lib/chart/timeBucketConverters';
+import { periodicityToTimeBucket } from '$lib/chart/timeBucketConverters';
 
 const maxTicks = 2000;
 
@@ -37,7 +37,7 @@ export default function quoteFeed(backendUrl: string, type: 'price' | 'liquidity
 	async function fetchData(symbol, startDate, endDate, params) {
 		const urlParams = new URLSearchParams({
 			pair_id: symbol,
-			time_bucket: feedParamsToTimeBucket(params.period, params.interval),
+			time_bucket: periodicityToTimeBucket(params.stx.getPeriodicity()),
 			start: dateUrlParam(startDate),
 			end: dateUrlParam(endDate)
 		});
@@ -65,7 +65,7 @@ export default function quoteFeed(backendUrl: string, type: 'price' | 'liquidity
 
 	async function fetchPaginationData(symbol, startDate, endDate, params, callback) {
 		const quotes = await fetchData(symbol, startDate, endDate, params);
-		const moreAvailable = dateUrlParam(startDate) > params.chart.firstTradeDate;
+		const moreAvailable = dateUrlParam(startDate) > params.stx.firstTradeDate;
 		callback({ quotes, moreAvailable });
 	}
 


### PR DESCRIPTION
It appears this defect was introduced with PR #97 (fix for #96).

Using timezone-aware dates in ChartIQ (necessary so the browser doesn't lock up in UTC+ timezones) causes the "hour" `timeUnit` to no longer work. For `4h` ticks, ChartIQ requires a "minute" `timeUnit` with `interval=60` and `period=4`. See: [ChartIQ setPeriodicity](https://documentation.chartiq.com/CIQ.ChartEngine.html#setPeriodicity).

However… using the above periodicity causes the x-axis floating label to display incorrectly (off by 2h). I believe this is a ChartIQ bug – will open an issue with them. For now, I added a one-line fix to adjust the time in the floating label.

I've tested this across with all time-bucket options across a variety of trading pairs. Everything seems to work correctly. I also tested with my laptop set to a UTC+ timezone to make sure the time zone bug was not re-introduced.

closes #143