### PR TITLE
Fix Microsoft Excel export of top trading pairs.

### DIFF
--- a/src/routes/trading-view/[chain]/[exchange]/export-data/+page.svelte
+++ b/src/routes/trading-view/[chain]/[exchange]/export-data/+page.svelte
@@ -44,13 +44,13 @@
 	<header class="ds-container">
 		<h1>Export trading pair data for {exchangeName}</h1>
 
-        <p>
-            Download the exchange top trading pairs as Microsoft Excel file for analysis.
-            This analysis is suitable for quick market overview.
-            <a class="body-link" href="/trading-view/backtesing">
-                For comprehensive analysis use the full backtesting datasets
-            </a>.
-        </p>
+		<p>
+			Download the exchange top trading pairs as Microsoft Excel file for analysis. This analysis is suitable for quick
+			market overview.
+			<a class="body-link" href="/trading-view/backtesing">
+				For comprehensive analysis use the full backtesting datasets
+			</a>.
+		</p>
 	</header>
 
 	<section class="ds-container">
@@ -104,16 +104,12 @@
 					disabled={downloadDisabled}
 				/>
 
-                <!--
+				<!--
                 Above downloadDisabled is untoggled for now as there is no way to reset
                 this outside refresh if the form values are changed
                 -->
 
-                <Button
-                    secondary=true
-					label="View full datasets"
-					href="/trading-view/backtesting"
-				/>
+				<Button secondary="true" label="View full datasets" href="/trading-view/backtesting" />
 			</div>
 		</form>
 	</section>
@@ -128,14 +124,12 @@
 			>
 		</p>
 
-        <AlertList status="warning">
-            <AlertItem title="Microsoft Excel export is currently in beta">
-                We are still finishing out data points. Some data might be incorrect or not available.
-            </AlertItem>
-        </AlertList>
+		<AlertList status="warning">
+			<AlertItem title="Microsoft Excel export is currently in beta">
+				We are still finishing out data points. Some data might be incorrect or not available.
+			</AlertItem>
+		</AlertList>
 	</section>
-
-
 </main>
 
 <style>
@@ -188,7 +182,6 @@
 			flex-direction: column;
 			padding-block: 0;
 		}
