### PR TITLE
Display non-borrowable reserves correctly

### DIFF
--- a/src/lib/components/Tooltip.svelte
+++ b/src/lib/components/Tooltip.svelte
@@ -2,42 +2,38 @@
 @component
 A tooltip component used with key metrics
 
-Example:
-
-    <Tooltip>
-        <span slot="tooltip-trigger">
-            a piece of text with underline
-        </span>
-
-        <div slot="tooltip-popup">
-            Hello there
-        </div>
-    </Tooltip>
-
-
-The `tooltip-trigger` underline etc. styling must
-be done in the parent compnoent because slots are used.
+The component includes an `underline` utility CSS class that
+can be used in the `trigger` slot element if desired.
 
 For more information see:
 - https://codepen.io/GemmaCroad/pen/LYpbdom
 - https://stackoverflow.com/a/40628352/315168
 - https://svelte.dev/tutorial/named-slots
--->
-<script lang="ts">
-</script>
 
-<dfn class="key-metric-tooltip">
-	<span class="tooltip-trigger">
-		<slot name="tooltip-trigger" />
+#### Usage
+```tsx
+<Tooltip>
+	<span slot="trigger">
+		a piece of text with underline
+	</span>
+	<div slot="popup">
+		Hello there
+	</div>
+</Tooltip>
+```
+-->
+<dfn class="tooltip">
+	<span class="trigger">
+		<slot name="trigger" />
 	</span>
 	<button>
-		<slot name="tooltip-popup" />
+		<slot name="popup" />
 	</button>
 </dfn>
 
 <style lang="postcss">
