### PR TITLE
Backtest results

### DIFF
--- a/src/routes/strategies/KeyMetric.svelte
+++ b/src/routes/strategies/KeyMetric.svelte
@@ -36,7 +36,9 @@ Display one key metric in a strategy tile.
 						<slot {value}>{formattedValue}</slot>
 					</span>
 
-					<Badge text={metric?.source === 'backtesting' ? 'backtested' : 'live'} />
+					{#if metric?.source === 'backtesting'}
+						<Badge text="backtested" />
+					{/if}
 				</svelte:fragment>
 
 				<svelte:fragment slot="tooltip-popup">
@@ -63,7 +65,6 @@ Display one key metric in a strategy tile.
 							<li>
 								<a href={backtestLink}>Read the backtest report</a>.
 							</li>
-
 
 							<li>
 								The period used for the backtest simulation is

--- a/src/routes/strategies/KeyMetric.svelte
+++ b/src/routes/strategies/KeyMetric.svelte
@@ -18,6 +18,7 @@ Display one key metric in a strategy tile.
 	export let metric: Record<string, any>;
 	export let name: string;
 	export let formatter: Formatter<any> | undefined = undefined;
+	export let backtestLink;
 
 	$: value = metric?.value;
 	$: formattedValue = formatter ? formatter(value) : value;
@@ -56,9 +57,13 @@ Display one key metric in a strategy tile.
 							</li>
 
 							<li>
-								Instead, a <a target="_blank" href="https://tradingstrategy.ai/glossary/backtest">backtested</a>
-								estimation is displayed.
+								Instead, a <a href={backtestLink}>backtested</a> estimation is displayed.
 							</li>
+
+							<li>
+								<a href={backtestLink}>Read the backtest report</a>.
+							</li>
+
 
 							<li>
 								The period used for the backtest simulation is

--- a/src/routes/strategies/KeyMetric.svelte
+++ b/src/routes/strategies/KeyMetric.svelte
@@ -18,7 +18,7 @@ Display one key metric in a strategy tile.
 	export let metric: Record<string, any>;
 	export let name: string;
 	export let formatter: Formatter<any> | undefined = undefined;
-	export let backtestLink;
+	export let backtestLink: string;
 
 	$: value = metric?.value;
 	$: formattedValue = formatter ? formatter(value) : value;

--- a/src/routes/strategies/StrategyTile.svelte
+++ b/src/routes/strategies/StrategyTile.svelte
@@ -43,19 +43,39 @@
 					<span class={determinePriceChangeClass(value)}>{formatPriceChange(value)}</span>
 				</KeyMetric>
 
-				<KeyMetric name="Total assets" metric={summaryStats?.key_metrics?.total_equity} formatter={formatDollar} {backtestLink}/>
+				<KeyMetric
+					name="Total assets"
+					metric={summaryStats?.key_metrics?.total_equity}
+					formatter={formatDollar}
+					{backtestLink}
+				/>
 			</dl>
 
 			<dl>
-				<KeyMetric name="Age" metric={summaryStats?.key_metrics?.started_at} formatter={formatDaysAgo} {backtestLink}/>
+				<KeyMetric name="Age" metric={summaryStats?.key_metrics?.started_at} formatter={formatDaysAgo} {backtestLink} />
 
-				<KeyMetric name="Maximum drawdown" metric={summaryStats?.key_metrics?.max_drawdown} formatter={formatPercent} {backtestLink}/>
+				<KeyMetric
+					name="Maximum drawdown"
+					metric={summaryStats?.key_metrics?.max_drawdown}
+					formatter={formatPercent}
+					{backtestLink}
+				/>
 			</dl>
 
 			<dl>
-				<KeyMetric name="Sharpe" metric={summaryStats?.key_metrics?.sharpe} formatter={formatKeyMetricNumber} {backtestLink}/>
+				<KeyMetric
+					name="Sharpe"
+					metric={summaryStats?.key_metrics?.sharpe}
+					formatter={formatKeyMetricNumber}
+					{backtestLink}
+				/>
 
-				<KeyMetric name="Sortino" metric={summaryStats?.key_metrics?.sortino} formatter={formatKeyMetricNumber} {backtestLink}/>
+				<KeyMetric
+					name="Sortino"
+					metric={summaryStats?.key_metrics?.sortino}
+					formatter={formatKeyMetricNumber}
+					{backtestLink}
+				/>
 			</dl>
 		</div>
 

--- a/src/routes/strategies/StrategyTile.svelte
+++ b/src/routes/strategies/StrategyTile.svelte
@@ -23,6 +23,7 @@
 
 	// Get the error message HTML
 	$: errorHtml = getTradeExecutorErrorHtml(strategy);
+	$: backtestLink = `/strategies/${strategy.id}/backtest`;
 </script>
 
 <li class="strategy tile tile b">
@@ -38,23 +39,23 @@
 			</div>
 
 			<dl>
-				<KeyMetric name="Profitability" metric={summaryStats?.key_metrics?.profitability} let:value>
+				<KeyMetric name="Profitability" metric={summaryStats?.key_metrics?.profitability} let:value {backtestLink}>
 					<span class={determinePriceChangeClass(value)}>{formatPriceChange(value)}</span>
 				</KeyMetric>
 
-				<KeyMetric name="Total assets" metric={summaryStats?.key_metrics?.total_equity} formatter={formatDollar} />
+				<KeyMetric name="Total assets" metric={summaryStats?.key_metrics?.total_equity} formatter={formatDollar} {backtestLink}/>
 			</dl>
 
 			<dl>
-				<KeyMetric name="Age" metric={summaryStats?.key_metrics?.started_at} formatter={formatDaysAgo} />
+				<KeyMetric name="Age" metric={summaryStats?.key_metrics?.started_at} formatter={formatDaysAgo} {backtestLink}/>
 
-				<KeyMetric name="Maximum drawdown" metric={summaryStats?.key_metrics?.max_drawdown} formatter={formatPercent} />
+				<KeyMetric name="Maximum drawdown" metric={summaryStats?.key_metrics?.max_drawdown} formatter={formatPercent} {backtestLink}/>
 			</dl>
 
 			<dl>
-				<KeyMetric name="Sharpe" metric={summaryStats?.key_metrics?.sharpe} formatter={formatKeyMetricNumber} />
+				<KeyMetric name="Sharpe" metric={summaryStats?.key_metrics?.sharpe} formatter={formatKeyMetricNumber} {backtestLink}/>
 
-				<KeyMetric name="Sortino" metric={summaryStats?.key_metrics?.sortino} formatter={formatKeyMetricNumber} />
+				<KeyMetric name="Sortino" metric={summaryStats?.key_metrics?.sortino} formatter={formatKeyMetricNumber} {backtestLink}/>
 			</dl>
 		</div>
 

--- a/src/routes/strategies/StrategyTile.svelte
+++ b/src/routes/strategies/StrategyTile.svelte
@@ -39,7 +39,7 @@
 			</div>
 
 			<dl>
-				<KeyMetric name="Profitability" metric={summaryStats?.key_metrics?.profitability} let:value {backtestLink}>
+				<KeyMetric name="Profitability" metric={summaryStats?.key_metrics?.profitability} {backtestLink} let:value>
 					<span class={determinePriceChangeClass(value)}>{formatPriceChange(value)}</span>
 				</KeyMetric>
 

--- a/src/routes/strategies/[strategy]/(nav)/+layout.svelte
+++ b/src/routes/strategies/[strategy]/(nav)/+layout.svelte
@@ -20,12 +20,10 @@
 
 <main class="strategy-layout ds-container">
 
-
-
 	<PageHeading>
 		<h1>{summary.name}</h1>
 		<p>{summary.long_description}</p>
-	{{ summary }} sss
+
 		{#if errorHtml}
 			<div class="error-wrapper">
 				<AlertList status="warning" size="sm">

--- a/src/routes/strategies/[strategy]/(nav)/+layout.svelte
+++ b/src/routes/strategies/[strategy]/(nav)/+layout.svelte
@@ -4,19 +4,28 @@
 	import StrategyNav from './StrategyNav.svelte';
 	import { getTradeExecutorErrorHtml } from 'trade-executor-frontend/strategy/error';
 
+	import type { StrategyRuntimeState } from 'trade-executor-frontend/strategy/runtimeState';
+
 	export let data;
 
+	let summary: StrategyRuntimeState;
 	$: summary = data.summary;
 
+	$: backtestAvailable = summary.backtest_available;
 	// Get the error message HTML
 	$: errorHtml = getTradeExecutorErrorHtml(summary);
+
+
 </script>
 
 <main class="strategy-layout ds-container">
+
+
+
 	<PageHeading>
 		<h1>{summary.name}</h1>
 		<p>{summary.long_description}</p>
-
+	{{ summary }} sss
 		{#if errorHtml}
 			<div class="error-wrapper">
 				<AlertList status="warning" size="sm">
@@ -29,7 +38,7 @@
 	</PageHeading>
 
 	<div class="subpage">
-		<StrategyNav strategyId={summary.id} portfolio={data.state.portfolio} currentPath={$page.url.pathname} />
+		<StrategyNav strategyId={summary.id} portfolio={data.state.portfolio} currentPath={$page.url.pathname} {backtestAvailable} />
 		<div>
 			<slot />
 			<p class="beta-notice">

--- a/src/routes/strategies/[strategy]/(nav)/+layout.svelte
+++ b/src/routes/strategies/[strategy]/(nav)/+layout.svelte
@@ -4,12 +4,9 @@
 	import StrategyNav from './StrategyNav.svelte';
 	import { getTradeExecutorErrorHtml } from 'trade-executor-frontend/strategy/error';
 
-	import type { StrategyRuntimeState } from 'trade-executor-frontend/strategy/runtimeState';
-
 	export let data;
 
-	let summary: StrategyRuntimeState;
-	$: summary = data.summary;
+	$: ({ summary } = data);
 
 	$: backtestAvailable = summary.backtest_available;
 	// Get the error message HTML

--- a/src/routes/strategies/[strategy]/(nav)/+layout.svelte
+++ b/src/routes/strategies/[strategy]/(nav)/+layout.svelte
@@ -14,12 +14,9 @@
 	$: backtestAvailable = summary.backtest_available;
 	// Get the error message HTML
 	$: errorHtml = getTradeExecutorErrorHtml(summary);
-
-
 </script>
 
 <main class="strategy-layout ds-container">
-
 	<PageHeading>
 		<h1>{summary.name}</h1>
 		<p>{summary.long_description}</p>
@@ -36,7 +33,12 @@
 	</PageHeading>
 
 	<div class="subpage">
-		<StrategyNav strategyId={summary.id} portfolio={data.state.portfolio} currentPath={$page.url.pathname} {backtestAvailable} />
+		<StrategyNav
+			strategyId={summary.id}
+			portfolio={data.state.portfolio}
+			currentPath={$page.url.pathname}
+			{backtestAvailable}
+		/>
 		<div>
 			<slot />
 			<p class="beta-notice">

--- a/src/routes/strategies/[strategy]/(nav)/StrategyNav.svelte
+++ b/src/routes/strategies/[strategy]/(nav)/StrategyNav.svelte
@@ -54,10 +54,10 @@
 		}
 	];
 
-	if(backtestAvailable) {
+	if(backtestAvailable || true) {
 		menuOptions.push(
 		{
-			label: `Backtest result`,
+			label: `Backtest results`,
 			targetUrl: `${basePath}/backtest`
 		});
 	}

--- a/src/routes/strategies/[strategy]/(nav)/StrategyNav.svelte
+++ b/src/routes/strategies/[strategy]/(nav)/StrategyNav.svelte
@@ -8,7 +8,7 @@
 <script lang="ts">
 	import fsm from 'svelte-fsm';
 	import { Button, Menu, MenuItem } from '$lib/components';
-	import type {StrategySummaryStatistics} from "trade-executor-frontend/strategy/runtimeState";
+	import type { StrategySummaryStatistics } from 'trade-executor-frontend/strategy/runtimeState';
 
 	export let strategyId: string;
 	export let portfolio: any;
@@ -54,9 +54,8 @@
 		}
 	];
 
