### PR TITLE
Source and decision making strategy pages

### DIFF
--- a/src/routes/strategy/[strategy_id]/decision-making/+page.svelte
+++ b/src/routes/strategy/[strategy_id]/decision-making/+page.svelte
@@ -9,43 +9,40 @@
 <script lang="ts">
 	import type { PageData } from './$types';
 	import warning from '$lib/assets/icons/warning.svg';
-	import { writable } from 'svelte/store';
 	import { AlertItem, AlertList } from '$lib/components/index.js';
 
 	export let data: PageData;
 
-	const errored = writable(false);
-	const errorUrl = writable('');
+	let errored = false;
+	let errorUrl = '';
 
 	// The URLs for strategy thinking images
 	$: imageUrls = data.imageUrls;
 
 	// https://stackoverflow.com/questions/69020710/fall-back-image-with-sveltekit
 	const fallback = warning;
-	const handleError = (ev) => {
-		ev.target.src = fallback;
-		errorUrl.set(ev.srcElement.src);
-		errored.set(true);
-	};
+	function handleError(ev: Event) {
+		const target = ev.target as HTMLImageElement;
+		errorUrl = target.src;
+		errored = true;
+		target.src = fallback;
+	}
 </script>
 
-{#if $errored}
-	<AlertList status="warning">
-		<AlertItem>
-			Could not load strategy decision making data. If the trade executor instance has been restarted recently, this
-			data may not be available until the first strategy decision making cycle is completed. The URL is <b
-				>{$errorUrl}.</b
-			>
-		</AlertItem>
-	</AlertList>
-{/if}
+<AlertList status="warning">
+	<AlertItem displayWhen={errored}>
+		Could not load strategy decision making data. If the trade executor instance has been restarted recently, this data
+		may not be available until the first strategy decision making cycle is completed. The URL is
+		<strong>{errorUrl}.</strong>
+	</AlertItem>
+</AlertList>
 
-<img class="light" src={imageUrls.light} on:error={handleError} />
-<img class="dark" src={imageUrls.dark} on:error={handleError} />
+<img class="light" src={imageUrls.light} alt="Strategy decision data (light)" on:error={handleError} />
+<img class="dark" src={imageUrls.dark} alt="Strategy decision data (dark)" on:error={handleError} />
 
 <style>
 	img {
-		margin: 20px 0;
+		margin: 1.5rem 0;
 		width: 100%;
 	}
 

--- a/src/routes/strategy/[strategy_id]/decision-making/+page.svelte
+++ b/src/routes/strategy/[strategy_id]/decision-making/+page.svelte
@@ -2,42 +2,58 @@
 
     Page to display the latest strategy thinking chart.
 
+    TODO: Image URLs/SVG rendering are not final. SVG images will
+    be replacead with Plotly JS charts and this is only MVP.
+
 -->
 <script lang="ts">
 	import type { PageData } from './$types';
-    import warning from '$lib/assets/icons/warning.svg';
-	import {writable} from "svelte/store";
-	import {AlertItem, AlertList} from "$lib/components/index.js";
+	import warning from '$lib/assets/icons/warning.svg';
+	import { writable } from 'svelte/store';
+	import { AlertItem, AlertList } from '$lib/components/index.js';
 
 	export let data: PageData;
 
 	const errored = writable(false);
+	const errorUrl = writable('');
 
 	// The URLs for strategy thinking images
 	$: imageUrls = data.imageUrls;
 
 	// https://stackoverflow.com/questions/69020710/fall-back-image-with-sveltekit
-    const fallback = warning;
-    const handleError = ev => {
-        ev.target.src = fallback;
-        errored.set(true);
-    }
+	const fallback = warning;
+	const handleError = (ev) => {
+		ev.target.src = fallback;
+		errorUrl.set(ev.srcElement.src);
+		errored.set(true);
+	};
 </script>
 
-{#if errored}
+{#if $errored}
 	<AlertList status="warning">
 		<AlertItem>
-			Could not load strategy decision making data. If the trade executor instance has been
-            restarted recently, this data may not be available until the first strategy decision
-            making cycle is completed.
+			Could not load strategy decision making data. If the trade executor instance has been restarted recently, this
+			data may not be available until the first strategy decision making cycle is completed. The URL is <b
+				>{$errorUrl}.</b
+			>
 		</AlertItem>
 	</AlertList>
 {/if}
 
-<img class="light" src={imageUrls.light} on:error={handleError}>
+<img class="light" src={imageUrls.light} on:error={handleError} />
+<img class="dark" src={imageUrls.dark} on:error={handleError} />
 
 <style>
 	img {
 		margin: 20px 0;
+		width: 100%;
+	}
+
+	.light {
+		display: var(--cm-dark, none);
+	}
+
+	.dark {
+		display: var(--cm-light, none);
 	}
 </style>

--- a/src/routes/strategy/[strategy_id]/decision-making/+page.svelte
+++ b/src/routes/strategy/[strategy_id]/decision-making/+page.svelte
@@ -1,22 +1,43 @@
 <!--
 
-    Page to display the source code of the strategy.
+    Page to display the latest strategy thinking chart.
 
-    TODO: Add nice source code formatting widget
 -->
 <script lang="ts">
 	import type { PageData } from './$types';
+    import warning from '$lib/assets/icons/warning.svg';
+	import {writable} from "svelte/store";
+	import {AlertItem, AlertList} from "$lib/components/index.js";
 
 	export let data: PageData;
 
-	// Currently loaded source code
+	const errored = writable(false);
+
+	// The URLs for strategy thinking images
 	$: imageUrls = data.imageUrls;
 
-
+	// https://stackoverflow.com/questions/69020710/fall-back-image-with-sveltekit
+    const fallback = warning;
+    const handleError = ev => {
+        ev.target.src = fallback;
+        errored.set(true);
+    }
 </script>
 
-<p>
-    {imageUrls.light}
-</p>
+{#if errored}
+	<AlertList status="warning">
+		<AlertItem>
+			Could not load strategy decision making data. If the trade executor instance has been
+            restarted recently, this data may not be available until the first strategy decision
+            making cycle is completed.
+		</AlertItem>
+	</AlertList>
+{/if}
 
-<img class="light" scr={imageUrls.light}>
+<img class="light" src={imageUrls.light} on:error={handleError}>
+
+<style>
+	img {
+		margin: 20px 0;
+	}
+</style>

--- a/src/routes/strategy/[strategy_id]/decision-making/+page.svelte
+++ b/src/routes/strategy/[strategy_id]/decision-making/+page.svelte
@@ -1,0 +1,22 @@
+<!--
+
+    Page to display the source code of the strategy.
+
+    TODO: Add nice source code formatting widget
+-->
+<script lang="ts">
+	import type { PageData } from './$types';
+
+	export let data: PageData;
+
+	// Currently loaded source code
+	$: imageUrls = data.imageUrls;
+
+
+</script>
+
+<p>
+    {imageUrls.light}
+</p>
+
+<img class="light" scr={imageUrls.light}>

--- a/src/routes/strategy/[strategy_id]/decision-making/+page.ts
+++ b/src/routes/strategy/[strategy_id]/decision-making/+page.ts
@@ -1,0 +1,30 @@
+/**
+ * Fetch the strategy decision making visualisation.
+ */
+import type { PageLoad } from './$types';
+import { error } from '@sveltejs/kit';
+import { publicApiError } from '$lib/helpers/publicApiError';
+import { getConfiguredStrategyById } from 'trade-executor-frontend/strategy/configuration';
+
+/**
+ * Generate a variant of decision making status image URL for both color schemes.
+ */
+export const load: PageLoad = async ({ params, fetch }) => {
+	const strategy = getConfiguredStrategyById(params.strategy_id);
+	if (!strategy) {
+		throw error(500, `Strategy not loaded: ${params.strategy_id}`);
+	}
+
+  const images: { [key: string]: Blob; } = {};
+  const size = "large";
+
+  for(let theme of ["light", "dark"]) {
+    const encoded = new URLSearchParams({ theme, size });
+    const url = `${strategy.url}/visualisation?${encoded}`;
+    images[theme] = url;
+  }
+
+	return {
+		imageUrls: images
+	};
+};

--- a/src/routes/strategy/[strategy_id]/decision-making/+page.ts
+++ b/src/routes/strategy/[strategy_id]/decision-making/+page.ts
@@ -15,14 +15,14 @@ export const load: PageLoad = async ({ params, fetch }) => {
 		throw error(500, `Strategy not loaded: ${params.strategy_id}`);
 	}
 
-  const images: { [key: string]: Blob; } = {};
-  const size = "large";
+	const images: { [key: string]: Blob } = {};
+	const type = 'large';
 
-  for(let theme of ["light", "dark"]) {
-    const encoded = new URLSearchParams({ theme, size });
-    const url = `${strategy.url}/visualisation?${encoded}`;
-    images[theme] = url;
-  }
+	for (let theme of ['light', 'dark']) {
+		const encoded = new URLSearchParams({ theme, type });
+		const url = `${strategy.url}/visualisation?${encoded}`;
+		images[theme] = url;
+	}
 
 	return {
 		imageUrls: images

--- a/src/routes/strategy/[strategy_id]/decision-making/+page.ts
+++ b/src/routes/strategy/[strategy_id]/decision-making/+page.ts
@@ -3,7 +3,6 @@
  */
 import type { PageLoad } from './$types';
 import { error } from '@sveltejs/kit';
-import { publicApiError } from '$lib/helpers/publicApiError';
 import { getConfiguredStrategyById } from 'trade-executor-frontend/strategy/configuration';
 
 /**
@@ -15,16 +14,14 @@ export const load: PageLoad = async ({ params, fetch }) => {
 		throw error(500, `Strategy not loaded: ${params.strategy_id}`);
 	}
 
-	const images: { [key: string]: Blob } = {};
+	const imageUrls: Record<string, string> = {};
 	const type = 'large';
 
 	for (let theme of ['light', 'dark']) {
 		const encoded = new URLSearchParams({ theme, type });
 		const url = `${strategy.url}/visualisation?${encoded}`;
-		images[theme] = url;
+		imageUrls[theme] = url;
 	}
 
-	return {
-		imageUrls: images
-	};
+	return { imageUrls };
 };

--- a/src/routes/strategy/[strategy_id]/source/+page.svelte
+++ b/src/routes/strategy/[strategy_id]/source/+page.svelte
@@ -6,21 +6,22 @@
 -->
 <script lang="ts">
 	import type { PageData } from './$types';
+    import SourceCode from "./SourceCode.svelte";
+    import { currentStrategy } from 'trade-executor-frontend/state/store';
+
 	export let data: PageData;
 
 	// Currently loaded source code
 	$: source = data.source;
 
+    // TODO: Hack for now, have metadata object to expose real strategy canocical source code URLs
+    $: githubUrl = `http://github.com/tradingstrategy-ai/trade-executor/tree/master/strategies/` + $currentStrategy.id + `.py`;
+
 </script>
 
+<p>
+    The source code of the {$currentStrategy.name} strategy.
+    <a class="body-link" href={githubUrl}>View source code on Github.</a>
+</p>
 
-<pre class="source">
-    {source}
-</pre>
-
-<style lang="postcss">
-    .source {
-        background: var(--cm-light, var(--c-parchment-extra-dark)) var(--cm-dark, var(--c-gray-extra-dark));
-        font-weight: bold;
-    }
-</style>
+<SourceCode {source} />

--- a/src/routes/strategy/[strategy_id]/source/+page.svelte
+++ b/src/routes/strategy/[strategy_id]/source/+page.svelte
@@ -6,22 +6,22 @@
 -->
 <script lang="ts">
 	import type { PageData } from './$types';
-    import SourceCode from "./SourceCode.svelte";
-    import { currentStrategy } from 'trade-executor-frontend/state/store';
+	import SourceCode from './SourceCode.svelte';
+	import { currentStrategy } from 'trade-executor-frontend/state/store';
 
 	export let data: PageData;
 
 	// Currently loaded source code
 	$: source = data.source;
 
-    // TODO: Hack for now, have metadata object to expose real strategy canocical source code URLs
-    $: githubUrl = `http://github.com/tradingstrategy-ai/trade-executor/tree/master/strategies/` + $currentStrategy.id + `.py`;
-
+	// TODO: Hack for now, have metadata object to expose real strategy canocical source code URLs
+	$: githubUrl =
+		`http://github.com/tradingstrategy-ai/trade-executor/tree/master/strategies/` + $currentStrategy.id + `.py`;
 </script>
 
 <p>
-    The source code of the {$currentStrategy.name} strategy.
-    <a class="body-link" href={githubUrl}>View source code on Github.</a>
+	The source code of the {$currentStrategy.name} strategy.
+	<a class="body-link" href={githubUrl}>View source code on Github.</a>
 </p>
 
 <SourceCode {source} />

--- a/src/routes/strategy/[strategy_id]/source/+page.svelte
+++ b/src/routes/strategy/[strategy_id]/source/+page.svelte
@@ -15,8 +15,7 @@
 	$: source = data.source;
 
 	// TODO: Hack for now, have metadata object to expose real strategy canocical source code URLs
-	$: githubUrl =
-		`http://github.com/tradingstrategy-ai/trade-executor/tree/master/strategies/` + $currentStrategy.id + `.py`;
+	$: githubUrl = `http://github.com/tradingstrategy-ai/trade-executor/tree/master/strategies/${$currentStrategy.id}.py`;
 </script>
 
 <p>

--- a/src/routes/strategy/[strategy_id]/source/+page.svelte
+++ b/src/routes/strategy/[strategy_id]/source/+page.svelte
@@ -1,0 +1,26 @@
+<!--
+
+    Page to display the source code of the strategy.
+
+    TODO: Add nice source code formatting widget
+-->
+<script lang="ts">
+	import type { PageData } from './$types';
+	export let data: PageData;
+
+	// Currently loaded source code
+	$: source = data.source;
+
+</script>
+
+
+<pre class="source">
+    {source}
+</pre>
+
+<style lang="postcss">
+    .source {
+        background: var(--cm-light, var(--c-parchment-extra-dark)) var(--cm-dark, var(--c-gray-extra-dark));
+        font-weight: bold;
+    }
+</style>

--- a/src/routes/strategy/[strategy_id]/source/+page.ts
+++ b/src/routes/strategy/[strategy_id]/source/+page.ts
@@ -1,0 +1,31 @@
+/**
+ * Fetch the source code page.
+ */
+import type { PageLoad } from './$types';
+import { error } from '@sveltejs/kit';
+import { publicApiError } from '$lib/helpers/publicApiError';
+import { getConfiguredStrategyById } from 'trade-executor-frontend/strategy/configuration';
+
+export const load: PageLoad = async ({ params, fetch }) => {
+	const strategy = getConfiguredStrategyById(params.strategy_id);
+	if (!strategy) {
+		throw error(500, `Strategy not loaded: ${params.strategy_id}`);
+	}
+
+	const url = `${strategy.url}/source`;
+	let resp = null;
+	try {
+		resp = await fetch(url);
+	} catch (e) {
+		const stack = [`Error loading data from URL: ${url}`, e.message];
+		throw error(503, { message: 'Service Unavailable', stack });
+	}
+
+	if (!resp.ok) {
+		throw await publicApiError(resp);
+	}
+
+	return {
+		source: resp.text()
+	};
+};

--- a/src/routes/strategy/[strategy_id]/source/SourceCode.svelte
+++ b/src/routes/strategy/[strategy_id]/source/SourceCode.svelte
@@ -5,45 +5,42 @@
     TODO: Add nice source code formatting widget
 -->
 <script lang="ts">
-
-    export let source;
+	export let source;
 
 	// Currently loaded source code
-	$: sourceLines = source.split("\n");
-
+	$: sourceLines = source.split('\n');
 </script>
-
 
 <pre class="source">
     {#each sourceLines as line}
-        <code>{line}</code><br>
-    {/each}
+		<code>{line}</code><br />
+	{/each}
 </pre>
 
 <style lang="postcss">
-    pre {
-        background: var(--cm-light, var(--c-parchment-dark)) var(--cm-dark, var(--c-ink));
-        color: var(--cm-light, var(--c-text-1-v1)) var(--cm-dark, var(--c-text-1-v1));
-        font-weight: bold;
-        padding: 5px;
-        counter-reset: line;
-        width: 100%;
+	pre {
+		background: var(--cm-light, var(--c-parchment-dark)) var(--cm-dark, var(--c-ink));
+		color: var(--cm-light, var(--c-text-1-v1)) var(--cm-dark, var(--c-text-1-v1));
+		font-weight: bold;
+		padding: 5px;
+		counter-reset: line;
+		width: 100%;
 
-        white-space: normal;
-        overflow-x: scroll;
-    }
+		white-space: normal;
+		overflow-x: scroll;
+	}
 
-    code {
-        counter-increment: line;
-        overflow-x: scroll;
-        white-space: pre;
-    }
+	code {
+		counter-increment: line;
+		overflow-x: scroll;
+		white-space: pre;
+	}
 
-    code:before{
-        display: inline-block;
-        content: counter(line);
-        user-select: none;
-        width: 40px;
-        opacity: 0.5;
-    }
+	code:before {
+		display: inline-block;
+		content: counter(line);
+		user-select: none;
+		width: 40px;
+		opacity: 0.5;
+	}
 </style>

--- a/src/routes/strategy/[strategy_id]/source/SourceCode.svelte
+++ b/src/routes/strategy/[strategy_id]/source/SourceCode.svelte
@@ -1,19 +1,23 @@
 <!--
+@component
+Display the source code of the strategy.
+TODO: Add nice source code formatting widget
 
-    Page to display the source code of the strategy.
-
-    TODO: Add nice source code formatting widget
+#### Usage:
+```tsx
+	<SourceCode source={code} />
+```
 -->
 <script lang="ts">
-	export let source;
+	export let source: string;
 
 	// Currently loaded source code
 	$: sourceLines = source.split('\n');
 </script>
 
 <pre class="source">
-    {#each sourceLines as line}
-		<code>{line}</code><br />
+	{#each sourceLines as line}
+		<code>{line}</code>
 	{/each}
 </pre>
 
@@ -25,22 +29,24 @@
 		padding: 5px;
 		counter-reset: line;
 		width: 100%;
-
-		white-space: normal;
+		height: calc(100vh - 16rem);
+		display: grid;
 		overflow-x: scroll;
+		overscroll-behavior: none;
 	}
 
 	code {
 		counter-increment: line;
-		overflow-x: scroll;
-		white-space: pre;
+		display: grid;
+		grid-template-columns: 2rem 1fr;
+		gap: 1rem;
 	}
 
 	code:before {
 		display: inline-block;
 		content: counter(line);
 		user-select: none;
-		width: 40px;
+		text-align: right;
 		opacity: 0.5;
 	}
 </style>

--- a/src/routes/strategy/[strategy_id]/source/SourceCode.svelte
+++ b/src/routes/strategy/[strategy_id]/source/SourceCode.svelte
@@ -1,0 +1,49 @@
+<!--
+
+    Page to display the source code of the strategy.
+
+    TODO: Add nice source code formatting widget
+-->
+<script lang="ts">
+
+    export let source;
+
+	// Currently loaded source code
+	$: sourceLines = source.split("\n");
+
+</script>
+
+
+<pre class="source">
+    {#each sourceLines as line}
+        <code>{line}</code><br>
+    {/each}
+</pre>
+
+<style lang="postcss">
+    pre {
+        background: var(--cm-light, var(--c-parchment-dark)) var(--cm-dark, var(--c-ink));
+        color: var(--cm-light, var(--c-text-1-v1)) var(--cm-dark, var(--c-text-1-v1));
+        font-weight: bold;
+        padding: 5px;
+        counter-reset: line;
+        width: 100%;
+
+        white-space: normal;
+        overflow-x: scroll;
+    }
+
+    code {
+        counter-increment: line;
+        overflow-x: scroll;
+        white-space: pre;
+    }
+
+    code:before{
+        display: inline-block;
+        content: counter(line);
+        user-select: none;
+        width: 40px;
+        opacity: 0.5;
+    }
+</style>


### PR DESCRIPTION
- Add /source page under strategy
- Add /decision making page under strategy

![image](https://user-images.githubusercontent.com/49922/205924923-f4f05ab7-505d-4443-9403-7093e1698b74.png)

![image](https://user-images.githubusercontent.com/49922/205924991-cb1bb56f-32b5-4101-8276-428a019362bc.png)

`trade-executor-frontend` navigation has been already updated here:

https://github.com/tradingstrategy-ai/trade-executor-frontend/commit/6251c2d808ea1f6491460dae4282c1b24eb74235
