### PR TITLE
JupyterLite Notebook MVP

### DIFF
--- a/.env
+++ b/.env
@@ -29,6 +29,7 @@ TS_PUBLIC_GHOST_API_URL=https://trading-strategy.ghost.io
 TS_PUBLIC_GHOST_CONTENT_API_KEY=4f54e499a627473f560945d524
 TS_PUBLIC_TYPESENSE_API_URL=https://4relmbjhcysqztv9p-1.a1.typesense.net
 TS_PUBLIC_TYPESENSE_API_KEY=G26ReHm1VZwTpKye2w4P5hZkmQghb6i9
+TS_PUBLIC_PYODIDE_URL=http://localhost:3140
 # Uncomment to test chain maintenance error
 # TS_PUBLIC_CHAINS_UNDER_MAINTENANCE='{ "binance": "BNB Chain" }'
 

--- a/.gitmodules
+++ b/.gitmodules
@@ -7,3 +7,6 @@
 [submodule "deps/fonts"]
 	path = deps/fonts
 	url = git@github.com:tradingstrategy-ai/fonts.git
+[submodule "deps/notebook-webcomponent"]
+	path = deps/notebook-webcomponent
+	url = git@github.com:tradingstrategy-ai/notebook-webcomponent.git

--- a/src/lib/components/Notebook.svelte
+++ b/src/lib/components/Notebook.svelte
@@ -1,0 +1,23 @@
+<script context="module" type="ts">
+	let initialized = false;
+
+	async function init() {
+		if (initialized) {
+			return;
+		}
+		const module = await import(/* @vite-ignore */ 'notebook-webcomponent/notebook.js');
+		module.default();
+		initialized = true;
+	}
+</script>
+
+<script type="ts">
+	import { pyodideUrl } from '$lib/config';
+	import { onMount } from 'svelte';
+
+	export let src: string;
+
+	onMount(init);
+</script>
+
+<jupyter-notebook {src} pyodideurl="{pyodideUrl}/pyodide.mjs" />

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -84,6 +84,16 @@ export const typesenseConfig = config(
 );
 
 /**
+ * Load URL for pyodide build (see: Notebook.svelte)
+ */
+export const pyodideUrl = config((url: string) => {
+	if (!url) {
+		console.warn('You need to confingure pyodide URL to enable embedded notebooks');
+	}
+	return url;
+}, 'PYODIDE_URL');
+
+/**
  * Specify chains under maintence as JSON string, e.g.:
  * TS_PUBLIC_CHAINS_UNDER_MAINTENANCE='{ "binance": "BNB Chain" }'
  */

--- a/src/routes/trading-view/[chain]/[exchange]/[pair]/+page.svelte
+++ b/src/routes/trading-view/[chain]/[exchange]/[pair]/+page.svelte
@@ -145,8 +145,8 @@ Render the pair trading page
 			<Button secondary label="Blockchain explorer" href={details.explorer_link} />
 			<Button
 				secondary
-				label="{summary.pair_symbol} API and historical data"
-				href="/trading-view/{summary.chain_slug}/{summary.exchange_slug}/{summary.pair_slug}/api-and-historical-data"
+				label="Open {summary.pair_symbol} notebook"
+				href="/trading-view/{summary.chain_slug}/{summary.exchange_slug}/{summary.pair_slug}/notebook"
 			/>
 		</div>
 	</section>

--- a/src/routes/trading-view/[chain]/[exchange]/[pair]/notebook/+page.svelte
+++ b/src/routes/trading-view/[chain]/[exchange]/[pair]/notebook/+page.svelte
@@ -1,0 +1,44 @@
+<script lang="ts">
+	import type { PageData } from './$types';
+	import Breadcrumbs from '$lib/breadcrumb/Breadcrumbs.svelte';
+	import Notebook from '$lib/components/Notebook.svelte';
+
+	export let data: PageData;
+
+	$: summary = data.summary;
+
+	$: breadcrumbs = {
+		[summary.exchange_slug]: summary.exchange_name,
+		[summary.pair_slug]: summary.pair_name,
+		notebook: 'Notebook'
+	};
+</script>
+
+<Breadcrumbs labels={breadcrumbs} />
+
+<main>
+	<header class="ds-container">
+		<h1>{summary.pair_symbol} token pair notebook</h1>
+	</header>
+
+	<section class="ds-container">
+		<Notebook
+			src="/trading-view/{summary.chain_slug}/{summary.exchange_slug}/{summary.pair_slug}/notebook/{summary.chain_slug}_{summary.exchange_slug}_{summary.pair_symbol}.ipynb"
+		/>
+	</section>
+</main>
+
+<style>
+	:global body {
+		background: var(--c-body) !important;
+	}
+
+	main {
+		display: grid;
+		gap: 1rem;
+	}
+
+	header h1 {
+		font: var(--f-h2-medium);
+	}
+</style>

