### PR TITLE
update outdated reference to sapper documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,6 @@ Our CI/CD pipeline runs the following chack on PRs or pushes to `master`:
 npm run format:check
 ```
 
-### SvelteKit and Svelte component installation issue
+### `dependencies` vs `devDependencies`
 
-[Any external Svelte components need to be installed as development dependency because of SSR](https://github.com/sveltejs/sapper-template#using-external-components).
+[`adapter-node` will bundle `devDependencies`](https://github.com/sveltejs/kit/tree/master/packages/adapter-node#deploying) whereas `dependencies` must be installed when deploying to production.


### PR DESCRIPTION
the note in the sapper documentation doesn't apply to sveltekit at all. `vite-plugin-svelte` will bundle any package it determines to be a Svelte library (i.e. ones that have `svelte` as a dependency or peer dependency)