### PR TITLE
Uniswap v3 search improvements

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
         "svelte-spinner": "^2.0.2",
         "svelte-tradingview-widget": "^2.3.0",
         "ts-custom-error": "^3.2.0",
-        "typesense": "^1.2.1",
+        "typesense": "^1.4.4",
         "web3": "^1.6.0"
       },
       "devDependencies": {
@@ -10789,9 +10789,9 @@
       }
     },
     "node_modules/typesense": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/typesense/-/typesense-1.4.0.tgz",
-      "integrity": "sha512-+Y6WYNB3+z5bR1/F5AfHQyqdeKGOZW0k2l0HSFgCFl+3wo6oY42lAhJG2JZk6k8ux3j4866IyruKsCG5NtlHMQ==",
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/typesense/-/typesense-1.4.4.tgz",
+      "integrity": "sha512-bs1aLdBPt3t4DuFoTe3wlZaIfhRBwP/ejiaOJXX5qi9DBF7bLeo+LY6A9zBvon0LUxzaUsJCsx7QAydIdER6tw==",
       "dependencies": {
         "axios": "^0.26.0",
         "loglevel": "^1.8.0"
@@ -19792,9 +19792,9 @@
       "dev": true
     },
     "typesense": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/typesense/-/typesense-1.4.0.tgz",
