### PR TITLE
GSC Mobile Usability fixes

### DIFF
--- a/src/lib/components/TradingDataInfo.svelte
+++ b/src/lib/components/TradingDataInfo.svelte
@@ -20,6 +20,8 @@ Container for displaying a set of trading data key/value pairs. Use with <Tradin
 		grid-template-columns: auto auto;
 		gap: var(--space-sl);
 		margin: 0;
+		overflow: hidden;
+		text-overflow: ellipsis;
 
 		& :global > * {
 			margin: 0;

--- a/src/lib/components/TradingDataInfo.svelte
+++ b/src/lib/components/TradingDataInfo.svelte
@@ -20,11 +20,11 @@ Container for displaying a set of trading data key/value pairs. Use with <Tradin
 		grid-template-columns: auto auto;
 		gap: var(--space-sl);
 		margin: 0;
-		overflow: hidden;
-		text-overflow: ellipsis;
 
 		& :global > * {
 			margin: 0;
+			overflow: hidden;
+			text-overflow: ellipsis;
 		}
 	}
 </style>

--- a/src/routes/glossary/+page.svelte
+++ b/src/routes/glossary/+page.svelte
@@ -91,9 +91,12 @@
 
 	.terms {
 		display: grid;
-		gap: var(--space-xxxs);
+		gap: var(--space-xs);
 		font: var(--f-ui-md-roman);
 		letter-spacing: var(--f-ui-md-spacing, normal);
+		@media (--viewport-sm-down) {
+			gap: var(--space-md);
+		}
 	}
 
 	.term:hover {
@@ -105,7 +108,7 @@
 		border: 1px solid hsla(var(--hsl-text));
 
 		@media (--viewport-lg-down) {
-			margin: var(--space-md) 0;
+			margin: var(--space-lg) 0 var(--space-xl);
 		}
 	}
 </style>

--- a/src/routes/trading-view/[chain]/tokens/[token]/+page.svelte
+++ b/src/routes/trading-view/[chain]/tokens/[token]/+page.svelte
@@ -87,6 +87,11 @@
 		}
 	}
 
+	main :global h1 {
+		overflow: hidden;
+		text-overflow: ellipsis;
+	}
+
 	h2 {
 		font: var(--f-h2-medium);
 	}


### PR DESCRIPTION
Close #434

I handled these issues:

![Zrzut ekranu 2023-05-16 o 15 16 12](https://github.com/tradingstrategy-ai/frontend/assets/37627284/30900113-f4f7-40c8-94d7-3942e26f2439)

### Glossary

Now the glossary entries spacing is better balanced for Desktop/Mobile usage.

![Zrzut ekranu 2023-05-16 o 15 16 26](https://github.com/tradingstrategy-ai/frontend/assets/37627284/bedfa5b9-967e-4114-95f6-17141936841b)


![Zrzut ekranu 2023-05-16 o 15 16 19](https://github.com/tradingstrategy-ai/frontend/assets/37627284/b7ddb1a0-2967-4fcb-aabd-d8205a129f0c)

### Trading Entity page

Issue was that a super long name was overlaying other UI. I handled this with truncation.

![Zrzut ekranu 2023-05-16 o 15 16 04](https://github.com/tradingstrategy-ai/frontend/assets/37627284/435bf4c9-6610-4fd3-834f-9ebe43175557)

