### PR TITLE
add buy+sell prices

### DIFF
--- a/src/lib/helpers/formatters.ts
+++ b/src/lib/helpers/formatters.ts
@@ -138,6 +138,23 @@ export function formatDollar(n: MaybeNumber, minFrag = 2, maxFrag = 2, prefix = 
 	}
 }
 
+/**
+ * Format price with '$' prefix, thousands separator, and useful
+ * number of fraction digits.
+ */
+export function formatPrice(n: MaybeNumber) {
+	if (!Number.isFinite(n)) return notFilledMarker;
+
+	const digits = n < 10 ? 4 : 2;
+
+	return n.toLocaleString('en', {
+		style: 'currency',
+		currency: 'USD',
+		minimumFractionDigits: digits,
+		maximumFractionDigits: digits
+	});
+}
+
 export function formatPriceChange(n: MaybeNumber): string {
 	if (!Number.isFinite(n)) return notFilledMarker;
 	return `${n > 0 ? '▲' : '▼'} ${formatPercent(Math.abs(n))}`;

--- a/src/lib/helpers/trade.ts
+++ b/src/lib/helpers/trade.ts
@@ -1,8 +1,7 @@
 /**
+ * Determine trade type ('Buy' vs. 'Sell') based on planned_quantity
  *
- * @param trade Trade object
- * @returns String 'Buy' or 'Sell'
  */
-export function tradeType(trade) {
-	return trade.planned_quantity > 0 ? 'Buy' : 'Sell';
+export function tradeType({ planned_quantity }: { planned_quantity: number }) {
+	return planned_quantity > 0 ? 'Buy' : 'Sell';
 }

--- a/src/lib/helpers/trade.ts
+++ b/src/lib/helpers/trade.ts
@@ -1,0 +1,8 @@
+/**
+ * 
+ * @param trade Trade object
+ * @returns String 'Buy' or 'Sell'
+ */
+export function tradeType(trade) {
+    return trade.planned_quantity > 0 ? 'Buy' : 'Sell';
+}

--- a/src/lib/helpers/trade.ts
+++ b/src/lib/helpers/trade.ts
@@ -1,8 +1,8 @@
 /**
- * 
+ *
  * @param trade Trade object
  * @returns String 'Buy' or 'Sell'
  */
 export function tradeType(trade) {
-    return trade.planned_quantity > 0 ? 'Buy' : 'Sell';
+	return trade.planned_quantity > 0 ? 'Buy' : 'Sell';
 }

--- a/src/routes/strategies/[strategy]/[status=positionStatus]-positions/[position]/+page.svelte
+++ b/src/routes/strategies/[strategy]/[status=positionStatus]-positions/[position]/+page.svelte
@@ -71,11 +71,11 @@
 
 			<DataBox label="Highest value" value={formatDollar(getValueAtPeak(positionStats))} />
 
-			{#if position.closed_at}
-				<DataBox label="Buy price">
-					{formatDollar(trades[0].executed_price)}
-				</DataBox>
+			<DataBox label="Buy price">
+				{formatDollar(trades[0].executed_price)}
+			</DataBox>
 
+			{#if position.closed_at}
 				<DataBox label="Sell price">
 					{formatDollar(trades.at(-1).executed_price)}
 				</DataBox>

--- a/src/routes/strategies/[strategy]/[status=positionStatus]-positions/[position]/+page.svelte
+++ b/src/routes/strategies/[strategy]/[status=positionStatus]-positions/[position]/+page.svelte
@@ -71,13 +71,15 @@
 
 			<DataBox label="Highest value" value={formatDollar(getValueAtPeak(positionStats))} />
 
-			<DataBox label="Buy price">
-				{formatDollar(trades[0].executed_price)}
-			</DataBox>
+			{#if position.closed_at}
+				<DataBox label="Buy price">
+					{formatDollar(trades[0].executed_price)}
+				</DataBox>
 
-			<DataBox label="Sell price">
-				{formatDollar(trades.at(-1).executed_price)}
-			</DataBox>
+				<DataBox label="Sell price">
+					{formatDollar(trades.at(-1).executed_price)}
+				</DataBox>
+			{/if}
 		</DataBoxes>
 
 		{#if hasFailedTrades}

--- a/src/routes/strategies/[strategy]/[status=positionStatus]-positions/[position]/+page.svelte
+++ b/src/routes/strategies/[strategy]/[status=positionStatus]-positions/[position]/+page.svelte
@@ -70,15 +70,14 @@
 			{/if}
 
 			<DataBox label="Highest value" value={formatDollar(getValueAtPeak(positionStats))} />
-			
+
 			<DataBox label="Buy price">
 				{formatDollar(trades[0].executed_price)}
-			</DataBox>	
+			</DataBox>
 
 			<DataBox label="Sell price">
 				{formatDollar(trades.at(-1).executed_price)}
 			</DataBox>
-			
 		</DataBoxes>
 
 		{#if hasFailedTrades}

--- a/src/routes/strategies/[strategy]/[status=positionStatus]-positions/[position]/+page.svelte
+++ b/src/routes/strategies/[strategy]/[status=positionStatus]-positions/[position]/+page.svelte
@@ -70,6 +70,15 @@
 			{/if}
 
 			<DataBox label="Highest value" value={formatDollar(getValueAtPeak(positionStats))} />
+			
+			<DataBox label="Buy price">
+				{formatDollar(trades[0].executed_price)}
+			</DataBox>	
+
+			<DataBox label="Sell price">
+				{formatDollar(trades.at(-1).executed_price)}
+			</DataBox>
+			
 		</DataBoxes>
 
 		{#if hasFailedTrades}

--- a/src/routes/strategies/[strategy]/[status=positionStatus]-positions/[position]/+page.svelte
+++ b/src/routes/strategies/[strategy]/[status=positionStatus]-positions/[position]/+page.svelte
@@ -5,6 +5,7 @@
 	import { formatDuration } from '$lib/helpers/formatters';
 	import { getValueAtOpen, getValueAtPeak, getValueAtClose } from 'trade-executor-frontend/state/positionHelpers';
 	import { AlertList, AlertItem, DataBox, DataBoxes, PageHeading, Timestamp, UpDownIndicator } from '$lib/components';
+	import { tradeType } from '$lib/helpers/trade';
 	import TradeTable from './TradeTable.svelte';
 	import StopLossIndicator from './StopLossIndicator.svelte';
 
@@ -17,11 +18,6 @@
 	const firstTrade = trades[0];
 	const lastTrade = trades.at(-1);
 	const hasFailedTrades = trades.some((trade) => trade.failed_at);
-
-	function tradeType(trade) {
-		return trade.planned_quantity > 0 ? 'Buy' : 'Sell';
-	}
-
 </script>
 
 <main class="ds-container">
@@ -77,7 +73,7 @@
 			{/if}
 
 			<DataBox label="Highest value" value={formatDollar(getValueAtPeak(positionStats))} />
-			
+
 			<DataBox label="{tradeType(firstTrade)} price">
 				{formatDollar(firstTrade.executed_price)}
 			</DataBox>

--- a/src/routes/strategies/[strategy]/[status=positionStatus]-positions/[position]/+page.svelte
+++ b/src/routes/strategies/[strategy]/[status=positionStatus]-positions/[position]/+page.svelte
@@ -14,7 +14,14 @@
 	const currentStats = getPositionLatestStats(position.position_id, state.stats);
 	const positionStats = state.stats.positions[position.position_id];
 	const trades = Object.values(position.trades);
+	const firstTrade = trades[0];
+	const lastTrade = trades.at(-1);
 	const hasFailedTrades = trades.some((trade) => trade.failed_at);
+
+	function tradeType(trade) {
+		return trade.planned_quantity > 0 ? 'Buy' : 'Sell';
+	}
+
 </script>
 
 <main class="ds-container">
@@ -70,14 +77,14 @@
 			{/if}
 
 			<DataBox label="Highest value" value={formatDollar(getValueAtPeak(positionStats))} />
-
-			<DataBox label="Buy price">
-				{formatDollar(trades[0].executed_price)}
+			
+			<DataBox label="{tradeType(firstTrade)} price">
+				{formatDollar(firstTrade.executed_price)}
 			</DataBox>
 
 			{#if position.closed_at}
-				<DataBox label="Sell price">
-					{formatDollar(trades.at(-1).executed_price)}
+				<DataBox label="{tradeType(lastTrade)} price">
+					{formatDollar(lastTrade.executed_price)}
 				</DataBox>
 			{/if}
 		</DataBoxes>

--- a/src/routes/strategies/[strategy]/[status=positionStatus]-positions/[position]/+page.svelte
+++ b/src/routes/strategies/[strategy]/[status=positionStatus]-positions/[position]/+page.svelte
@@ -1,8 +1,8 @@
 <script lang="ts">
 	import { getPositionLatestStats } from 'trade-executor-frontend/state/stats';
-	import { formatDollar, formatProfitability, formatTokenAmount } from 'trade-executor-frontend/helpers/formatters';
+	import { formatProfitability, formatTokenAmount } from 'trade-executor-frontend/helpers/formatters';
 	import { determineProfitability } from 'trade-executor-frontend/helpers/profit';
-	import { formatDuration } from '$lib/helpers/formatters';
+	import { formatDuration, formatPrice } from '$lib/helpers/formatters';
 	import { getValueAtOpen, getValueAtPeak, getValueAtClose } from 'trade-executor-frontend/state/positionHelpers';
 	import { AlertList, AlertItem, DataBox, DataBoxes, PageHeading, Timestamp, UpDownIndicator } from '$lib/components';
 	import { tradeType } from '$lib/helpers/trade';
@@ -15,8 +15,6 @@
 	const currentStats = getPositionLatestStats(position.position_id, state.stats);
 	const positionStats = state.stats.positions[position.position_id];
 	const trades = Object.values(position.trades);
-	const firstTrade = trades[0];
-	const lastTrade = trades.at(-1);
 	const hasFailedTrades = trades.some((trade) => trade.failed_at);
 </script>
 
@@ -34,17 +32,6 @@
 				</a>
 			</DataBox>
 
-			<DataBox label="Opened">
-				<Timestamp date={position.opened_at} format="iso" withTime />
-			</DataBox>
-
-			{#if position.closed_at}
-				<DataBox label="Closed">
-					<Timestamp date={position.closed_at} format="iso" withTime />
-				</DataBox>
-				<DataBox label="Duration" value={formatDuration(position.closed_at - position.opened_at)} />
-			{/if}
-
 			<DataBox label="Profitability">
 				<div class="profitability">
 					<UpDownIndicator
@@ -58,31 +45,43 @@
 				</div>
 			</DataBox>
 
+			<DataBox label="Opened">
+				<Timestamp date={position.opened_at} format="iso" withTime />
+			</DataBox>
+
 			{#if position.closed_at}
+				<DataBox label="Closed">
+					<Timestamp date={position.closed_at} format="iso" withTime />
+				</DataBox>
+			{/if}
+
+			<DataBox label="{tradeType(trades[0])} price">
+				{formatPrice(trades[0].executed_price)}
+			</DataBox>
+
+			{#if position.closed_at}
+				{@const lastTrade = trades.at(-1)}
+				<DataBox label="{tradeType(lastTrade)} price">
+					{formatPrice(lastTrade.executed_price)}
+				</DataBox>
+			{/if}
+
+			{#if position.closed_at}
+				<DataBox label="Duration" value={formatDuration(position.closed_at - position.opened_at)} />
 				<DataBox label="Last revaluation">
 					<Timestamp date={position.last_pricing_at} format="iso" withTime />
 				</DataBox>
-				<DataBox label="Value at open" value={formatDollar(getValueAtOpen(positionStats))} />
-				<DataBox label="Value before close" value={formatDollar(getValueAtClose(positionStats))} />
+				<DataBox label="Value at open" value={formatPrice(getValueAtOpen(positionStats))} />
+				<DataBox label="Value before close" value={formatPrice(getValueAtClose(positionStats))} />
 			{:else}
 				<DataBox label="Quantity">
 					{formatTokenAmount(currentStats?.quantity)}
 					{position.pair.base.token_symbol}
 				</DataBox>
-				<DataBox label="Value now" value={formatDollar(currentStats?.value)} />
+				<DataBox label="Value now" value={formatPrice(currentStats?.value)} />
 			{/if}
 
-			<DataBox label="Highest value" value={formatDollar(getValueAtPeak(positionStats))} />
-
-			<DataBox label="{tradeType(firstTrade)} price">
-				{formatDollar(firstTrade.executed_price)}
-			</DataBox>
-
-			{#if position.closed_at}
-				<DataBox label="{tradeType(lastTrade)} price">
-					{formatDollar(lastTrade.executed_price)}
-				</DataBox>
-			{/if}
+			<DataBox label="Highest value" value={formatPrice(getValueAtPeak(positionStats))} />
 		</DataBoxes>
 
 		{#if hasFailedTrades}

--- a/src/routes/strategies/[strategy]/[status=positionStatus]-positions/[position]/TradeTable.svelte
+++ b/src/routes/strategies/[strategy]/[status=positionStatus]-positions/[position]/TradeTable.svelte
@@ -4,7 +4,9 @@
 	import { createTable, createRender } from 'svelte-headless-table';
 	import { addClickableRows } from '$lib/components/datatable/plugins';
 	import { DataTable, Button, Timestamp } from '$lib/components';
-	import { formatDollar, formatTokenAmount } from 'trade-executor-frontend/helpers/formatters';
+	import { formatTokenAmount } from 'trade-executor-frontend/helpers/formatters';
+	import { formatPrice } from '$lib/helpers/formatters';
+	import { tradeType } from '$lib/helpers/trade';
 
 	export let trades: TradeExecution[];
 
@@ -16,9 +18,8 @@
 		table.column({
 			id: 'trade_id',
 			header: 'Id',
-			accessor: ({ trade_id, planned_quantity }) => {
-				const label = planned_quantity > 0 ? 'Buy' : 'Sell';
-				return `#${trade_id}: ${label}`;
+			accessor: (trade) => {
+				return `#${trade.trade_id}: ${tradeType(trade)}`;
 			}
 		}),
 		table.column({
@@ -32,15 +33,20 @@
 			cell: ({ value }) => createRender(Timestamp, { date: value, format: 'iso', withSeconds: true })
 		}),
 		table.column({
-			id: 'value',
-			header: 'Value',
-			accessor: ({ executed_reserve, planned_reserve }) => formatDollar(parseFloat(executed_reserve || planned_reserve))
-		}),
-		table.column({
 			id: 'quantity',
 			header: 'Quantity',
 			accessor: ({ executed_quantity, planned_quantity }) =>
 				formatTokenAmount(parseFloat(executed_quantity || planned_quantity))
+		}),
+		table.column({
+			id: 'price',
+			header: 'Price',
+			accessor: ({ executed_price, planned_price }) => formatPrice(parseFloat(executed_price || planned_price))
+		}),
+		table.column({
+			id: 'value',
+			header: 'Value',
+			accessor: ({ executed_reserve, planned_reserve }) => formatPrice(parseFloat(executed_reserve || planned_reserve))
 		}),
 		table.column({
 			header: '',
@@ -76,7 +82,7 @@
 	}
 
 	.trade-table :global {
-		& :is(.executed_at, .value, .quantity) {
+		& :is(.executed_at, .quantity, .price, .value) {
 			text-align: right;
 		}
 	}

--- a/src/routes/strategies/[strategy]/[status=positionStatus]-positions/[position]/trade-[trade]/+page.svelte
+++ b/src/routes/strategies/[strategy]/[status=positionStatus]-positions/[position]/trade-[trade]/+page.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import { formatDollar, formatAmount, formatBPS } from 'trade-executor-frontend/helpers/formatters';
 	import { DataBox, DataBoxes, PageHeading, Timestamp } from '$lib/components';
+	import { tradeType } from '$lib/helpers/trade';
 	import StopLossIndicator from '../StopLossIndicator.svelte';
 	import TransactionTable from './TransactionTable.svelte';
 
@@ -13,7 +14,7 @@
 	<PageHeading level={2}>
 		<h1>Trade #{trade.trade_id}</h1>
 		<h2>
-			{trade.planned_quantity > 0 ? 'Buy' : 'Sell'}
+			{tradeType(trade)}
 			{trade.pair.base.token_symbol}
 			{#if trade.trade_type === 'stop_loss'}
 				<StopLossIndicator lg />
@@ -43,6 +44,7 @@
 			{trade.pair.base.token_symbol}
 		</DataBox>
 		<DataBox label="Gas fees" value="N/A" />
+		<DataBox label="Price" value={formatDollar(trade.executed_price)} />
 	</DataBoxes>
 
 	<TransactionTable {chain} transactions={trade.blockchain_transactions} />

--- a/src/routes/strategies/[strategy]/[status=positionStatus]-positions/[position]/trade-[trade]/+page.svelte
+++ b/src/routes/strategies/[strategy]/[status=positionStatus]-positions/[position]/trade-[trade]/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
-	import { formatDollar, formatAmount, formatBPS } from 'trade-executor-frontend/helpers/formatters';
+	import { formatAmount, formatBPS } from 'trade-executor-frontend/helpers/formatters';
+	import { formatPrice } from '$lib/helpers/formatters';
 	import { DataBox, DataBoxes, PageHeading, Timestamp } from '$lib/components';
 	import { tradeType } from '$lib/helpers/trade';
 	import StopLossIndicator from '../StopLossIndicator.svelte';
@@ -32,8 +33,8 @@
 			<Timestamp date={trade.executed_at} format="iso" withTime />
 		</DataBox>
 		<DataBox label="Slippage tolerance" value="{formatBPS(trade.planned_max_slippage)} BPS" />
-		<DataBox label="Expected value" value={formatDollar(trade.planned_reserve)} />
-		<DataBox label="Realized value" value={formatDollar(trade.executed_reserve)} />
+		<DataBox label="Expected value" value={formatPrice(trade.planned_reserve)} />
+		<DataBox label="Realized value" value={formatPrice(trade.executed_reserve)} />
 		<DataBox label="Liquidity provider fees" value="N/A" />
 		<DataBox label="Expected quantity">
 			{formatAmount(Number(trade.planned_quantity))}
@@ -44,7 +45,7 @@
 			{trade.pair.base.token_symbol}
 		</DataBox>
 		<DataBox label="Gas fees" value="N/A" />
-		<DataBox label="Price" value={formatDollar(trade.executed_price)} />
+		<DataBox label="Price" value={formatPrice(trade.executed_price)} />
 	</DataBoxes>
 
 	<TransactionTable {chain} transactions={trade.blockchain_transactions} />


### PR DESCRIPTION
### Details

- Adds buy and sell price databoxes to the position summary 
![Screenshot from 2023-06-27 16-28-55](https://github.com/tradingstrategy-ai/frontend/assets/74208897/95f79df8-0f52-483e-9153-ec82aa200a0a)
- Also adds price databox to trade level summary

### Considerations

- Logic may change when shorting is implemented
- In the future, may require some redesigning

### Tasks

- Fixes https://github.com/tradingstrategy-ai/frontend/issues/472