### PR TITLE
Fix strategy log filter (>= level number)

### DIFF
--- a/src/lib/components/Tabs.svelte
+++ b/src/lib/components/Tabs.svelte
@@ -17,7 +17,8 @@ Display tabs and associated content panels. Optional `selected` prop defaults to
 <script lang="ts">
 	import { createEventDispatcher } from 'svelte';
 
-	export let items: Record<string, string>;
+	type Item = string | { label: string };
+	export let items: Record<string, Item>;
 	export let selected: string = Object.keys(items)[0];
 
 	const uid = crypto.randomUUID().slice(0, 8);
@@ -32,8 +33,9 @@ Display tabs and associated content panels. Optional `selected` prop defaults to
 <section class="tabs">
 	{#each Object.entries(items) as [key, value]}
 		{@const id = `${uid}-${key}`}
+		{@const label = typeof value === 'string' ? value : value.label}
 		<input {id} type="radio" name={uid} bind:group={selected} value={key} on:change={dispatchChange} />
-		<label for={id}>{value}</label>
+		<label for={id}>{label}</label>
 	{/each}
 
 	<div class="content">

--- a/src/routes/strategies/[strategy]/(nav)/logs/+page.svelte
+++ b/src/routes/strategies/[strategy]/(nav)/logs/+page.svelte
@@ -26,7 +26,10 @@
 <section class="logs">
 	<SummaryBox title="Strategy logs" subtitle="Choose logging level">
 		<Tabs items={levels} bind:selected --tab-padding="var(--space-lg) 0 0">
-			<LogEntriesList {logs} />
+			<!-- key block is needed to reset scroll position -->
+			{#key selected}
+				<LogEntriesList {logs} />
+			{/key}
 		</Tabs>
 	</SummaryBox>
 </section>

--- a/src/routes/strategies/[strategy]/(nav)/logs/+page.svelte
+++ b/src/routes/strategies/[strategy]/(nav)/logs/+page.svelte
@@ -9,13 +9,23 @@
 
 	export let data;
 
-	let selected: string;
-	$: logs = data.logs.filter(({ level }: ComponentProps<LogEntry>) => level === selected);
+	const levels = {
+		trade: { label: 'Trade', number: 21 },
+		info: { label: 'Info', number: 20 }
+	} as const;
+
+	let selected: keyof typeof levels = 'trade';
+
+	type LogItem = ComponentProps<LogEntry> & { level_number: number };
+
+	$: logs = data.logs.filter(({ level, level_number }: LogItem) => {
+		return level === selected || level_number >= levels[selected]?.number;
+	});
 </script>
 
 <section class="logs">
 	<SummaryBox title="Strategy logs" subtitle="Choose logging level">
-		<Tabs items={{ trade: 'Trade', info: 'Info' }} bind:selected --tab-padding="var(--space-lg) 0 0">
+		<Tabs items={levels} bind:selected --tab-padding="var(--space-lg) 0 0">
 			<LogEntriesList {logs} />
 		</Tabs>
 	</SummaryBox>

--- a/src/routes/strategies/[strategy]/(nav)/logs/LogEntriesList.svelte
+++ b/src/routes/strategies/[strategy]/(nav)/logs/LogEntriesList.svelte
@@ -10,7 +10,8 @@ Display log messages as a scrollable panel
 </script>
 
 <div class="log-panel terminal-viewport">
-	{#each logs.reverse() as { timestamp, level, message }}
+	<!-- reverse mutates the array, so we need to call it on a copy -->
+	{#each [...logs].reverse() as { timestamp, level, message }}
 		<LogEntry {timestamp} {level} {message} />
 	{/each}
 </div>


### PR DESCRIPTION
fix #572

- show strategy executor log entries >= log level
- fix log entry order/scroll position bug