--- a/src/routes/trading-view/[chain]/[exchange]/[pair]/notebook/+page.ts
+++ b/src/routes/trading-view/[chain]/[exchange]/[pair]/notebook/+page.ts
@@ -1,0 +1,26 @@
+import type { PageLoad } from './$types';
+import { backendUrl } from '$lib/config';
+import getApiError from '$lib/chain/getApiError';
+
+const apiUrl = `${backendUrl}/pair-details`;
+
+export const load: PageLoad = async ({ params, fetch, setHeaders }) => {
+	const chain_slug = params.chain;
+	const exchange_slug = params.exchange;
+	const pair_slug = params.pair;
+
+	const encoded = new URLSearchParams({ exchange_slug, chain_slug, pair_slug });
+	const resp = await fetch(`${apiUrl}?${encoded}`);
+
+	if (!resp.ok) {
+		throw getApiError(resp, 'Trading pair', [chain_slug, exchange_slug, pair_slug]);
+	}
+
+	// Cache the pair data pages for 30 minutes at the Cloudflare edge so the
+	// pages are served really fast if they get popular, and also for speed test
+	setHeaders({
+		'cache-control': 'public, max-age=1800' // 30 minutes: 30 * 60 = 1800
+	});
+
+	return resp.json();
+};

--- a/src/routes/trading-view/[chain]/[exchange]/[pair]/notebook/[...file].ipynb/+server.ts
+++ b/src/routes/trading-view/[chain]/[exchange]/[pair]/notebook/[...file].ipynb/+server.ts
@@ -1,0 +1,16 @@
+import type { RequestHandler } from './$types';
+import template from './template.ipynb?raw';
+
+export const GET: RequestHandler = async ({ params }) => {
+	const headers = {
+		'Content-Type': 'application/x-ipynb+json'
+	};
+	return new Response(render(params), { headers });
+};
+
+function render({ chain, exchange, pair }: any) {
+	return template
+		.replace(/%chain_slug%/g, chain)
+		.replace(/%exchange_slug%/g, exchange)
+		.replace(/%pair_slug%/g, pair);
+}

--- a/src/routes/trading-view/[chain]/[exchange]/[pair]/notebook/[...file].ipynb/template.ipynb
+++ b/src/routes/trading-view/[chain]/[exchange]/[pair]/notebook/[...file].ipynb/template.ipynb
@@ -1,0 +1,79 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Trading Pair Analysis & Backtesting\n",
+    "\n",
+    "This is a basic notebook that can be used for performing technical analysis and backtesting for a single trading pair.\n",
+    "\n",
+    "## Initialize API Client\n",
+    "\n",
+    "Enter your API key in the second line below, then run the cell in order to verify you have configired it correctly."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from tradingstrategy.client import Client\n",
+    "\n",
+    "api_key = 'secret-token:tradingstrategy-YOUR-API-KEY-HERE'\n",
+    "\n",
+    "client = Client.create_jupyter_client(api_key=api_key)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Configure Trading Pair variables\n",
+    "\n",
+    "The values below must be configured correctly in order to perform analysis on a trading pair."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "chain_slug = '%chain_slug%'\n",
+    "exchange_slug = '%exchange_slug%'\n",
+    "pair_slug = '%pair_slug%'\n",
+    "\n",
+    "print(chain_slug, exchange_slug, pair_slug)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3.10.6 ('trading-strategy-AwkJE5xA-py3.10')",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.6"
+  },
+  "orig_nbformat": 4,
+  "vscode": {
+   "interpreter": {
+    "hash": "836a178a3af65d04cd4756f12aba4ed8578c36caff7b414844f1345f102e53f2"
+   }
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/svelte.config.js
+++ b/svelte.config.js
@@ -19,7 +19,8 @@ const config = {
 		alias: {
 			'design-system-fonts': 'deps/fonts',
 			'bootstrap-theme': 'deps/theme/dist',
-			'trade-executor-frontend': 'deps/trade-executor-frontend/src/lib'
+			'trade-executor-frontend': 'deps/trade-executor-frontend/src/lib',
+			'notebook-webcomponent': 'deps/notebook-webcomponent/dist/notebook/build'
 		},
 
 		env: {


### PR DESCRIPTION
closes #183 

This is a WIP / draft PR. It adds a `Notebook.svelte` component which wraps the `notebook-webcomponent` custom web component. A notebook can be opened by navigating to any trading pair and clicking the **Open [PAIR] Notebook** button.

## pyodide dependency

The notebook component has a dependency on a custom `pyodide` build. This must be hosted somewhere and made available to `frontend` by setting the `TS_PUBLIC_PYODIDE_URL` environment variable. For local development, `TS_PUBLIC_PYODIDE_URL` is set to `http://localhost:3140` in `.env`.

We have a custom `jupyterlite-pyodide-build` build project here:
https://github.com/tradingstrategy-ai/jupyterlite-pyodide-build

Build artifacts can be found under the project's [Actions](https://github.com/tradingstrategy-ai/jupyterlite-pyodide-build/actions).

The following is a "known good" build (the workflow failed, but the build job was successful and produced working build artifacts).
https://github.com/tradingstrategy-ai/jupyterlite-pyodide-build/actions/runs/2985282963

To serve the `pyodide` build locally:
- download and unpack the **pyodide build**
- cd into `pyodide`
- run a local web server with `CORS` enabled, e.g.:
```
npx http-server --port=3140 --cors
```
