### PR TITLE
Strategy tile updates II

### DIFF
--- a/src/lib/components/Badge.svelte
+++ b/src/lib/components/Badge.svelte
@@ -1,14 +1,20 @@
-<!-- Badge component used for key metrics in strategy tiles -->
+<!--
+@component
+Badge component used for inline text labels.
 
+#### Usage:
+```tsx
+	<Badge secondary text="foo" />
+```
+-->
 <script lang="ts">
-	// Text on the badge
 	export let text = '';
+	export let secondary = false;
 
-	// Colour scheme
-	export let colourScheme = 'transparent';
+	$: kind = secondary ? 'secondary' : 'primary';
 </script>
 
-<span class="badge" class:transparent={colourScheme === 'transparent'} class:orange={colourScheme === 'orange'}>
+<span class="badge {kind}">
 	{text}
 </span>
 
@@ -16,16 +22,17 @@
 	.badge {
 		display: inline-block;
 		font: 700 10px/12px var(--ff-ui);
+		letter-spacing: 0.02em;
 		text-transform: uppercase;
 		padding: 3px 4px;
 		vertical-align: middle;
 	}
 
-	.transparent {
+	.primary {
 		color: var(--c-text-light);
 	}
 
-	.orange {
+	.secondary {
 		background: orange;
 		color: white;
 	}

--- a/src/lib/components/index.ts
+++ b/src/lib/components/index.ts
@@ -1,5 +1,6 @@
 export { default as AlertItem } from './AlertItem.svelte';
 export { default as AlertList } from './AlertList.svelte';
+export { default as Badge } from './Badge.svelte';
 export { default as Banner } from './Banner.svelte';
 export { default as BlogRoll } from './BlogRoll.svelte';
 export { default as Button } from './Button.svelte';

--- a/src/lib/helpers/formatters.ts
+++ b/src/lib/helpers/formatters.ts
@@ -238,7 +238,7 @@ export function formatPercent(n: MaybeNumber): string {
 	// Negative zero hot fix
 	// Don't format -0 %
 	// https://stackoverflow.com/a/7223395/315168
-	if(Object.is(-0, n)) {
+	if (Object.is(-0, n)) {
 		n = 0;
 	}
 

--- a/src/lib/helpers/formatters.ts
+++ b/src/lib/helpers/formatters.ts
@@ -234,6 +234,14 @@ export function formatShortAddress(address: MaybeString): string {
  */
 export function formatPercent(n: MaybeNumber): string {
 	if (!Number.isFinite(n)) return notFilledMarker;
+
+	// Negative zero hot fix
+	// Don't format -0 %
+	// https://stackoverflow.com/a/7223395/315168
+	if(Object.is(-0, n)) {
+		n = 0;
+	}
+
 	return n.toLocaleString('en', {
 		minimumFractionDigits: 1,
 		maximumFractionDigits: 1,

--- a/src/routes/strategies/Badge.svelte
+++ b/src/routes/strategies/Badge.svelte
@@ -20,14 +20,13 @@
         display: inline-block;
         font: 700 10px/12px var(--ff-ui);
         text-transform: uppercase;
-        padding: 2px 4px;
-        border-radius: 4px;
+        padding: 3px 4px;
         vertical-align: middle;
     }
 
     .grey {
-        background: var(--c-background-1);
-        color: var(--c-text-inverted);
+        //background: var(--c-background-1);
+        color: var(--c-text-light);
     }
 
     .orange {

--- a/src/routes/strategies/Badge.svelte
+++ b/src/routes/strategies/Badge.svelte
@@ -1,37 +1,33 @@
 <!-- Badge component used for key metrics in strategy tiles -->
 
 <script lang="ts">
-    // Text on the badge
-    export let text = "";
+	// Text on the badge
+	export let text = '';
 
-    // Colour scheme
-    export let colourScheme = "grey";
+	// Colour scheme
+	export let colourScheme = 'grey';
 </script>
 
-<span class="badge"
-    class:grey={colourScheme==='grey'}
-    class:orange={colourScheme==='orange'}
->
-    {text}
+<span class="badge" class:grey={colourScheme === 'grey'} class:orange={colourScheme === 'orange'}>
+	{text}
 </span>
 
 <style lang="postcss">
-    .badge {
-        display: inline-block;
-        font: 700 10px/12px var(--ff-ui);
-        text-transform: uppercase;
-        padding: 3px 4px;
-        vertical-align: middle;
-    }
+	.badge {
+		display: inline-block;
+		font: 700 10px/12px var(--ff-ui);
+		text-transform: uppercase;
+		padding: 3px 4px;
+		vertical-align: middle;
+	}
 
-    .grey {
-        //background: var(--c-background-1);
-        color: var(--c-text-light);
-    }
+	.grey {
+		//background: var(--c-background-1);
+		color: var(--c-text-light);
+	}
 
-    .orange {
-        background: orange;
-        color: white;
-    }
-
+	.orange {
+		background: orange;
+		color: white;
+	}
 </style>

--- a/src/routes/strategies/Badge.svelte
+++ b/src/routes/strategies/Badge.svelte
@@ -5,10 +5,10 @@
 	export let text = '';
 
 	// Colour scheme
-	export let colourScheme = 'grey';
+	export let colourScheme = 'transparent';
 </script>
 
-<span class="badge" class:grey={colourScheme === 'grey'} class:orange={colourScheme === 'orange'}>
+<span class="badge" class:transparent={colourScheme === 'transparent'} class:orange={colourScheme === 'orange'}>
 	{text}
 </span>
 
@@ -21,8 +21,7 @@
 		vertical-align: middle;
 	}
 
-	.grey {
-		//background: var(--c-background-1);
+	.transparent {
 		color: var(--c-text-light);
 	}
 

--- a/src/routes/strategies/Badge.svelte
+++ b/src/routes/strategies/Badge.svelte
@@ -1,0 +1,38 @@
+<!-- Badge component used for key metrics in strategy tiles -->
+
+<script lang="ts">
+    // Text on the badge
+    export let text = "";
+
+    // Colour scheme
+    export let colourScheme = "grey";
+</script>
+
+<span class="badge"
+    class:grey={colourScheme==='grey'}
+    class:orange={colourScheme==='orange'}
+>
+    {text}
+</span>
+
+<style lang="postcss">
+    .badge {
+        display: inline-block;
+        font: 700 10px/12px var(--ff-ui);
+        text-transform: uppercase;
+        padding: 2px 4px;
+        border-radius: 4px;
+        vertical-align: middle;
+    }
+
+    .grey {
+        background: var(--c-background-1);
+        color: var(--c-text-inverted);
+    }
+
+    .orange {
+        background: orange;
+        color: white;
+    }
+
+</style>

--- a/src/routes/strategies/KeyMetric.svelte
+++ b/src/routes/strategies/KeyMetric.svelte
@@ -14,6 +14,7 @@ Display one key metric in a strategy tile.
 <script lang="ts">
 	import { Timestamp } from '$lib/components';
 	import KeyMetricTooltip from './KeyMetricTooltip.svelte';
+	import Badge from "./Badge.svelte";
 
 	export let metric: Record<string, any>;
 	export let name: string;
@@ -21,6 +22,7 @@ Display one key metric in a strategy tile.
 
 	const value = metric?.value;
 	const formattedValue = formatter ? formatter(value) : value;
+
 </script>
 
 <div class="key-metric" data-testid={`key-metric-${metric?.kind}`}>
@@ -28,42 +30,57 @@ Display one key metric in a strategy tile.
 		{name}
 	</dt>
 	<dd>
-		<span data-testid={`key-metric-${metric?.kind}-value`}>
-			<slot {value}>{formattedValue}</slot>
-		</span>
-
 		{#if metric?.value}
 			{#if metric?.source == 'backtesting'}
-				<KeyMetricTooltip icon="history" iconClass="icon-warning">
-					<p>
-						This strategy has not been running long enough to display
-						<a target="_blank" href={metric?.help_link}>{name}</a>
-						based on the live trade execution data. Instead, a
-						<a target="_blank" href="https://tradingstrategy.ai/glossary/backtest">backtested</a>
-						estimation is displayed.
-					</p>
+				<KeyMetricTooltip>
+					<span slot="tooltip-trigger">
+						<span class="tooltip-trigger-content">
+							<span class="value" data-testid={`key-metric-${metric?.kind}-value`}>
+								<slot>{formattedValue}</slot>
+							</span>
+							<Badge text="backtested"/>
+						</span>
+					</span>
 
-					<p>
-						The period used for the backtest simulation is
-						<span class="timespan">
-							<Timestamp date={metric.calculation_window_start_at} format="iso" />—<Timestamp
-								date={metric.calculation_window_end_at}
-								format="iso"
-							/></span
-						>.
-					</p>
+					<div slot="tooltip-popup">
 
-					{#if metric?.help_link}
-						<p>
-							See <a target="_blank" href={metric?.help_link}>{name}</a>
-							in glossary on more information what this metric means and how it is calculated.
-						</p>
-					{/if}
+						<h4>{name}</h4>
 
-					<p>Past performance is no guarantee of future results.</p>
+						<ul>
+							{#if metric?.help_link}
+								<li>
+									See the glossary for the definition of <a target="_blank" href={metric?.help_link}>{name}</a>
+									and how it is calculated.
+								</li>
+
+								<li>
+									This strategy has not been trading long enough to reliable calculate
+									<a target="_blank" href={metric?.help_link}>{name}</a> based on the live trading data.
+								</li>
+
+								<li>
+									Instead, a <a target="_blank" href="https://tradingstrategy.ai/glossary/backtest">backtested</a>
+									estimation is displayed. See <a href="https://tradingstrategy.ai/glossary/backtest">backtest results</a>.
+								</li>
+
+								<li>
+									The period used for the backtest simulation is
+									<span class="timespan">
+										<Timestamp date={metric.calculation_window_start_at} format="iso" />—<Timestamp
+											date={metric.calculation_window_end_at}
+											format="iso"
+										/></span
+									>.
+								</li>
+							{/if}
+
+						</ul>
+
+						<p class="disclaimer">Past performance is no guarantee of future results.</p>
+					</div>
 				</KeyMetricTooltip>
 			{:else}
-				<KeyMetricTooltip icon="question-circle">
+				<KeyMetricTooltip text="live" colourScheme="grey">
 					<p>This metric is based on the live trade execution for the duration the strategy had been running.</p>
 
 					{#if metric?.help_link}
@@ -100,6 +117,36 @@ Display one key metric in a strategy tile.
 
 		& .timespan {
 			white-space: nowrap;
+		}
+
+		& .tooltip-trigger-content {
+			cursor: pointer;
+		}
+
+		& .value {
+			border-bottom: 1px dotted black;
+			font: var(--f-ui-md-medium);
+			letter-spacing: var(--f-ui-xl-spacing, normal);
+			margin: 0;
+			gap: var(--space-ss);
+		}
+
+		& h4 {
+			font: var(--f-ui-large-medium);
+			letter-spacing: var(--f-ui-xxl-spacing, normal);
+		}
+
+		& ul {
+			margin: var(--space-ss) 0;
+		}
+
+		& .disclaimer {
+			font: var(--f-ui-xsmall-light);
+			color: var(--c-text-light);
+		}
+
+		& .timespan {
+			font-weight: 500;
 		}
 	}
 </style>

--- a/src/routes/strategies/KeyMetric.svelte
+++ b/src/routes/strategies/KeyMetric.svelte
@@ -30,7 +30,7 @@ Display one key metric in a strategy tile.
 		{name}
 	</dt>
 	<dd>
-		{#if metric?.value}
+		{#if metric?.value !== undefined}
 
 			<KeyMetricTooltip>
 				<span slot="tooltip-trigger">
@@ -67,7 +67,7 @@ Display one key metric in a strategy tile.
 
 							<li>
 								Instead, a <a target="_blank" href="https://tradingstrategy.ai/glossary/backtest">backtested</a>
-								estimation is displayed. See <a href="https://tradingstrategy.ai/glossary/backtest">backtest results</a>.
+								estimation is displayed.
 							</li>
 
 							<li>
@@ -82,7 +82,7 @@ Display one key metric in a strategy tile.
 						{:else}
 							{#if metric?.calculation_method == "historical_data"}
 								<li>
-									The period for live trading is
+									The calculation period for live trading is
 									<span class="timespan">
 										<Timestamp date={metric.calculation_window_start_at} format="iso" />—<Timestamp
 											date={metric.calculation_window_end_at}
@@ -91,7 +91,7 @@ Display one key metric in a strategy tile.
 									>.
 								</li>
 							{:else}
-								<li>This value is the real-time</li>
+								<li>This is the latest real-time value from the live trade execution</li>
 							{/if}
 						{/if}
 
@@ -131,7 +131,7 @@ Display one key metric in a strategy tile.
 		}
 
 		& .value {
-			border-bottom: 1px dotted black;
+			border-bottom: 1px dotted hsla(var(--hsl-text));
 			font: var(--f-ui-md-medium);
 			letter-spacing: var(--f-ui-xl-spacing, normal);
 			margin: 0;

--- a/src/routes/strategies/KeyMetric.svelte
+++ b/src/routes/strategies/KeyMetric.svelte
@@ -12,16 +12,15 @@ Display one key metric in a strategy tile.
 ```
 -->
 <script lang="ts">
-	import { Timestamp } from '$lib/components';
+	import { Badge, Timestamp } from '$lib/components';
 	import KeyMetricTooltip from './KeyMetricTooltip.svelte';
-	import Badge from './Badge.svelte';
 
 	export let metric: Record<string, any>;
 	export let name: string;
 	export let formatter: Formatter<any> | undefined = undefined;
 
-	const value = metric?.value;
-	const formattedValue = formatter ? formatter(value) : value;
+	$: value = metric?.value;
+	$: formattedValue = formatter ? formatter(value) : value;
 </script>
 
 <div class="key-metric" data-testid={`key-metric-${metric?.kind}`}>
@@ -29,20 +28,14 @@ Display one key metric in a strategy tile.
 		{name}
 	</dt>
 	<dd>
-		{#if metric?.value !== undefined}
+		{#if value !== undefined}
 			<KeyMetricTooltip>
 				<span slot="tooltip-trigger">
-					<span class="tooltip-trigger-content">
-						<span class="value" data-testid={`key-metric-${metric?.kind}-value`}>
-							<slot>{formattedValue}</slot>
-						</span>
-
-						{#if metric?.source == 'backtesting'}
-							<Badge text="backtested" />
-						{:else}
-							<Badge text="live" />
-						{/if}
+					<span class="value" data-testid={`key-metric-${metric?.kind}-value`}>
+						<slot {value}>{formattedValue}</slot>
 					</span>
+
+					<Badge text={metric?.source === 'backtesting' ? 'backtested' : 'live'} />
 				</span>
 
 				<div slot="tooltip-popup">
@@ -118,10 +111,6 @@ Display one key metric in a strategy tile.
 
 		& .timespan {
 			white-space: nowrap;
-		}
-
-		& .tooltip-trigger-content {
-			cursor: pointer;
 		}
 
 		& .value {

--- a/src/routes/strategies/KeyMetric.svelte
+++ b/src/routes/strategies/KeyMetric.svelte
@@ -30,15 +30,15 @@ Display one key metric in a strategy tile.
 	<dd>
 		{#if value !== undefined}
 			<KeyMetricTooltip>
-				<span slot="tooltip-trigger">
+				<svelte:fragment slot="tooltip-trigger">
 					<span class="value" data-testid={`key-metric-${metric?.kind}-value`}>
 						<slot {value}>{formattedValue}</slot>
 					</span>
 
 					<Badge text={metric?.source === 'backtesting' ? 'backtested' : 'live'} />
-				</span>
+				</svelte:fragment>
 
-				<div slot="tooltip-popup">
+				<svelte:fragment slot="tooltip-popup">
 					<h4>{name}</h4>
 
 					<ul>
@@ -85,7 +85,7 @@ Display one key metric in a strategy tile.
 					</ul>
 
 					<p class="disclaimer">Past performance is no guarantee of future results.</p>
-				</div>
+				</svelte:fragment>
 			</KeyMetricTooltip>
 		{/if}
 	</dd>

--- a/src/routes/strategies/KeyMetric.svelte
+++ b/src/routes/strategies/KeyMetric.svelte
@@ -14,7 +14,7 @@ Display one key metric in a strategy tile.
 <script lang="ts">
 	import { Timestamp } from '$lib/components';
 	import KeyMetricTooltip from './KeyMetricTooltip.svelte';
-	import Badge from "./Badge.svelte";
+	import Badge from './Badge.svelte';
 
 	export let metric: Record<string, any>;
 	export let name: string;
@@ -22,7 +22,6 @@ Display one key metric in a strategy tile.
 
 	const value = metric?.value;
 	const formattedValue = formatter ? formatter(value) : value;
-
 </script>
 
 <div class="key-metric" data-testid={`key-metric-${metric?.kind}`}>
@@ -31,7 +30,6 @@ Display one key metric in a strategy tile.
 	</dt>
 	<dd>
 		{#if metric?.value !== undefined}
-
 			<KeyMetricTooltip>
 				<span slot="tooltip-trigger">
 					<span class="tooltip-trigger-content">
@@ -40,15 +38,14 @@ Display one key metric in a strategy tile.
 						</span>
 
 						{#if metric?.source == 'backtesting'}
-							<Badge text="backtested"/>
+							<Badge text="backtested" />
 						{:else}
-							<Badge text="live"/>
+							<Badge text="live" />
 						{/if}
 					</span>
 				</span>
 
 				<div slot="tooltip-popup">
-
 					<h4>{name}</h4>
 
 					<ul>
@@ -79,22 +76,19 @@ Display one key metric in a strategy tile.
 									/></span
 								>.
 							</li>
+						{:else if metric?.calculation_method == 'historical_data'}
+							<li>
+								The calculation period for live trading is
+								<span class="timespan">
+									<Timestamp date={metric.calculation_window_start_at} format="iso" />—<Timestamp
+										date={metric.calculation_window_end_at}
+										format="iso"
+									/></span
+								>.
+							</li>
 						{:else}
-							{#if metric?.calculation_method == "historical_data"}
-								<li>
-									The calculation period for live trading is
-									<span class="timespan">
-										<Timestamp date={metric.calculation_window_start_at} format="iso" />—<Timestamp
-											date={metric.calculation_window_end_at}
-											format="iso"
-										/></span
-									>.
-								</li>
-							{:else}
-								<li>This is the latest real-time value from the live trade execution</li>
-							{/if}
+							<li>This is the latest real-time value from the live trade execution</li>
 						{/if}
-
 					</ul>
 
 					<p class="disclaimer">Past performance is no guarantee of future results.</p>
@@ -149,7 +143,6 @@ Display one key metric in a strategy tile.
 			& li {
 				margin: var(--space-ss) 0;
 			}
-
 		}
 
 		& .disclaimer {

--- a/src/routes/strategies/KeyMetric.svelte
+++ b/src/routes/strategies/KeyMetric.svelte
@@ -31,40 +31,58 @@ Display one key metric in a strategy tile.
 	</dt>
 	<dd>
 		{#if metric?.value}
-			{#if metric?.source == 'backtesting'}
-				<KeyMetricTooltip>
-					<span slot="tooltip-trigger">
-						<span class="tooltip-trigger-content">
-							<span class="value" data-testid={`key-metric-${metric?.kind}-value`}>
-								<slot>{formattedValue}</slot>
-							</span>
-							<Badge text="backtested"/>
+
+			<KeyMetricTooltip>
+				<span slot="tooltip-trigger">
+					<span class="tooltip-trigger-content">
+						<span class="value" data-testid={`key-metric-${metric?.kind}-value`}>
+							<slot>{formattedValue}</slot>
 						</span>
+
+						{#if metric?.source == 'backtesting'}
+							<Badge text="backtested"/>
+						{:else}
+							<Badge text="live"/>
+						{/if}
 					</span>
+				</span>
 
-					<div slot="tooltip-popup">
+				<div slot="tooltip-popup">
 
-						<h4>{name}</h4>
+					<h4>{name}</h4>
 
-						<ul>
-							{#if metric?.help_link}
+					<ul>
+						{#if metric?.help_link}
+							<li>
+								See the glossary for the definition of <a target="_blank" href={metric?.help_link}>{name}</a>
+								and how it is calculated.
+							</li>
+						{/if}
+
+						{#if metric?.source == 'backtesting'}
+							<li>
+								This strategy has not been trading long enough to reliable calculate
+								<a target="_blank" href={metric?.help_link}>{name}</a> based on the live trading data.
+							</li>
+
+							<li>
+								Instead, a <a target="_blank" href="https://tradingstrategy.ai/glossary/backtest">backtested</a>
+								estimation is displayed. See <a href="https://tradingstrategy.ai/glossary/backtest">backtest results</a>.
+							</li>
+
+							<li>
+								The period used for the backtest simulation is
+								<span class="timespan">
+									<Timestamp date={metric.calculation_window_start_at} format="iso" />—<Timestamp
+										date={metric.calculation_window_end_at}
+										format="iso"
+									/></span
+								>.
+							</li>
+						{:else}
+							{#if metric?.calculation_method == "historical_data"}
 								<li>
-									See the glossary for the definition of <a target="_blank" href={metric?.help_link}>{name}</a>
-									and how it is calculated.
-								</li>
-
-								<li>
-									This strategy has not been trading long enough to reliable calculate
-									<a target="_blank" href={metric?.help_link}>{name}</a> based on the live trading data.
-								</li>
-
-								<li>
-									Instead, a <a target="_blank" href="https://tradingstrategy.ai/glossary/backtest">backtested</a>
-									estimation is displayed. See <a href="https://tradingstrategy.ai/glossary/backtest">backtest results</a>.
-								</li>
-
-								<li>
-									The period used for the backtest simulation is
+									The period for live trading is
 									<span class="timespan">
 										<Timestamp date={metric.calculation_window_start_at} format="iso" />—<Timestamp
 											date={metric.calculation_window_end_at}
@@ -72,27 +90,16 @@ Display one key metric in a strategy tile.
 										/></span
 									>.
 								</li>
+							{:else}
+								<li>This value is the real-time</li>
 							{/if}
+						{/if}
 
-						</ul>
+					</ul>
 
-						<p class="disclaimer">Past performance is no guarantee of future results.</p>
-					</div>
-				</KeyMetricTooltip>
-			{:else}
-				<KeyMetricTooltip text="live" colourScheme="grey">
-					<p>This metric is based on the live trade execution for the duration the strategy had been running.</p>
-
-					{#if metric?.help_link}
-						<p>
-							See <a target="_blank" href={metric?.help_link}>{name}</a>
-							in glossary on more information what this metric means and how it is calculated.
-						</p>
-					{/if}
-
-					<p>Past performance is no guarantee of future results.</p>
-				</KeyMetricTooltip>
-			{/if}
+					<p class="disclaimer">Past performance is no guarantee of future results.</p>
+				</div>
+			</KeyMetricTooltip>
 		{/if}
 	</dd>
 </div>
@@ -138,6 +145,11 @@ Display one key metric in a strategy tile.
 
 		& ul {
 			margin: var(--space-ss) 0;
+
+			& li {
+				margin: var(--space-ss) 0;
+			}
+
 		}
 
 		& .disclaimer {

--- a/src/routes/strategies/KeyMetricTooltip.svelte
+++ b/src/routes/strategies/KeyMetricTooltip.svelte
@@ -5,29 +5,26 @@ A tooltip component used with key metrics
 See:
 - https://codepen.io/GemmaCroad/pen/LYpbdom
 - https://stackoverflow.com/a/40628352/315168
+- https://svelte.dev/tutorial/named-slots
 -->
 <script lang="ts">
-	import { Icon } from '$lib/components';
-
-	export let title = '';
-	export let icon: MaybeString = undefined;
-	export let iconClass: MaybeString = undefined;
+	export let text = '';
+	export let colourScheme = "grey";
 </script>
 
 <dfn class="key-metric-tooltip">
-	{title}
-	<span class={`icon-wrapper ${iconClass}`}>
-		{#if icon}
-			<Icon name={icon} />
-		{/if}
-	</span>
+	<slot name="tooltip-trigger" class="tooltip-trigger">
+		---
+	</slot>
 	<button>
-		<slot />
+		<slot name="tooltip-popup"/>
 	</button>
 </dfn>
 
 <style lang="postcss">
+
 	.key-metric-tooltip {
+
 		&::before {
 			content: attr(title);
 			padding: 0 0 1em;
@@ -44,7 +41,7 @@ See:
 			text-align: left;
 
 			--c-accent: var(--hsl-box);
-			background: hsla(var(--c-accent));
+			background: var(--c-background-4);
 			color: hsla(var(--hsl-text));
 			outline-color: var(--c-accent);
 			outline-offset: -1px;
@@ -62,13 +59,8 @@ See:
 		& :global(p) {
 			margin-bottom: 0.5em;
 		}
-
-		& .icon-wrapper {
-			color: hsla(var(--hsl-text));
-		}
-
-		& .icon-warning {
-			color: hsla(var(--hsl-warning));
-		}
 	}
+
+
+
 </style>

--- a/src/routes/strategies/KeyMetricTooltip.svelte
+++ b/src/routes/strategies/KeyMetricTooltip.svelte
@@ -11,17 +11,14 @@ See:
 </script>
 
 <dfn class="key-metric-tooltip">
-	<slot name="tooltip-trigger" class="tooltip-trigger">
-	</slot>
+	<slot name="tooltip-trigger" class="tooltip-trigger" />
 	<button>
-		<slot name="tooltip-popup"/>
+		<slot name="tooltip-popup" />
 	</button>
 </dfn>
 
 <style lang="postcss">
-
 	.key-metric-tooltip {
-
 		&::before {
 			content: attr(title);
 			padding: 0 0 1em;
@@ -59,7 +56,4 @@ See:
 			margin-bottom: 0.5em;
 		}
 	}
-
-
-
 </style>

--- a/src/routes/strategies/KeyMetricTooltip.svelte
+++ b/src/routes/strategies/KeyMetricTooltip.svelte
@@ -12,7 +12,6 @@ See:
 
 <dfn class="key-metric-tooltip">
 	<slot name="tooltip-trigger" class="tooltip-trigger">
-		---
 	</slot>
 	<button>
 		<slot name="tooltip-popup"/>

--- a/src/routes/strategies/KeyMetricTooltip.svelte
+++ b/src/routes/strategies/KeyMetricTooltip.svelte
@@ -11,7 +11,9 @@ See:
 </script>
 
 <dfn class="key-metric-tooltip">
-	<slot name="tooltip-trigger" class="tooltip-trigger" />
+	<span class="tooltip-trigger">
+		<slot name="tooltip-trigger" />
+	</span>
 	<button>
 		<slot name="tooltip-popup" />
 	</button>
@@ -19,9 +21,8 @@ See:
 
 <style lang="postcss">
 	.key-metric-tooltip {
-		&::before {
-			content: attr(title);
-			padding: 0 0 1em;
+		& .tooltip-trigger {
+			cursor: pointer;
 		}
 
 		& button {

--- a/src/routes/strategies/KeyMetricTooltip.svelte
+++ b/src/routes/strategies/KeyMetricTooltip.svelte
@@ -8,8 +8,6 @@ See:
 - https://svelte.dev/tutorial/named-slots
 -->
 <script lang="ts">
-	export let text = '';
-	export let colourScheme = "grey";
 </script>
 
 <dfn class="key-metric-tooltip">
@@ -50,6 +48,8 @@ See:
 
 			/* Need z-index or otherwise the warning text below might be rendered on the top of this text */
 			z-index: 10000;
+
+			padding: var(--space-sl);
 		}
 
 		& :global(a) {

--- a/src/routes/strategies/StrategyTile.svelte
+++ b/src/routes/strategies/StrategyTile.svelte
@@ -24,7 +24,6 @@
 	// Get the error message HTML
 	$: errorHtml = getTradeExecutorErrorHtml(strategy);
 
-	console.log(summaryStats);
 </script>
 
 <li class="strategy tile tile b">

--- a/src/routes/strategies/StrategyTile.svelte
+++ b/src/routes/strategies/StrategyTile.svelte
@@ -23,6 +23,8 @@
 
 	// Get the error message HTML
 	$: errorHtml = getTradeExecutorErrorHtml(strategy);
+
+	console.log(summaryStats);
 </script>
 
 <li class="strategy tile tile b">
@@ -38,7 +40,7 @@
 			</div>
 
 			<dl>
-				<KeyMetric name="Performance" metric={summaryStats?.key_metrics?.profitability} let:value>
+				<KeyMetric name="Profitability" metric={summaryStats?.key_metrics?.profitability} let:value>
 					<span class={determinePriceChangeClass(value)}>{formatPriceChange(value)}</span>
 				</KeyMetric>
 
@@ -48,7 +50,7 @@
 			<dl>
 				<KeyMetric name="Age" metric={summaryStats?.key_metrics?.started_at} formatter={formatDaysAgo} />
 
-				<KeyMetric name="Max drawdown" metric={summaryStats?.key_metrics?.max_drawdown} formatter={formatPercent} />
+				<KeyMetric name="Maximum drawdown" metric={summaryStats?.key_metrics?.max_drawdown} formatter={formatPercent} />
 			</dl>
 
 			<dl>

--- a/src/routes/strategies/StrategyTile.svelte
+++ b/src/routes/strategies/StrategyTile.svelte
@@ -38,14 +38,8 @@
 			</div>
 
 			<dl>
-				<!--
-					TODO: Not sure what is going here because could not pass `value` as is.
-					This bit might need some refactoring.
-				-->
 				<KeyMetric name="Profitability" metric={summaryStats?.key_metrics?.profitability} let:value>
-					<span class={determinePriceChangeClass(summaryStats?.key_metrics?.profitability?.value)}>
-						{formatPriceChange(summaryStats?.key_metrics?.profitability?.value)}
-					</span>
+					<span class={determinePriceChangeClass(value)}>{formatPriceChange(value)}</span>
 				</KeyMetric>
 
 				<KeyMetric name="Total assets" metric={summaryStats?.key_metrics?.total_equity} formatter={formatDollar} />

--- a/src/routes/strategies/StrategyTile.svelte
+++ b/src/routes/strategies/StrategyTile.svelte
@@ -40,8 +40,14 @@
 			</div>
 
 			<dl>
+				<!--
+					TODO: Not sure what is going here because could not pass `value` as is.
+					This bit might need some refactoring.
+				-->
 				<KeyMetric name="Profitability" metric={summaryStats?.key_metrics?.profitability} let:value>
-					<span class={determinePriceChangeClass(value)}>{formatPriceChange(value)}</span>
+					<span class={determinePriceChangeClass(summaryStats?.key_metrics?.profitability?.value)}>
+						{formatPriceChange(summaryStats?.key_metrics?.profitability?.value)}
+					</span>
 				</KeyMetric>
 
 				<KeyMetric name="Total assets" metric={summaryStats?.key_metrics?.total_equity} formatter={formatDollar} />

--- a/src/routes/strategies/StrategyTile.svelte
+++ b/src/routes/strategies/StrategyTile.svelte
@@ -23,7 +23,6 @@
 
 	// Get the error message HTML
 	$: errorHtml = getTradeExecutorErrorHtml(strategy);
-
 </script>
 
 <li class="strategy tile tile b">


### PR DESCRIPTION
- Rework the tooltip and backtest hint design
- More help links
- Tweak name and values

NOTE: Currently `MATIC-USD breakout on Uniswap v3` is set to special mode that it always displays live data instead of backtest data for the UI testing purposes.

![image](https://github.com/tradingstrategy-ai/frontend/assets/49922/ecd36122-92be-4aaf-8268-efb4a5d47b84)
