### PR TITLE
add button to copy python identifier

### DIFF
--- a/src/routes/trading-view/[chain]/[exchange]/[pair]/+page.svelte
+++ b/src/routes/trading-view/[chain]/[exchange]/[pair]/+page.svelte
@@ -15,7 +15,7 @@ Render the pair trading page
 	import InfoSummary from './InfoSummary.svelte';
 	import ChartSection from './ChartSection.svelte';
 	import TimePeriodSummaryTable from './TimePeriodSummaryTable.svelte';
-	import {page} from '$app/stores';
+	import { page } from '$app/stores';
 
 	export let data: PageData;
 
@@ -104,9 +104,13 @@ Render the pair trading page
 			<Button
 				label="Copy python identifier"
 				on:click={() => {
-					navigator.clipboard.writeText(`(ChainId.${summary.chain_slug}, \"${summary.exchange_slug}\", \"${summary.base_token_symbol}\", \"${summary.quote_token_symbol}\", ${summary.pool_swap_fee * 10000}), # ${summary.pair_name} ${$page.url}`);
+					navigator.clipboard.writeText(
+						`(ChainId.${summary.chain_slug}, \"${summary.exchange_slug}\", \"${summary.base_token_symbol}\", \"${
+							summary.quote_token_symbol
+						}\", ${summary.pool_swap_fee * 10000}), # ${summary.pair_name} ${$page.url}`
+					);
 
-					// e.g. 
+					// e.g.
 					// (ChainId.ethereum, "uniswap-v3", "WETH", "USDC", 5), # Ether-USD Coin http://localhost:5173/trading-view/ethereum/uniswap-v3/eth-usdc-fee-5
 				}}
 			/>

--- a/src/routes/trading-view/[chain]/[exchange]/[pair]/+page.svelte
+++ b/src/routes/trading-view/[chain]/[exchange]/[pair]/+page.svelte
@@ -104,8 +104,7 @@ Render the pair trading page
 			<Button
 				label="Copy python identifier"
 				on:click={() => {
-					console.log(summary)
-					navigator.clipboard.writeText(`(ChainId.${summary.chain_slug}, \"${summary.exchange_slug}\", \"${summary.base_token_symbol}\", \"${summary.quote_token_symbol}\", ${summary.pool_swap_fee}), # ${summary.pair_name} ${$page.url}`);
+					navigator.clipboard.writeText(`(ChainId.${summary.chain_slug}, \"${summary.exchange_slug}\", \"${summary.base_token_symbol}\", \"${summary.quote_token_symbol}\", ${summary.pool_swap_fee * 10000}), # ${summary.pair_name} ${$page.url}`);
 				}}
 			/>
 		</div>

--- a/src/routes/trading-view/[chain]/[exchange]/[pair]/+page.svelte
+++ b/src/routes/trading-view/[chain]/[exchange]/[pair]/+page.svelte
@@ -15,6 +15,7 @@ Render the pair trading page
 	import InfoSummary from './InfoSummary.svelte';
 	import ChartSection from './ChartSection.svelte';
 	import TimePeriodSummaryTable from './TimePeriodSummaryTable.svelte';
+	import {page} from '$app/stores';
 
 	export let data: PageData;
 
@@ -99,6 +100,12 @@ Render the pair trading page
 			<Button
 				label="{summary.pair_symbol} API and historical data"
 				href="./{summary.pair_slug}/api-and-historical-data"
+			/>
+			<Button
+				label="Copy python identifier"
+				on:click={() => {
+					navigator.clipboard.writeText(`(ChainId.${summary.chain_slug}, \"${summary.exchange_slug}\", \"${summary.base_token_sumbol_friendly}\", \"${summary.quote_token_symbol_friendly}\", ${summary.pool_swap_fee}), # ${summary.pair_name} ${$page.url}`);
+				}}
 			/>
 		</div>
 	</section>

--- a/src/routes/trading-view/[chain]/[exchange]/[pair]/+page.svelte
+++ b/src/routes/trading-view/[chain]/[exchange]/[pair]/+page.svelte
@@ -41,6 +41,20 @@ Render the pair trading page
 		isUniswapV3 ? `${swapFee} pool` : 'token price',
 		`on ${details.exchange_name}`
 	].join(' ');
