### PR TITLE
add Sentry error logging for node server

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,6 +33,7 @@ services:
       - TS_PRIVATE_MAILERLITE_URL
       - TS_PRIVATE_MAILERLITE_API_KEY
       - TS_PRIVATE_MAILERLITE_GROUPS
+      - TS_PRIVATE_SENTRY_DSN
       # https://www.npmjs.com/package/@trading-strategy-ai/web-top-node
       - TOP_WEB_API_KEY
       # Datadog APM env vars

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "frontend",
       "version": "0.0.1",
       "dependencies": {
+        "@sentry/node": "^7.46.0",
         "@trading-strategy-ai/web-top-node": "^0.1.0-beta.9",
         "@tryghost/content-api": "^1.11.5",
         "assert-ts": "^0.3.4",
@@ -1246,6 +1247,99 @@
         }
       }
     },
+    "node_modules/@sentry-internal/tracing": {
+      "version": "7.46.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/tracing/-/tracing-7.46.0.tgz",
+      "integrity": "sha512-KYoppa7PPL8Er7bdPoxTNUfIY804JL7hhOEomQHYD22rLynwQ4AaLm3YEY75QWwcGb0B7ZDMV+tSumW7Rxuwuw==",
+      "dependencies": {
+        "@sentry/core": "7.46.0",
+        "@sentry/types": "7.46.0",
+        "@sentry/utils": "7.46.0",
+        "tslib": "^1.9.3"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@sentry-internal/tracing/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+    },
+    "node_modules/@sentry/core": {
+      "version": "7.46.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-7.46.0.tgz",
+      "integrity": "sha512-BnNHGh/ZTztqQedFko7vb2u6yLs/kWesOQNivav32ZbsEpVCjcmG1gOJXh2YmGIvj3jXOC9a4xfIuh+lYFcA6A==",
+      "dependencies": {
+        "@sentry/types": "7.46.0",
+        "@sentry/utils": "7.46.0",
+        "tslib": "^1.9.3"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@sentry/core/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+    },
+    "node_modules/@sentry/node": {
+      "version": "7.46.0",
+      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-7.46.0.tgz",
+      "integrity": "sha512-+GrgJMCye2WXGarRiU5IJHCK27xg7xbPc2XjGojBKbBoZfqxVAWbXEK4bnBQgRGP1pCmrU/M6ZhVgR3dP580xA==",
+      "dependencies": {
+        "@sentry-internal/tracing": "7.46.0",
+        "@sentry/core": "7.46.0",
+        "@sentry/types": "7.46.0",
+        "@sentry/utils": "7.46.0",
+        "cookie": "^0.4.1",
+        "https-proxy-agent": "^5.0.0",
+        "lru_map": "^0.3.3",
+        "tslib": "^1.9.3"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@sentry/node/node_modules/cookie": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.2.tgz",
+      "integrity": "sha512-aSWTXFzaKWkvHO1Ny/s+ePFpvKsPnjc551iI41v3ny/ow6tBG5Vd+FuqGNhh1LxOmVzOlGUriIlOaokOvhaStA==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/@sentry/node/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+    },
+    "node_modules/@sentry/types": {
+      "version": "7.46.0",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.46.0.tgz",
+      "integrity": "sha512-2FMEMgt2h6u7AoELhNhu9L54GAh67KKfK2pJ1kEXJHmWxM9FSCkizjLs/t+49xtY7jEXr8qYq8bV967VfDPQ9g==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@sentry/utils": {
+      "version": "7.46.0",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.46.0.tgz",
+      "integrity": "sha512-elRezDAF84guMG0OVIIZEWm6wUpgbda4HGks98CFnPsrnMm3N1bdBI9XdlxYLtf+ir5KsGR5YlEIf/a0kRUwAQ==",
+      "dependencies": {
+        "@sentry/types": "7.46.0",
+        "tslib": "^1.9.3"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@sentry/utils/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+    },
     "node_modules/@sinclair/typebox": {
       "version": "0.25.24",
       "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.25.24.tgz",
@@ -1971,7 +2065,6 @@
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
       "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
-      "dev": true,
       "dependencies": {
         "debug": "4"
       },
@@ -2879,7 +2972,6 @@
       "version": "4.3.4",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
       "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-      "dev": true,
       "dependencies": {
         "ms": "2.1.2"
       },
@@ -4231,7 +4323,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
       "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
-      "dev": true,
       "dependencies": {
         "agent-base": "6",
         "debug": "4"
@@ -5084,6 +5175,11 @@
         "get-func-name": "^2.0.0"
       }
     },
+    "node_modules/lru_map": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/lru_map/-/lru_map-0.3.3.tgz",
+      "integrity": "sha512-Pn9cox5CsMYngeDbmChANltQl+5pi6XmTrraMSzhPmMBbmgcxmqWry0U3PGapCU1yB4/LqCcom7qhHZiF/jGfQ=="
+    },
     "node_modules/lru-cache": {
       "version": "7.17.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.17.0.tgz",
@@ -5267,8 +5363,7 @@
     "node_modules/ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-      "dev": true
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "node_modules/nanoid": {
       "version": "3.3.4",
@@ -8756,6 +8851,89 @@
         "picomatch": "^2.3.1"
       }
     },
+    "@sentry-internal/tracing": {
+      "version": "7.46.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/tracing/-/tracing-7.46.0.tgz",
+      "integrity": "sha512-KYoppa7PPL8Er7bdPoxTNUfIY804JL7hhOEomQHYD22rLynwQ4AaLm3YEY75QWwcGb0B7ZDMV+tSumW7Rxuwuw==",
+      "requires": {
+        "@sentry/core": "7.46.0",
+        "@sentry/types": "7.46.0",
+        "@sentry/utils": "7.46.0",
+        "tslib": "^1.9.3"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        }
+      }
+    },
+    "@sentry/core": {
+      "version": "7.46.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-7.46.0.tgz",
+      "integrity": "sha512-BnNHGh/ZTztqQedFko7vb2u6yLs/kWesOQNivav32ZbsEpVCjcmG1gOJXh2YmGIvj3jXOC9a4xfIuh+lYFcA6A==",
+      "requires": {
+        "@sentry/types": "7.46.0",
+        "@sentry/utils": "7.46.0",
+        "tslib": "^1.9.3"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        }
+      }
+    },
+    "@sentry/node": {
+      "version": "7.46.0",
+      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-7.46.0.tgz",
+      "integrity": "sha512-+GrgJMCye2WXGarRiU5IJHCK27xg7xbPc2XjGojBKbBoZfqxVAWbXEK4bnBQgRGP1pCmrU/M6ZhVgR3dP580xA==",
+      "requires": {
+        "@sentry-internal/tracing": "7.46.0",
+        "@sentry/core": "7.46.0",
+        "@sentry/types": "7.46.0",
+        "@sentry/utils": "7.46.0",
+        "cookie": "^0.4.1",
+        "https-proxy-agent": "^5.0.0",
+        "lru_map": "^0.3.3",
+        "tslib": "^1.9.3"
+      },
+      "dependencies": {
+        "cookie": {
+          "version": "0.4.2",
+          "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.2.tgz",
+          "integrity": "sha512-aSWTXFzaKWkvHO1Ny/s+ePFpvKsPnjc551iI41v3ny/ow6tBG5Vd+FuqGNhh1LxOmVzOlGUriIlOaokOvhaStA=="
+        },
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        }
+      }
+    },
+    "@sentry/types": {
+      "version": "7.46.0",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.46.0.tgz",
+      "integrity": "sha512-2FMEMgt2h6u7AoELhNhu9L54GAh67KKfK2pJ1kEXJHmWxM9FSCkizjLs/t+49xtY7jEXr8qYq8bV967VfDPQ9g=="
+    },
+    "@sentry/utils": {
+      "version": "7.46.0",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.46.0.tgz",
+      "integrity": "sha512-elRezDAF84guMG0OVIIZEWm6wUpgbda4HGks98CFnPsrnMm3N1bdBI9XdlxYLtf+ir5KsGR5YlEIf/a0kRUwAQ==",
+      "requires": {
+        "@sentry/types": "7.46.0",
+        "tslib": "^1.9.3"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        }
+      }
+    },
     "@sinclair/typebox": {
       "version": "0.25.24",
       "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.25.24.tgz",
@@ -9310,7 +9488,6 @@
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
       "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
-      "dev": true,
       "requires": {
         "debug": "4"
       }
@@ -9955,7 +10132,6 @@
       "version": "4.3.4",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
       "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-      "dev": true,
       "requires": {
         "ms": "2.1.2"
       }
@@ -10968,7 +11144,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
       "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
-      "dev": true,
       "requires": {
         "agent-base": "6",
         "debug": "4"
@@ -11601,6 +11776,11 @@
         "get-func-name": "^2.0.0"
       }
     },
+    "lru_map": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/lru_map/-/lru_map-0.3.3.tgz",
+      "integrity": "sha512-Pn9cox5CsMYngeDbmChANltQl+5pi6XmTrraMSzhPmMBbmgcxmqWry0U3PGapCU1yB4/LqCcom7qhHZiF/jGfQ=="
+    },
     "lru-cache": {
       "version": "7.17.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.17.0.tgz",
@@ -11733,8 +11913,7 @@
     "ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-      "dev": true
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "nanoid": {
       "version": "3.3.4",

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "vitest-github-actions-reporter": "^0.9.0"
   },
   "dependencies": {
+    "@sentry/node": "^7.46.0",
     "@trading-strategy-ai/web-top-node": "^0.1.0-beta.9",
     "@tryghost/content-api": "^1.11.5",
     "assert-ts": "^0.3.4",

--- a/src/app.d.ts
+++ b/src/app.d.ts
@@ -1,14 +1,18 @@
-// See https://kit.svelte.dev/docs/types#app
-// for information about these interfaces
-// and what to do when importing types
-declare namespace App {
-	interface Error {
-		message: string;
-		chainName?: string;
-		stack?: string[];
-	}
+// For information about these interfaces, see:
+// https://kit.svelte.dev/docs/types#app
+declare global {
+	namespace App {
+		interface Error {
+			message: string;
+			chainName?: string;
+			stack?: string[];
+			eventId?: string;
+		}
 
-	// interface Locals {}
-	// interface PageData {}
-	// interface Platform {}
+		// interface Locals {}
+		// interface PageData {}
+		// interface Platform {}
+	}
 }
+
+export {};

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -34,6 +34,11 @@ export const siteMode = config((mode = 'local') => {
 }, 'SITE_MODE');
 
 /**
+ * Load version tag
+ */
+export const version = config((version: string) => version, 'FRONTEND_VERSION_TAG');
+
+/**
  * Load backend URL and fail loudly if not set
  */
 export const backendUrl = config((url: string) => {

--- a/src/routes/+error.svelte
+++ b/src/routes/+error.svelte
@@ -33,14 +33,20 @@
 		>
 			<Button label="Explore DEX data" href="/trading-view" />
 		</ErrorPageInfo>
-	{:else}
-		<ErrorPageInfo {status} title={status === 503 ? 'Service is unavailable' : $page.error.message}>
+	{:else if status === 503}
+		<ErrorPageInfo {status} title={'Service is unavailable'}>
 			{#if stack}
 				<Button icon="console" on:click={() => (showLogs = !showLogs)}>
 					{showLogs ? 'Hide logs' : 'Show logs'}
 				</Button>
 			{/if}
 		</ErrorPageInfo>
+	{:else}
+		<ErrorPageInfo
+			{status}
+			title={$page.error?.message ?? 'Internal Error'}
+			details={$page.error?.eventId ? `Event ID: ${$page.error.eventId}` : ''}
+		/>
 	{/if}
 
 	<aside class="ds-container">

--- a/src/routes/sentry-test/+page.svelte
+++ b/src/routes/sentry-test/+page.svelte
@@ -1,0 +1,9 @@
+<script lang="ts">
+	throw new Error('Sentry test error');
+</script>
+
+<h2>Sentry test page</h2>
+<p>This content will not be displayed due to error thrown above.</p>
+<p>
+	This page exists only to test Sentry error logging and should be deleted once Sentry has been tested in production.
+</p>


### PR DESCRIPTION
closes #406

I have tested this locally (with `dev` server and with `docker-compose`). It works when I use a DSN from trial instance of Sentry that I created. But when I switch to the `sentry.tradingstrategy.ai` DSN, I don't see any errors coming though.

@hieuh25 or @sontn1988 – any thoughts?
