### PR TITLE
Crashed at timestasmp

### DIFF
--- a/src/lib/trade-executor/strategy/error.ts
+++ b/src/lib/trade-executor/strategy/error.ts
@@ -12,6 +12,7 @@
  */
 
 import type { StrategyRuntimeState } from './runtime-state';
+import {formatDatetime, formatDuration} from "$lib/helpers/formatters";
 
 /**
  * Get the HTML error message and help link in the case a trade executor is facing an issue.
@@ -22,8 +23,18 @@ export function getTradeExecutorErrorHtml(state: StrategyRuntimeState): string |
 	if (!state.connected) {
 		return `Trade executor offline. Cannot display the strategy statistics.`;
 	} else if (!state.executor_running) {
+
+    // Add a timestamp and relative timestamp for quick diagnostics
+    let crashedAtMsg;
+    if(state.crashed_at) {
+      const diffSeconds = Date.now() / 1000 - state.crashed_at;
+      crashedAtMsg = `Strategy executor halted ${formatDatetime(state.crashed_at)}, ${formatDuration(diffSeconds)} ago.`;
+    } else {
+      crashedAtMsg = "";
+    }
+
 		return `Strategy execution is currently paused due to an error. The trade execution engine is waiting for a manual action. 
-                <a href="/strategies/${tradeExecutorId}/status">See instance status page for more information</a>.`;
+                <a href="/strategies/${tradeExecutorId}/status">See instance status page for more information</a>. ${crashedAtMsg}`;
 	} else if (state.frozen_positions > 0) {
 		return `Strategy has currently frozen trading positions that needing manual actions. 
                 <a href="/strategies/${tradeExecutorId}/frozen-positions">See frozen positions page for more information</a>.`;

--- a/src/lib/trade-executor/strategy/error.ts
+++ b/src/lib/trade-executor/strategy/error.ts
@@ -12,7 +12,7 @@
  */
 
 import type { StrategyRuntimeState } from './runtime-state';
-import {formatDatetime, formatDuration} from "$lib/helpers/formatters";
+import { formatDatetime, formatDuration } from '$lib/helpers/formatters';
 
 /**
  * Get the HTML error message and help link in the case a trade executor is facing an issue.
@@ -23,15 +23,16 @@ export function getTradeExecutorErrorHtml(state: StrategyRuntimeState): string |
 	if (!state.connected) {
 		return `Trade executor offline. Cannot display the strategy statistics.`;
 	} else if (!state.executor_running) {
-
-    // Add a timestamp and relative timestamp for quick diagnostics
-    let crashedAtMsg;
-    if(state.crashed_at) {
-      const diffSeconds = Date.now() / 1000 - state.crashed_at;
-      crashedAtMsg = `Strategy executor halted ${formatDatetime(state.crashed_at)}, ${formatDuration(diffSeconds)} ago.`;
-    } else {
-      crashedAtMsg = "";
-    }
+		// Add a timestamp and relative timestamp for quick diagnostics
+		let crashedAtMsg;
+		if (state.crashed_at) {
+			const diffSeconds = Date.now() / 1000 - state.crashed_at;
+			crashedAtMsg = `Strategy executor halted ${formatDatetime(state.crashed_at)}, ${formatDuration(
+				diffSeconds
+			)} ago.`;
+		} else {
+			crashedAtMsg = '';
+		}
 
 		return `Strategy execution is currently paused due to an error. The trade execution engine is waiting for a manual action. 
                 <a href="/strategies/${tradeExecutorId}/status">See instance status page for more information</a>. ${crashedAtMsg}`;

--- a/src/lib/trade-executor/strategy/runtime-state.ts
+++ b/src/lib/trade-executor/strategy/runtime-state.ts
@@ -7,6 +7,7 @@ import type { StrategyConfiguration } from './configuration';
 // https://github.com/fram-x/assert-ts/issues/23
 import { assert } from 'assert-ts';
 import loadError from '../assets/load-error.jpg';
+import type {UnixTimestamp} from "trade-executor/state/interface";
 
 type Nullable<Type> = Type | null;
 type PerformanceTuple = [number, number];
@@ -111,6 +112,8 @@ export interface StrategyRuntimeState {
 	// Backtest files are available on the server.
 	// Display Backtest menu entry.
 	backtest_available: boolean;
+	// UNIX timestamp when the executor main loop crashed with an exception
+	crashed_at: Nullable<UnixTimestamp>;
 }
 
 export async function getStrategiesWithRuntimeState(
@@ -176,7 +179,8 @@ export async function getStrategiesWithRuntimeState(
 				link: `/strategy/${strat.id}`,
 				error,
 				frozen_positions: payload.frozen_positions,
-				backtest_available: payload.backtest_available
+				backtest_available: payload.backtest_available,
+        crashed_at: payload.crashed_at
 			};
 		})
 	);

--- a/src/lib/trade-executor/strategy/runtime-state.ts
+++ b/src/lib/trade-executor/strategy/runtime-state.ts
@@ -7,7 +7,7 @@ import type { StrategyConfiguration } from './configuration';
 // https://github.com/fram-x/assert-ts/issues/23
 import { assert } from 'assert-ts';
 import loadError from '../assets/load-error.jpg';
-import type {UnixTimestamp} from "trade-executor/state/interface";
+import type { UnixTimestamp } from 'trade-executor/state/interface';
 
 type Nullable<Type> = Type | null;
 type PerformanceTuple = [number, number];
@@ -180,7 +180,7 @@ export async function getStrategiesWithRuntimeState(
 				error,
 				frozen_positions: payload.frozen_positions,
 				backtest_available: payload.backtest_available,
-        crashed_at: payload.crashed_at
+				crashed_at: payload.crashed_at
 			};
 		})
 	);


### PR DESCRIPTION
- Show timestamp of trade-executor crash in the message, both UTC and relative
- Speeds up diagnostics