### PR TITLE
Improve log readability

### DIFF
--- a/src/routes/strategy/[strategy_id]/logs/LogMessageList.svelte
+++ b/src/routes/strategy/[strategy_id]/logs/LogMessageList.svelte
@@ -45,6 +45,8 @@ Display log messages as a scrollable panel
 		overflow-y: scroll;
 		font: var(--f-mono-body-regular);
 		letter-spacing: var(--f-mono-body-spacing);
+		font-size: 12px;
+		line-height: 1em;
 	}
 
 	.log {

--- a/src/routes/strategy/[strategy_id]/logs/LogMessageList.svelte
+++ b/src/routes/strategy/[strategy_id]/logs/LogMessageList.svelte
@@ -53,7 +53,7 @@ Display log messages as a scrollable panel
 		display: grid;
 		grid-template-columns: auto 1fr;
 		gap: 1.25rem;
-		border-block: 1px solid #666;
+		border-block: 1px solid #222;
 		padding: 0.5rem 1rem;
 		background: black;
 		font-weight: bolder;

--- a/src/routes/strategy/[strategy_id]/logs/LogMessageList.svelte
+++ b/src/routes/strategy/[strategy_id]/logs/LogMessageList.svelte
@@ -60,7 +60,7 @@ Display log messages as a scrollable panel
 	}
 
 	.log-info {
-		color: grey;
+		color: lightgrey;
 	}
 
 	.log-trade {

--- a/src/routes/strategy/[strategy_id]/logs/LogMessageList.svelte
+++ b/src/routes/strategy/[strategy_id]/logs/LogMessageList.svelte
@@ -54,6 +54,7 @@ Display log messages as a scrollable panel
 		border-block: 1px solid #666;
 		padding: 0.5rem 1rem;
 		background: black;
+		font-weight: bolder;
 	}
 
 	.log-info {
@@ -61,15 +62,15 @@ Display log messages as a scrollable panel
 	}
 
 	.log-trade {
-		color: green;
+		color: lightgreen;
 	}
 
 	.log-warning {
-		color: yellow;
+		color: lightyellow;
 	}
 
 	.log-error {
-		color: red;
+		color: lightcoral;
 	}
 
 	.log-critical {
@@ -80,7 +81,7 @@ Display log messages as a scrollable panel
 	time {
 		display: flex;
 		flex-direction: column;
-		color: #444;
+		color: #888;
 		text-align: right;
 	}
 


### PR DESCRIPTION
Logs are not readable on non-retina screens.

Update with 

- Bolder font
- Better colours
- Adjust line height and font size to increase information density
- Further dim the separator line

![image](https://user-images.githubusercontent.com/49922/205272159-c4d1b511-2f61-417a-b1fa-33ddfd30ab39.png)