-
 	}
 
 	@media (--viewport-md-up) {

--- a/src/routes/trading-view/[chain]/[exchange]/export-data/+page.svelte
+++ b/src/routes/trading-view/[chain]/[exchange]/export-data/+page.svelte
@@ -97,12 +97,7 @@
 			</div>
 
 			<div class="cta">
-				<Button
-					label="Download Excel"
-					href="{downloadUrl}?{downloadParams}"
-					download
-					disabled={downloadDisabled}
-				/>
+				<Button label="Download Excel" href="{downloadUrl}?{downloadParams}" download disabled={downloadDisabled} />
 
 				<!--
                 Above downloadDisabled is untoggled for now as there is no way to reset

--- a/src/routes/trading-view/[chain]/[exchange]/export-data/+page.svelte
+++ b/src/routes/trading-view/[chain]/[exchange]/export-data/+page.svelte
@@ -98,7 +98,7 @@
 
 			<div class="cta">
 				<Button
-					label="Download trading pair data"
+					label="Download Excel"
 					href="{downloadUrl}?{downloadParams}"
 					download
 					disabled={downloadDisabled}

--- a/src/routes/trading-view/[chain]/[exchange]/export-data/+page.svelte
+++ b/src/routes/trading-view/[chain]/[exchange]/export-data/+page.svelte
@@ -100,11 +100,11 @@
 				<Button label="Download Excel" href="{downloadUrl}?{downloadParams}" download disabled={downloadDisabled} />
 
 				<!--
-                Above downloadDisabled is untoggled for now as there is no way to reset
-                this outside refresh if the form values are changed
-                -->
+					Above downloadDisabled is untoggled for now as there is no way to reset
+					this outside refresh if the form values are changed
+				-->
 
-				<Button secondary="true" label="View full datasets" href="/trading-view/backtesting" />
+				<Button secondary label="View full datasets" href="/trading-view/backtesting" />
 			</div>
 		</form>
 	</section>
@@ -127,7 +127,7 @@
 	</section>
 </main>
 
-<style>
+<style lang="postcss">
 	main {
 		--container-max-width: 720px;
 		display: grid;
@@ -166,22 +166,14 @@
 
 	.cta {
 		margin-top: var(--space-md);
-
-		display: flex;
-		flex-wrap: wrap;
-		justify-content: left;
-		gap: var(--space-ls) var(--space-xl);
 		padding-block: var(--space-lg);
+		display: flex;
+		gap: var(--space-xl);
 
 		@media (--viewport-xs) {
-			flex-direction: column;
 			padding-block: 0;
-		}
-	}
-
-	@media (--viewport-md-up) {
-		.cta {
-			justify-items: start;
+			flex-direction: column;
+			gap: var(--space-ls);
 		}
 	}
 </style>

--- a/src/routes/trading-view/[chain]/[exchange]/export-data/+page.svelte
+++ b/src/routes/trading-view/[chain]/[exchange]/export-data/+page.svelte
@@ -54,7 +54,7 @@
 	</header>
 
 	<section class="ds-container">
-		<form>
+		<form on:change={() => (downloadDisabled = false)}>
 			{#if data.exchange_slug}
 				<div>
 					<label for="exampleFormControlInput1">Selected exchange</label>
@@ -97,12 +97,13 @@
 			</div>
 
 			<div class="cta">
-				<Button label="Download Excel" href="{downloadUrl}?{downloadParams}" download disabled={downloadDisabled} />
-
-				<!--
-					Above downloadDisabled is untoggled for now as there is no way to reset
-					this outside refresh if the form values are changed
-				-->
+				<Button
+					label="Download Excel"
+					href="{downloadUrl}?{downloadParams}"
+					download
+					disabled={downloadDisabled}
+					on:click={() => (downloadDisabled = true)}
+				/>
 
 				<Button secondary label="View full datasets" href="/trading-view/backtesting" />
 			</div>

--- a/src/routes/trading-view/[chain]/[exchange]/export-data/+page.svelte
+++ b/src/routes/trading-view/[chain]/[exchange]/export-data/+page.svelte
@@ -47,7 +47,7 @@
 		<p>
 			Download the exchange top trading pairs as Microsoft Excel file for analysis. This analysis is suitable for quick
 			market overview.
-			<a class="body-link" href="/trading-view/backtesing">
+			<a class="body-link" href="/trading-view/backtesting">
 				For comprehensive analysis use the full backtesting datasets
 			</a>.
 		</p>

--- a/src/routes/trading-view/[chain]/[exchange]/export-data/+page.svelte
+++ b/src/routes/trading-view/[chain]/[exchange]/export-data/+page.svelte
@@ -2,7 +2,7 @@
 	import type { PageData } from './$types';
 	import { backendUrl } from '$lib/config';
 	import Breadcrumbs from '$lib/breadcrumb/Breadcrumbs.svelte';
-	import { Button } from '$lib/components';
+	import { Button, AlertItem, AlertList } from '$lib/components';
 
 	export let data: PageData;
 
@@ -43,7 +43,14 @@
 <main>
 	<header class="ds-container">
 		<h1>Export trading pair data for {exchangeName}</h1>
-		<p>Download data as Microsoft Excel file for analysis.</p>
+
+        <p>
+            Download the exchange top trading pairs as Microsoft Excel file for analysis.
+            This analysis is suitable for quick market overview.
+            <a class="body-link" href="/trading-view/backtesing">
+                For comprehensive analysis use the full backtesting datasets
+            </a>.
+        </p>
 	</header>
 
 	<section class="ds-container">
@@ -72,10 +79,10 @@
 			<div>
 				<label for="export_dataset">Sorted by</label>
 				<select class="form-control" id="sorted_by" bind:value={selectedSort}>
-					<option value="liquidity_change_24h">Liquidity % change 24h</option>
-					<option value="usd_liquidity_change_24h">Liquidity USD change 24h</option>
-					<option value="usd_liquidity_latest">Liquidity available latest</option>
-					<option value="usd_volume_24h">Volume 24h</option>
+					<option value="liquidity_change_relative_24h">Liquidity % change 24h</option>
+					<option value="liquidity_change_abs_24h">Liquidity USD change 24h</option>
+					<option value="liquidity">Liquidity available latest</option>
+					<option value="volume_1d">Volume 24h</option>
 					<option value="price_change_24h">Price change 24h</option>
 				</select>
 			</div>
@@ -95,7 +102,17 @@
 					href="{downloadUrl}?{downloadParams}"
 					download
 					disabled={downloadDisabled}
-					on:click={() => (downloadDisabled = true)}
+				/>
+
+                <!--
+                Above downloadDisabled is untoggled for now as there is no way to reset
+                this outside refresh if the form values are changed
+                -->
+
+                <Button
+                    secondary=true
+					label="View full datasets"
+					href="/trading-view/backtesting"
 				/>
 			</div>
 		</form>
@@ -109,9 +126,16 @@
 			<a class="body-link" rel="external" href="https://tradingstrategy.ai/api/explorer/"
 				>the column format in PairSummary section of the API documentation.</a
 			>
-			For all datasets, see <a class="body-link" href="/trading-view/backtesting">Backtesting</a> page.
 		</p>
+
+        <AlertList status="warning">
+            <AlertItem title="Microsoft Excel export is currently in beta">
+                We are still finishing out data points. Some data might be incorrect or not available.
+            </AlertItem>
+        </AlertList>
 	</section>
+
+
 </main>
 
 <style>
@@ -153,7 +177,18 @@
 
 	.cta {
 		margin-top: var(--space-md);
-		display: grid;
+
+		display: flex;
+		flex-wrap: wrap;
+		justify-content: left;
+		gap: var(--space-ls) var(--space-xl);
+		padding-block: var(--space-lg);
+
+		@media (--viewport-xs) {
+			flex-direction: column;
+			padding-block: 0;
+		}
+
 	}
 
 	@media (--viewport-md-up) {


### PR DESCRIPTION
- Wrong labels were used for sorting options, causing a backend crash
- Added a warning about the beta quality
- Prod users to full datasets more aggressively
- There is a test error, but not sure if it is related

<img width="827" alt="image" src="https://user-images.githubusercontent.com/49922/210781187-6c5969ca-e2d2-4966-85f2-7221c39b8070.png">
