### PR TITLE
Top-nav search button discoverability

### DIFF
--- a/src/lib/components/Button.svelte
+++ b/src/lib/components/Button.svelte
@@ -42,10 +42,10 @@
 		justify-content: center;
 		align-items: center;
 		height: var(--button-height, 3.5rem);
-		padding: 0 1.5rem;
+		padding: var(--button-padding, 0 1.5rem);
 		border: 1px solid transparent;
 		border-radius: 0.5rem;
-		font: 500 var(--fs-ui-lg);
+		font: var(--button-font, 500 var(--fs-ui-lg));
 		text-decoration: none;
 		text-transform: capitalize;
 		text-align: center;

--- a/src/lib/components/Header.svelte
+++ b/src/lib/components/Header.svelte
@@ -40,6 +40,14 @@
 <style lang="postcss">
 	@custom-media --nav-collapsed (width < 1125px);
 
+	:global :root {
+		--header-height: 5.5rem;
+
+		@media (--nav-collapsed) {
+			--header-height: 3.75rem;
+		}
+	}
+
 	header {
 		display: grid;
 		grid-template-columns:
@@ -52,7 +60,7 @@
 		grid-auto-flow: column;
 		align-items: center;
 		gap: 1.25rem;
-		height: 5.5rem;
+		height: var(--header-height);
 	}
 
 	header > * {
@@ -96,10 +104,6 @@
 	@media (--nav-collapsed) {
 		.desktop-only {
 			display: none;
-		}
-
-		header {
-			height: 3.75rem;
 		}
 
 		.logo {

--- a/src/lib/search/Search.svelte
+++ b/src/lib/search/Search.svelte
@@ -17,13 +17,15 @@ Display site-wide search box for use in top-nav.
 	let q = '';
 	let hasFocus = false;
 
+	$: hasQuery = q.trim() !== '';
+
 	$: tradingEntities.search({
 		q,
 		sort_by: ['type_rank:asc', 'liquidity:desc', '_text_match:desc'],
 		group_by: ['type']
 	});
 
-	$: hits = q ? $tradingEntities.hits : [];
+	$: hits = hasQuery ? $tradingEntities.hits : [];
 
 	async function toggleFocus() {
 		setTimeout(() => (hasFocus = !hasFocus));
@@ -33,6 +35,7 @@ Display site-wide search box for use in top-nav.
 <div
 	class="search"
 	class:hasFocus
+	class:hasQuery
 	on:focus|capture={toggleFocus}
 	on:blur|capture={toggleFocus}
 	data-testid="nav-search"
@@ -41,8 +44,7 @@ Display site-wide search box for use in top-nav.
 		<Icon name="search" />
 	</label>
 
-	<form class="desktop-only" action="/search">
-		<!-- prettier-ignore -->
+	<form class="desktop-only" action="/search" role="search">
 		<TextInput
 			bind:value={q}
 			aria-label="search-desktop"
@@ -56,7 +58,7 @@ Display site-wide search box for use in top-nav.
 	</form>
 
 	<div class="results">
-		<form class="mobile-only" action="/search">
+		<form class="mobile-only" action="/search" role="search">
 			<TextInput
 				bind:value={q}
 				id="search-input-mobile"
@@ -70,8 +72,8 @@ Display site-wide search box for use in top-nav.
 			/>
 		</form>
 
-		{#if q}
-			<ul>
+		{#if hasQuery}
+			<ul id="search-results">
 				{#each hits as { document }, index (document.id)}
 					<TradingEntityHit {document} layout="basic" />
 				{/each}
@@ -79,7 +81,7 @@ Display site-wide search box for use in top-nav.
 		{/if}
 
 		<div class="buttons">
-			{#if q}
+			{#if hasQuery}
 				<Button label="Show all results" href="/search?q={q}" />
 			{:else}
 				Search exchanges, tokens and trading pairs.
@@ -130,42 +132,65 @@ Display site-wide search box for use in top-nav.
 		position: absolute;
 		z-index: 1;
 		right: 0;
-		display: grid;
-		gap: 1rem;
 		padding: 0.75rem 0.625rem;
+		display: flex;
+		flex-direction: column;
+		gap: 1rem;
 		background: var(--c-body);
 		box-shadow: 0 0 0 1px var(--c-shadow-1), 0 4px 20px var(--c-shadow-1);
 		transition: opacity 0.25s;
 		--text-input-height: 2.875rem;
 
+		@nest :not(.hasFocus) & {
+			opacity: 0;
+			pointer-events: none;
+		}
+
 		@media (--search-layout-desktop) {
 			width: 450px;
 			margin-top: 0.25rem;
+			max-height: calc(100vh - 1.75rem - var(--header-height, 5rem) / 2);
 		}
 
 		@media (--search-layout-mobile) {
 			left: 0;
 			top: 0;
-		}
 
-		@nest :not(.hasFocus) & {
-			opacity: 0;
-			pointer-events: none;
+			@nest .hasQuery & {
+				height: 100vh;
+				gap: 0.625rem;
+			}
 		}
 	}
 
+	/* Prevent body scrolling when search dialog is open and has results on mobile */
+	/* NOTE: using CSS ids as work-around for postcss-present-env :has pseudo-selector flakiness */
+	:global body:has(#search-input-mobile:focus):has(#search-results) {
+		overflow: hidden;
+	}
+
 	ul {
-		display: grid;
-		gap: 1rem;
 		padding: 0;
+		flex: 1;
+		display: grid;
+		gap: 0.5rem;
+		align-content: start;
+		overflow-y: auto;
 	}
 
 	.buttons {
 		display: grid;
-		gap: 0.75rem;
+		gap: 0.75rem 0.625rem;
 		font: 500 var(--fs-ui-md);
 		letter-spacing: 0.01em;
 		color: var(--c-text-7);
 		text-align: center;
+		--button-font: 500 var(--fs-ui-md);
+		--button-padding: 0;
+		--button-height: 2.5rem;
+
+		@nest .hasQuery & {
+			grid-template-columns: 1fr 1fr;
+		}
 	}
 </style>

--- a/src/lib/search/Search.test.ts
+++ b/src/lib/search/Search.test.ts
@@ -4,7 +4,7 @@ import userEvent from '@testing-library/user-event';
 import Search from './Search.svelte';
 
 // use mock tradingEntities store so it doesn't try to make real search requests
-// see: src/lib/search/__mocks__/trading-entities.ts
+// see: ./__mocks__/trading-entities.ts
 vi.mock('./trading-entities');
 
 // There's no easy way in vitest / testing library to apply and test the effects of CSS.
@@ -41,5 +41,43 @@ describe('Search component', () => {
 		searchBox.focus();
 		await user.keyboard('eth{Enter}');
 		expect(formSubmitHandler).toHaveBeenCalled();
+	});
+
+	/**
+	 * Mobile Safari does not correctly reflect viewport height with % or vh units when virtual
+	 * keyboard is open (grr!). It does, however, support the VisualViewport JS API for getting the
+	 * (real) visual viewport size. See:
+	 * https://developer.mozilla.org/en-US/docs/Web/API/Visual_Viewport_API
+	 *
+	 * The tests below are (unfortunately) quite implementation-specific, due to current limitations
+	 * in applying and testing component CSS
+	 */
+	describe('with window.visualViewport object', () => {
+		beforeEach(() => {
+			vi.stubGlobal('visualViewport', {
+				height: 300,
+				addEventListener: vi.fn(),
+				removeEventListener: vi.fn()
+			});
+		});
+
+		test('should set --viewportHeight CSS variable', async () => {
+			const { getByTestId } = render(Search);
+			const navSearch = getByTestId('nav-search');
+			expect(navSearch.style.getPropertyValue('--viewport-height')).toEqual('300px');
+		});
+
+		test('should register visualViewport event listener', async () => {
+			render(Search);
+			expect(window.visualViewport?.addEventListener).toHaveBeenCalled();
+		});
+
+		test('should unregister visualViewport event listener when unmounted', async () => {
+			const { unmount } = render(Search);
+			const removeListener = window.visualViewport?.removeEventListener;
+			expect(removeListener).not.toHaveBeenCalled();
+			unmount();
+			expect(removeListener).toHaveBeenCalled();
+		});
 	});
 });

--- a/src/lib/search/TradingEntityHit.svelte
+++ b/src/lib/search/TradingEntityHit.svelte
@@ -112,6 +112,12 @@ line item; supports basic (top-nav) and advanced (/search page) layouts.
 
 		&.basic {
 			padding: 0.875rem 0.75rem;
+			border: none;
+			background: var(--c-background-4);
+
+			@media (--viewport-sm-up) {
+				padding-block: 1rem;
+			}
 		}
 
 		&.advanced {


### PR DESCRIPTION
closes tradingstrategy-ai/design-system#87

@allozaur the figma design depends on various global Theme 0.2 updates which have not been implemented yet. To keep the code DRY / continue using existing components, I took some minor liberties with the design to back-port the search layout changes into the Theme 0.1 style. The result is somewhat of a hybrid but I think it works for now.

As we find time to prioritized Theme 0.2 updates across the site, the "final" version will match your figma designs much more closely.

Let me know if you have any tweaks to this intermediate / hybrid version in the meantime.