-	if(backtestAvailable) {
-		menuOptions.push(
-		{
+	if (backtestAvailable) {
+		menuOptions.push({
 			label: `Backtest results`,
 			targetUrl: `${basePath}/backtest`
 		});

--- a/src/routes/strategies/[strategy]/(nav)/StrategyNav.svelte
+++ b/src/routes/strategies/[strategy]/(nav)/StrategyNav.svelte
@@ -8,16 +8,11 @@
 <script lang="ts">
 	import fsm from 'svelte-fsm';
 	import { Button, Menu, MenuItem } from '$lib/components';
-	import type { StrategySummaryStatistics } from 'trade-executor-frontend/strategy/runtimeState';
 
 	export let strategyId: string;
 	export let portfolio: any;
 	export let currentPath: string;
 	export let backtestAvailable: boolean;
-
-	// We can find out from the summary if certain menu items
-	// should be enabled or not
-	export let summary: StrategySummaryStatistics;
 
 	let menuWrapper: HTMLElement;
 	let menuHeight = '';
@@ -51,17 +46,11 @@
 		{
 			label: `Decision making`,
 			targetUrl: `${basePath}/decision-making`
-		}
-	];
-
-	if (backtestAvailable) {
-		menuOptions.push({
+		},
+		{
 			label: `Backtest results`,
 			targetUrl: `${basePath}/backtest`
-		});
-	}
-
-	menuOptions.concat([
+		},
 		{
 			label: `Instance status`,
 			targetUrl: `${basePath}/status`
@@ -74,14 +63,26 @@
 			label: `Source Code`,
 			targetUrl: `${basePath}/source`
 		}
-	]);
+	];
 
 	$: currentOption = menuOptions.find(({ targetUrl }) => currentPath.endsWith(targetUrl));
 
 	$: visibleOptions = menuOptions.filter((option) => {
-		const isFrozenPositionsOption = option.targetUrl.includes('frozen-positions');
-		const hasFrozenPositions = getCount(portfolio.frozen_positions) > 0;
-		return !isFrozenPositionsOption || hasFrozenPositions || currentOption === option;
+		// always show current nav option
+		if (option === currentOption) return true;
+
+		// only show frozen positions if there are any
+		if (option.targetUrl.includes('frozen-positions')) {
+			return getCount(portfolio.frozen_positions) > 0;
+		}
+
+		// only show backtest if available
+		if (option.targetUrl.includes('backtest')) {
+			return backtestAvailable;
+		}
+
+		// show all other options
+		return true;
 	});
 
 	function getCount(positions: any = {}) {

--- a/src/routes/strategies/[strategy]/(nav)/StrategyNav.svelte
+++ b/src/routes/strategies/[strategy]/(nav)/StrategyNav.svelte
@@ -1,10 +1,23 @@
+<!-- Trade executor status
+
+- Left side nav
+
+- Collapse to dropdown on mobile
+
+-->
 <script lang="ts">
 	import fsm from 'svelte-fsm';
 	import { Button, Menu, MenuItem } from '$lib/components';
+	import type {StrategySummaryStatistics} from "trade-executor-frontend/strategy/runtimeState";
 
 	export let strategyId: string;
 	export let portfolio: any;
 	export let currentPath: string;
+	export let backtestAvailable: boolean;
+
+	// We can find out from the summary if certain menu items
+	// should be enabled or not
+	export let summary: StrategySummaryStatistics;
 
 	let menuWrapper: HTMLElement;
 	let menuHeight = '';
@@ -38,7 +51,18 @@
 		{
 			label: `Decision making`,
 			targetUrl: `${basePath}/decision-making`
-		},
+		}
+	];
+
+	if(backtestAvailable) {
+		menuOptions.push(
+		{
+			label: `Backtest result`,
+			targetUrl: `${basePath}/backtest`
+		});
+	}
+
+	menuOptions.concat([
 		{
 			label: `Instance status`,
 			targetUrl: `${basePath}/status`
@@ -51,7 +75,7 @@
 			label: `Source Code`,
 			targetUrl: `${basePath}/source`
 		}
-	];
+	]);
 
 	$: currentOption = menuOptions.find(({ targetUrl }) => currentPath.endsWith(targetUrl));
 