-	.key-metric-tooltip {
-		& .tooltip-trigger {
+	.tooltip {
+		& .trigger {
 			cursor: pointer;
 			/* Undo base CSS abbr font style */
 			font-style: normal;

--- a/src/lib/components/TradingDataInfoRow.svelte
+++ b/src/lib/components/TradingDataInfoRow.svelte
@@ -17,10 +17,10 @@ Display a single row of trading data (should be nested in <TradingDataInfo>)
 -->
 <script lang="ts">
 	export let label: string;
-	export let labelHref: string = '';
-	export let value: string | number;
-	export let valueHref: string = '';
-	let className: string = '';
+	export let labelHref = '';
+	export let value: string | number = '';
+	export let valueHref = '';
+	let className = '';
 	export { className as class };
 </script>
 
@@ -28,7 +28,9 @@ Display a single row of trading data (should be nested in <TradingDataInfo>)
 	{#if labelHref}<a href={labelHref}>{label}</a>{:else}{label}{/if}
 </dt>
 <dd class={className}>
-	{#if valueHref}<a href={valueHref}>{value}</a>{:else}{value}{/if}
+	<slot>
+		{#if valueHref}<a href={valueHref}>{value}</a>{:else}{value}{/if}
+	</slot>
 </dd>
 
 <style lang="postcss">

--- a/src/lib/components/TradingDataInfoRow.svelte
+++ b/src/lib/components/TradingDataInfoRow.svelte
@@ -1,36 +1,31 @@
 <!--
 @component
-Display a single row of trading data (should be nested in <TradingDataInfo>)
+Display a single row of trading data (should be nested in <TradingDataInfo>). Accepts
+`label` and `value` as a prop or named slot (e.g., to add additional styling or an
+anchor tag).
 
 #### Usage
 ```tsx
 	<TradingDataInfo>
-		<TradingDataInfoRow
-			label="Row label"
-			labelHref="http://optional.label.href"
-			value="Row value"
-			valueHref="http://optional.value.href"
-			class="optional-css-class"
-		/>
+		<TradingDataInfoRow label="Row label" value="Row value"	/>
+		<TradingDataInfoRow label="Row label">
+			<a slot="value" href="http://example.com">
+				Linked row value
+			</a>
+		</TradingDataInfoRow>
 	</TradingDataInfo>
 ```
 -->
 <script lang="ts">
-	export let label: string;
-	export let labelHref = '';
+	export let label = '';
 	export let value: string | number = '';
-	export let valueHref = '';
-	let className = '';
-	export { className as class };
 </script>
 
 <dt>
-	{#if labelHref}<a href={labelHref}>{label}</a>{:else}{label}{/if}
+	<slot name="label">{label}</slot>
 </dt>
-<dd class={className}>
-	<slot>
-		{#if valueHref}<a href={valueHref}>{value}</a>{:else}{value}{/if}
-	</slot>
+<dd>
+	<slot name="value">{value}</slot>
 </dd>
 
 <style lang="postcss">
@@ -42,7 +37,7 @@ Display a single row of trading data (should be nested in <TradingDataInfo>)
 		font: var(--f-ui-large-bold);
 	}
 
-	a {
+	:is(dt, dd) :global(a) {
 		font: inherit;
 		text-decoration: underline;
 	}

--- a/src/lib/explorer/BorrowAprCell.svelte
+++ b/src/lib/explorer/BorrowAprCell.svelte
@@ -1,0 +1,19 @@
+<script lang="ts">
+	import { type Reserve, isBorrowable } from '$lib/helpers/lending-reserve';
+	import { formatInterestRate } from '$lib/helpers/formatters';
+	import { Tooltip } from '$lib/components';
+
+	export let apr: number;
+	export let reserve: Reserve | Record<string, any>;
+</script>
+
+{#if !reserve.additional_details}
+	---
+{:else if !isBorrowable(reserve)}
+	<Tooltip>
+		<span slot="trigger" class="underline">N/A</span>
+		<svelte:fragment slot="popup">Non-borrowable reserve</svelte:fragment>
+	</Tooltip>
+{:else}
+	{formatInterestRate(apr)}
+{/if}

--- a/src/lib/explorer/BorrowAprCell.svelte
+++ b/src/lib/explorer/BorrowAprCell.svelte
@@ -1,10 +1,11 @@
 <script lang="ts">
-	import { type Reserve, isBorrowable } from '$lib/helpers/lending-reserve';
+	import type { LendingReserve } from './lending-reserve-client';
+	import { isBorrowable } from '$lib/helpers/lending-reserve';
 	import { formatInterestRate } from '$lib/helpers/formatters';
 	import { Tooltip } from '$lib/components';
 
 	export let apr: number;
-	export let reserve: Reserve | Record<string, any>;
+	export let reserve: LendingReserve;
 </script>
 
 {#if !reserve.additional_details}

--- a/src/lib/explorer/LendingReserveTable.svelte
+++ b/src/lib/explorer/LendingReserveTable.svelte
@@ -6,6 +6,7 @@
 	import { addClickableRows } from '$lib/components/datatable/plugins';
 	import { Button, DataTable } from '$lib/components';
 	import { formatInterestRate } from '$lib/helpers/formatters';
+	import BorrowAprCell from './BorrowAprCell.svelte';
 
 	export let loading = false;
 	export let rows: LendingReserveIndexResponse['rows'] | undefined = undefined;
@@ -55,7 +56,7 @@
 			id: 'variable_borrow_apr_latest',
 			accessor: (row) => row?.additional_details?.variable_borrow_apr_latest,
 			header: 'Borrow APR',
-			cell: ({ value }) => formatInterestRate(value)
+			cell: ({ value, row }) => createRender(BorrowAprCell, { apr: value, reserve: row.original })
 		}),
 		table.column({
 			id: 'cta',

--- a/src/lib/explorer/LendingReserveTable.svelte
+++ b/src/lib/explorer/LendingReserveTable.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import type { LendingReserveIndexResponse } from './lending-reserve-client';
+	import type { LendingReserve } from './lending-reserve-client';
 	import { writable, type Writable } from 'svelte/store';
 	import { createRender, createTable } from 'svelte-headless-table';
 	import { addSortBy, addPagination, addHiddenColumns } from 'svelte-headless-table/plugins';
@@ -9,15 +9,15 @@
 	import BorrowAprCell from './BorrowAprCell.svelte';
 
 	export let loading = false;
-	export let rows: LendingReserveIndexResponse['rows'] | undefined = undefined;
+	export let rows: LendingReserve[] | undefined = undefined;
 	export let totalRowCount = 0;
 	export let page = 0;
 	export let sort = 'variable_borrow_apr_latest';
 	export let direction: 'asc' | 'desc' = 'asc';
 	export let hiddenColumns: string[] = [];
 
-	const tableRows: Writable<LendingReserveIndexResponse['rows']> = writable([]);
-	$: $tableRows = loading ? new Array(10).fill({}) : rows || [];
+	const tableRows: Writable<LendingReserve[]> = writable([]);
+	$: $tableRows = loading ? new Array(10).fill({}) : rows ?? [];
 
 	const table = createTable(tableRows, {
 		sort: addSortBy({

--- a/src/lib/explorer/lending-reserve-client.ts
+++ b/src/lib/explorer/lending-reserve-client.ts
@@ -1,5 +1,31 @@
 import { fetchPublicApi } from '$lib/helpers/public-api';
 
+export type LendingReserve = {
+	reserve_id: number;
+	reserve_slug: string;
+	protocol_slug: string;
+	protocol_name: string;
+	chain_id: number;
+	chain_slug: string;
+	chain_name: string;
+	asset_id: number;
+	asset_name: string;
+	asset_symbol: string;
+	asset_address: Address;
+	atoken_id: number;
+	atoken_address: Address;
+	stable_debt_token_id: number;
+	stable_debt_token_address: Address;
+	variable_debt_token_id: number;
+	variable_debt_token_address: Address;
+	interest_rate_strategy_address: Address;
+	additional_details: {
+		supply_apr_latest: number;
+		stable_borrow_apr_latest: number;
+		variable_borrow_apr_latest: number;
+	};
+};
+
 export type LendingReserveIndexParams = Partial<{
 	protocol_slug: string;
 	chain_slug: string;
@@ -12,7 +38,7 @@ export type LendingReserveIndexParams = Partial<{
 type LendingReserveSearchKey = keyof LendingReserveIndexParams;
 
 export type LendingReserveIndexResponse = {
-	rows: Record<string, any>[];
+	rows: LendingReserve[];
 	totalRowCount: number;
 };
 

--- a/src/lib/helpers/formatters.ts
+++ b/src/lib/helpers/formatters.ts
@@ -201,9 +201,8 @@ export function formatMillion2(n: MaybeNumber): string {
 /**
  * Grabs only the domain part from the URL
  */
-export function formatUrlAsDomain(u: string): string {
-	const url = new URL(u);
-	return url.hostname;
+export function formatUrlAsDomain(url: string): string {
+	return new URL(url).hostname;
 }
 
 /**

--- a/src/lib/helpers/lending-reserve.ts
+++ b/src/lib/helpers/lending-reserve.ts
@@ -1,28 +1,4 @@
-export interface Reserve {
-	reserve_id: number;
-	reserve_slug: string;
-	protocol_slug: string;
-	protocol_name: string;
-	chain_id: number;
-	chain_slug: string;
-	chain_name: string;
-	asset_id: number;
-	asset_name: string;
-	asset_symbol: string;
-	asset_address: Address;
-	atoken_id: number;
-	atoken_address: Address;
-	stable_debt_token_id: number;
-	stable_debt_token_address: Address;
-	variable_debt_token_id: number;
-	variable_debt_token_address: Address;
-	interest_rate_strategy_address: Address;
-	additional_details: {
-		supply_apr_latest: number;
-		stable_borrow_apr_latest: number;
-		variable_borrow_apr_latest: number;
-	};
-}
+import type { LendingReserve } from '$lib/explorer/lending-reserve-client';
 
 /**
  * Return URL for a lending reserve on a given chain and lending protocol
@@ -44,7 +20,7 @@ export function lendingReserveUrl(chain: string, protocol: string, underlyingAss
  * Current: inferred from non-zero Variable Borrow APR
  * Future: may have a flag on API entity based on smart-contract value
  */
-export function isBorrowable({ additional_details }: Reserve) {
+export function isBorrowable({ additional_details }: LendingReserve) {
 	return additional_details.variable_borrow_apr_latest > 0;
 }
 

--- a/src/lib/helpers/lending-reserve.ts
+++ b/src/lib/helpers/lending-reserve.ts
@@ -1,3 +1,29 @@
+export interface Reserve {
+	reserve_id: number;
+	reserve_slug: string;
+	protocol_slug: string;
+	protocol_name: string;
+	chain_id: number;
+	chain_slug: string;
+	chain_name: string;
+	asset_id: number;
+	asset_name: string;
+	asset_symbol: string;
+	asset_address: Address;
+	atoken_id: number;
+	atoken_address: Address;
+	stable_debt_token_id: number;
+	stable_debt_token_address: Address;
+	variable_debt_token_id: number;
+	variable_debt_token_address: Address;
+	interest_rate_strategy_address: Address;
+	additional_details: {
+		supply_apr_latest: number;
+		stable_borrow_apr_latest: number;
+		variable_borrow_apr_latest: number;
+	};
+}
+
 /**
  * Return URL for a lending reserve on a given chain and lending protocol
  */
@@ -11,6 +37,15 @@ export function lendingReserveUrl(chain: string, protocol: string, underlyingAss
 		marketName: `proto_${marketSlug}_v3`
 	});
 	return `https://app.aave.com/reserve-overview/?${params}`;
+}
+
+/**
+ * Determine if reserve is borrowable.
+ * Current: inferred from non-zero Variable Borrow APR
+ * Future: may have a flag on API entity based on smart-contract value
+ */
+export function isBorrowable({ additional_details }: Reserve) {
+	return additional_details.variable_borrow_apr_latest > 0;
 }
 
 /***

--- a/src/lib/trade-executor/helpers/formatters.ts
+++ b/src/lib/trade-executor/helpers/formatters.ts
@@ -352,14 +352,6 @@ export function formatUnixTimestampAsHours(ts: number, newlined = false, seconds
 }
 
 /**
- * Grabs only the domain part from the URL
- */
-export function formatUrlAsDomain(u: string): string {
-	const url = new URL(u);
-	return url.hostname;
-}
-
-/**
  * Format a datetime string to human readable format.
  *
  * Mostly useful for formattiong ISO-8601 datetime strings coming from the backend.

--- a/src/routes/strategies/KeyMetric.svelte
+++ b/src/routes/strategies/KeyMetric.svelte
@@ -31,7 +31,7 @@ Display one key metric in a strategy tile.
 	<dd>
 		{#if value !== undefined}
 			<Tooltip>
-				<svelte:fragment slot="tooltip-trigger">
+				<svelte:fragment slot="trigger">
 					<span class="value underline" data-testid={`key-metric-${metric?.kind}-value`}>
 						<slot {value}>{formattedValue}</slot>
 					</span>
@@ -41,7 +41,7 @@ Display one key metric in a strategy tile.
 					{/if}
 				</svelte:fragment>
 
-				<svelte:fragment slot="tooltip-popup">
+				<svelte:fragment slot="popup">
 					<h4>{name}</h4>
 
 					<ul>

--- a/src/routes/strategies/StrategyTile.svelte
+++ b/src/routes/strategies/StrategyTile.svelte
@@ -106,29 +106,29 @@
 			<div class="logos">
 				{#if assetManagementMode === 'enzyme'}
 					<Tooltip>
-						<img slot="tooltip-trigger" alt="Enzyme vault" src={getLogoUrl('token', 'enzyme')} />
-						<span slot="tooltip-popup">This strategy's assets are managed using an Enzyme vault</span>
+						<img slot="trigger" alt="Enzyme vault" src={getLogoUrl('token', 'enzyme')} />
+						<span slot="popup">This strategy's assets are managed using an Enzyme vault</span>
 					</Tooltip>
 				{:else if assetManagementMode === 'hot_wallet'}
 					<Tooltip>
-						<img slot="tooltip-trigger" alt="Hot wallet" src={getLogoUrl('wallet', 'metamask')} />
-						<span slot="tooltip-popup">This strategy's assets are managed using a hot wallet</span>
+						<img slot="trigger" alt="Hot wallet" src={getLogoUrl('wallet', 'metamask')} />
+						<span slot="popup">This strategy's assets are managed using a hot wallet</span>
 					</Tooltip>
 				{/if}
 
 				{#if chainSlug}
 					{@const chainName = `${chainSlug.charAt(0).toUpperCase()}${chainSlug.slice(1)}`}
 					<Tooltip>
-						<img slot="tooltip-trigger" alt={chainName} src={getLogoUrl('blockchain', chainSlug)} />
-						<span slot="tooltip-popup">This strategy runs on {chainName} blockchain</span>
+						<img slot="trigger" alt={chainName} src={getLogoUrl('blockchain', chainSlug)} />
+						<span slot="popup">This strategy runs on {chainName} blockchain</span>
 					</Tooltip>
 				{/if}
 
 				{#each getStrategyTokens(strategy) as token}
 					{@const symbol = token.toUpperCase()}
 					<Tooltip>
-						<img slot="tooltip-trigger" alt={symbol} src={getLogoUrl('token', token)} />
-						<span slot="tooltip-popup">This strategy trades {symbol}</span>
+						<img slot="trigger" alt={symbol} src={getLogoUrl('token', token)} />
+						<span slot="popup">This strategy trades {symbol}</span>
 					</Tooltip>
 				{/each}
 			</div>

--- a/src/routes/strategies/[strategy]/(nav)/[status=positionStatus]-positions/FlagCell.svelte
+++ b/src/routes/strategies/[strategy]/(nav)/[status=positionStatus]-positions/FlagCell.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import type { PositionFlagMap } from './position-flags';
-	import Tooltip from '$lib/components/Tooltip.svelte';
+	import { Tooltip } from '$lib/components';
 
 	// input as getPositionFlags(position)
 	export let flags: PositionFlagMap;

--- a/src/routes/strategies/[strategy]/(nav)/[status=positionStatus]-positions/FlagCell.svelte
+++ b/src/routes/strategies/[strategy]/(nav)/[status=positionStatus]-positions/FlagCell.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-	import type { TradingPosition } from 'trade-executor/state/interface';
 	import type { PositionFlagMap } from './position-flags';
 	import Tooltip from '$lib/components/Tooltip.svelte';
 
@@ -11,13 +10,13 @@
 	{#each [...flags] as [key, flag], idx}
 		{#if idx > 0},{/if}
 		<Tooltip>
-			<span slot="tooltip-trigger">
+			<span slot="trigger">
 				<span class="flag">
 					{flag.abbreviation}
 				</span>
 			</span>
 
-			<div slot="tooltip-popup" class="tooltip-content">
+			<div slot="popup" class="tooltip-content">
 				{@html flag.helpTextHTML}
 			</div>
 		</Tooltip>

--- a/src/routes/strategies/[strategy]/[status=positionStatus]-positions/[position]/+page.svelte
+++ b/src/routes/strategies/[strategy]/[status=positionStatus]-positions/[position]/+page.svelte
@@ -74,7 +74,7 @@
 
 			<DataBox label="Profitability" size="sm">
 				<Tooltip>
-					<svelte:fragment slot="tooltip-trigger">
+					<svelte:fragment slot="trigger">
 						<UpDownIndicator
 							value={positionInfo.profitability}
 							formatter={formatProfitability}
@@ -84,7 +84,7 @@
 							<span class="underline">{formatted}</span>
 						</UpDownIndicator>
 					</svelte:fragment>
-					<span slot="tooltip-popup">
+					<span slot="popup">
 						{#if positionInfo.stillOpen}
 							{positionInfoDescription.unrealisedProfitability}
 						{:else}
@@ -95,8 +95,8 @@
 
 				{#if positionInfo.stopLossTriggered}
 					<Tooltip>
-						<PositionDataIndicator slot="tooltip-trigger" text="stop loss" />
-						<span slot="tooltip-popup">
+						<PositionDataIndicator slot="trigger" text="stop loss" />
+						<span slot="popup">
 							{positionInfoDescription.stopLossTriggered}
 						</span>
 					</Tooltip>
@@ -106,10 +106,10 @@
 			<DataBox label="Time" size="sm">
 				<div>
 					<Tooltip>
-						<span slot="tooltip-trigger" class="underline">
+						<span slot="trigger" class="underline">
 							<Timestamp date={positionInfo.openedAt} format="iso" withTime />
 						</span>
-						<span slot="tooltip-popup">
+						<span slot="popup">
 							{positionInfoDescription.openedAt}
 						</span>
 					</Tooltip>
@@ -118,20 +118,20 @@
 
 				{#if !positionInfo.stillOpen}
 					<Tooltip>
-						<span slot="tooltip-trigger" class="underline">
+						<span slot="trigger" class="underline">
 							<Timestamp date={positionInfo.closedAt} format="iso" withTime />
 						</span>
-						<span slot="tooltip-popup">
+						<span slot="popup">
 							{positionInfoDescription.closedAt}
 						</span>
 					</Tooltip>
 				{/if}
 
 				<Tooltip>
-					<span slot="tooltip-trigger" class="underline">
+					<span slot="trigger" class="underline">
 						{formatDuration(positionInfo.durationSeconds)}
 					</span>
-					<span slot="tooltip-popup">
+					<span slot="popup">
 						{positionInfoDescription.durationSeconds}
 					</span>
 				</Tooltip>
@@ -144,10 +144,10 @@
 			<DataBox label="Price" size="sm">
 				<div>
 					<Tooltip>
-						<span slot="tooltip-trigger" class="underline">
+						<span slot="trigger" class="underline">
 							{formatPrice(positionInfo.openPrice)}
 						</span>
-						<span slot="tooltip-popup">
+						<span slot="popup">
 							{positionInfoDescription.openPrice}
 						</span>
 					</Tooltip>
@@ -156,19 +156,19 @@
 
 				{#if positionInfo.stillOpen}
 					<Tooltip>
-						<span slot="tooltip-trigger" class="underline">
+						<span slot="trigger" class="underline">
 							{formatPrice(positionInfo.currentPrice)}
 						</span>
-						<span slot="tooltip-popup">
+						<span slot="popup">
 							{positionInfoDescription.currentPrice}
 						</span>
 					</Tooltip>
 				{:else}
 					<Tooltip>
-						<span slot="tooltip-trigger" class="underline">
+						<span slot="trigger" class="underline">
 							{formatPrice(positionInfo.closePrice)}
 						</span>
-						<span slot="tooltip-popup">
+						<span slot="popup">
 							{positionInfoDescription.closePrice}
 						</span>
 					</Tooltip>
@@ -177,29 +177,29 @@
 
 			<DataBox label="Size" size="sm">
 				<Tooltip>
-					<span slot="tooltip-trigger" class="underline">
+					<span slot="trigger" class="underline">
 						<span>{formatPrice(positionInfo.valueAtOpen)}</span>
 					</span>
-					<span slot="tooltip-popup">
+					<span slot="popup">
 						{positionInfoDescription.valueAtOpen}
 					</span>
 				</Tooltip>
 
 				<Tooltip>
-					<span slot="tooltip-trigger" class="underline">
+					<span slot="trigger" class="underline">
 						{formatTokenAmount(positionInfo.quantityAtOpen)}
 						{position.pair.base.token_symbol}
 					</span>
-					<span slot="tooltip-popup">
+					<span slot="popup">
 						{positionInfoDescription.quantityAtOpen}
 					</span>
 				</Tooltip>
 
 				<Tooltip>
-					<span slot="tooltip-trigger" class="underline">
+					<span slot="trigger" class="underline">
 						{formatPercent(positionInfo.portfolioWeightAtOpen)}
 					</span>
-					<span slot="tooltip-popup">
+					<span slot="popup">
 						{positionInfoDescription.portfolioWeightAtOpen}
 					</span>
 				</Tooltip>
@@ -209,21 +209,21 @@
 				<DataBox label="Stop loss" size="sm">
 					{#if positionInfo.stopLossPercentOpen === undefined}
 						<Tooltip>
-							<span slot="tooltip-trigger" class="underline"> N/A </span>
-							<span slot="tooltip-popup">
+							<span slot="trigger" class="underline"> N/A </span>
+							<span slot="popup">
 								{positionInfoDescription.stopLossPercentOpenMissing}
 							</span>
 						</Tooltip>
 					{:else}
 						<Tooltip>
-							<span slot="tooltip-trigger" class="underline">
+							<span slot="trigger" class="underline">
 								<!--
 								Stop loss is usually expressed percent of the total position, but
 								internally we use the flipped definition as it makes calculations simpler
 								-->
 								{formatPercent(1 - positionInfo.stopLossPercentOpen)}
 							</span>
-							<span slot="tooltip-popup">
+							<span slot="popup">
 								{positionInfoDescription.stopLossPercentOpen}
 							</span>
 						</Tooltip>
@@ -232,10 +232,10 @@
 					{#if positionInfo.trailingStopLossPercent}
 						<Tooltip>
 							<PositionDataIndicator
-								slot="tooltip-trigger"
+								slot="trigger"
 								text={`Trailing stop loss: ${formatPercent(positionInfo.trailingStopLossPercent)}`}
 							/>
-							<span slot="tooltip-popup">
+							<span slot="popup">
 								{positionInfoDescription.trailingStopLossPercent}
 							</span>
 						</Tooltip>
@@ -246,17 +246,17 @@
 			<DataBox label="Risk" size="sm">
 				{#if positionInfo.portfolioRiskPercent === undefined}
 					<Tooltip>
-						<span slot="tooltip-trigger" class="underline"> N/A </span>
-						<span slot="tooltip-popup">
+						<span slot="trigger" class="underline"> N/A </span>
+						<span slot="popup">
 							{positionInfoDescription.portfolioRiskPercentMissing}
 						</span>
 					</Tooltip>
 				{:else}
 					<Tooltip>
-						<span slot="tooltip-trigger" class="underline">
+						<span slot="trigger" class="underline">
 							{formatPercent(positionInfo.portfolioRiskPercent)}
 						</span>
-						<span slot="tooltip-popup">
+						<span slot="popup">
 							{positionInfoDescription.portfolioRiskPercent}
 						</span>
 					</Tooltip>
@@ -265,10 +265,10 @@
 
 			<DataBox label="Volume" size="sm">
 				<Tooltip>
-					<span slot="tooltip-trigger" class="underline">
+					<span slot="trigger" class="underline">
 						{formatDollar(positionInfo.volume)}
 					</span>
-					<span slot="tooltip-popup">
+					<span slot="popup">
 						{positionInfoDescription.volume}
 					</span>
 				</Tooltip>
@@ -277,26 +277,26 @@
 			<DataBox label="Fees" size="sm">
 				{#if positionInfo.tradingFees === undefined}
 					<Tooltip>
-						<span slot="tooltip-trigger" class="underline"> N/A </span>
-						<span slot="tooltip-popup">
+						<span slot="trigger" class="underline"> N/A </span>
+						<span slot="popup">
 							{positionInfoDescription.tradingFeesMissing}
 						</span>
 					</Tooltip>
 				{:else}
 					<Tooltip>
-						<span slot="tooltip-trigger" class="underline">
+						<span slot="trigger" class="underline">
 							{formatDollar(positionInfo.tradingFees, 4)}
 						</span>
-						<span slot="tooltip-popup">
+						<span slot="popup">
 							{positionInfoDescription.tradingFees}
 						</span>
 					</Tooltip>
 
 					<Tooltip>
-						<span slot="tooltip-trigger" class="underline">
+						<span slot="trigger" class="underline">
 							{formatPercent(positionInfo.tradingFeesPercent, 4)}
 						</span>
-						<span slot="tooltip-popup">
+						<span slot="popup">
 							{positionInfoDescription.tradingFeesPercent}
 						</span>
 					</Tooltip>

--- a/src/routes/trading-view/[chain]/[exchange]/InfoTable.svelte
+++ b/src/routes/trading-view/[chain]/[exchange]/InfoTable.svelte
@@ -16,31 +16,41 @@ Render exchange summary table on exchange page.
 <TradingDataInfo>
 	<TradingDataInfoRow label="Name" value={nameDetails.name} />
 
-	<TradingDataInfoRow
-		label="Homepage"
-		value={details.homepage ? formatUrlAsDomain(details.homepage) : 'Not available'}
-		valueHref={details.homepage}
-	/>
+	<TradingDataInfoRow label="Homepage">
+		<svelte:fragment slot="value">
+			{#if details.homepage}
+				<a href={details.homepage}>{formatUrlAsDomain(details.homepage)}</a>
+			{:else}
+				Not available
+			{/if}
+		</svelte:fragment>
+	</TradingDataInfoRow>
 
-	<TradingDataInfoRow
-		label="Volume 30d"
-		labelHref="https://tradingstrategy.ai/docs/programming/market-data/tracking.html#volume-calculations"
-		value={formatDollar((details.buy_volume_30d || 0) + (details.sell_volume_30d || 0))}
-	/>
+	<TradingDataInfoRow>
+		<a slot="label" href="https://tradingstrategy.ai/docs/programming/market-data/tracking.html#volume-calculations">
+			Volume 30d
+		</a>
+		<svelte:fragment slot="value">
+			{formatDollar((details.buy_volume_30d ?? 0) + (details.sell_volume_30d ?? 0))}
+		</svelte:fragment>
+	</TradingDataInfoRow>
 
-	<TradingDataInfoRow
-		label="Volume all-time"
-		labelHref="https://tradingstrategy.ai/docs/programming/market-data/tracking.html#volume-calculations"
-		value={formatDollar((details.buy_volume_all_time || 0) + (details.sell_volume_all_time || 0))}
-	/>
+	<TradingDataInfoRow>
+		<a slot="label" href="https://tradingstrategy.ai/docs/programming/market-data/tracking.html#volume-calculations">
+			Volume all-time
+		</a>
+		<svelte:fragment slot="value">
+			{formatDollar((details.buy_volume_all_time ?? 0) + (details.sell_volume_all_time ?? 0))}
+		</svelte:fragment>
+	</TradingDataInfoRow>
 
 	<TradingDataInfoRow label="Trading pairs" value={formatAmount(details.pair_count)} />
 
-	<TradingDataInfoRow
-		label="Tracked trading pairs"
-		labelHref="https://tradingstrategy.ai/docs/programming/market-data/tracking.html"
-		value={formatAmount(details.active_pair_count)}
-	/>
+	<TradingDataInfoRow value={formatAmount(details.active_pair_count)}>
+		<a slot="label" href="https://tradingstrategy.ai/docs/programming/market-data/tracking.html">
+			Tracked trading pairs
+		</a>
+	</TradingDataInfoRow>
 
 	{#if details.first_trade_at}
 		<TradingDataInfoRow label="Launched" value={format(fromUnixTime(details.first_trade_at), 'MMM yyyy')} />
@@ -52,11 +62,11 @@ Render exchange summary table on exchange page.
 
 	<TradingDataInfoRow label="Type" value={exchangeTypeLabel(details.exchange_type)} />
 
-	<TradingDataInfoRow label="Blockchain" value={details.chain_name} valueHref="/trading-view/{details.chain_slug}" />
+	<TradingDataInfoRow label="Blockchain">
+		<a slot="value" href="/trading-view/{details.chain_slug}">{details.chain_name}</a>
+	</TradingDataInfoRow>
 
-	<TradingDataInfoRow
-		label="Internal id"
-		labelHref="https://tradingstrategy.ai/docs/programming/market-data/internal-id.html"
-		value={details.exchange_id}
-	/>
+	<TradingDataInfoRow value={details.exchange_id}>
+		<a slot="label" href="https://tradingstrategy.ai/docs/programming/market-data/internal-id.html">Internal id</a>
+	</TradingDataInfoRow>
 </TradingDataInfo>

--- a/src/routes/trading-view/[chain]/[exchange]/[pair]/InfoTable.svelte
+++ b/src/routes/trading-view/[chain]/[exchange]/[pair]/InfoTable.svelte
@@ -17,68 +17,75 @@
 </script>
 
 <TradingDataInfo>
-	<TradingDataInfoRow
-		label="Token"
-		value={summary.base_token_symbol_friendly}
-		valueHref="/trading-view/{summary.chain_slug}/tokens/{summary.base_token_address}"
-	/>
+	<TradingDataInfoRow label="Token">
+		<a slot="value" href="/trading-view/{summary.chain_slug}/tokens/{summary.base_token_address}">
+			{summary.base_token_symbol_friendly}
+		</a>
+	</TradingDataInfoRow>
 
-	<TradingDataInfoRow
-		label="Quoted in"
-		value={summary.quote_token_symbol_friendly}
-		valueHref="/trading-view/{summary.chain_slug}/tokens/{summary.quote_token_address}"
-	/>
+	<TradingDataInfoRow label="Quoted in">
+		<a slot="value" href="/trading-view/{summary.chain_slug}/tokens/{summary.quote_token_address}">
+			{summary.quote_token_symbol_friendly}
+		</a>
+	</TradingDataInfoRow>
 
-	<TradingDataInfoRow
-		label="Price"
-		value="{formatDollar(summary.usd_price_latest, 3, 3, '')} USD"
-		class={priceChangeColorClass}
-	/>
+	<TradingDataInfoRow label="Price">
+		<span slot="value" class={priceChangeColorClass}>
+			{formatDollar(summary.usd_price_latest, 3, 3, '')} USD
+		</span>
+	</TradingDataInfoRow>
 
 	{#if tokenPrice}
-		<TradingDataInfoRow
-			label="Token price"
-			value="{formatDollar(tokenPrice, 3, 3, '')} {summary.quote_token_symbol_friendly}"
-			class={priceChangeColorClass}
-		/>
+		<TradingDataInfoRow label="Token price">
+			<span slot="value" class={priceChangeColorClass}>
+				{formatDollar(tokenPrice, 3, 3, '')}
+				{summary.quote_token_symbol_friendly}
+			</span>
+		</TradingDataInfoRow>
 	{/if}
 
-	<TradingDataInfoRow
-		label="Change 24h"
-		value={formatPriceChange(summary.price_change_24h || null)}
-		class={priceChangeColorClass}
-	/>
+	<TradingDataInfoRow label="Change 24h">
+		<span slot="value" class={priceChangeColorClass}>
+			{formatPriceChange(summary.price_change_24h)}
+		</span>
+	</TradingDataInfoRow>
 
-	<TradingDataInfoRow label="Volume 24h" value={formatDollar(summary.usd_volume_24h || null)} />
+	<TradingDataInfoRow label="Volume 24h" value={formatDollar(summary.usd_volume_24h)} />
 
 	{#if summary.liquidity_type === 'xyliquidity'}
-		<TradingDataInfoRow label="Liquidity" value={formatDollar(summary.usd_liquidity_latest || null)} />
+		<TradingDataInfoRow label="Liquidity" value={formatDollar(summary.usd_liquidity_latest)} />
 	{/if}
 
 	{#if summary.exchange_rate}
-		<TradingDataInfoRow
-			label="Dollar exchange rate"
-			value="{formatDollar(summary.exchange_rate, 3, 3, '')} USD / {summary.quote_token_symbol_friendly}"
-		/>
+		<TradingDataInfoRow label="Dollar exchange rate">
+			<svelte:fragment slot="value">
+				{formatDollar(summary.exchange_rate, 3, 3, '')} USD /
+				{summary.quote_token_symbol_friendly}
+			</svelte:fragment>
+		</TradingDataInfoRow>
 	{/if}
 
-	<TradingDataInfoRow label="Token tax" labelHref={tokenTaxDocsUrl} value={getTokenTaxDescription(details)} />
+	<TradingDataInfoRow value={getTokenTaxDescription(details)}>
+		<a slot="label" href={tokenTaxDocsUrl}>Token tax</a>
+	</TradingDataInfoRow>
 
 	{#if summary.pool_swap_fee}
 		<TradingDataInfoRow label="Swap fee" value={formatSwapFee(summary.pool_swap_fee)} />
 	{/if}
 
-	<TradingDataInfoRow
-		label="Exchange"
-		value={details.exchange_name}
-		valueHref="/trading-view/{summary.chain_slug}/{summary.exchange_slug}"
-	/>
+	<TradingDataInfoRow label="Exchange">
+		<a slot="value" href="/trading-view/{summary.chain_slug}/{summary.exchange_slug}">
+			{details.exchange_name}
+		</a>
+	</TradingDataInfoRow>
 
-	<TradingDataInfoRow label="Blockchain" value={details.chain_name} valueHref="/trading-view/{summary.chain_slug}" />
+	<TradingDataInfoRow label="Blockchain">
+		<a slot="value" href="/trading-view/{summary.chain_slug}">
+			{details.chain_name}
+		</a>
+	</TradingDataInfoRow>
 
-	<TradingDataInfoRow
-		label="Internal id"
-		labelHref="https://tradingstrategy.ai/docs/programming/market-data/internal-id.html"
-		value={summary.pair_id}
-	/>
+	<TradingDataInfoRow value={summary.pair_id}>
+		<a slot="label" href="https://tradingstrategy.ai/docs/programming/market-data/internal-id.html">Internal id</a>
+	</TradingDataInfoRow>
 </TradingDataInfo>

--- a/src/routes/trading-view/[chain]/lending/[protocol]/[reserve]/+page.svelte
+++ b/src/routes/trading-view/[chain]/lending/[protocol]/[reserve]/+page.svelte
@@ -4,7 +4,7 @@
 	import { type TimeBucket, ReserveInterestChart } from '$lib/chart';
 	import InfoTable from './InfoTable.svelte';
 	import InfoSummary from './InfoSummary.svelte';
-	import { lendingReserveUrl } from '$lib/helpers/lending-reserve';
+	import { isBorrowable, lendingReserveUrl } from '$lib/helpers/lending-reserve';
 
 	export let data;
 	$: ({ reserve } = data);
@@ -18,9 +18,10 @@
 
 	$: reserveUrl = lendingReserveUrl(reserve.chain_slug, reserve.protocol_slug, reserve.asset_address);
 
-	// Hide chart for Aave v3 GHO token
+	// Hide chart for Aave v3 GHO token as well as non-borrowable reserves
 	// see: https://docs-gho.vercel.app/concepts/overview
 	$: isGhoToken = reserve.protocol_slug === 'aave_v3' && reserve.asset_symbol === 'GHO';
+	$: showChart = !isGhoToken && isBorrowable(reserve);
 
 	let timeBucket: TimeBucket = '1d';
 </script>
@@ -52,7 +53,7 @@
 	</section>
 </main>
 
-{#if !isGhoToken}
+{#if showChart}
 	<Section padding="md">
 		<div class="chart-header">
 			<h3>Interest rates</h3>

--- a/src/routes/trading-view/[chain]/lending/[protocol]/[reserve]/+page.svelte
+++ b/src/routes/trading-view/[chain]/lending/[protocol]/[reserve]/+page.svelte
@@ -5,6 +5,7 @@
 	import InfoTable from './InfoTable.svelte';
 	import InfoSummary from './InfoSummary.svelte';
 	import { isBorrowable, lendingReserveUrl } from '$lib/helpers/lending-reserve';
+	import { formatUrlAsDomain } from '$lib/helpers/formatters';
 
 	export let data;
 	$: ({ reserve } = data);
@@ -42,7 +43,7 @@
 		<svelte:fragment slot="cta">
 			{#if reserveUrl}
 				<Button href={reserveUrl} target="_blank" rel="noreferrer">
-					View on {new URL(reserveUrl).host}
+					View on {formatUrlAsDomain(reserveUrl)}
 				</Button>
 			{/if}
 		</svelte:fragment>

--- a/src/routes/trading-view/[chain]/lending/[protocol]/[reserve]/+page.svelte
+++ b/src/routes/trading-view/[chain]/lending/[protocol]/[reserve]/+page.svelte
@@ -21,7 +21,8 @@
 	// Hide chart for Aave v3 GHO token as well as non-borrowable reserves
 	// see: https://docs-gho.vercel.app/concepts/overview
 	$: isGhoToken = reserve.protocol_slug === 'aave_v3' && reserve.asset_symbol === 'GHO';
-	$: showChart = !isGhoToken && isBorrowable(reserve);
+	$: borrowable = isBorrowable(reserve);
+	$: showChart = borrowable && !isGhoToken;
 
 	let timeBucket: TimeBucket = '1d';
 </script>
@@ -48,8 +49,8 @@
 	</PageHeader>
 
 	<section class="ds-container ds-2-col info" data-testid="reserve-info">
-		<InfoTable {reserve} />
-		<InfoSummary {reserve} />
+		<InfoTable {reserve} {borrowable} />
+		<InfoSummary {reserve} {borrowable} />
 	</section>
 </main>
 

--- a/src/routes/trading-view/[chain]/lending/[protocol]/[reserve]/+page.ts
+++ b/src/routes/trading-view/[chain]/lending/[protocol]/[reserve]/+page.ts
@@ -1,4 +1,4 @@
-import type { Reserve } from '$lib/helpers/lending-reserve.js';
+import type { LendingReserve } from '$lib/explorer/lending-reserve-client.js';
 import { fetchPublicApi } from '$lib/helpers/public-api';
 
 export async function load({ params, fetch }) {
@@ -7,6 +7,6 @@ export async function load({ params, fetch }) {
 			chain_slug: params.chain,
 			protocol_slug: params.protocol,
 			reserve_slug: params.reserve
-		}) as Promise<Reserve>
+		}) as Promise<LendingReserve>
 	};
 }

--- a/src/routes/trading-view/[chain]/lending/[protocol]/[reserve]/+page.ts
+++ b/src/routes/trading-view/[chain]/lending/[protocol]/[reserve]/+page.ts
@@ -1,3 +1,4 @@
+import type { Reserve } from '$lib/helpers/lending-reserve.js';
 import { fetchPublicApi } from '$lib/helpers/public-api';
 
 export async function load({ params, fetch }) {
@@ -6,6 +7,6 @@ export async function load({ params, fetch }) {
 			chain_slug: params.chain,
 			protocol_slug: params.protocol,
 			reserve_slug: params.reserve
-		})
+		}) as Promise<Reserve>
 	};
 }

--- a/src/routes/trading-view/[chain]/lending/[protocol]/[reserve]/InfoSummary.svelte
+++ b/src/routes/trading-view/[chain]/lending/[protocol]/[reserve]/InfoSummary.svelte
@@ -3,6 +3,7 @@
 	import { SECONDS_PER_DAY, compoundInterest } from '$lib/helpers/lending-reserve';
 
 	export let reserve: any;
+	export let borrowable: boolean;
 
 	$: details = reserve.additional_details;
 
@@ -15,23 +16,30 @@
 		The asset token
 		<a href="/trading-view/{reserve.chain_slug}/tokens/{reserve.asset_address}">{reserve.asset_name}</a>, which trades
 		as <strong>{reserve.asset_symbol}</strong> on
-		<a href="/trading-view/{reserve.chain_slug}">{reserve.chain_name}</a>, is available to borrow as an
+		<a href="/trading-view/{reserve.chain_slug}">{reserve.chain_name}</a>, is available
+		{borrowable ? 'to borrow' : ''} as an
 		<strong>{reserve.protocol_name}</strong> lending reserve.
 	</p>
 
 	<p>
-		The <strong>variable borrow APR</strong> is currently
-		<strong>{formatInterestRate(details.variable_borrow_apr_latest)}</strong>
-		and the <strong>supply APR</strong> is currently
+		{#if borrowable}
+			The <strong>variable borrow APR</strong> is currently
+			<strong>{formatInterestRate(details.variable_borrow_apr_latest)}</strong> and the
+		{:else}
+			This reserve is <strong>not borrowable</strong>. The
+		{/if}
+		<strong>supply APR</strong> is currently
 		<strong>{formatInterestRate(details.supply_apr_latest)}</strong>.
 	</p>
 
-	<p>
-		At the current variable borrow rate, the cost of borrowing
-		<strong>${examplePrincipal.toLocaleString('en')} USD</strong> worth of
-		<strong>{reserve.asset_symbol}</strong> is approximately
-		<strong>{formatDollar(exampleInterest)} / 24h</strong>.
-	</p>
+	{#if borrowable}
+		<p>
+			At the current variable borrow rate, the cost of borrowing
+			<strong>${examplePrincipal.toLocaleString('en')} USD</strong> worth of
+			<strong>{reserve.asset_symbol}</strong> is approximately
+			<strong>{formatDollar(exampleInterest)} / 24h</strong>.
+		</p>
+	{/if}
 </div>
 
 <style lang="postcss">

--- a/src/routes/trading-view/[chain]/lending/[protocol]/[reserve]/InfoTable.svelte
+++ b/src/routes/trading-view/[chain]/lending/[protocol]/[reserve]/InfoTable.svelte
@@ -1,23 +1,32 @@
 <script lang="ts">
 	import { TradingDataInfo, TradingDataInfoRow } from '$lib/components';
+	import type { Reserve } from '$lib/helpers/lending-reserve';
 	import { formatInterestRate } from '$lib/helpers/formatters';
 
-	export let reserve: Record<string, any>;
+	export let reserve: Reserve;
+	export let borrowable: boolean;
+
+	$: details = reserve.additional_details;
 </script>
 
 <TradingDataInfo>
-	<TradingDataInfoRow
-		label="Supply rate"
-		value="{formatInterestRate(reserve.additional_details.supply_apr_latest)} APR"
-	/>
-	<TradingDataInfoRow
-		label="Borrow rate – variable"
-		value="{formatInterestRate(reserve.additional_details.variable_borrow_apr_latest)} APR"
-	/>
-	<TradingDataInfoRow
-		label="Borrow rate – stable"
-		value="{formatInterestRate(reserve.additional_details.stable_borrow_apr_latest)} APR"
-	/>
+	<TradingDataInfoRow label="Supply rate">
+		{formatInterestRate(details.supply_apr_latest)} APR
+	</TradingDataInfoRow>
+	<TradingDataInfoRow label="Borrow rate – variable">
+		{#if borrowable}
+			{formatInterestRate(details.variable_borrow_apr_latest)} APR
+		{:else}
+			N/A
+		{/if}
+	</TradingDataInfoRow>
+	<TradingDataInfoRow label="Borrow rate – stable">
+		{#if borrowable}
+			{formatInterestRate(details.stable_borrow_apr_latest)} APR
+		{:else}
+			N/A
+		{/if}
+	</TradingDataInfoRow>
 	<TradingDataInfoRow label="Protocol" value={reserve.protocol_name} />
 	<TradingDataInfoRow
 		label="Asset Token"

--- a/src/routes/trading-view/[chain]/lending/[protocol]/[reserve]/InfoTable.svelte
+++ b/src/routes/trading-view/[chain]/lending/[protocol]/[reserve]/InfoTable.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { TradingDataInfo, TradingDataInfoRow } from '$lib/components';
+	import { Tooltip, TradingDataInfo, TradingDataInfoRow } from '$lib/components';
 	import type { Reserve } from '$lib/helpers/lending-reserve';
 	import { formatInterestRate } from '$lib/helpers/formatters';
 
@@ -10,27 +10,60 @@
 </script>
 
 <TradingDataInfo>
-	<TradingDataInfoRow label="Supply rate" value="{formatInterestRate(details.supply_apr_latest)} APR" />
-	<TradingDataInfoRow label="Borrow rate – variable">
+	<TradingDataInfoRow value="{formatInterestRate(details.supply_apr_latest)} APR">
+		<Tooltip slot="label">
+			<span slot="trigger" class="underline">Supply rate</span>
+			<div slot="popup">APR earned when supplying this token as collateral</div>
+		</Tooltip>
+	</TradingDataInfoRow>
+	<TradingDataInfoRow>
+		<Tooltip slot="label">
+			<span slot="trigger" class="underline">Borrow rate – variable</span>
+			<div slot="popup">
+				APR paid when borrowing this token using the reserve's <em>variable rate</em>. This is based on the offer and
+				demand in {reserve.protocol_name}. This rate will fluctuate over time and could be the optimal rate depending on
+				market conditions.
+			</div>
+		</Tooltip>
+
 		<svelte:fragment slot="value">
 			{#if borrowable}
 				{formatInterestRate(details.variable_borrow_apr_latest)} APR
 			{:else}
-				N/A
+				<Tooltip>
+					<span slot="trigger" class="underline">N/A</span>
+					<div slot="popup">This reserve is not currently borrowable.</div>
+				</Tooltip>
 			{/if}
 		</svelte:fragment>
 	</TradingDataInfoRow>
-	<TradingDataInfoRow label="Borrow rate – stable">
+	<TradingDataInfoRow>
+		<Tooltip slot="label">
+			<span slot="trigger" class="underline">Borrow rate – stable</span>
+			<div slot="popup">
+				APR paid when borrowing this token using the reserve's <em>stable rate</em>. Stable rates act as a fixed rate in
+				the short-term, but can be re-balanced in the long-term in response to changes in market conditions.
+			</div>
+		</Tooltip>
+
 		<svelte:fragment slot="value">
 			{#if borrowable}
 				{formatInterestRate(details.stable_borrow_apr_latest)} APR
 			{:else}
-				N/A
+				<Tooltip>
+					<span slot="trigger" class="underline">N/A</span>
+					<div slot="popup">This reserve is not currently borrowable.</div>
+				</Tooltip>
 			{/if}
 		</svelte:fragment>
 	</TradingDataInfoRow>
 	<TradingDataInfoRow label="Protocol" value={reserve.protocol_name} />
-	<TradingDataInfoRow label="Asset Token">
+	<TradingDataInfoRow>
+		<Tooltip slot="label">
+			<span slot="trigger" class="underline">Asset Token</span>
+			<div slot="popup">Underlying asset token to be supplied as collateral and/or borrowed.</div>
+		</Tooltip>
+
 		<a slot="value" href="/trading-view/{reserve.chain_slug}/tokens/{reserve.asset_address}">
 			{reserve.asset_name}
 		</a>
@@ -39,3 +72,9 @@
 		<a slot="value" href="/trading-view/{reserve.chain_slug}">{reserve.chain_name}</a>
 	</TradingDataInfoRow>
 </TradingDataInfo>
+
+<style lang="postcss">
+	div[slot='popup'] {
+		max-width: 25rem;
+	}
+</style>

--- a/src/routes/trading-view/[chain]/lending/[protocol]/[reserve]/InfoTable.svelte
+++ b/src/routes/trading-view/[chain]/lending/[protocol]/[reserve]/InfoTable.svelte
@@ -1,9 +1,9 @@
 <script lang="ts">
 	import { Tooltip, TradingDataInfo, TradingDataInfoRow } from '$lib/components';
-	import type { Reserve } from '$lib/helpers/lending-reserve';
+	import type { LendingReserve } from '$lib/explorer/lending-reserve-client';
 	import { formatInterestRate } from '$lib/helpers/formatters';
 
-	export let reserve: Reserve;
+	export let reserve: LendingReserve;
 	export let borrowable: boolean;
 
 	$: details = reserve.additional_details;

--- a/src/routes/trading-view/[chain]/lending/[protocol]/[reserve]/InfoTable.svelte
+++ b/src/routes/trading-view/[chain]/lending/[protocol]/[reserve]/InfoTable.svelte
@@ -10,28 +10,32 @@
 </script>
 
 <TradingDataInfo>
-	<TradingDataInfoRow label="Supply rate">
-		{formatInterestRate(details.supply_apr_latest)} APR
-	</TradingDataInfoRow>
+	<TradingDataInfoRow label="Supply rate" value="{formatInterestRate(details.supply_apr_latest)} APR" />
 	<TradingDataInfoRow label="Borrow rate – variable">
-		{#if borrowable}
-			{formatInterestRate(details.variable_borrow_apr_latest)} APR
-		{:else}
-			N/A
-		{/if}
+		<svelte:fragment slot="value">
+			{#if borrowable}
+				{formatInterestRate(details.variable_borrow_apr_latest)} APR
+			{:else}
+				N/A
+			{/if}
+		</svelte:fragment>
 	</TradingDataInfoRow>
 	<TradingDataInfoRow label="Borrow rate – stable">
-		{#if borrowable}
-			{formatInterestRate(details.stable_borrow_apr_latest)} APR
-		{:else}
-			N/A
-		{/if}
+		<svelte:fragment slot="value">
+			{#if borrowable}
+				{formatInterestRate(details.stable_borrow_apr_latest)} APR
+			{:else}
+				N/A
+			{/if}
+		</svelte:fragment>
 	</TradingDataInfoRow>
 	<TradingDataInfoRow label="Protocol" value={reserve.protocol_name} />
-	<TradingDataInfoRow
-		label="Asset Token"
-		value={reserve.asset_name}
-		valueHref="/trading-view/{reserve.chain_slug}/tokens/{reserve.asset_address}"
-	/>
-	<TradingDataInfoRow label="Blockchain" value={reserve.chain_name} valueHref="/trading-view/{reserve.chain_slug}" />
+	<TradingDataInfoRow label="Asset Token">
+		<a slot="value" href="/trading-view/{reserve.chain_slug}/tokens/{reserve.asset_address}">
+			{reserve.asset_name}
+		</a>
+	</TradingDataInfoRow>
+	<TradingDataInfoRow label="Blockchain">
+		<a slot="value" href="/trading-view/{reserve.chain_slug}">{reserve.chain_name}</a>
+	</TradingDataInfoRow>
 </TradingDataInfo>

--- a/src/routes/trading-view/[chain]/tokens/[token]/InfoTable.svelte
+++ b/src/routes/trading-view/[chain]/tokens/[token]/InfoTable.svelte
@@ -13,10 +13,10 @@
 	<TradingDataInfoRow label="Standard" value={getTokenStandardName(data.chain_slug)} />
 	<TradingDataInfoRow label="Available liquidity" value={formatDollar(data.liquidity_latest)} />
 	<TradingDataInfoRow label="Volume 24h" value={formatDollar(data.volume_24h)} />
-	<TradingDataInfoRow label="Blockchain" value={data.chain_name} valueHref="/trading-view/{data.chain_slug}" />
-	<TradingDataInfoRow
-		label="Internal id"
-		labelHref="https://tradingstrategy.ai/docs/programming/market-data/internal-id.html"
-		value={data.token_id}
-	/>
+	<TradingDataInfoRow label="Blockchain">
+		<a slot="value" href="/trading-view/{data.chain_slug}">{data.chain_name}</a>
+	</TradingDataInfoRow>
+	<TradingDataInfoRow value={data.token_id}>
+		<a slot="label" href="https://tradingstrategy.ai/docs/programming/market-data/internal-id.html">Internal id</a>
+	</TradingDataInfoRow>
 </TradingDataInfo>


### PR DESCRIPTION
- display borrow rates as "N/A" for non-borrowable reserves (on both index and details page)
- adjust summary text for non-borrowable tokens
- add tooltips to lending reserve info table

close #539
