### PR TITLE
Adjust strategy tile charts 

### DIFF
--- a/src/routes/strategies/ChartThumbnail.svelte
+++ b/src/routes/strategies/ChartThumbnail.svelte
@@ -18,11 +18,12 @@
 	const scaleX = scaleUtc([startDate, floorUTCDate(new Date())], [0, width]);
 	const valRange = getValueRange();
 
-	// Try to smooth out small changes look big changes linear scaling
-	if(valRange[0] > -0.2) {
+	// Try to smooth out, so small changes do not look irrationally large
+	// by bumping up the range to -20%/20% if the strategy has moved less
+	if (valRange[0] > -0.2) {
 		valRange[0] = -0.2; // Set bottom chart to -20%
 	}
-	if(valRange[1] < 0.2) {
+	if (valRange[1] < 0.2) {
 		valRange[1] = 0.2; // Set top bottom chart to +20% profit
 	}
 

--- a/src/routes/strategies/ChartThumbnail.svelte
+++ b/src/routes/strategies/ChartThumbnail.svelte
@@ -15,26 +15,18 @@
 
 	const width = 500;
 	const height = 300;
+	const yScaleMin = 0.2; // see getValueDomain()
 	const scaleX = scaleUtc([startDate, floorUTCDate(new Date())], [0, width]);
-	const valRange = getValueRange();
-
-	// Try to smooth out, so small changes do not look irrationally large
-	// by bumping up the range to -20%/20% if the strategy has moved less
-	if (valRange[0] > -0.2) {
-		valRange[0] = -0.2; // Set bottom chart to -20%
-	}
-	if (valRange[1] < 0.2) {
-		valRange[1] = 0.2; // Set top bottom chart to +20% profit
-	}
-
-	const scaleY = scaleLinear(valRange, [height, 0]);
+	const scaleY = scaleLinear(getValueDomain(), [height, 0]);
 	const y0 = scaleY(0);
 
 	const profitClass = determinePriceChangeClass(data.at(-1)?.[1]);
 
-	function getValueRange() {
-		const range = extent(data, (tick: ChartTick) => tick[1]);
-		return range.every(Number.isFinite) ? range : [0, 0];
+	// Try to smooth out, so small changes do not look irrationally large
+	// by bumping up the y-Axis domain -20%/20% if the strategy has moved less
+	function getValueDomain() {
+		const domain = extent(data, (tick: ChartTick) => tick[1]);
+		return extent([...domain, -yScaleMin, yScaleMin]);
 	}
 
 	function getPathCommands() {

--- a/src/routes/strategies/ChartThumbnail.svelte
+++ b/src/routes/strategies/ChartThumbnail.svelte
@@ -16,7 +16,17 @@
 	const width = 500;
 	const height = 300;
 	const scaleX = scaleUtc([startDate, floorUTCDate(new Date())], [0, width]);
-	const scaleY = scaleLinear(getValueRange(), [height, 0]);
+	const valRange = getValueRange();
+
+	// Try to smooth out small changes look big changes linear scaling
+	if(valRange[0] > -0.2) {
+		valRange[0] = -0.2; // Set bottom chart to -20%
+	}
+	if(valRange[1] < 0.2) {
+		valRange[1] = 0.2; // Set top bottom chart to +20% profit
+	}
+
+	const scaleY = scaleLinear(valRange, [height, 0]);
 	const y0 = scaleY(0);
 
 	const profitClass = determinePriceChangeClass(data.at(-1)?.[1]);


### PR DESCRIPTION
- Adjust strategy tile charts so that small moves are dampened not looking irrational (always max scale)
- 
![image](https://github.com/tradingstrategy-ai/frontend/assets/49922/60f9abc7-ed82-4dcd-8695-5dfed0e53de6)