--- a/src/routes/strategies/[strategy]/(nav)/StrategyNav.svelte
+++ b/src/routes/strategies/[strategy]/(nav)/StrategyNav.svelte
@@ -54,7 +54,7 @@
 		}
 	];
 
-	if(backtestAvailable || true) {
+	if(backtestAvailable) {
 		menuOptions.push(
 		{
 			label: `Backtest results`,

--- a/src/routes/strategies/[strategy]/(nav)/backtest/+page.svelte
+++ b/src/routes/strategies/[strategy]/(nav)/backtest/+page.svelte
@@ -1,64 +1,94 @@
 <!--
-	Page to display the strategy backtest results.
+Page to display the strategy backtest results.
+
+- We are working hard to make iframe resize to work cross-domain,
+  because trade-executor HTML report is being served from a different domain
+  and the web browser policy prevents us to access iframe content to read its internal height
+
+- We work around this using a postMessage hack
+  https://stackoverflow.com/a/44547866/315168
+
 -->
 <script lang="ts">
 
-    import {Button, SummaryBox} from "$lib/components";
+    import {AlertItem, Button, SummaryBox} from "$lib/components";
     import { onMount } from 'svelte';
     import type {StrategyRuntimeState} from "trade-executor-frontend/strategy/runtimeState";
+    import AlertList from "$lib/components/AlertList.svelte";
 
     export let data: StrategyRuntimeState;
 
-
     export let iframeSrc;
-    export let wantedHeight=100;
+    export let wantedHeight = 100;
 
     console.log(data);
 
     $: strategy = data?.strategy;
+    $: backtested = strategy?.summary?.backtest_available;
     $: baseUrl = strategy?.url;
     $: iframeUrl = baseUrl ? `${baseUrl}/file?type=html` : null;
     $: notebookUrl = baseUrl ? `${baseUrl}/file?type=notebook` : null;
     $: notebookName = `${strategy?.id}.ipynb`;
 
-    function onLoad(evt) {
-        console.log("loaded", evt);
-        const desiredHeight = this.contentWindow.document.documentElement.scrollHeight;
-        //el.style.height =  + 'px';]
-        console.log("Height", desiredHeight);
-        wantedHeight = desiredHeight;
+    // iframe (or any plugin crap) wants to communicate with us
+    // Listen for the height messages from the iframe
+    // Backtested result HTML comes with a special JS snippet to post its content height to parent frame
+    // See code here https://github.com/tradingstrategy-ai/trade-executor/blob/4a336031ded403d4fff9819d339a680d6f65b210/tradeexecutor/backtest/report.py#L51
+    function onMessage(evt) {
+        console.log("Message", evt);
     }
 
+    // Trigger iframe load lazily so that other
+    // message handlers are ready
 	onMount(() => {
 		iframeSrc = iframeUrl;
 	});
 
 </script>
 
+<svelte:window on:messsage={onMessage} />
+
 <section class="backtest">
-    <SummaryBox title="Backtest data" ctaPosition="top">
-        <div class="content">
-            View the backtest results below or download the notebook repeat the backtests yourself.
-        </div>
-        <div class="actions">
-            <!-- TODO: <a download> does not seem to work here, but always causes the page load instead of downlaod -->
-            <Button label="Download notebook" download={notebookName} disabled={notebookUrl == null} href={notebookUrl} />
-            <!-- TODO: The webhook endpoint missing -->
-            <Button label="Download raw backtest data" disabled />
-        </div>
-    </SummaryBox>
+    {#if backtested}
+        <SummaryBox title="Backtest data" ctaPosition="top">
+            <div class="content">
+                <ul>
+                    <li>
+                        View the backtest result report below or download the notebook run the backtests yourself.
+                    </li>
+                    <li>
+                        <a class="help-link" href="/glossary/backtest">Learn more about backtests</a>.
+                    </li>
+                </ul>
+            </div>
 
-    {#if iframeSrc}
-        <iframe on:load={onLoad} src={iframeSrc} bind:clientHeight={wantedHeight}>
+            <div class="actions">
+                <!-- TODO: <a download> does not seem to work here, but always causes the page load instead of downlaod -->
+                <Button label="Download notebook" download={notebookName} disabled={notebookUrl == null} href={notebookUrl} />
+                <!-- TODO: The webhook endpoint missing -->
+                <Button label="Download raw backtest data" disabled />
+            </div>
+        </SummaryBox>
 
-        </iframe>
+        {#if iframeSrc}
+            <iframe src={iframeSrc} bind:clientHeight={wantedHeight}>
+            </iframe>
+        {/if}
+    {:else}
+        <AlertList>
+            <AlertItem>Backtest report not available for this stratey.</AlertItem>
+        </AlertList>
     {/if}
-
 </section>
 
 <style>
     iframe {
+        margin: var(--space-lg) 0;
         width: 100%;
         border: 0;
+    }
+
+    .help-link {
+        text-decoration: underline;
     }
 </style>

--- a/src/routes/strategies/[strategy]/(nav)/backtest/+page.svelte
+++ b/src/routes/strategies/[strategy]/(nav)/backtest/+page.svelte
@@ -2,16 +2,29 @@
 	Page to display the strategy backtest results.
 -->
 <script lang="ts">
-	import PortfolioPerformanceChart from './PortfolioPerformanceChart.svelte';
-	import { getPortfolioLatestStats } from 'trade-executor-frontend/state/stats';
-	import SummaryStatistics from './SummaryStatistics.svelte';
 
-	export let data;
-	$: ({ state, summary } = data);
+	import {wallet} from "$lib/wallet";
+    import connectWizard from "wizard/connect-wallet/store";
+    import depositWizard from "wizard/deposit/store";
+    import redeemWizard from "wizard/redeem/store";
+    import {Button, SummaryBox} from "$lib/components";
+
+    export let data;
 
 </script>
 
 <section class="backtest">
+    <SummaryBox title="Backtest data" ctaPosition="top">
+        <div class="content">
+            View the backtest results below or downlaod the notebook used to test the strategy.
+        </div>
+        <div class="actions">
+            <Button label="Download notebook"  />
+            <!-- TODO: The webhook endpoint missing -->
+            <Button label="Download raw backtest data" disabled />
+        </div>
+    </SummaryBox>
+
 </section>
 
 <style>

--- a/src/routes/strategies/[strategy]/(nav)/backtest/+page.svelte
+++ b/src/routes/strategies/[strategy]/(nav)/backtest/+page.svelte
@@ -3,33 +3,62 @@
 -->
 <script lang="ts">
 
-	import {wallet} from "$lib/wallet";
-    import connectWizard from "wizard/connect-wallet/store";
-    import depositWizard from "wizard/deposit/store";
-    import redeemWizard from "wizard/redeem/store";
     import {Button, SummaryBox} from "$lib/components";
+    import { onMount } from 'svelte';
+    import type {StrategyRuntimeState} from "trade-executor-frontend/strategy/runtimeState";
 
-    export let data;
+    export let data: StrategyRuntimeState;
+
+
+    export let iframeSrc;
+    export let wantedHeight=100;
+
+    console.log(data);
+
+    $: strategy = data?.strategy;
+    $: baseUrl = strategy?.url;
+    $: iframeUrl = baseUrl ? `${baseUrl}/file?type=html` : null;
+    $: notebookUrl = baseUrl ? `${baseUrl}/file?type=notebook` : null;
+    $: notebookName = `${strategy?.id}.ipynb`;
+
+    function onLoad(evt) {
+        console.log("loaded", evt);
+        const desiredHeight = this.contentWindow.document.documentElement.scrollHeight;
+        //el.style.height =  + 'px';]
+        console.log("Height", desiredHeight);
+        wantedHeight = desiredHeight;
+    }
+
+	onMount(() => {
+		iframeSrc = iframeUrl;
+	});
 
 </script>
 
 <section class="backtest">
     <SummaryBox title="Backtest data" ctaPosition="top">
         <div class="content">
-            View the backtest results below or downlaod the notebook used to test the strategy.
+            View the backtest results below or download the notebook repeat the backtests yourself.
         </div>
         <div class="actions">
-            <Button label="Download notebook"  />
+            <!-- TODO: <a download> does not seem to work here, but always causes the page load instead of downlaod -->
+            <Button label="Download notebook" download={notebookName} disabled={notebookUrl == null} href={notebookUrl} />
             <!-- TODO: The webhook endpoint missing -->
             <Button label="Download raw backtest data" disabled />
         </div>
     </SummaryBox>
 
+    {#if iframeSrc}
+        <iframe on:load={onLoad} src={iframeSrc} bind:clientHeight={wantedHeight}>
+
+        </iframe>
+    {/if}
+
 </section>
 
 <style>
-	.performance {
-		display: grid;
-		gap: var(--space-lg);
-	}
+    iframe {
+        width: 100%;
+        border: 0;
+    }
 </style>

--- a/src/routes/strategies/[strategy]/(nav)/backtest/+page.svelte
+++ b/src/routes/strategies/[strategy]/(nav)/backtest/+page.svelte
@@ -1,0 +1,22 @@
+<!--
+	Page to display the strategy backtest results.
+-->
+<script lang="ts">
+	import PortfolioPerformanceChart from './PortfolioPerformanceChart.svelte';
+	import { getPortfolioLatestStats } from 'trade-executor-frontend/state/stats';
+	import SummaryStatistics from './SummaryStatistics.svelte';
+
+	export let data;
+	$: ({ state, summary } = data);
+
+</script>
+
+<section class="backtest">
+</section>
+
+<style>
+	.performance {
+		display: grid;
+		gap: var(--space-lg);
+	}
+</style>

--- a/src/routes/strategies/[strategy]/(nav)/backtest/+page.svelte
+++ b/src/routes/strategies/[strategy]/(nav)/backtest/+page.svelte
@@ -10,85 +10,102 @@ Page to display the strategy backtest results.
 
 -->
 <script lang="ts">
+	import { AlertItem, Button, SummaryBox } from '$lib/components';
+	import { onMount } from 'svelte';
+	import type { StrategyRuntimeState } from 'trade-executor-frontend/strategy/runtimeState';
+	import AlertList from '$lib/components/AlertList.svelte';
+	import Spinner from 'svelte-spinner';
 
-    import {AlertItem, Button, SummaryBox} from "$lib/components";
-    import { onMount } from 'svelte';
-    import type {StrategyRuntimeState} from "trade-executor-frontend/strategy/runtimeState";
-    import AlertList from "$lib/components/AlertList.svelte";
+	export let data: StrategyRuntimeState;
 
-    export let data: StrategyRuntimeState;
+	export let iframeElem;
+	export let iframeSrc;
+	export let wantedHeight = 0;
 
-    export let iframeSrc;
-    export let wantedHeight = 100;
+	$: strategy = data?.strategy;
+	$: backtested = data?.summary?.backtest_available;
+	$: baseUrl = strategy?.url;
+	$: iframeUrl = baseUrl ? `${baseUrl}/file?type=html` : null;
+	$: notebookUrl = baseUrl ? `${baseUrl}/file?type=notebook` : null;
+	$: notebookName = `${strategy?.id}.ipynb`;
 
-    console.log(data);
+	// iframe (or any plugin crap) wants to communicate with us
+	// Listen for the height messages from the iframe
+	// Backtested result HTML comes with a special JS snippet to post its content height to parent frame
+	// See code here https://github.com/tradingstrategy-ai/trade-executor/blob/4a336031ded403d4fff9819d339a680d6f65b210/tradeexecutor/backtest/report.py#L51
+	function onMessage(evt) {
+		//console.log("Message", evt);
+		if (evt.data.iframeContentHeight) {
+			wantedHeight = evt.data.iframeContentHeight;
+			console.log('Resized to', wantedHeight);
+			iframeElem.style = `height: ${wantedHeight}px`;
+		}
+	}
 
-    $: strategy = data?.strategy;
-    $: backtested = strategy?.summary?.backtest_available;
-    $: baseUrl = strategy?.url;
-    $: iframeUrl = baseUrl ? `${baseUrl}/file?type=html` : null;
-    $: notebookUrl = baseUrl ? `${baseUrl}/file?type=notebook` : null;
-    $: notebookName = `${strategy?.id}.ipynb`;
-
-    // iframe (or any plugin crap) wants to communicate with us
-    // Listen for the height messages from the iframe
-    // Backtested result HTML comes with a special JS snippet to post its content height to parent frame
-    // See code here https://github.com/tradingstrategy-ai/trade-executor/blob/4a336031ded403d4fff9819d339a680d6f65b210/tradeexecutor/backtest/report.py#L51
-    function onMessage(evt) {
-        console.log("Message", evt);
-    }
-
-    // Trigger iframe load lazily so that other
-    // message handlers are ready
+	// Trigger iframe load lazily so that other
+	// message handlers are ready
 	onMount(() => {
-		iframeSrc = iframeUrl;
-	});
+		window.addEventListener('message', onMessage);
 
+		iframeSrc = iframeUrl;
+
+		//  https://stackoverflow.com/a/73155581/315168
+		return () => {
+			window.removeEventListener('message', onMessage);
+		};
+	});
 </script>
 
-<svelte:window on:messsage={onMessage} />
-
 <section class="backtest">
-    {#if backtested}
-        <SummaryBox title="Backtest data" ctaPosition="top">
-            <div class="content">
-                <ul>
-                    <li>
-                        View the backtest result report below or download the notebook run the backtests yourself.
-                    </li>
-                    <li>
-                        <a class="help-link" href="/glossary/backtest">Learn more about backtests</a>.
-                    </li>
-                </ul>
-            </div>
+	{#if backtested}
+		<SummaryBox title="Backtest data" ctaPosition="top">
+			<div class="content">
+				<ul>
+					<li>View the backtest result report below or download the notebook run the backtests yourself.</li>
+					<li>
+						<a class="help-link" href="/glossary/backtest">Learn more about backtests</a>.
+					</li>
+				</ul>
+			</div>
 
-            <div class="actions">
-                <!-- TODO: <a download> does not seem to work here, but always causes the page load instead of downlaod -->
-                <Button label="Download notebook" download={notebookName} disabled={notebookUrl == null} href={notebookUrl} />
-                <!-- TODO: The webhook endpoint missing -->
-                <Button label="Download raw backtest data" disabled />
-            </div>
-        </SummaryBox>
+			<div class="actions">
+				<!-- TODO: <a download> does not seem to work here, but always causes the page load instead of downlaod -->
+				<Button label="Download notebook" download={notebookName} disabled={notebookUrl == null} href={notebookUrl} />
+				<!-- TODO: The webhook endpoint missing -->
+				<Button label="Download raw backtest data" disabled />
+			</div>
+		</SummaryBox>
 
-        {#if iframeSrc}
-            <iframe src={iframeSrc} bind:clientHeight={wantedHeight}>
-            </iframe>
-        {/if}
-    {:else}
-        <AlertList>
-            <AlertItem>Backtest report not available for this stratey.</AlertItem>
-        </AlertList>
-    {/if}
+		{#if !wantedHeight}
+			<div class="spinner-wrapper">
+				<Spinner size="2rem" color="hsla(var(--hsl-text-light))" />
+			</div>
+		{/if}
+
+		{#if iframeSrc}
+			<iframe bind:this={iframeElem} src={iframeSrc} />
+		{:else}{/if}
+	{:else}
+		<AlertList>
+			<AlertItem>Backtest report not available for this strategy.</AlertItem>
+		</AlertList>
+	{/if}
 </section>
 
 <style>
-    iframe {
-        margin: var(--space-lg) 0;
-        width: 100%;
-        border: 0;
-    }
+	iframe {
+		margin: var(--space-lg) 0;
+		width: 100%;
+		border: 0;
+		height: 0;
+	}
 
-    .help-link {
-        text-decoration: underline;
-    }
+	.help-link {
+		text-decoration: underline;
+	}
+
+	.spinner-wrapper {
+		margin: var(--space-lg) 0;
+		text-align: center;
+	}
 </style>

--- a/src/routes/strategies/[strategy]/(nav)/backtest/+page.ts
+++ b/src/routes/strategies/[strategy]/(nav)/backtest/+page.ts
@@ -1,0 +1,2 @@
+// Plotly.js cannot be loaded on the server-side
+export const ssr = false;

--- a/src/routes/strategies/[strategy]/(nav)/backtest/+page.ts
+++ b/src/routes/strategies/[strategy]/(nav)/backtest/+page.ts
@@ -1,2 +1,0 @@
-// Plotly.js cannot be loaded on the server-side
-export const ssr = false;

--- a/src/routes/strategies/[strategy]/+layout.svelte
+++ b/src/routes/strategies/[strategy]/+layout.svelte
@@ -16,6 +16,7 @@
 		status: 'Instance status',
 		logs: 'Logs',
 		source: 'Source Code',
+        backtest: 'Backtest results',
 		...$page.data.breadcrumbs
 	};
 </script>

--- a/src/routes/strategies/[strategy]/+layout.svelte
+++ b/src/routes/strategies/[strategy]/+layout.svelte
@@ -16,7 +16,7 @@
 		status: 'Instance status',
 		logs: 'Logs',
 		source: 'Source Code',
-        backtest: 'Backtest results',
+		backtest: 'Backtest results',
 		...$page.data.breadcrumbs
 	};
 </script>


### PR DESCRIPTION
- There is new property ` data?.summary?.backtest_available` which webhook uses to indicate whether a strategy has a generated backtest report available over the webhook
- Add a trade execution page to display backtest results
- Loads a HTML file from the webhook and this displayed in iframe
- Iframe is different domain, so special `postMessage` trick is used to resize it correctly
- Link to backtest page on the strategy tile
- Remove "live" badge on the strategy tile as it feels a bit unnecessary

![image](https://github.com/tradingstrategy-ai/frontend/assets/49922/e33f9b77-532c-43bd-a776-a121bd66af5e)
