### PR TITLE
Misc pair details fixes

### DIFF
--- a/src/lib/helpers/formatters.ts
+++ b/src/lib/helpers/formatters.ts
@@ -260,7 +260,7 @@ export function formatPercent(n: MaybeNumber): string {
  *
  * Uses `minimumSignificantDigits` instead of `minimumFractionDigits`
  */
-export function formatPoolSwapFee(n: MaybeNumber): string {
+export function formatSwapFee(n: MaybeNumber): string {
 	if (!Number.isFinite(n)) return '';
 	return n.toLocaleString('en', {
 		minimumSignificantDigits: 1,

--- a/src/lib/search/TradingEntityHit.svelte
+++ b/src/lib/search/TradingEntityHit.svelte
@@ -11,7 +11,7 @@ line item; supports basic (top-nav) and advanced (/search page) layouts.
 <script lang="ts">
 	import type { DocumentSchema } from 'typesense/lib/Typesense/Documents';
 	import { determinePriceChangeClass } from '$lib/helpers/price';
-	import { formatDollar, formatPoolSwapFee, formatPriceChange } from '$lib/helpers/formatters';
+	import { formatDollar, formatSwapFee, formatPriceChange } from '$lib/helpers/formatters';
 	import { Icon } from '$lib/components';
 
 	// Any token with less than this liquidity
@@ -58,7 +58,7 @@ line item; supports basic (top-nav) and advanced (/search page) layouts.
 				<div class="desc">
 					{document.description}
 					{#if document.pool_swap_fee}
-						<span class="pool-swap-fee">({formatPoolSwapFee(document.pool_swap_fee)})</span>
+						<span class="pool-swap-fee">({formatSwapFee(document.pool_swap_fee)})</span>
 					{/if}
 					{#if isAdvancedLayout && isLowQuality}
 						<Icon name="warning" />

--- a/src/routes/trading-view/[chain]/[exchange]/[pair]/+page.svelte
+++ b/src/routes/trading-view/[chain]/[exchange]/[pair]/+page.svelte
@@ -113,12 +113,12 @@ Render the pair trading page
 		<header>
 			<h2>Time period summary</h2>
 			<p>
-				The price and liquidity of {summary.base_token_symbol_friendly} in this trading pair. The amounts are converted to
-				US dollar through {summary.quote_token_symbol_friendly}/USD.
+				The price {isUniswapV3 ? 'and volume' : 'and liquidity'} of {summary.base_token_symbol_friendly} in this trading
+				pair. The amounts are converted to US dollar through {summary.quote_token_symbol_friendly}/USD.
 			</p>
 		</header>
 
-		<TimePeriodSummaryTable pairId={summary.pair_id} />
+		<TimePeriodSummaryTable pairId={summary.pair_id} hideLiquidityAndTrades={isUniswapV3} />
 	</section>
 </main>
 

--- a/src/routes/trading-view/[chain]/[exchange]/[pair]/+page.svelte
+++ b/src/routes/trading-view/[chain]/[exchange]/[pair]/+page.svelte
@@ -8,7 +8,7 @@ Render the pair trading page
 <script lang="ts">
 	import type { PageData } from './$types';
 	import { getTokenTaxInformation } from '$lib/helpers/tokentax';
-	import { formatPoolSwapFee } from '$lib/helpers/formatters';
+	import { formatSwapFee } from '$lib/helpers/formatters';
 	import { AlertItem, AlertList, Button, PageHeader } from '$lib/components';
 	import Breadcrumbs from '$lib/breadcrumb/Breadcrumbs.svelte';
 	import InfoTable from './InfoTable.svelte';
@@ -22,6 +22,8 @@ Render the pair trading page
 	$: details = data.additional_details;
 
 	$: tokenTax = getTokenTaxInformation(details);
+	$: isUniswapV3 = summary.exchange_type === 'uniswap_v3';
+	$: swapFee = formatSwapFee(summary.pool_swap_fee);
 
 	// Ridiculous token price warning: it is common with scam tokens to price the
 	// token super low so that prices are not readable when converted to USD.
@@ -35,11 +37,13 @@ Render the pair trading page
 
 <svelte:head>
 	<title>
-		{summary.pair_symbol} token price on {details.exchange_name}
+		{summary.pair_symbol}
+		{isUniswapV3 ? `${swapFee} pool` : 'token price'}
+		on {details.exchange_name}
 	</title>
 	<meta
 		name="description"
-		content={`Price and liquidity for ${summary.pair_symbol} on ${details.exchange_name} on ${details.chain_name}`}
+		content="Price and liquidity for {summary.pair_symbol} on {details.exchange_name} on {details.chain_name}"
 	/>
 </svelte:head>
 
@@ -49,8 +53,8 @@ Render the pair trading page
 	<PageHeader subtitle="token pair on {details.exchange_name} on {details.chain_name}">
 		<svelte:fragment slot="title">
 			{summary.pair_symbol}
-			{#if summary.pool_swap_fee}
-				<span class="pool-swap-fee">{formatPoolSwapFee(summary.pool_swap_fee)}</span>
+			{#if isUniswapV3}
+				<span class="pool-swap-fee">{swapFee}</span>
 			{/if}
 		</svelte:fragment>
 	</PageHeader>
@@ -62,7 +66,7 @@ Render the pair trading page
 		</div>
 
 		<AlertList status="warning">
-			<AlertItem title="Uniswap V3 beta" displayWhen={summary.exchange_type === 'uniswap_v3'}>
+			<AlertItem title="Uniswap V3 beta" displayWhen={isUniswapV3}>
 				We are in the process of integrating Uniswap V3 data. This page is available as a beta preview, but please note
 				that the data for this trading pair is currently incomplete.
 			</AlertItem>

--- a/src/routes/trading-view/[chain]/[exchange]/[pair]/InfoSummary.svelte
+++ b/src/routes/trading-view/[chain]/[exchange]/[pair]/InfoSummary.svelte
@@ -46,16 +46,15 @@
 		<strong class={priceChangeColorClass}>{formatDollar(summary.usd_price_latest)}</strong>
 		and is
 		<strong class={priceChangeColorClass}>
-			{formatPriceChange(summary.price_change_24h)}
-			{summary.price_change_24h > 0 ? 'up' : 'down'}
+			{formatPriceChange(summary.price_change_24h || null)}
+			{summary.price_change_24h > 0 ? 'up' : summary.price_change_24h < 0 ? 'down' : ''}
 		</strong>
 		against US Dollar for the last 24h.
 	</p>
 
 	<p>
-		The pair has <strong>{formatDollar(summary.usd_volume_24h)}</strong> 24h trading volume with
-		<strong>{formatDollar(summary.usd_liquidity_latest)}</strong>
-		liquidity available at the moment.
+		The pair has <strong>{formatDollar(summary.usd_volume_24h || null)}</strong> 24h trading volume with
+		<strong>{formatDollar(summary.usd_liquidity_latest || null)}</strong> liquidity available at the moment.
 		{#if details.first_trade_at}
 			The trading of {summary.pair_symbol} started at
 			<strong>{formatTimeAgo(details.first_trade_at, { unit: 'day' })}</strong>.

--- a/src/routes/trading-view/[chain]/[exchange]/[pair]/InfoTable.svelte
+++ b/src/routes/trading-view/[chain]/[exchange]/[pair]/InfoTable.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { formatDollar, formatPoolSwapFee, formatPriceChange } from '$lib/helpers/formatters';
+	import { formatDollar, formatSwapFee, formatPriceChange } from '$lib/helpers/formatters';
 	import { determinePriceChangeClass } from '$lib/helpers/price';
 	import { getTokenTaxDescription, tokenTaxDocsUrl } from '$lib/helpers/tokentax';
 	import { TradingDataInfo, TradingDataInfoRow } from '$lib/components';
@@ -63,7 +63,7 @@
 	<TradingDataInfoRow label="Token tax" labelHref={tokenTaxDocsUrl} value={getTokenTaxDescription(details)} />
 
 	{#if summary.pool_swap_fee}
-		<TradingDataInfoRow label="Pool swap fee" value={formatPoolSwapFee(summary.pool_swap_fee)} />
+		<TradingDataInfoRow label="Swap fee" value={formatSwapFee(summary.pool_swap_fee)} />
 	{/if}
 
 	<TradingDataInfoRow

--- a/src/routes/trading-view/[chain]/[exchange]/[pair]/InfoTable.svelte
+++ b/src/routes/trading-view/[chain]/[exchange]/[pair]/InfoTable.svelte
@@ -45,13 +45,13 @@
 
 	<TradingDataInfoRow
 		label="Change 24h"
-		value={formatPriceChange(summary.price_change_24h)}
+		value={formatPriceChange(summary.price_change_24h || null)}
 		class={priceChangeColorClass}
 	/>
 
-	<TradingDataInfoRow label="Volume 24h" value={formatDollar(summary.usd_volume_24h)} />
+	<TradingDataInfoRow label="Volume 24h" value={formatDollar(summary.usd_volume_24h || null)} />
 
-	<TradingDataInfoRow label="Liquidity" value={formatDollar(summary.usd_liquidity_latest)} />
+	<TradingDataInfoRow label="Liquidity" value={formatDollar(summary.usd_liquidity_latest || null)} />
 
 	{#if summary.exchange_rate}
 		<TradingDataInfoRow

--- a/src/routes/trading-view/[chain]/[exchange]/[pair]/TimePeriodSummaryColumn.svelte
+++ b/src/routes/trading-view/[chain]/[exchange]/[pair]/TimePeriodSummaryColumn.svelte
@@ -69,26 +69,27 @@ Display summary performance data for a given period; lazy-loads data when scroll
 			{formatPriceChange(tradeData.price_close / tradeData.price_open - 1)}
 		</li>
 		<li class:skeleton>
-			{formatDollar(tradeData.price_open)}
+			<!-- coercing 0 values to null in order to render "---" fallback -->
+			{formatDollar(tradeData.price_open || null)}
 		</li>
 		<li class:skeleton>
-			{formatDollar(tradeData.price_high)}
+			{formatDollar(tradeData.price_high || null)}
 		</li>
 		<li class:skeleton>
-			{formatDollar(tradeData.price_low)}
+			{formatDollar(tradeData.price_low || null)}
 		</li>
 		<li class:skeleton>
-			{formatDollar(tradeData.price_close)}
+			{formatDollar(tradeData.price_close || null)}
 		</li>
 		<li class:skeleton style:--skeleton-width="7ch">
-			{formatDollar(tradeData.volume)}
+			{formatDollar(tradeData.volume || null)}
 		</li>
 		{#if !hideLiquidityAndTrades}
 			<li class:skeleton style:--skeleton-width="7ch">
-				{formatDollar(tradeData.liquidity_high)}
+				{formatDollar(tradeData.liquidity_high || null)}
 			</li>
 			<li class:skeleton style:--skeleton-width="7ch">
-				{formatDollar(tradeData.liquidity_low)}
+				{formatDollar(tradeData.liquidity_low || null)}
 			</li>
 			<li class:skeleton>
 				{formatAmount(tradeData.buys)}

--- a/src/routes/trading-view/[chain]/[exchange]/[pair]/TimePeriodSummaryColumn.svelte
+++ b/src/routes/trading-view/[chain]/[exchange]/[pair]/TimePeriodSummaryColumn.svelte
@@ -6,6 +6,7 @@ Display summary performance data for a given period; lazy-loads data when scroll
 ```tsx
 	<TimePeriodSummaryColumn
 		pairId={1234}
+		hideLiquidityAndTrades={true|false}
 		period="hourly|daily|weekly|monthly"
 		active={true|false}
 	/>
@@ -18,6 +19,7 @@ Display summary performance data for a given period; lazy-loads data when scroll
 	import { determinePriceChangeClass } from '$lib/helpers/price';
 
 	export let pairId: number | string;
+	export let hideLiquidityAndTrades = false;
 	export let period: string;
 	export let active = false;
 
@@ -81,18 +83,20 @@ Display summary performance data for a given period; lazy-loads data when scroll
 		<li class:skeleton style:--skeleton-width="7ch">
 			{formatDollar(tradeData.volume)}
 		</li>
-		<li class:skeleton style:--skeleton-width="7ch">
-			{formatDollar(tradeData.liquidity_high)}
-		</li>
-		<li class:skeleton style:--skeleton-width="7ch">
-			{formatDollar(tradeData.liquidity_low)}
-		</li>
-		<li class:skeleton>
-			{formatAmount(tradeData.buys)}
-		</li>
-		<li class:skeleton>
-			{formatAmount(tradeData.sells)}
-		</li>
+		{#if !hideLiquidityAndTrades}
+			<li class:skeleton style:--skeleton-width="7ch">
+				{formatDollar(tradeData.liquidity_high)}
+			</li>
+			<li class:skeleton style:--skeleton-width="7ch">
+				{formatDollar(tradeData.liquidity_low)}
+			</li>
+			<li class:skeleton>
+				{formatAmount(tradeData.buys)}
+			</li>
+			<li class:skeleton>
+				{formatAmount(tradeData.sells)}
+			</li>
+		{/if}
 	</ul>
 </div>
 

--- a/src/routes/trading-view/[chain]/[exchange]/[pair]/TimePeriodSummaryTable.svelte
+++ b/src/routes/trading-view/[chain]/[exchange]/[pair]/TimePeriodSummaryTable.svelte
@@ -4,7 +4,7 @@ Display summary performance table for various periods.
 
 #### Usage:
 ```tsx
-	<TimePeriodSummaryTable pairId={1234} />
+	<TimePeriodSummaryTable pairId={1234} exchangeType="uniswap_v2" />
 ```
 -->
 <script lang="ts">
@@ -12,6 +12,7 @@ Display summary performance table for various periods.
 	import TimePeriodPicker from './TimePeriodPicker.svelte';
 
 	export let pairId: number | string;
+	export let hideLiquidityAndTrades = false;
 
 	let selected = 'daily';
 </script>
@@ -29,14 +30,16 @@ Display summary performance table for various periods.
 		<li>Lowest</li>
 		<li>Close</li>
 		<li>Volume</li>
-		<li>Highest liquidity</li>
-		<li>Lowest liquidity</li>
-		<li>Buying trades</li>
-		<li>Selling trades</li>
+		{#if !hideLiquidityAndTrades}
+			<li>Highest liquidity</li>
+			<li>Lowest liquidity</li>
+			<li>Buying trades</li>
+			<li>Selling trades</li>
+		{/if}
 	</ul>
 
 	{#each ['hourly', 'daily', 'weekly', 'monthly'] as period}
-		<TimePeriodSummaryColumn {pairId} {period} active={period === selected} />
+		<TimePeriodSummaryColumn {pairId} {hideLiquidityAndTrades} {period} active={period === selected} />
 	{/each}
 </div>
 


### PR DESCRIPTION
close #314, #315, #316, #321

**NOTE:** The `pair` attribute `pool_swap_fee` has been renamed to `pair_swap_fee` in `backend`. It should be renamed in `frontend` as well… but it needs to be updated in the Typesense `search` index first.

See:
- tradingstrategy-ai/search#14
- tradingstrategy-ai/frontend#327