### PR TITLE
Display loading state when paging/sorting pairs table

### DIFF
--- a/src/lib/explorer/PairsTable.svelte
+++ b/src/lib/explorer/PairsTable.svelte
@@ -12,6 +12,7 @@
 	export let page: number;
 	export let sort: string;
 	export let direction: 'asc' | 'desc';
+	export let loading = false;
 
 	const dispatch = createEventDispatcher();
 
@@ -99,7 +100,7 @@
 </script>
 
 <div class="pairs-table">
-	<DataTable isResponsive hasPagination {tableViewModel} />
+	<DataTable isResponsive hasPagination {loading} {tableViewModel} />
 </div>
 
 <style lang="postcss">

--- a/src/routes/trading-view/trading-pairs/+page.svelte
+++ b/src/routes/trading-view/trading-pairs/+page.svelte
@@ -3,12 +3,21 @@
 -->
 <script lang="ts">
 	import type { PageData } from './$types';
+	import type { Navigation } from '@sveltejs/kit';
 	import { goto, afterNavigate, disableScrollHandling } from '$app/navigation';
+	import { navigating } from '$app/stores';
 	import Breadcrumbs from '$lib/breadcrumb/Breadcrumbs.svelte';
 	import PairsTable from '$lib/explorer/PairsTable.svelte';
 	import { HeroBanner, Section } from '$lib/components';
 
 	export let data: PageData;
+
+	$: loading = isNavigatingWithinPage($navigating);
+
+	function isNavigatingWithinPage(nav: Navigation | null) {
+		if (!nav) return false;
+		return nav.from?.route.id === nav.to?.route.id;
+	}
 
 	function handleChange({ detail }) {
 		goto('?' + new URLSearchParams(detail));
@@ -30,7 +39,7 @@
 	</Section>
 
 	<Section layout="boxed" padding="sm">
-		<PairsTable {...data} on:change={handleChange} />
+		<PairsTable {...data} {loading} on:change={handleChange} />
 	</Section>
 </main>
 


### PR DESCRIPTION
@allozaur I tried applying the `loading` state to the pairs table.

Due to the amount of variance in the length of data to be shown when re-sorting or paginating, the result is a much "jumpier" UI – the width of columns changes once when entering loading state and again when exiting. Without the loading UI, the column width changes just once (when the new data has finished loading) which seems much less jarring.

Any thoughts on how to apply a similar loading effect without affecting the column widths?

**Side note:** I removed the loading state from the Exchanges table b/c it isn't needed there (client-side pagination and sort – too fast for it to be useful).