-      "integrity": "sha512-+Y6WYNB3+z5bR1/F5AfHQyqdeKGOZW0k2l0HSFgCFl+3wo6oY42lAhJG2JZk6k8ux3j4866IyruKsCG5NtlHMQ==",
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/typesense/-/typesense-1.4.4.tgz",
+      "integrity": "sha512-bs1aLdBPt3t4DuFoTe3wlZaIfhRBwP/ejiaOJXX5qi9DBF7bLeo+LY6A9zBvon0LUxzaUsJCsx7QAydIdER6tw==",
       "requires": {
         "axios": "^0.26.0",
         "loglevel": "^1.8.0"

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "svelte-spinner": "^2.0.2",
     "svelte-tradingview-widget": "^2.3.0",
     "ts-custom-error": "^3.2.0",
-    "typesense": "^1.2.1",
+    "typesense": "^1.4.4",
     "web3": "^1.6.0"
   },
   "optionalDependencies": {

--- a/src/lib/components/PageHeader.svelte
+++ b/src/lib/components/PageHeader.svelte
@@ -1,6 +1,7 @@
 <!--
 @component
-Display single- or double-line page header
+Display single- or double-line page header. The `title` and `subtitle` can be passed
+as props (simple strings) or named slots (for nested markup).
 
 #### Usage
 ```tsx
@@ -8,14 +9,18 @@ Display single- or double-line page header
 ```
 -->
 <script lang="ts">
-	export let title: string;
+	export let title: string = '';
 	export let subtitle: string = '';
 </script>
 
 <header class="ds-container">
 	<h1 class:multiline={subtitle}>
-		{title}
-		{#if subtitle}<small>{subtitle}</small>{/if}
+		<slot name="title">{title}</slot>
+		{#if $$slots.subtitle || subtitle}
+			<small>
+				<slot name="subtitle">{subtitle}</slot>
+			</small>
+		{/if}
 	</h1>
 </header>
 

--- a/src/lib/helpers/formatters.ts
+++ b/src/lib/helpers/formatters.ts
@@ -250,6 +250,20 @@ export function formatPercent(n: MaybeNumber): string {
 }
 
 /**
+ * Custom percent formatter for pool swap fee (Uniswap V3)
+ *
+ * Uses `minimumSignificantDigits` instead of `minimumFractionDigits`
+ */
+export function formatPoolSwapFee(n: MaybeNumber): string {
+	if (!Number.isFinite(n)) return '';
+	return n.toLocaleString('en', {
+		minimumSignificantDigits: 1,
+		maximumSignificantDigits: 1,
+		style: 'percent'
+	});
+}
+
+/**
  * Formats the time duration string as
  *
  * Timedelta is received from the API as a duration in seconds.

--- a/src/lib/search/Search.svelte
+++ b/src/lib/search/Search.svelte
@@ -21,7 +21,7 @@ Display site-wide search box for use in top-nav.
 
 	$: tradingEntities.search({
 		q,
-		sort_by: ['type_rank:asc', 'liquidity:desc', '_text_match:desc'],
+		sort_by: ['type_rank:asc', 'liquidity:desc', 'pool_swap_fee:asc'],
 		group_by: ['type']
 	});
 

--- a/src/lib/search/TradingEntityHit.svelte
+++ b/src/lib/search/TradingEntityHit.svelte
@@ -9,6 +9,7 @@ line item; supports basic (top-nav) and advanced (/search page) layouts.
 ```
 -->
 <script lang="ts">
+	import type { DocumentSchema } from 'typesense/lib/Typesense/Documents';
 	import { determinePriceChangeClass } from '$lib/helpers/price';
 	import { formatDollar, formatPriceChange } from '$lib/helpers/formatters';
 	import { Icon } from '$lib/components';
@@ -21,12 +22,13 @@ line item; supports basic (top-nav) and advanced (/search page) layouts.
 	 * object returned by Typesense `tradingEntity` search hits; see:
 	 * https://github.com/tradingstrategy-ai/search/blob/main/docs/trading-entities.md
 	 */
-	export let document;
+	export let document: DocumentSchema;
 	export let layout: 'basic' | 'advanced';
 
 	const isBasicLayout = layout === 'basic';
 	const isAdvancedLayout = layout === 'advanced';
-	const isLowQuality = document.liquidity < LIQUIDITY_QUALITY_THRESHOLD;
+	const hasLiquidityFactor = document.quality_factors?.includes('liquidity');
+	const isLowQuality = hasLiquidityFactor && document.liquidity < LIQUIDITY_QUALITY_THRESHOLD;
 	const hasPriceChange = Number.isFinite(document.price_change_24h);
 	const hasValidPrice = document.price_usd_latest > 0;
 	const hasTradingData = [document.liquidity, document.volume_24h, document.price_change_24h].some(Number.isFinite);

--- a/src/lib/search/TradingEntityHit.svelte
+++ b/src/lib/search/TradingEntityHit.svelte
@@ -11,7 +11,7 @@ line item; supports basic (top-nav) and advanced (/search page) layouts.
 <script lang="ts">
 	import type { DocumentSchema } from 'typesense/lib/Typesense/Documents';
 	import { determinePriceChangeClass } from '$lib/helpers/price';
-	import { formatDollar, formatPercent, formatPriceChange } from '$lib/helpers/formatters';
+	import { formatDollar, formatPoolSwapFee, formatPriceChange } from '$lib/helpers/formatters';
 	import { Icon } from '$lib/components';
 
 	// Any token with less than this liquidity
@@ -50,7 +50,7 @@ line item; supports basic (top-nav) and advanced (/search page) layouts.
 				<div class="desc">
 					{document.description}
 					{#if document.pool_swap_fee}
-						<span class="pool-swap-fee">({formatPercent(document.pool_swap_fee)})</span>
+						<span class="pool-swap-fee">({formatPoolSwapFee(document.pool_swap_fee)})</span>
 					{/if}
 					{#if isAdvancedLayout && isLowQuality}
 						<Icon name="warning" />

--- a/src/lib/search/TradingEntityHit.svelte
+++ b/src/lib/search/TradingEntityHit.svelte
@@ -11,7 +11,7 @@ line item; supports basic (top-nav) and advanced (/search page) layouts.
 <script lang="ts">
 	import type { DocumentSchema } from 'typesense/lib/Typesense/Documents';
 	import { determinePriceChangeClass } from '$lib/helpers/price';
-	import { formatDollar, formatPriceChange } from '$lib/helpers/formatters';
+	import { formatDollar, formatPercent, formatPriceChange } from '$lib/helpers/formatters';
 	import { Icon } from '$lib/components';
 
 	// Any token with less than this liquidity
@@ -49,6 +49,9 @@ line item; supports basic (top-nav) and advanced (/search page) layouts.
 			<div class="primary">
 				<div class="desc">
 					{document.description}
+					{#if document.pool_swap_fee}
+						<span class="pool-swap-fee">({formatPercent(document.pool_swap_fee)})</span>
+					{/if}
 					{#if isAdvancedLayout && isLowQuality}
 						<Icon name="warning" />
 					{/if}
@@ -188,10 +191,13 @@ line item; supports basic (top-nav) and advanced (/search page) layouts.
 		gap: var(--space-ss);
 		font: var(--f-ui-md-medium);
 		letter-spacing: var(--f-ui-md-spacing, normal);
+		--reduced-font-weight: 400;
 
 		@media (--viewport-md-up) {
 			@nest .advanced & {
 				font: var(--f-heading-sm-medium);
+				letter-spacing: var(--f-heading-sm-spacing, normal);
+				--reduced-font-weight: 500;
 			}
 		}
 
@@ -204,6 +210,11 @@ line item; supports basic (top-nav) and advanced (/search page) layouts.
 			& :global svg {
 				margin: calc(-1 * var(--space-xxs)) 0 0 var(--space-xxs);
 			}
+		}
+
+		& .pool-swap-fee {
+			font-weight: var(--reduced-font-weight);
+			opacity: 0.7;
 		}
 
 		& .price-change,

--- a/src/routes/search/SortSelect.svelte
+++ b/src/routes/search/SortSelect.svelte
@@ -12,22 +12,22 @@ pre-defined set of sort options.
 	const options = {
 		'liquidity:desc': {
 			label: '▼ Liquidity',
-			params: ['liquidity:desc', '_text_match:desc']
+			params: ['liquidity:desc', 'pool_swap_fee:asc', '_text_match:desc']
 		},
 
 		'volume:desc': {
 			label: '▼ Volume',
-			params: ['volume_24h:desc', '_text_match:desc']
+			params: ['volume_24h:desc', 'pool_swap_fee:asc', '_text_match:desc']
 		},
 
 		'price_change:desc': {
 			label: '▼ Price change',
-			params: ['price_change_24h:desc', '_text_match:desc']
+			params: ['price_change_24h:desc', 'pool_swap_fee:asc', '_text_match:desc']
 		},
 
 		'price_change:asc': {
 			label: '▲ Price change',
-			params: ['price_change_24h:asc', '_text_match:desc']
+			params: ['price_change_24h:asc', 'pool_swap_fee:asc', '_text_match:desc']
 		}
 	};
 

--- a/src/routes/search/SortSelect.test.ts
+++ b/src/routes/search/SortSelect.test.ts
@@ -24,11 +24,11 @@ describe('SortSelect component', () => {
 
 	describe('getSortParams module function', () => {
 		test('should return params for matching option', () => {
-			expect(getSortParams('volume:desc')).toStrictEqual(['volume_24h:desc', '_text_match:desc']);
+			expect(getSortParams('volume:desc')).toStrictEqual(['volume_24h:desc', 'pool_swap_fee:asc', '_text_match:desc']);
 		});
 
 		test('should return default params for non-matching option', () => {
-			expect(getSortParams('foo:bar')).toStrictEqual(['liquidity:desc', '_text_match:desc']);
+			expect(getSortParams('foo:bar')).toStrictEqual(['liquidity:desc', 'pool_swap_fee:asc', '_text_match:desc']);
 		});
 	});
 });

--- a/src/routes/trading-view/[chain]/[exchange]/[pair]/+page.svelte
+++ b/src/routes/trading-view/[chain]/[exchange]/[pair]/+page.svelte
@@ -8,6 +8,7 @@ Render the pair trading page
 <script lang="ts">
 	import type { PageData } from './$types';
 	import { getTokenTaxInformation } from '$lib/helpers/tokentax';
+	import { formatPoolSwapFee } from '$lib/helpers/formatters';
 	import { AlertItem, AlertList, Button, PageHeader } from '$lib/components';
 	import Breadcrumbs from '$lib/breadcrumb/Breadcrumbs.svelte';
 	import InfoTable from './InfoTable.svelte';
@@ -45,7 +46,14 @@ Render the pair trading page
 <Breadcrumbs labels={breadcrumbs} />
 
 <main>
-	<PageHeader title={summary.pair_symbol} subtitle="token pair on {details.exchange_name} on {details.chain_name}" />
+	<PageHeader subtitle="token pair on {details.exchange_name} on {details.chain_name}">
+		<svelte:fragment slot="title">
+			{summary.pair_symbol}
+			{#if summary.pool_swap_fee}
+				<span class="pool-swap-fee">{formatPoolSwapFee(summary.pool_swap_fee)}</span>
+			{/if}
+		</svelte:fragment>
+	</PageHeader>
 
 	<section class="ds-container info" data-testid="pair-info">
 		<div class="ds-2-col">
@@ -113,6 +121,11 @@ Render the pair trading page
 		@media (--viewport-lg-up) {
 			gap: 5rem;
 		}
+	}
+
+	.pool-swap-fee {
+		margin-left: var(--space-xxs);
+		color: var(--c-text-2-v1);
 	}
 
 	.info {

--- a/src/routes/trading-view/[chain]/[exchange]/[pair]/InfoTable.svelte
+++ b/src/routes/trading-view/[chain]/[exchange]/[pair]/InfoTable.svelte
@@ -1,11 +1,11 @@
 <script lang="ts">
-	import { formatDollar, formatPriceChange } from '$lib/helpers/formatters';
+	import { formatDollar, formatPoolSwapFee, formatPriceChange } from '$lib/helpers/formatters';
 	import { determinePriceChangeClass } from '$lib/helpers/price';
 	import { getTokenTaxDescription, tokenTaxDocsUrl } from '$lib/helpers/tokentax';
 	import { TradingDataInfoRow } from '$lib/components';
 
-	export let summary;
-	export let details;
+	export let summary: Record<string, any>;
+	export let details: Record<string, any>;
 
 	// Reverse-calculate raw price using the US/quota token exchange rate
 	function calculateTokenPrice(exchangeRate: number, priceUsd: number) {
@@ -61,6 +61,10 @@
 	{/if}
 
 	<TradingDataInfoRow label="Token tax" labelHref={tokenTaxDocsUrl} value={getTokenTaxDescription(details)} />
+
+	{#if summary.pool_swap_fee}
+		<TradingDataInfoRow label="Pool swap fee" value={formatPoolSwapFee(summary.pool_swap_fee)} />
+	{/if}
 
 	<TradingDataInfoRow
 		label="Exchange"


### PR DESCRIPTION
closes #197 

**Screenshot from top-nav "quick search":**

<img width="1128" alt="image" src="https://user-images.githubusercontent.com/35901/209404505-a3b0d7d1-8af8-453f-8eb2-af9eba3b424a.png">

**Screenshot from advanced search:**
> **NOTE:** the Uniswap v2 pairs are flagged as low-quality due to their low liquidity; the liquidity is ignored for the Uniswap v3 pairs

<img width="1124" alt="image" src="https://user-images.githubusercontent.com/35901/209404694-a5aef584-9205-41cb-b5b3-3dec88580a25.png">