+
+	// e.g.
+	// (ChainId.ethereum, "uniswap-v3", "WETH", "USDC", 5), # Ether-USD Coin http://localhost:5173/trading-view/ethereum/uniswap-v3/eth-usdc-fee-5
+	function copyPythonIdentifier() {
+		const parts = [
+			`ChainId.${summary.chain_slug}`,
+			`"${summary.exchange_slug}"`,
+			`"${summary.base_token_symbol}"`,
+			`"${summary.quote_token_symbol}"`,
+			summary.pool_swap_fee * 10000
+		];
+		const text = `(${parts.join(', ')}), # ${summary.pair_name} ${$page.url}`;
+		navigator.clipboard.writeText(text);
+	}
 </script>
 
 <svelte:head>
@@ -101,19 +115,7 @@ Render the pair trading page
 				label="{summary.pair_symbol} API and historical data"
 				href="./{summary.pair_slug}/api-and-historical-data"
 			/>
-			<Button
-				label="Copy python identifier"
-				on:click={() => {
-					navigator.clipboard.writeText(
-						`(ChainId.${summary.chain_slug}, \"${summary.exchange_slug}\", \"${summary.base_token_symbol}\", \"${
-							summary.quote_token_symbol
-						}\", ${summary.pool_swap_fee * 10000}), # ${summary.pair_name} ${$page.url}`
-					);
-
-					// e.g.
-					// (ChainId.ethereum, "uniswap-v3", "WETH", "USDC", 5), # Ether-USD Coin http://localhost:5173/trading-view/ethereum/uniswap-v3/eth-usdc-fee-5
-				}}
-			/>
+			<Button label="Copy Python identifier" on:click={copyPythonIdentifier} />
 		</div>
 	</section>
 

--- a/src/routes/trading-view/[chain]/[exchange]/[pair]/+page.svelte
+++ b/src/routes/trading-view/[chain]/[exchange]/[pair]/+page.svelte
@@ -104,7 +104,8 @@ Render the pair trading page
 			<Button
 				label="Copy python identifier"
 				on:click={() => {
-					navigator.clipboard.writeText(`(ChainId.${summary.chain_slug}, \"${summary.exchange_slug}\", \"${summary.base_token_sumbol_friendly}\", \"${summary.quote_token_symbol_friendly}\", ${summary.pool_swap_fee}), # ${summary.pair_name} ${$page.url}`);
+					console.log(summary)
+					navigator.clipboard.writeText(`(ChainId.${summary.chain_slug}, \"${summary.exchange_slug}\", \"${summary.base_token_symbol}\", \"${summary.quote_token_symbol}\", ${summary.pool_swap_fee}), # ${summary.pair_name} ${$page.url}`);
 				}}
 			/>
 		</div>

--- a/src/routes/trading-view/[chain]/[exchange]/[pair]/+page.svelte
+++ b/src/routes/trading-view/[chain]/[exchange]/[pair]/+page.svelte
@@ -105,6 +105,9 @@ Render the pair trading page
 				label="Copy python identifier"
 				on:click={() => {
 					navigator.clipboard.writeText(`(ChainId.${summary.chain_slug}, \"${summary.exchange_slug}\", \"${summary.base_token_symbol}\", \"${summary.quote_token_symbol}\", ${summary.pool_swap_fee * 10000}), # ${summary.pair_name} ${$page.url}`);
+
+					// e.g. 
+					// (ChainId.ethereum, "uniswap-v3", "WETH", "USDC", 5), # Ether-USD Coin http://localhost:5173/trading-view/ethereum/uniswap-v3/eth-usdc-fee-5
 				}}
 			/>
 		</div>


### PR DESCRIPTION
### Details

- adds button to allow user to copy python specific information regarding the trading pair

### Notes

- Perhaps we should also have some sort of indication (tooltip) that code has been copied e.g. Github shows a `Copied` tooltip when copying a codeblock?

### Tasks

- Fixes #420 