### PR TITLE
Upgrade PostCSS Preset ENV to 9.x

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -37,6 +37,7 @@
         "viem": "^1.1.4"
       },
       "devDependencies": {
+        "@csstools/postcss-global-data": "^2.1.0",
         "@playwright/test": "^1.37.1",
         "@sveltejs/adapter-node": "^1.3.1",
         "@sveltejs/kit": "^1.23.0",
@@ -558,6 +559,28 @@
       "dependencies": {
         "postcss-value-parser": "^4.2.0"
       },
+      "engines": {
+        "node": "^14 || ^16 || >=18"
+      },
+      "peerDependencies": {
+        "postcss": "^8.4"
+      }
+    },
+    "node_modules/@csstools/postcss-global-data": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/postcss-global-data/-/postcss-global-data-2.1.0.tgz",
+      "integrity": "sha512-n8SoAaapXATQ/fI8c0GVM+VNfvpNo6fN/79GGTjqatEG8bZNh72b2r+KKLVMcQHvRKjDlXxzurxnf6L5nsxDGA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
       "engines": {
         "node": "^14 || ^16 || >=18"
       },
@@ -8808,9 +8831,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.4.28",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.28.tgz",
-      "integrity": "sha512-Z7V5j0cq8oEKyejIKfpD8b4eBy9cwW2JWPk0+fB1HOAMsfHbnAXLLS+PfVWlzMSLQaWttKDt607I0XHmpE67Vw==",
+      "version": "8.4.29",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.29.tgz",
+      "integrity": "sha512-cbI+jaqIeu/VGqXEarWkRCCffhjgXc0qjBtXpqJhTBohMUjUQnbBr0xqX3vEKudc4iviTewcJo5ajcec5+wdJw==",
       "dev": true,
       "funding": [
         {

--- a/package-lock.json
+++ b/package-lock.json
@@ -51,7 +51,7 @@
         "eslint-config-prettier": "^8.10.0",
         "eslint-plugin-svelte": "^2.33.0",
         "jsdom": "^22.1.0",
-        "postcss-preset-env": "^7.8.3",
+        "postcss-preset-env": "^9.1.3",
         "prettier": "^2.8.8",
         "prettier-plugin-svelte": "^2.10.1",
         "svelte": "^4.2.0",
@@ -275,285 +275,808 @@
         "node": ">= 10.0.0"
       }
     },
-    "node_modules/@csstools/postcss-cascade-layers": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@csstools/postcss-cascade-layers/-/postcss-cascade-layers-1.1.1.tgz",
-      "integrity": "sha512-+KdYrpKC5TgomQr2DlZF4lDEpHcoxnj5IGddYYfBWJAKfj1JtuHUIqMa+E1pJJ+z3kvDViWMqyqPlG4Ja7amQA==",
+    "node_modules/@csstools/cascade-layer-name-parser": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@csstools/cascade-layer-name-parser/-/cascade-layer-name-parser-1.0.4.tgz",
+      "integrity": "sha512-zXMGsJetbLoXe+gjEES07MEGjL0Uy3hMxmnGtVBrRpVKr5KV9OgCB09zr/vLrsEtoVQTgJFewxaU8IYSAE4tjg==",
       "dev": true,
-      "dependencies": {
-        "@csstools/selector-specificity": "^2.0.2",
-        "postcss-selector-parser": "^6.0.10"
-      },
-      "engines": {
-        "node": "^12 || ^14 || >=16"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/csstools"
-      },
-      "peerDependencies": {
-        "postcss": "^8.2"
-      }
-    },
-    "node_modules/@csstools/postcss-color-function": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@csstools/postcss-color-function/-/postcss-color-function-1.1.1.tgz",
-      "integrity": "sha512-Bc0f62WmHdtRDjf5f3e2STwRAl89N2CLb+9iAwzrv4L2hncrbDwnQD9PCq0gtAt7pOI2leIV08HIBUd4jxD8cw==",
-      "dev": true,
-      "dependencies": {
-        "@csstools/postcss-progressive-custom-properties": "^1.1.0",
-        "postcss-value-parser": "^4.2.0"
-      },
-      "engines": {
-        "node": "^12 || ^14 || >=16"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/csstools"
-      },
-      "peerDependencies": {
-        "postcss": "^8.2"
-      }
-    },
-    "node_modules/@csstools/postcss-font-format-keywords": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@csstools/postcss-font-format-keywords/-/postcss-font-format-keywords-1.0.1.tgz",
-      "integrity": "sha512-ZgrlzuUAjXIOc2JueK0X5sZDjCtgimVp/O5CEqTcs5ShWBa6smhWYbS0x5cVc/+rycTDbjjzoP0KTDnUneZGOg==",
-      "dev": true,
-      "dependencies": {
-        "postcss-value-parser": "^4.2.0"
-      },
-      "engines": {
-        "node": "^12 || ^14 || >=16"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/csstools"
-      },
-      "peerDependencies": {
-        "postcss": "^8.2"
-      }
-    },
-    "node_modules/@csstools/postcss-hwb-function": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@csstools/postcss-hwb-function/-/postcss-hwb-function-1.0.2.tgz",
-      "integrity": "sha512-YHdEru4o3Rsbjmu6vHy4UKOXZD+Rn2zmkAmLRfPet6+Jz4Ojw8cbWxe1n42VaXQhD3CQUXXTooIy8OkVbUcL+w==",
-      "dev": true,
-      "dependencies": {
-        "postcss-value-parser": "^4.2.0"
-      },
-      "engines": {
-        "node": "^12 || ^14 || >=16"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/csstools"
-      },
-      "peerDependencies": {
-        "postcss": "^8.2"
-      }
-    },
-    "node_modules/@csstools/postcss-ic-unit": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@csstools/postcss-ic-unit/-/postcss-ic-unit-1.0.1.tgz",
-      "integrity": "sha512-Ot1rcwRAaRHNKC9tAqoqNZhjdYBzKk1POgWfhN4uCOE47ebGcLRqXjKkApVDpjifL6u2/55ekkpnFcp+s/OZUw==",
-      "dev": true,
-      "dependencies": {
-        "@csstools/postcss-progressive-custom-properties": "^1.1.0",
-        "postcss-value-parser": "^4.2.0"
-      },
-      "engines": {
-        "node": "^12 || ^14 || >=16"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/csstools"
-      },
-      "peerDependencies": {
-        "postcss": "^8.2"
-      }
-    },
-    "node_modules/@csstools/postcss-is-pseudo-class": {
-      "version": "2.0.7",
-      "resolved": "https://registry.npmjs.org/@csstools/postcss-is-pseudo-class/-/postcss-is-pseudo-class-2.0.7.tgz",
-      "integrity": "sha512-7JPeVVZHd+jxYdULl87lvjgvWldYu+Bc62s9vD/ED6/QTGjy0jy0US/f6BG53sVMTBJ1lzKZFpYmofBN9eaRiA==",
-      "dev": true,
-      "dependencies": {
-        "@csstools/selector-specificity": "^2.0.0",
-        "postcss-selector-parser": "^6.0.10"
-      },
-      "engines": {
-        "node": "^12 || ^14 || >=16"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/csstools"
-      },
-      "peerDependencies": {
-        "postcss": "^8.2"
-      }
-    },
-    "node_modules/@csstools/postcss-nested-calc": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@csstools/postcss-nested-calc/-/postcss-nested-calc-1.0.0.tgz",
-      "integrity": "sha512-JCsQsw1wjYwv1bJmgjKSoZNvf7R6+wuHDAbi5f/7MbFhl2d/+v+TvBTU4BJH3G1X1H87dHl0mh6TfYogbT/dJQ==",
-      "dev": true,
-      "dependencies": {
-        "postcss-value-parser": "^4.2.0"
-      },
-      "engines": {
-        "node": "^12 || ^14 || >=16"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/csstools"
-      },
-      "peerDependencies": {
-        "postcss": "^8.2"
-      }
-    },
-    "node_modules/@csstools/postcss-normalize-display-values": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@csstools/postcss-normalize-display-values/-/postcss-normalize-display-values-1.0.1.tgz",
-      "integrity": "sha512-jcOanIbv55OFKQ3sYeFD/T0Ti7AMXc9nM1hZWu8m/2722gOTxFg7xYu4RDLJLeZmPUVQlGzo4jhzvTUq3x4ZUw==",
-      "dev": true,
-      "dependencies": {
-        "postcss-value-parser": "^4.2.0"
-      },
-      "engines": {
-        "node": "^12 || ^14 || >=16"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/csstools"
-      },
-      "peerDependencies": {
-        "postcss": "^8.2"
-      }
-    },
-    "node_modules/@csstools/postcss-oklab-function": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@csstools/postcss-oklab-function/-/postcss-oklab-function-1.1.1.tgz",
-      "integrity": "sha512-nJpJgsdA3dA9y5pgyb/UfEzE7W5Ka7u0CX0/HIMVBNWzWemdcTH3XwANECU6anWv/ao4vVNLTMxhiPNZsTK6iA==",
-      "dev": true,
-      "dependencies": {
-        "@csstools/postcss-progressive-custom-properties": "^1.1.0",
-        "postcss-value-parser": "^4.2.0"
-      },
-      "engines": {
-        "node": "^12 || ^14 || >=16"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/csstools"
-      },
-      "peerDependencies": {
-        "postcss": "^8.2"
-      }
-    },
-    "node_modules/@csstools/postcss-progressive-custom-properties": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@csstools/postcss-progressive-custom-properties/-/postcss-progressive-custom-properties-1.3.0.tgz",
-      "integrity": "sha512-ASA9W1aIy5ygskZYuWams4BzafD12ULvSypmaLJT2jvQ8G0M3I8PRQhC0h7mG0Z3LI05+agZjqSR9+K9yaQQjA==",
-      "dev": true,
-      "dependencies": {
-        "postcss-value-parser": "^4.2.0"
-      },
-      "engines": {
-        "node": "^12 || ^14 || >=16"
-      },
-      "peerDependencies": {
-        "postcss": "^8.3"
-      }
-    },
-    "node_modules/@csstools/postcss-stepped-value-functions": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@csstools/postcss-stepped-value-functions/-/postcss-stepped-value-functions-1.0.1.tgz",
-      "integrity": "sha512-dz0LNoo3ijpTOQqEJLY8nyaapl6umbmDcgj4AD0lgVQ572b2eqA1iGZYTTWhrcrHztWDDRAX2DGYyw2VBjvCvQ==",
-      "dev": true,
-      "dependencies": {
-        "postcss-value-parser": "^4.2.0"
-      },
-      "engines": {
-        "node": "^12 || ^14 || >=16"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/csstools"
-      },
-      "peerDependencies": {
-        "postcss": "^8.2"
-      }
-    },
-    "node_modules/@csstools/postcss-text-decoration-shorthand": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@csstools/postcss-text-decoration-shorthand/-/postcss-text-decoration-shorthand-1.0.0.tgz",
-      "integrity": "sha512-c1XwKJ2eMIWrzQenN0XbcfzckOLLJiczqy+YvfGmzoVXd7pT9FfObiSEfzs84bpE/VqfpEuAZ9tCRbZkZxxbdw==",
-      "dev": true,
-      "dependencies": {
-        "postcss-value-parser": "^4.2.0"
-      },
-      "engines": {
-        "node": "^12 || ^14 || >=16"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/csstools"
-      },
-      "peerDependencies": {
-        "postcss": "^8.2"
-      }
-    },
-    "node_modules/@csstools/postcss-trigonometric-functions": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@csstools/postcss-trigonometric-functions/-/postcss-trigonometric-functions-1.0.2.tgz",
-      "integrity": "sha512-woKaLO///4bb+zZC2s80l+7cm07M7268MsyG3M0ActXXEFi6SuhvriQYcb58iiKGbjwwIU7n45iRLEHypB47Og==",
-      "dev": true,
-      "dependencies": {
-        "postcss-value-parser": "^4.2.0"
-      },
-      "engines": {
-        "node": "^14 || >=16"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/csstools"
-      },
-      "peerDependencies": {
-        "postcss": "^8.2"
-      }
-    },
-    "node_modules/@csstools/postcss-unset-value": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@csstools/postcss-unset-value/-/postcss-unset-value-1.0.2.tgz",
-      "integrity": "sha512-c8J4roPBILnelAsdLr4XOAR/GsTm0GJi4XpcfvoWk3U6KiTCqiFYc63KhRMQQX35jYMp4Ao8Ij9+IZRgMfJp1g==",
-      "dev": true,
-      "engines": {
-        "node": "^12 || ^14 || >=16"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/csstools"
-      },
-      "peerDependencies": {
-        "postcss": "^8.2"
-      }
-    },
-    "node_modules/@csstools/selector-specificity": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@csstools/selector-specificity/-/selector-specificity-2.1.1.tgz",
-      "integrity": "sha512-jwx+WCqszn53YHOfvFMJJRd/B2GqkCBt+1MJSG6o5/s8+ytHMvDZXsJgUEWLk12UnLd7HYKac4BYU5i/Ron1Cw==",
-      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
       "engines": {
         "node": "^14 || ^16 || >=18"
       },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/csstools"
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^2.3.1",
+        "@csstools/css-tokenizer": "^2.2.0"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-3.0.2.tgz",
+      "integrity": "sha512-NMVs/l7Y9eIKL5XjbCHEgGcG8LOUT2qVcRjX6EzkCdlvftHVKr2tHIPzHavfrULRZ5Q2gxrJ9f44dAlj6fX97Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "engines": {
+        "node": "^14 || ^16 || >=18"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-1.1.3.tgz",
+      "integrity": "sha512-7mJZ8gGRtSQfQKBQFi5N0Z+jzNC0q8bIkwojP1W0w+APzEqHu5wJoGVsvKxVnVklu9F8tW1PikbBRseYnAdv+g==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "engines": {
+        "node": "^14 || ^16 || >=18"
       },
       "peerDependencies": {
-        "postcss": "^8.4",
-        "postcss-selector-parser": "^6.0.10"
+        "@csstools/css-parser-algorithms": "^2.3.1",
+        "@csstools/css-tokenizer": "^2.2.0"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-1.3.1.tgz",
+      "integrity": "sha512-cehc/DQCyb4hL4fspvyL7WiY+uAy8Iuaz0yTyndC/AyBmxkNpgtSgCSsr0aR4vkaSFVZfNNVlKbjHFwOsPGB1Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "dependencies": {
+        "@csstools/color-helpers": "^3.0.2",
+        "@csstools/css-calc": "^1.1.3"
+      },
+      "engines": {
+        "node": "^14 || ^16 || >=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^2.3.1",
+        "@csstools/css-tokenizer": "^2.2.0"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-2.3.1.tgz",
+      "integrity": "sha512-xrvsmVUtefWMWQsGgFffqWSK03pZ1vfDki4IVIIUxxDKnGBzqNgv0A7SB1oXtVNEkcVO8xi1ZrTL29HhSu5kGA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "engines": {
+        "node": "^14 || ^16 || >=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^2.2.0"
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-2.2.0.tgz",
+      "integrity": "sha512-wErmsWCbsmig8sQKkM6pFhr/oPha1bHfvxsUY5CYSQxwyhA9Ulrs8EqCgClhg4Tgg2XapVstGqSVcz0xOYizZA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "engines": {
+        "node": "^14 || ^16 || >=18"
+      }
+    },
+    "node_modules/@csstools/media-query-list-parser": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@csstools/media-query-list-parser/-/media-query-list-parser-2.1.4.tgz",
+      "integrity": "sha512-V/OUXYX91tAC1CDsiY+HotIcJR+vPtzrX8pCplCpT++i8ThZZsq5F5dzZh/bDM3WUOjrvC1ljed1oSJxMfjqhw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "engines": {
+        "node": "^14 || ^16 || >=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^2.3.1",
+        "@csstools/css-tokenizer": "^2.2.0"
+      }
+    },
+    "node_modules/@csstools/postcss-cascade-layers": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/postcss-cascade-layers/-/postcss-cascade-layers-4.0.0.tgz",
+      "integrity": "sha512-dVPVVqQG0FixjM9CG/+8eHTsCAxRKqmNh6H69IpruolPlnEF1611f2AoLK8TijTSAsqBSclKd4WHs1KUb/LdJw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "dependencies": {
+        "@csstools/selector-specificity": "^3.0.0",
+        "postcss-selector-parser": "^6.0.13"
+      },
+      "engines": {
+        "node": "^14 || ^16 || >=18"
+      },
+      "peerDependencies": {
+        "postcss": "^8.4"
+      }
+    },
+    "node_modules/@csstools/postcss-color-function": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@csstools/postcss-color-function/-/postcss-color-function-3.0.3.tgz",
+      "integrity": "sha512-5oNUbO89SX7BuSB0ZiUxDaQt4R2K3A+RQZlxNHOvghZJO/UqgomLPII6JkgrywLQ0Y4JDzbyNuwr0OKo2v0RsQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "dependencies": {
+        "@csstools/css-color-parser": "^1.3.1",
+        "@csstools/css-parser-algorithms": "^2.3.1",
+        "@csstools/css-tokenizer": "^2.2.0",
+        "@csstools/postcss-progressive-custom-properties": "^3.0.0"
+      },
+      "engines": {
+        "node": "^14 || ^16 || >=18"
+      },
+      "peerDependencies": {
+        "postcss": "^8.4"
+      }
+    },
+    "node_modules/@csstools/postcss-color-mix-function": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@csstools/postcss-color-mix-function/-/postcss-color-mix-function-2.0.3.tgz",
+      "integrity": "sha512-q/fv8pdRR07GAJTvemXbQ02hwVGmVcOjBJj7+gnlGrAVwSzrPEsJc8zM/EzoqVJTZtm/DwG6TWu+VJIxVpyUBg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "dependencies": {
+        "@csstools/css-color-parser": "^1.3.1",
+        "@csstools/css-parser-algorithms": "^2.3.1",
+        "@csstools/css-tokenizer": "^2.2.0",
+        "@csstools/postcss-progressive-custom-properties": "^3.0.0"
+      },
+      "engines": {
+        "node": "^14 || ^16 || >=18"
+      },
+      "peerDependencies": {
+        "postcss": "^8.4"
+      }
+    },
+    "node_modules/@csstools/postcss-exponential-functions": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/postcss-exponential-functions/-/postcss-exponential-functions-1.0.0.tgz",
+      "integrity": "sha512-FPndJ/7oGlML7/4EhLi902wGOukO0Nn37PjwOQGc0BhhjQPy3np3By4d3M8s9Cfmp9EHEKgUHRN2DQ5HLT/hTw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "dependencies": {
+        "@csstools/css-calc": "^1.1.3",
+        "@csstools/css-parser-algorithms": "^2.3.1",
+        "@csstools/css-tokenizer": "^2.2.0"
+      },
+      "engines": {
+        "node": "^14 || ^16 || >=18"
+      },
+      "peerDependencies": {
+        "postcss": "^8.4"
+      }
+    },
+    "node_modules/@csstools/postcss-font-format-keywords": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/postcss-font-format-keywords/-/postcss-font-format-keywords-3.0.0.tgz",
+      "integrity": "sha512-ntkGj+1uDa/u6lpjPxnkPcjJn7ChO/Kcy08YxctOZI7vwtrdYvFhmE476dq8bj1yna306+jQ9gzXIG/SWfOaRg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "dependencies": {
+        "postcss-value-parser": "^4.2.0"
+      },
+      "engines": {
+        "node": "^14 || ^16 || >=18"
+      },
+      "peerDependencies": {
+        "postcss": "^8.4"
+      }
+    },
+    "node_modules/@csstools/postcss-gradients-interpolation-method": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@csstools/postcss-gradients-interpolation-method/-/postcss-gradients-interpolation-method-4.0.3.tgz",
+      "integrity": "sha512-dEK3WbajX538Zu3lPMtBPAO1pooR7zslJ1mDrWKQzlwQczls3fEz+tlRhd7KWMMlsoIwNGMIGq2W/GqEErDjkg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "dependencies": {
+        "@csstools/css-color-parser": "^1.3.1",
+        "@csstools/css-parser-algorithms": "^2.3.1",
+        "@csstools/css-tokenizer": "^2.2.0",
+        "@csstools/postcss-progressive-custom-properties": "^3.0.0"
+      },
+      "engines": {
+        "node": "^14 || ^16 || >=18"
+      },
+      "peerDependencies": {
+        "postcss": "^8.4"
+      }
+    },
+    "node_modules/@csstools/postcss-hwb-function": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@csstools/postcss-hwb-function/-/postcss-hwb-function-3.0.3.tgz",
+      "integrity": "sha512-2TqrRD8JzSwQCRKKNc9BFhSEmsz+mR3RtwSw5mQSGILC+LIYCVWeYwC33cI+saFWv0DGZ0NXLx5VSX2tdJyU6w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "dependencies": {
+        "@csstools/css-color-parser": "^1.3.1",
+        "@csstools/css-parser-algorithms": "^2.3.1",
+        "@csstools/css-tokenizer": "^2.2.0"
+      },
+      "engines": {
+        "node": "^14 || ^16 || >=18"
+      },
+      "peerDependencies": {
+        "postcss": "^8.4"
+      }
+    },
+    "node_modules/@csstools/postcss-ic-unit": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/postcss-ic-unit/-/postcss-ic-unit-3.0.0.tgz",
+      "integrity": "sha512-FH3+zfOfsgtX332IIkRDxiYLmgwyNk49tfltpC6dsZaO4RV2zWY6x9VMIC5cjvmjlDO7DIThpzqaqw2icT8RbQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "dependencies": {
+        "@csstools/postcss-progressive-custom-properties": "^3.0.0",
+        "postcss-value-parser": "^4.2.0"
+      },
+      "engines": {
+        "node": "^14 || ^16 || >=18"
+      },
+      "peerDependencies": {
+        "postcss": "^8.4"
+      }
+    },
+    "node_modules/@csstools/postcss-is-pseudo-class": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@csstools/postcss-is-pseudo-class/-/postcss-is-pseudo-class-4.0.1.tgz",
+      "integrity": "sha512-KJGLbjjjg+mdNclLyCfsZaJS4xCaRaxKAnmWKpIp1FarEem3ZdoOxTlIELwvlE5BVg1t3QTmp0+DPSlLTTFMhA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "dependencies": {
+        "@csstools/selector-specificity": "^3.0.0",
+        "postcss-selector-parser": "^6.0.13"
+      },
+      "engines": {
+        "node": "^14 || ^16 || >=18"
+      },
+      "peerDependencies": {
+        "postcss": "^8.4"
+      }
+    },
+    "node_modules/@csstools/postcss-logical-float-and-clear": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/postcss-logical-float-and-clear/-/postcss-logical-float-and-clear-2.0.0.tgz",
+      "integrity": "sha512-Wki4vxsF6icRvRz8eF9bPpAvwaAt0RHwhVOyzfoFg52XiIMjb6jcbHkGxwpJXP4DVrnFEwpwmrz5aTRqOW82kg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "engines": {
+        "node": "^14 || ^16 || >=18"
+      },
+      "peerDependencies": {
+        "postcss": "^8.4"
+      }
+    },
+    "node_modules/@csstools/postcss-logical-resize": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/postcss-logical-resize/-/postcss-logical-resize-2.0.0.tgz",
+      "integrity": "sha512-lCQ1aX8c5+WI4t5EoYf3alTzJNNocMqTb+u1J9CINdDhFh1fjovqK+0aHalUHsNstZmzFPNzIkU4Mb3eM9U8SA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "dependencies": {
+        "postcss-value-parser": "^4.2.0"
+      },
+      "engines": {
+        "node": "^14 || ^16 || >=18"
+      },
+      "peerDependencies": {
+        "postcss": "^8.4"
+      }
+    },
+    "node_modules/@csstools/postcss-logical-viewport-units": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@csstools/postcss-logical-viewport-units/-/postcss-logical-viewport-units-2.0.1.tgz",
+      "integrity": "sha512-R5s19SscS7CHoxvdYNMu2Y3WDwG4JjdhsejqjunDB1GqfzhtHSvL7b5XxCkUWqm2KRl35hI6kJ4HEaCDd/3BXg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "dependencies": {
+        "@csstools/css-tokenizer": "^2.2.0"
+      },
+      "engines": {
+        "node": "^14 || ^16 || >=18"
+      },
+      "peerDependencies": {
+        "postcss": "^8.4"
+      }
+    },
+    "node_modules/@csstools/postcss-media-minmax": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/@csstools/postcss-media-minmax/-/postcss-media-minmax-1.0.7.tgz",
+      "integrity": "sha512-5LGLdu8cJgRPmvkjUNqOPKIKeHbyQmoGKooB5Rh0mp5mLaNI9bl+IjFZ2keY0cztZYsriJsGf6Lu8R5XetuwoQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "dependencies": {
+        "@csstools/css-calc": "^1.1.3",
+        "@csstools/css-parser-algorithms": "^2.3.1",
+        "@csstools/css-tokenizer": "^2.2.0",
+        "@csstools/media-query-list-parser": "^2.1.4"
+      },
+      "engines": {
+        "node": "^14 || ^16 || >=18"
+      },
+      "peerDependencies": {
+        "postcss": "^8.4"
+      }
+    },
+    "node_modules/@csstools/postcss-media-queries-aspect-ratio-number-values": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@csstools/postcss-media-queries-aspect-ratio-number-values/-/postcss-media-queries-aspect-ratio-number-values-2.0.2.tgz",
+      "integrity": "sha512-kQJR6NvTRidsaRjCdHGjra2+fLoFiDQOm5B2aZrhmXqng/hweXjruboKzB326rxQO2L0m0T+gCKbZgyuncyhLg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "dependencies": {
+        "@csstools/css-parser-algorithms": "^2.3.1",
+        "@csstools/css-tokenizer": "^2.2.0",
+        "@csstools/media-query-list-parser": "^2.1.4"
+      },
+      "engines": {
+        "node": "^14 || ^16 || >=18"
+      },
+      "peerDependencies": {
+        "postcss": "^8.4"
+      }
+    },
+    "node_modules/@csstools/postcss-nested-calc": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/postcss-nested-calc/-/postcss-nested-calc-3.0.0.tgz",
+      "integrity": "sha512-HsB66aDWAouOwD/GcfDTS0a7wCuVWaTpXcjl5VKP0XvFxDiU+r0T8FG7xgb6ovZNZ+qzvGIwRM+CLHhDgXrYgQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "dependencies": {
+        "postcss-value-parser": "^4.2.0"
+      },
+      "engines": {
+        "node": "^14 || ^16 || >=18"
+      },
+      "peerDependencies": {
+        "postcss": "^8.4"
+      }
+    },
+    "node_modules/@csstools/postcss-normalize-display-values": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/postcss-normalize-display-values/-/postcss-normalize-display-values-3.0.0.tgz",
+      "integrity": "sha512-6Nw55PRXEKEVqn3bzA8gRRPYxr5tf5PssvcE5DRA/nAxKgKtgNZMCHCSd1uxTCWeyLnkf6h5tYRSB0P1Vh/K/A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "dependencies": {
+        "postcss-value-parser": "^4.2.0"
+      },
+      "engines": {
+        "node": "^14 || ^16 || >=18"
+      },
+      "peerDependencies": {
+        "postcss": "^8.4"
+      }
+    },
+    "node_modules/@csstools/postcss-oklab-function": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@csstools/postcss-oklab-function/-/postcss-oklab-function-3.0.3.tgz",
+      "integrity": "sha512-8Wdpmy8mvVyHsToJkrnNpwpAgqCPNpQMLNqkR62smbEuFcmRHEiDnb0OlkKjErzmiBMr7vjZAQ6e2lA9oVguQQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "dependencies": {
+        "@csstools/css-color-parser": "^1.3.1",
+        "@csstools/css-parser-algorithms": "^2.3.1",
+        "@csstools/css-tokenizer": "^2.2.0",
+        "@csstools/postcss-progressive-custom-properties": "^3.0.0"
+      },
+      "engines": {
+        "node": "^14 || ^16 || >=18"
+      },
+      "peerDependencies": {
+        "postcss": "^8.4"
+      }
+    },
+    "node_modules/@csstools/postcss-progressive-custom-properties": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/postcss-progressive-custom-properties/-/postcss-progressive-custom-properties-3.0.0.tgz",
+      "integrity": "sha512-2/D3CCL9DN2xhuUTP8OKvKnaqJ1j4yZUxuGLsCUOQ16wnDAuMLKLkflOmZF5tsPh/02VPeXRmqIN+U595WAulw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "dependencies": {
+        "postcss-value-parser": "^4.2.0"
+      },
+      "engines": {
+        "node": "^14 || ^16 || >=18"
+      },
+      "peerDependencies": {
+        "postcss": "^8.4"
+      }
+    },
+    "node_modules/@csstools/postcss-relative-color-syntax": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@csstools/postcss-relative-color-syntax/-/postcss-relative-color-syntax-2.0.3.tgz",
+      "integrity": "sha512-9MOzad5i0fnkOI6qXzcznuyGhLYARBkR8wDsyqbANkZ20srHJZ6PAy44g5eNw3+B7yvslUK4hx9ehnbbI9x4rw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "dependencies": {
+        "@csstools/css-color-parser": "^1.3.1",
+        "@csstools/css-parser-algorithms": "^2.3.1",
+        "@csstools/css-tokenizer": "^2.2.0",
+        "@csstools/postcss-progressive-custom-properties": "^3.0.0"
+      },
+      "engines": {
+        "node": "^14 || ^16 || >=18"
+      },
+      "peerDependencies": {
+        "postcss": "^8.4"
+      }
+    },
+    "node_modules/@csstools/postcss-scope-pseudo-class": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/postcss-scope-pseudo-class/-/postcss-scope-pseudo-class-3.0.0.tgz",
+      "integrity": "sha512-GFNVsD97OuEcfHmcT0/DAZWAvTM/FFBDQndIOLawNc1Wq8YqpZwBdHa063Lq+Irk7azygTT+Iinyg3Lt76p7rg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "dependencies": {
+        "postcss-selector-parser": "^6.0.13"
+      },
+      "engines": {
+        "node": "^14 || ^16 || >=18"
+      },
+      "peerDependencies": {
+        "postcss": "^8.4"
+      }
+    },
+    "node_modules/@csstools/postcss-stepped-value-functions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@csstools/postcss-stepped-value-functions/-/postcss-stepped-value-functions-3.0.1.tgz",
+      "integrity": "sha512-y1sykToXorFE+5cjtp//xAMWEAEple0kcZn2QhzEFIZDDNvGOCp5JvvmmPGsC3eDlj6yQp70l9uXZNLnimEYfA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "dependencies": {
+        "@csstools/css-calc": "^1.1.3",
+        "@csstools/css-parser-algorithms": "^2.3.1",
+        "@csstools/css-tokenizer": "^2.2.0"
+      },
+      "engines": {
+        "node": "^14 || ^16 || >=18"
+      },
+      "peerDependencies": {
+        "postcss": "^8.4"
+      }
+    },
+    "node_modules/@csstools/postcss-text-decoration-shorthand": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@csstools/postcss-text-decoration-shorthand/-/postcss-text-decoration-shorthand-3.0.2.tgz",
+      "integrity": "sha512-vO2onX7/TPU3LMrSvg+FhMxTujhU+LELP9zln7SiB5BJqZi+y/ZOJZRBHFvCfM9J1lnNkskMN96bP5g3yg7Jmw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "dependencies": {
+        "@csstools/color-helpers": "^3.0.2",
+        "postcss-value-parser": "^4.2.0"
+      },
+      "engines": {
+        "node": "^14 || ^16 || >=18"
+      },
+      "peerDependencies": {
+        "postcss": "^8.4"
+      }
+    },
+    "node_modules/@csstools/postcss-trigonometric-functions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@csstools/postcss-trigonometric-functions/-/postcss-trigonometric-functions-3.0.1.tgz",
+      "integrity": "sha512-hW+JPv0MPQfWC1KARgvJI6bisEUFAZWSvUNq/khGCupYV/h6Z9R2ZFz0Xc633LXBst0ezbXpy7NpnPurSx5Klw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "dependencies": {
+        "@csstools/css-calc": "^1.1.3",
+        "@csstools/css-parser-algorithms": "^2.3.1",
+        "@csstools/css-tokenizer": "^2.2.0"
+      },
+      "engines": {
+        "node": "^14 || ^16 || >=18"
+      },
+      "peerDependencies": {
+        "postcss": "^8.4"
+      }
+    },
+    "node_modules/@csstools/postcss-unset-value": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/postcss-unset-value/-/postcss-unset-value-3.0.0.tgz",
+      "integrity": "sha512-P0JD1WHh3avVyKKRKjd0dZIjCEeaBer8t1BbwGMUDtSZaLhXlLNBqZ8KkqHzYWXOJgHleXAny2/sx8LYl6qhEA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "engines": {
+        "node": "^14 || ^16 || >=18"
+      },
+      "peerDependencies": {
+        "postcss": "^8.4"
+      }
+    },
+    "node_modules/@csstools/selector-specificity": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/selector-specificity/-/selector-specificity-3.0.0.tgz",
+      "integrity": "sha512-hBI9tfBtuPIi885ZsZ32IMEU/5nlZH/KOVYJCOh7gyMxaVLGmLedYqFN6Ui1LXkI8JlC8IsuC0rF0btcRZKd5g==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "engines": {
+        "node": "^14 || ^16 || >=18"
+      },
+      "peerDependencies": {
+        "postcss-selector-parser": "^6.0.13"
       }
     },
     "node_modules/@datadog/native-appsec": {
@@ -4154,9 +4677,9 @@
       }
     },
     "node_modules/autoprefixer": {
-      "version": "10.4.13",
-      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.13.tgz",
-      "integrity": "sha512-49vKpMqcZYsJjwotvt4+h/BCjJVnhGwcLpDt5xkcaOG3eLrG/HUYLagrihYsQ+qrIBgIzX1Rw7a6L8I/ZA1Atg==",
+      "version": "10.4.15",
+      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.15.tgz",
+      "integrity": "sha512-KCuPB8ZCIqFdA4HwKXsvz7j6gvSDNhDP7WnUjBleRkKjPdvCmHFuQ77ocavI8FT6NdvlBnE2UFr2H4Mycn8Vew==",
       "dev": true,
       "funding": [
         {
@@ -4166,11 +4689,15 @@
         {
           "type": "tidelift",
           "url": "https://tidelift.com/funding/github/npm/autoprefixer"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
         }
       ],
       "dependencies": {
-        "browserslist": "^4.21.4",
-        "caniuse-lite": "^1.0.30001426",
+        "browserslist": "^4.21.10",
+        "caniuse-lite": "^1.0.30001520",
         "fraction.js": "^4.2.0",
         "normalize-range": "^0.1.2",
         "picocolors": "^1.0.0",
@@ -4389,9 +4916,9 @@
       "integrity": "sha512-cKV8tMCEpQs4hK/ik71d6LrPOnpkpGBR0wzxqr68g2m/LB2GxVYQroAjMJZRVM1Y4BCjCKc3vAamxSzOY2RP+w=="
     },
     "node_modules/browserslist": {
-      "version": "4.21.5",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.5.tgz",
-      "integrity": "sha512-tUkiguQGW7S3IhB7N+c2MV/HZPSCPAAiYBZXLsBhFB/PCy6ZKKsZrmBayHV9fdGV/ARIfJ14NkxKzRDjvp7L6w==",
+      "version": "4.21.10",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.10.tgz",
+      "integrity": "sha512-bipEBdZfVH5/pwrvqc+Ub0kUPVfGUhlKxbvfD+z1BDnPEO/X98ruXGA1WP5ASpAFKan7Qr6j736IacbZQuAlKQ==",
       "dev": true,
       "funding": [
         {
@@ -4401,13 +4928,17 @@
         {
           "type": "tidelift",
           "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
         }
       ],
       "dependencies": {
-        "caniuse-lite": "^1.0.30001449",
-        "electron-to-chromium": "^1.4.284",
-        "node-releases": "^2.0.8",
-        "update-browserslist-db": "^1.0.10"
+        "caniuse-lite": "^1.0.30001517",
+        "electron-to-chromium": "^1.4.477",
+        "node-releases": "^2.0.13",
+        "update-browserslist-db": "^1.0.11"
       },
       "bin": {
         "browserslist": "cli.js"
@@ -4551,9 +5082,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001522",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001522.tgz",
-      "integrity": "sha512-TKiyTVZxJGhsTszLuzb+6vUZSjVOAhClszBr2Ta2k9IwtNBT/4dzmL6aywt0HCgEZlmwJzXJd8yNiob6HgwTRg==",
+      "version": "1.0.30001532",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001532.tgz",
+      "integrity": "sha512-FbDFnNat3nMnrROzqrsg314zhqN5LGQ1kyyMk2opcrwGbVGpHRhgCWtAgD5YJUqNAiQ+dklreil/c3Qf1dfCTw==",
       "dev": true,
       "funding": [
         {
@@ -4858,51 +5389,74 @@
       "dev": true
     },
     "node_modules/css-blank-pseudo": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/css-blank-pseudo/-/css-blank-pseudo-3.0.3.tgz",
-      "integrity": "sha512-VS90XWtsHGqoM0t4KpH053c4ehxZ2E6HtGI7x68YFV0pTo/QmkV/YFA+NnlvK8guxZVNWGQhVNJGC39Q8XF4OQ==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/css-blank-pseudo/-/css-blank-pseudo-6.0.0.tgz",
+      "integrity": "sha512-VbfLlOWO7sBHBTn6pwDQzc07Z0SDydgDBfNfCE0nvrehdBNv9RKsuupIRa/qal0+fBZhAALyQDPMKz5lnvcchw==",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
       "dependencies": {
-        "postcss-selector-parser": "^6.0.9"
-      },
-      "bin": {
-        "css-blank-pseudo": "dist/cli.cjs"
+        "postcss-selector-parser": "^6.0.13"
       },
       "engines": {
-        "node": "^12 || ^14 || >=16"
+        "node": "^14 || ^16 || >=18"
       },
       "peerDependencies": {
         "postcss": "^8.4"
       }
     },
     "node_modules/css-has-pseudo": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/css-has-pseudo/-/css-has-pseudo-3.0.4.tgz",
-      "integrity": "sha512-Vse0xpR1K9MNlp2j5w1pgWIJtm1a8qS0JwS9goFYcImjlHEmywP9VUF05aGBXzGpDJF86QXk4L0ypBmwPhGArw==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/css-has-pseudo/-/css-has-pseudo-6.0.0.tgz",
+      "integrity": "sha512-X+r+JBuoO37FBOWVNhVJhxtSBUFHgHbrcc0CjFT28JEdOw1qaDwABv/uunyodUuSy2hMPe9j/HjssxSlvUmKjg==",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
       "dependencies": {
-        "postcss-selector-parser": "^6.0.9"
-      },
-      "bin": {
-        "css-has-pseudo": "dist/cli.cjs"
+        "@csstools/selector-specificity": "^3.0.0",
+        "postcss-selector-parser": "^6.0.13",
+        "postcss-value-parser": "^4.2.0"
       },
       "engines": {
-        "node": "^12 || ^14 || >=16"
+        "node": "^14 || ^16 || >=18"
       },
       "peerDependencies": {
         "postcss": "^8.4"
       }
     },
     "node_modules/css-prefers-color-scheme": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/css-prefers-color-scheme/-/css-prefers-color-scheme-6.0.3.tgz",
-      "integrity": "sha512-4BqMbZksRkJQx2zAjrokiGMd07RqOa2IxIrrN10lyBe9xhn9DEvjUK79J6jkeiv9D9hQFXKb6g1jwU62jziJZA==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/css-prefers-color-scheme/-/css-prefers-color-scheme-9.0.0.tgz",
+      "integrity": "sha512-03QGAk/FXIRseDdLb7XAiu6gidQ0Nd8945xuM7VFVPpc6goJsG9uIO8xQjTxwbPdPIIV4o4AJoOJyt8gwDl67g==",
       "dev": true,
-      "bin": {
-        "css-prefers-color-scheme": "dist/cli.cjs"
-      },
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
       "engines": {
-        "node": "^12 || ^14 || >=16"
+        "node": "^14 || ^16 || >=18"
       },
       "peerDependencies": {
         "postcss": "^8.4"
@@ -4953,14 +5507,20 @@
       "dev": true
     },
     "node_modules/cssdb": {
-      "version": "7.4.1",
-      "resolved": "https://registry.npmjs.org/cssdb/-/cssdb-7.4.1.tgz",
-      "integrity": "sha512-0Q8NOMpXJ3iTDDbUv9grcmQAfdDx4qz+fN/+Md2FGbevT+6+bJNQ2LjB2YIUlLbpBTM32idU1Sb+tb/uGt6/XQ==",
+      "version": "7.7.2",
+      "resolved": "https://registry.npmjs.org/cssdb/-/cssdb-7.7.2.tgz",
+      "integrity": "sha512-pQPYP7/kch4QlkTcLuUNiNL2v/E+O+VIdotT+ug62/+2B2/jkzs5fMM6RHCzGCZ9C82pODEMSIzRRUzJOrl78g==",
       "dev": true,
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/csstools"
-      }
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        }
+      ]
     },
     "node_modules/cssesc": {
       "version": "3.0.0",
@@ -5438,9 +5998,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.308",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.308.tgz",
-      "integrity": "sha512-qyTx2aDFjEni4UnRWEME9ubd2Xc9c0zerTUl/ZinvD4QPsF0S7kJTV/Es/lPCTkNX6smyYar+z/n8Cl6pFr8yQ==",
+      "version": "1.4.515",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.515.tgz",
+      "integrity": "sha512-VTq6vjk3kCfG2qdzQRd/i9dIyVVm0dbtZIgFzrLgfB73mXDQT2HPKVRc1EoZcAVUv9XhXAu08DWqJuababdGGg==",
       "dev": true
     },
     "node_modules/elliptic": {
@@ -6247,16 +6807,16 @@
       }
     },
     "node_modules/fraction.js": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-4.2.0.tgz",
-      "integrity": "sha512-MhLuK+2gUcnZe8ZHlaaINnQLl0xRIGRfcGk2yl8xoQAfHrSsL3rYu6FCmBdkdbhc9EPlwyGHewaRsvwRMJtAlA==",
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-4.3.6.tgz",
+      "integrity": "sha512-n2aZ9tNfYDwaHhvFTkhFErqOMIb8uyzSQ+vGJBjZyanAKZVbGUQ1sngfk9FdkBw7G26O7AgNjLcecLffD1c7eg==",
       "dev": true,
       "engines": {
         "node": "*"
       },
       "funding": {
         "type": "patreon",
-        "url": "https://www.patreon.com/infusion"
+        "url": "https://github.com/sponsors/rawify"
       }
     },
     "node_modules/fresh": {
@@ -7840,9 +8400,9 @@
       }
     },
     "node_modules/node-releases": {
-      "version": "2.0.10",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.10.tgz",
-      "integrity": "sha512-5GFldHPXVG/YZmFzJvKK2zDSzPKhEp0+ZR5SVaoSag9fsL5YgHbUHDfnG5494ISANDcK4KwPXAx2xqVEydmd7w==",
+      "version": "2.0.13",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.13.tgz",
+      "integrity": "sha512-uYr7J37ae/ORWdZeQ1xxMJe3NtdmqMC/JZK+geofDrkLUApKRHPd18/TxtBOJ4A0/+uUIliorNrfYV6s1b02eQ==",
       "dev": true
     },
     "node_modules/normalize-path": {
@@ -8276,22 +8836,22 @@
       }
     },
     "node_modules/postcss-attribute-case-insensitive": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/postcss-attribute-case-insensitive/-/postcss-attribute-case-insensitive-5.0.2.tgz",
-      "integrity": "sha512-XIidXV8fDr0kKt28vqki84fRK8VW8eTuIa4PChv2MqKuT6C9UjmSKzen6KaWhWEoYvwxFCa7n/tC1SZ3tyq4SQ==",
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/postcss-attribute-case-insensitive/-/postcss-attribute-case-insensitive-6.0.2.tgz",
+      "integrity": "sha512-IRuCwwAAQbgaLhxQdQcIIK0dCVXg3XDUnzgKD8iwdiYdwU4rMWRWyl/W9/0nA4ihVpq5pyALiHB2veBJ0292pw==",
       "dev": true,
       "dependencies": {
         "postcss-selector-parser": "^6.0.10"
       },
       "engines": {
-        "node": "^12 || ^14 || >=16"
+        "node": "^14 || ^16 || >=18"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/csstools"
       },
       "peerDependencies": {
-        "postcss": "^8.2"
+        "postcss": "^8.4"
       }
     },
     "node_modules/postcss-clamp": {
@@ -8310,34 +8870,41 @@
       }
     },
     "node_modules/postcss-color-functional-notation": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/postcss-color-functional-notation/-/postcss-color-functional-notation-4.2.4.tgz",
-      "integrity": "sha512-2yrTAUZUab9s6CpxkxC4rVgFEVaR6/2Pipvi6qcgvnYiVqZcbDHEoBDhrXzyb7Efh2CCfHQNtcqWcIruDTIUeg==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/postcss-color-functional-notation/-/postcss-color-functional-notation-6.0.0.tgz",
+      "integrity": "sha512-kaWTgnhRKFtfMF8H0+NQBFxgr5CGg05WGe07Mc1ld6XHwwRWlqSbHOW0zwf+BtkBQpsdVUu7+gl9dtdvhWMedw==",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
       "dependencies": {
+        "@csstools/postcss-progressive-custom-properties": "^3.0.0",
         "postcss-value-parser": "^4.2.0"
       },
       "engines": {
-        "node": "^12 || ^14 || >=16"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/csstools"
+        "node": "^14 || ^16 || >=18"
       },
       "peerDependencies": {
-        "postcss": "^8.2"
+        "postcss": "^8.4"
       }
     },
     "node_modules/postcss-color-hex-alpha": {
-      "version": "8.0.4",
-      "resolved": "https://registry.npmjs.org/postcss-color-hex-alpha/-/postcss-color-hex-alpha-8.0.4.tgz",
-      "integrity": "sha512-nLo2DCRC9eE4w2JmuKgVA3fGL3d01kGq752pVALF68qpGLmx2Qrk91QTKkdUqqp45T1K1XV8IhQpcu1hoAQflQ==",
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/postcss-color-hex-alpha/-/postcss-color-hex-alpha-9.0.2.tgz",
+      "integrity": "sha512-SfPjgr//VQ/DOCf80STIAsdAs7sbIbxATvVmd+Ec7JvR8onz9pjawhq3BJM3Pie40EE3TyB0P6hft16D33Nlyg==",
       "dev": true,
       "dependencies": {
         "postcss-value-parser": "^4.2.0"
       },
       "engines": {
-        "node": "^12 || ^14 || >=16"
+        "node": "^14 || ^16 || >=18"
       },
       "funding": {
         "type": "opencollective",
@@ -8348,160 +8915,210 @@
       }
     },
     "node_modules/postcss-color-rebeccapurple": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/postcss-color-rebeccapurple/-/postcss-color-rebeccapurple-7.1.1.tgz",
-      "integrity": "sha512-pGxkuVEInwLHgkNxUc4sdg4g3py7zUeCQ9sMfwyHAT+Ezk8a4OaaVZ8lIY5+oNqA/BXXgLyXv0+5wHP68R79hg==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/postcss-color-rebeccapurple/-/postcss-color-rebeccapurple-9.0.0.tgz",
+      "integrity": "sha512-RmUFL+foS05AKglkEoqfx+KFdKRVmqUAxlHNz4jLqIi7046drIPyerdl4B6j/RA2BSP8FI8gJcHmLRrwJOMnHw==",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
       "dependencies": {
         "postcss-value-parser": "^4.2.0"
       },
       "engines": {
-        "node": "^12 || ^14 || >=16"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/csstools"
+        "node": "^14 || ^16 || >=18"
       },
       "peerDependencies": {
-        "postcss": "^8.2"
+        "postcss": "^8.4"
       }
     },
     "node_modules/postcss-custom-media": {
-      "version": "8.0.2",
-      "resolved": "https://registry.npmjs.org/postcss-custom-media/-/postcss-custom-media-8.0.2.tgz",
-      "integrity": "sha512-7yi25vDAoHAkbhAzX9dHx2yc6ntS4jQvejrNcC+csQJAXjj15e7VcWfMgLqBNAbOvqi5uIa9huOVwdHbf+sKqg==",
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/postcss-custom-media/-/postcss-custom-media-10.0.0.tgz",
+      "integrity": "sha512-NxDn7C6GJ7X8TsWOa8MbCdq9rLERRLcPfQSp856k1jzMreL8X9M6iWk35JjPRIb9IfRnVohmxAylDRx7n4Rv4g==",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
       "dependencies": {
-        "postcss-value-parser": "^4.2.0"
+        "@csstools/cascade-layer-name-parser": "^1.0.3",
+        "@csstools/css-parser-algorithms": "^2.3.0",
+        "@csstools/css-tokenizer": "^2.1.1",
+        "@csstools/media-query-list-parser": "^2.1.2"
       },
       "engines": {
-        "node": "^12 || ^14 || >=16"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/csstools"
+        "node": "^14 || ^16 || >=18"
       },
       "peerDependencies": {
-        "postcss": "^8.3"
+        "postcss": "^8.4"
       }
     },
     "node_modules/postcss-custom-properties": {
-      "version": "12.1.11",
-      "resolved": "https://registry.npmjs.org/postcss-custom-properties/-/postcss-custom-properties-12.1.11.tgz",
-      "integrity": "sha512-0IDJYhgU8xDv1KY6+VgUwuQkVtmYzRwu+dMjnmdMafXYv86SWqfxkc7qdDvWS38vsjaEtv8e0vGOUQrAiMBLpQ==",
+      "version": "13.3.0",
+      "resolved": "https://registry.npmjs.org/postcss-custom-properties/-/postcss-custom-properties-13.3.0.tgz",
+      "integrity": "sha512-q4VgtIKSy5+KcUvQ0WxTjDy9DZjQ5VCXAZ9+tT9+aPMbA0z6s2t1nMw0QHszru1ib5ElkXl9JUpYYU37VVUs7g==",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
       "dependencies": {
+        "@csstools/cascade-layer-name-parser": "^1.0.4",
+        "@csstools/css-parser-algorithms": "^2.3.1",
+        "@csstools/css-tokenizer": "^2.2.0",
         "postcss-value-parser": "^4.2.0"
       },
       "engines": {
-        "node": "^12 || ^14 || >=16"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/csstools"
+        "node": "^14 || ^16 || >=18"
       },
       "peerDependencies": {
-        "postcss": "^8.2"
+        "postcss": "^8.4"
       }
     },
     "node_modules/postcss-custom-selectors": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/postcss-custom-selectors/-/postcss-custom-selectors-6.0.3.tgz",
-      "integrity": "sha512-fgVkmyiWDwmD3JbpCmB45SvvlCD6z9CG6Ie6Iere22W5aHea6oWa7EM2bpnv2Fj3I94L3VbtvX9KqwSi5aFzSg==",
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/postcss-custom-selectors/-/postcss-custom-selectors-7.1.4.tgz",
+      "integrity": "sha512-TU2xyUUBTlpiLnwyE2ZYMUIYB41MKMkBZ8X8ntkqRDQ8sdBLhFFsPgNcOliBd5+/zcK51C9hRnSE7hKUJMxQSw==",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
       "dependencies": {
-        "postcss-selector-parser": "^6.0.4"
+        "@csstools/cascade-layer-name-parser": "^1.0.3",
+        "@csstools/css-parser-algorithms": "^2.3.0",
+        "@csstools/css-tokenizer": "^2.1.1",
+        "postcss-selector-parser": "^6.0.13"
       },
       "engines": {
-        "node": "^12 || ^14 || >=16"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/csstools"
+        "node": "^14 || ^16 || >=18"
       },
       "peerDependencies": {
-        "postcss": "^8.3"
+        "postcss": "^8.4"
       }
     },
     "node_modules/postcss-dir-pseudo-class": {
-      "version": "6.0.5",
-      "resolved": "https://registry.npmjs.org/postcss-dir-pseudo-class/-/postcss-dir-pseudo-class-6.0.5.tgz",
-      "integrity": "sha512-eqn4m70P031PF7ZQIvSgy9RSJ5uI2171O/OO/zcRNYpJbvaeKFUlar1aJ7rmgiQtbm0FSPsRewjpdS0Oew7MPA==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/postcss-dir-pseudo-class/-/postcss-dir-pseudo-class-8.0.0.tgz",
+      "integrity": "sha512-Oy5BBi0dWPwij/IA+yDYj+/OBMQ9EPqAzTHeSNUYrUWdll/PRJmcbiUj0MNcsBi681I1gcSTLvMERPaXzdbvJg==",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
       "dependencies": {
-        "postcss-selector-parser": "^6.0.10"
+        "postcss-selector-parser": "^6.0.13"
       },
       "engines": {
-        "node": "^12 || ^14 || >=16"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/csstools"
+        "node": "^14 || ^16 || >=18"
       },
       "peerDependencies": {
-        "postcss": "^8.2"
+        "postcss": "^8.4"
       }
     },
     "node_modules/postcss-double-position-gradients": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/postcss-double-position-gradients/-/postcss-double-position-gradients-3.1.2.tgz",
-      "integrity": "sha512-GX+FuE/uBR6eskOK+4vkXgT6pDkexLokPaz/AbJna9s5Kzp/yl488pKPjhy0obB475ovfT1Wv8ho7U/cHNaRgQ==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/postcss-double-position-gradients/-/postcss-double-position-gradients-5.0.0.tgz",
+      "integrity": "sha512-wR8npIkrIVUTicUpCWSSo1f/g7gAEIH70FMqCugY4m4j6TX4E0T2Q5rhfO0gqv00biBZdLyb+HkW8x6as+iJNQ==",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
       "dependencies": {
-        "@csstools/postcss-progressive-custom-properties": "^1.1.0",
+        "@csstools/postcss-progressive-custom-properties": "^3.0.0",
         "postcss-value-parser": "^4.2.0"
       },
       "engines": {
-        "node": "^12 || ^14 || >=16"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/csstools"
-      },
-      "peerDependencies": {
-        "postcss": "^8.2"
-      }
-    },
-    "node_modules/postcss-env-function": {
-      "version": "4.0.6",
-      "resolved": "https://registry.npmjs.org/postcss-env-function/-/postcss-env-function-4.0.6.tgz",
-      "integrity": "sha512-kpA6FsLra+NqcFnL81TnsU+Z7orGtDTxcOhl6pwXeEq1yFPpRMkCDpHhrz8CFQDr/Wfm0jLiNQ1OsGGPjlqPwA==",
-      "dev": true,
-      "dependencies": {
-        "postcss-value-parser": "^4.2.0"
-      },
-      "engines": {
-        "node": "^12 || ^14 || >=16"
+        "node": "^14 || ^16 || >=18"
       },
       "peerDependencies": {
         "postcss": "^8.4"
       }
     },
     "node_modules/postcss-focus-visible": {
-      "version": "6.0.4",
-      "resolved": "https://registry.npmjs.org/postcss-focus-visible/-/postcss-focus-visible-6.0.4.tgz",
-      "integrity": "sha512-QcKuUU/dgNsstIK6HELFRT5Y3lbrMLEOwG+A4s5cA+fx3A3y/JTq3X9LaOj3OC3ALH0XqyrgQIgey/MIZ8Wczw==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/postcss-focus-visible/-/postcss-focus-visible-9.0.0.tgz",
+      "integrity": "sha512-zA4TbVaIaT8npZBEROhZmlc+GBKE8AELPHXE7i4TmIUEQhw/P/mSJfY9t6tBzpQ1rABeGtEOHYrW4SboQeONMQ==",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
       "dependencies": {
-        "postcss-selector-parser": "^6.0.9"
+        "postcss-selector-parser": "^6.0.13"
       },
       "engines": {
-        "node": "^12 || ^14 || >=16"
+        "node": "^14 || ^16 || >=18"
       },
       "peerDependencies": {
         "postcss": "^8.4"
       }
     },
     "node_modules/postcss-focus-within": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/postcss-focus-within/-/postcss-focus-within-5.0.4.tgz",
-      "integrity": "sha512-vvjDN++C0mu8jz4af5d52CB184ogg/sSxAFS+oUJQq2SuCe7T5U2iIsVJtsCp2d6R4j0jr5+q3rPkBVZkXD9fQ==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/postcss-focus-within/-/postcss-focus-within-8.0.0.tgz",
+      "integrity": "sha512-E7+J9nuQzZaA37D/MUZMX1K817RZGDab8qw6pFwzAkDd/QtlWJ9/WTKmzewNiuxzeq6WWY7ATiRePVoDKp+DnA==",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
       "dependencies": {
-        "postcss-selector-parser": "^6.0.9"
+        "postcss-selector-parser": "^6.0.13"
       },
       "engines": {
-        "node": "^12 || ^14 || >=16"
+        "node": "^14 || ^16 || >=18"
       },
       "peerDependencies": {
         "postcss": "^8.4"
@@ -8517,38 +9134,50 @@
       }
     },
     "node_modules/postcss-gap-properties": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/postcss-gap-properties/-/postcss-gap-properties-3.0.5.tgz",
-      "integrity": "sha512-IuE6gKSdoUNcvkGIqdtjtcMtZIFyXZhmFd5RUlg97iVEvp1BZKV5ngsAjCjrVy+14uhGBQl9tzmi1Qwq4kqVOg==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/postcss-gap-properties/-/postcss-gap-properties-5.0.0.tgz",
+      "integrity": "sha512-YjsEEL6890P7MCv6fch6Am1yq0EhQCJMXyT4LBohiu87+4/WqR7y5W3RIv53WdA901hhytgRvjlrAhibhW4qsA==",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
       "engines": {
-        "node": "^12 || ^14 || >=16"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/csstools"
+        "node": "^14 || ^16 || >=18"
       },
       "peerDependencies": {
-        "postcss": "^8.2"
+        "postcss": "^8.4"
       }
     },
     "node_modules/postcss-image-set-function": {
-      "version": "4.0.7",
-      "resolved": "https://registry.npmjs.org/postcss-image-set-function/-/postcss-image-set-function-4.0.7.tgz",
-      "integrity": "sha512-9T2r9rsvYzm5ndsBE8WgtrMlIT7VbtTfE7b3BQnudUqnBcBo7L758oc+o+pdj/dUV0l5wjwSdjeOH2DZtfv8qw==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/postcss-image-set-function/-/postcss-image-set-function-6.0.0.tgz",
+      "integrity": "sha512-bg58QnJexFpPBU4IGPAugAPKV0FuFtX5rHYNSKVaV91TpHN7iwyEzz1bkIPCiSU5+BUN00e+3fV5KFrwIgRocw==",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
       "dependencies": {
         "postcss-value-parser": "^4.2.0"
       },
       "engines": {
-        "node": "^12 || ^14 || >=16"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/csstools"
+        "node": "^14 || ^16 || >=18"
       },
       "peerDependencies": {
-        "postcss": "^8.2"
+        "postcss": "^8.4"
       }
     },
     "node_modules/postcss-initial": {
@@ -8561,23 +9190,31 @@
       }
     },
     "node_modules/postcss-lab-function": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/postcss-lab-function/-/postcss-lab-function-4.2.1.tgz",
-      "integrity": "sha512-xuXll4isR03CrQsmxyz92LJB2xX9n+pZJ5jE9JgcnmsCammLyKdlzrBin+25dy6wIjfhJpKBAN80gsTlCgRk2w==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/postcss-lab-function/-/postcss-lab-function-6.0.3.tgz",
+      "integrity": "sha512-+0WxmblCb2Khfj9wpJQKd/9QhtHK/ImIqfnXX4HEoTDmjdtI6IUjXnC83bYX0CaHitpPjWnoQjoasW7qb1TCHw==",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
       "dependencies": {
-        "@csstools/postcss-progressive-custom-properties": "^1.1.0",
-        "postcss-value-parser": "^4.2.0"
+        "@csstools/css-color-parser": "^1.3.1",
+        "@csstools/css-parser-algorithms": "^2.3.1",
+        "@csstools/css-tokenizer": "^2.2.0",
+        "@csstools/postcss-progressive-custom-properties": "^3.0.0"
       },
       "engines": {
-        "node": "^12 || ^14 || >=16"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/csstools"
+        "node": "^14 || ^16 || >=18"
       },
       "peerDependencies": {
-        "postcss": "^8.2"
+        "postcss": "^8.4"
       }
     },
     "node_modules/postcss-load-config": {
@@ -8610,53 +9247,60 @@
       }
     },
     "node_modules/postcss-logical": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/postcss-logical/-/postcss-logical-5.0.4.tgz",
-      "integrity": "sha512-RHXxplCeLh9VjinvMrZONq7im4wjWGlRJAqmAVLXyZaXwfDWP73/oq4NdIp+OZwhQUMj0zjqDfM5Fj7qby+B4g==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/postcss-logical/-/postcss-logical-7.0.0.tgz",
+      "integrity": "sha512-zYf3vHkoW82f5UZTEXChTJvH49Yl9X37axTZsJGxrCG2kOUwtaAoz9E7tqYg0lsIoJLybaL8fk/2mOi81zVIUw==",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "dependencies": {
+        "postcss-value-parser": "^4.2.0"
+      },
       "engines": {
-        "node": "^12 || ^14 || >=16"
+        "node": "^14 || ^16 || >=18"
       },
       "peerDependencies": {
         "postcss": "^8.4"
       }
     },
-    "node_modules/postcss-media-minmax": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/postcss-media-minmax/-/postcss-media-minmax-5.0.0.tgz",
-      "integrity": "sha512-yDUvFf9QdFZTuCUg0g0uNSHVlJ5X1lSzDZjPSFaiCWvjgsvu8vEVxtahPrLMinIDEEGnx6cBe6iqdx5YWz08wQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=10.0.0"
-      },
-      "peerDependencies": {
-        "postcss": "^8.1.0"
-      }
-    },
     "node_modules/postcss-nesting": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/postcss-nesting/-/postcss-nesting-10.2.0.tgz",
-      "integrity": "sha512-EwMkYchxiDiKUhlJGzWsD9b2zvq/r2SSubcRrgP+jujMXFzqvANLt16lJANC+5uZ6hjI7lpRmI6O8JIl+8l1KA==",
+      "version": "12.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-nesting/-/postcss-nesting-12.0.1.tgz",
+      "integrity": "sha512-6LCqCWP9pqwXw/njMvNK0hGY44Fxc4B2EsGbn6xDcxbNRzP8GYoxT7yabVVMLrX3quqOJ9hg2jYMsnkedOf8pA==",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
       "dependencies": {
-        "@csstools/selector-specificity": "^2.0.0",
-        "postcss-selector-parser": "^6.0.10"
+        "@csstools/selector-specificity": "^3.0.0",
+        "postcss-selector-parser": "^6.0.13"
       },
       "engines": {
-        "node": "^12 || ^14 || >=16"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/csstools"
+        "node": "^14 || ^16 || >=18"
       },
       "peerDependencies": {
-        "postcss": "^8.2"
+        "postcss": "^8.4"
       }
     },
     "node_modules/postcss-opacity-percentage": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/postcss-opacity-percentage/-/postcss-opacity-percentage-1.1.3.tgz",
-      "integrity": "sha512-An6Ba4pHBiDtyVpSLymUUERMo2cU7s+Obz6BTrS+gxkbnSBNKSuD0AVUc+CpBMrpVPKKfoVz0WQCX+Tnst0i4A==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/postcss-opacity-percentage/-/postcss-opacity-percentage-2.0.0.tgz",
+      "integrity": "sha512-lyDrCOtntq5Y1JZpBFzIWm2wG9kbEdujpNt4NLannF+J9c8CgFIzPa80YQfdza+Y+yFfzbYj/rfoOsYsooUWTQ==",
       "dev": true,
       "funding": [
         {
@@ -8669,29 +9313,35 @@
         }
       ],
       "engines": {
-        "node": "^12 || ^14 || >=16"
+        "node": "^14 || ^16 || >=18"
       },
       "peerDependencies": {
         "postcss": "^8.2"
       }
     },
     "node_modules/postcss-overflow-shorthand": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/postcss-overflow-shorthand/-/postcss-overflow-shorthand-3.0.4.tgz",
-      "integrity": "sha512-otYl/ylHK8Y9bcBnPLo3foYFLL6a6Ak+3EQBPOTR7luMYCOsiVTUk1iLvNf6tVPNGXcoL9Hoz37kpfriRIFb4A==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/postcss-overflow-shorthand/-/postcss-overflow-shorthand-5.0.0.tgz",
+      "integrity": "sha512-2rlxDyeSics/hC2FuMdPnWiP9WUPZ5x7FTuArXLFVpaSQ2woPSfZS4RD59HuEokbZhs/wPUQJ1E3MT6zVv94MQ==",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
       "dependencies": {
         "postcss-value-parser": "^4.2.0"
       },
       "engines": {
-        "node": "^12 || ^14 || >=16"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/csstools"
+        "node": "^14 || ^16 || >=18"
       },
       "peerDependencies": {
-        "postcss": "^8.2"
+        "postcss": "^8.4"
       }
     },
     "node_modules/postcss-page-break": {
@@ -8704,108 +9354,134 @@
       }
     },
     "node_modules/postcss-place": {
-      "version": "7.0.5",
-      "resolved": "https://registry.npmjs.org/postcss-place/-/postcss-place-7.0.5.tgz",
-      "integrity": "sha512-wR8igaZROA6Z4pv0d+bvVrvGY4GVHihBCBQieXFY3kuSuMyOmEnnfFzHl/tQuqHZkfkIVBEbDvYcFfHmpSet9g==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/postcss-place/-/postcss-place-9.0.0.tgz",
+      "integrity": "sha512-qLEPD9VPH5opDVemwmRaujODF9nExn24VOC3ghgVLEvfYN7VZLwJHes0q/C9YR5hI2UC3VgBE8Wkdp1TxCXhtg==",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
       "dependencies": {
         "postcss-value-parser": "^4.2.0"
       },
       "engines": {
-        "node": "^12 || ^14 || >=16"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/csstools"
+        "node": "^14 || ^16 || >=18"
       },
       "peerDependencies": {
-        "postcss": "^8.2"
+        "postcss": "^8.4"
       }
     },
     "node_modules/postcss-preset-env": {
-      "version": "7.8.3",
-      "resolved": "https://registry.npmjs.org/postcss-preset-env/-/postcss-preset-env-7.8.3.tgz",
-      "integrity": "sha512-T1LgRm5uEVFSEF83vHZJV2z19lHg4yJuZ6gXZZkqVsqv63nlr6zabMH3l4Pc01FQCyfWVrh2GaUeCVy9Po+Aag==",
+      "version": "9.1.3",
+      "resolved": "https://registry.npmjs.org/postcss-preset-env/-/postcss-preset-env-9.1.3.tgz",
+      "integrity": "sha512-h8iPXykc4i/MDkbu8GuROt90mQJcj4//P49keGW+mcfs9xWeUZFotsT0m2YV9zpdCvSNJojOww1Os6BpVTpHbA==",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
       "dependencies": {
-        "@csstools/postcss-cascade-layers": "^1.1.1",
-        "@csstools/postcss-color-function": "^1.1.1",
-        "@csstools/postcss-font-format-keywords": "^1.0.1",
-        "@csstools/postcss-hwb-function": "^1.0.2",
-        "@csstools/postcss-ic-unit": "^1.0.1",
-        "@csstools/postcss-is-pseudo-class": "^2.0.7",
-        "@csstools/postcss-nested-calc": "^1.0.0",
-        "@csstools/postcss-normalize-display-values": "^1.0.1",
-        "@csstools/postcss-oklab-function": "^1.1.1",
-        "@csstools/postcss-progressive-custom-properties": "^1.3.0",
-        "@csstools/postcss-stepped-value-functions": "^1.0.1",
-        "@csstools/postcss-text-decoration-shorthand": "^1.0.0",
-        "@csstools/postcss-trigonometric-functions": "^1.0.2",
-        "@csstools/postcss-unset-value": "^1.0.2",
-        "autoprefixer": "^10.4.13",
-        "browserslist": "^4.21.4",
-        "css-blank-pseudo": "^3.0.3",
-        "css-has-pseudo": "^3.0.4",
-        "css-prefers-color-scheme": "^6.0.3",
-        "cssdb": "^7.1.0",
-        "postcss-attribute-case-insensitive": "^5.0.2",
+        "@csstools/postcss-cascade-layers": "^4.0.0",
+        "@csstools/postcss-color-function": "^3.0.3",
+        "@csstools/postcss-color-mix-function": "^2.0.3",
+        "@csstools/postcss-exponential-functions": "^1.0.0",
+        "@csstools/postcss-font-format-keywords": "^3.0.0",
+        "@csstools/postcss-gradients-interpolation-method": "^4.0.3",
+        "@csstools/postcss-hwb-function": "^3.0.3",
+        "@csstools/postcss-ic-unit": "^3.0.0",
+        "@csstools/postcss-is-pseudo-class": "^4.0.1",
+        "@csstools/postcss-logical-float-and-clear": "^2.0.0",
+        "@csstools/postcss-logical-resize": "^2.0.0",
+        "@csstools/postcss-logical-viewport-units": "^2.0.1",
+        "@csstools/postcss-media-minmax": "^1.0.7",
+        "@csstools/postcss-media-queries-aspect-ratio-number-values": "^2.0.2",
+        "@csstools/postcss-nested-calc": "^3.0.0",
+        "@csstools/postcss-normalize-display-values": "^3.0.0",
+        "@csstools/postcss-oklab-function": "^3.0.3",
+        "@csstools/postcss-progressive-custom-properties": "^3.0.0",
+        "@csstools/postcss-relative-color-syntax": "^2.0.3",
+        "@csstools/postcss-scope-pseudo-class": "^3.0.0",
+        "@csstools/postcss-stepped-value-functions": "^3.0.1",
+        "@csstools/postcss-text-decoration-shorthand": "^3.0.2",
+        "@csstools/postcss-trigonometric-functions": "^3.0.1",
+        "@csstools/postcss-unset-value": "^3.0.0",
+        "autoprefixer": "^10.4.15",
+        "browserslist": "^4.21.10",
+        "css-blank-pseudo": "^6.0.0",
+        "css-has-pseudo": "^6.0.0",
+        "css-prefers-color-scheme": "^9.0.0",
+        "cssdb": "^7.7.1",
+        "postcss-attribute-case-insensitive": "^6.0.2",
         "postcss-clamp": "^4.1.0",
-        "postcss-color-functional-notation": "^4.2.4",
-        "postcss-color-hex-alpha": "^8.0.4",
-        "postcss-color-rebeccapurple": "^7.1.1",
-        "postcss-custom-media": "^8.0.2",
-        "postcss-custom-properties": "^12.1.10",
-        "postcss-custom-selectors": "^6.0.3",
-        "postcss-dir-pseudo-class": "^6.0.5",
-        "postcss-double-position-gradients": "^3.1.2",
-        "postcss-env-function": "^4.0.6",
-        "postcss-focus-visible": "^6.0.4",
-        "postcss-focus-within": "^5.0.4",
+        "postcss-color-functional-notation": "^6.0.0",
+        "postcss-color-hex-alpha": "^9.0.2",
+        "postcss-color-rebeccapurple": "^9.0.0",
+        "postcss-custom-media": "^10.0.0",
+        "postcss-custom-properties": "^13.3.0",
+        "postcss-custom-selectors": "^7.1.4",
+        "postcss-dir-pseudo-class": "^8.0.0",
+        "postcss-double-position-gradients": "^5.0.0",
+        "postcss-focus-visible": "^9.0.0",
+        "postcss-focus-within": "^8.0.0",
         "postcss-font-variant": "^5.0.0",
-        "postcss-gap-properties": "^3.0.5",
-        "postcss-image-set-function": "^4.0.7",
+        "postcss-gap-properties": "^5.0.0",
+        "postcss-image-set-function": "^6.0.0",
         "postcss-initial": "^4.0.1",
-        "postcss-lab-function": "^4.2.1",
-        "postcss-logical": "^5.0.4",
-        "postcss-media-minmax": "^5.0.0",
-        "postcss-nesting": "^10.2.0",
-        "postcss-opacity-percentage": "^1.1.2",
-        "postcss-overflow-shorthand": "^3.0.4",
+        "postcss-lab-function": "^6.0.3",
+        "postcss-logical": "^7.0.0",
+        "postcss-nesting": "^12.0.1",
+        "postcss-opacity-percentage": "^2.0.0",
+        "postcss-overflow-shorthand": "^5.0.0",
         "postcss-page-break": "^3.0.4",
-        "postcss-place": "^7.0.5",
-        "postcss-pseudo-class-any-link": "^7.1.6",
+        "postcss-place": "^9.0.0",
+        "postcss-pseudo-class-any-link": "^9.0.0",
         "postcss-replace-overflow-wrap": "^4.0.0",
-        "postcss-selector-not": "^6.0.1",
+        "postcss-selector-not": "^7.0.1",
         "postcss-value-parser": "^4.2.0"
       },
       "engines": {
-        "node": "^12 || ^14 || >=16"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/csstools"
+        "node": "^14 || ^16 || >=18"
       },
       "peerDependencies": {
-        "postcss": "^8.2"
+        "postcss": "^8.4"
       }
     },
     "node_modules/postcss-pseudo-class-any-link": {
-      "version": "7.1.6",
-      "resolved": "https://registry.npmjs.org/postcss-pseudo-class-any-link/-/postcss-pseudo-class-any-link-7.1.6.tgz",
-      "integrity": "sha512-9sCtZkO6f/5ML9WcTLcIyV1yz9D1rf0tWc+ulKcvV30s0iZKS/ONyETvoWsr6vnrmW+X+KmuK3gV/w5EWnT37w==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/postcss-pseudo-class-any-link/-/postcss-pseudo-class-any-link-9.0.0.tgz",
+      "integrity": "sha512-QNCYIL98VKFKY6HGDEJpF6+K/sg9bxcUYnOmNHJxZS5wsFDFaVoPeG68WAuhsqwbIBSo/b9fjEnTwY2mTSD+uA==",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
       "dependencies": {
-        "postcss-selector-parser": "^6.0.10"
+        "postcss-selector-parser": "^6.0.13"
       },
       "engines": {
-        "node": "^12 || ^14 || >=16"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/csstools"
+        "node": "^14 || ^16 || >=18"
       },
       "peerDependencies": {
-        "postcss": "^8.2"
+        "postcss": "^8.4"
       }
     },
     "node_modules/postcss-replace-overflow-wrap": {
@@ -8860,28 +9536,28 @@
       }
     },
     "node_modules/postcss-selector-not": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/postcss-selector-not/-/postcss-selector-not-6.0.1.tgz",
-      "integrity": "sha512-1i9affjAe9xu/y9uqWH+tD4r6/hDaXJruk8xn2x1vzxC2U3J3LKO3zJW4CyxlNhA56pADJ/djpEwpH1RClI2rQ==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-selector-not/-/postcss-selector-not-7.0.1.tgz",
+      "integrity": "sha512-1zT5C27b/zeJhchN7fP0kBr16Cc61mu7Si9uWWLoA3Px/D9tIJPKchJCkUH3tPO5D0pCFmGeApAv8XpXBQJ8SQ==",
       "dev": true,
       "dependencies": {
         "postcss-selector-parser": "^6.0.10"
       },
       "engines": {
-        "node": "^12 || ^14 || >=16"
+        "node": "^14 || ^16 || >=18"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/csstools"
       },
       "peerDependencies": {
-        "postcss": "^8.2"
+        "postcss": "^8.4"
       }
     },
     "node_modules/postcss-selector-parser": {
-      "version": "6.0.11",
-      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.11.tgz",
-      "integrity": "sha512-zbARubNdogI9j7WY4nQJBiNqQf3sLS3wCP4WfOidu+p28LofJqDH1tcXypGrcmMHhDk2t9wGhCsYe/+szLTy1g==",
+      "version": "6.0.13",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.13.tgz",
+      "integrity": "sha512-EaV1Gl4mUEV4ddhDnv/xtj7sxwrwxdetHdWUGnT4VJQf+4d05v6lHYZr8N573k5Z0BViss7BDhfWtKS3+sfAqQ==",
       "dev": true,
       "dependencies": {
         "cssesc": "^3.0.0",
@@ -10496,9 +11172,9 @@
       }
     },
     "node_modules/update-browserslist-db": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.10.tgz",
-      "integrity": "sha512-OztqDenkfFkbSG+tRxBeAnCVPckDBcvibKd35yDONx6OU8N7sqgwc7rCbkJ/WcYtVRZ4ba68d6byhC21GFh7sQ==",
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.11.tgz",
+      "integrity": "sha512-dCwEFf0/oT85M1fHBg4F0jtLwJrutGoHSQXCh7u4o2t1drG+c0a9Flnqww6XUKSfQMPpJBRjU8d4RXB09qtvaA==",
       "dev": true,
       "funding": [
         {
@@ -10508,6 +11184,10 @@
         {
           "type": "tidelift",
           "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
         }
       ],
       "dependencies": {
@@ -10515,7 +11195,7 @@
         "picocolors": "^1.0.0"
       },
       "bin": {
-        "browserslist-lint": "cli.js"
+        "update-browserslist-db": "cli.js"
       },
       "peerDependencies": {
         "browserslist": ">= 4.21.0"

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "node": "^18.14.0"
   },
   "devDependencies": {
+    "@csstools/postcss-global-data": "^2.1.0",
     "@playwright/test": "^1.37.1",
     "@sveltejs/adapter-node": "^1.3.1",
     "@sveltejs/kit": "^1.23.0",

--- a/package.json
+++ b/package.json
@@ -20,10 +20,6 @@
   "engines": {
     "node": "^18.14.0"
   },
-  "browserslist": [
-    "defaults",
-    "not IE 11"
-  ],
   "devDependencies": {
     "@playwright/test": "^1.37.1",
     "@sveltejs/adapter-node": "^1.3.1",
@@ -39,7 +35,7 @@
     "eslint-config-prettier": "^8.10.0",
     "eslint-plugin-svelte": "^2.33.0",
     "jsdom": "^22.1.0",
-    "postcss-preset-env": "^7.8.3",
+    "postcss-preset-env": "^9.1.3",
     "prettier": "^2.8.8",
     "prettier-plugin-svelte": "^2.10.1",
     "svelte": "^4.2.0",

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,5 +1,11 @@
-import presetEnv from 'postcss-preset-env';
+import postcssPresetEnv from 'postcss-preset-env';
+import postcssGlobalData from '@csstools/postcss-global-data';
 
 export default {
-	plugins: [presetEnv()]
+	plugins: [
+		postcssGlobalData({
+			files: ['./src/lib/components/css/breakpoints.css']
+		}),
+		postcssPresetEnv()
+	]
 };

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,9 +1,5 @@
 import presetEnv from 'postcss-preset-env';
 
 export default {
-	plugins: [
-		presetEnv({
-			features: { 'nesting-rules': true }
-		})
-	]
+	plugins: [presetEnv()]
 };

--- a/src/lib/breadcrumb/Breadcrumbs.svelte
+++ b/src/lib/breadcrumb/Breadcrumbs.svelte
@@ -99,7 +99,7 @@ https://search.google.com/structured-data/testing-tool
 	li {
 		white-space: nowrap;
 
-		& > * {
+		> * {
 			padding: var(--space-ss) var(--space-sm);
 
 			&:not(:hover) {
@@ -107,7 +107,7 @@ https://search.google.com/structured-data/testing-tool
 			}
 		}
 
-		& > span {
+		> span {
 			color: hsla(var(--hsl-text));
 		}
 

--- a/src/lib/chart/ChartIQ.svelte
+++ b/src/lib/chart/ChartIQ.svelte
@@ -223,7 +223,7 @@ Dynamically ChartIQ modules (if available) and render chart element.
 			--CHART-aspect-ratio: 4/6;
 		}
 
-		& :is(.loading, .inner) {
+		:is(.loading, .inner) {
 			position: absolute;
 			top: 0;
 			bottom: 0;
@@ -231,12 +231,12 @@ Dynamically ChartIQ modules (if available) and render chart element.
 			right: 0;
 		}
 
-		& .inner {
+		.inner {
 			z-index: 99;
 			pointer-events: none;
 		}
 
-		& .loading {
+		.loading {
 			z-index: 100;
 			display: flex;
 			justify-content: center;

--- a/src/lib/chart/HudMetric.svelte
+++ b/src/lib/chart/HudMetric.svelte
@@ -33,7 +33,7 @@ Use in conjunction with HudRow to display chart HUD (heads-up-display) data.
 		align-items: center;
 		margin: 0;
 
-		& dt {
+		dt {
 			color: hsla(var(--hsl-text-light));
 		}
 	}

--- a/src/lib/chart/ReserveInterestChart.svelte
+++ b/src/lib/chart/ReserveInterestChart.svelte
@@ -122,16 +122,16 @@
 		display: inline-block;
 		padding: var(--space-xs) var(--space-sl);
 
-		& h3 {
+		h3 {
 			margin: 0;
 			font-weight: 500;
 		}
 
-		& :global dl .secondary:not(.idx-0) {
+		:global dl .secondary:not(.idx-0) {
 			margin-left: var(--space-md);
 		}
 
-		& :global .secondary dt {
+		:global .secondary dt {
 			font-weight: 500;
 			color: var(--label-color);
 

--- a/src/lib/components/AlertItem.svelte
+++ b/src/lib/components/AlertItem.svelte
@@ -38,17 +38,17 @@ Display a single alert item (should always be nested within AlertList).
 		gap: var(--space-md) var(--space-sm);
 		font: inherit; /* see AlertList */
 
-		& :global .icon {
+		:global .icon {
 			display: block;
 			margin-top: -0.1em;
 		}
 
-		& :global a {
+		:global a {
 			font-weight: 700;
 			text-decoration: underline;
 		}
 
-		& strong {
+		strong {
 			font-weight: 700;
 
 			@media (--viewport-lg-up) {
@@ -62,7 +62,7 @@ Display a single alert item (should always be nested within AlertList).
 			}
 		}
 
-		& .inner {
+		.inner {
 			display: grid;
 			grid-template-columns: 1fr;
 			gap: var(--space-md);
@@ -72,7 +72,7 @@ Display a single alert item (should always be nested within AlertList).
 			}
 		}
 
-		& .cta {
+		.cta {
 			display: grid;
 			align-content: start;
 		}

--- a/src/lib/components/Banner.svelte
+++ b/src/lib/components/Banner.svelte
@@ -26,23 +26,23 @@
 		display: contents;
 		--section-background: hsla(var(--hsla-background-accent-1));
 
-		& :is(h2, footer) {
+		:is(h2, footer) {
 			text-align: center;
 		}
 
-		& :is(h2, footer, .content) {
+		:is(h2, footer, .content) {
 			padding-inline: var(--space-md);
 		}
 
 		@media (--viewport-sm-down) {
-			& h2 {
+			h2 {
 				font: var(--f-heading-md-medium);
 				letter-spacing: var(--f-heading-md-spacing, normal);
 			}
 		}
 
 		@media (--viewport-md-up) {
-			& .content :global(:where(p, li)) {
+			.content :global(:where(p, li)) {
 				font: var(--f-ui-xl-roman);
 				letter-spacing: var(--f-ui-xl-spacing, normal);
 				margin-bottom: var(--space-lg);

--- a/src/lib/components/ContentCard.svelte
+++ b/src/lib/components/ContentCard.svelte
@@ -34,6 +34,7 @@ logic is required. Use `slot="cta"` instead of `ctaLabel` when custom button opt
 	};
 </script>
 
+<!-- svelte-ignore a11y-no-static-element-interactions -->
 <svelte:element this={tag} {...anchorProps} class="content-card tile b" class:ctaFullWidth on:click>
 	{#if icon || $$slots.icon}
 		<div class="icon symbol tile c">
@@ -133,7 +134,7 @@ logic is required. Use `slot="cta"` instead of `ctaLabel` when custom button opt
 			margin-top: var(--space-sm);
 		}
 
-		@nest .ctaFullWidth & :global .button {
+		.ctaFullWidth & :global .button {
 			width: 100%;
 		}
 	}

--- a/src/lib/components/ContentCard.svelte
+++ b/src/lib/components/ContentCard.svelte
@@ -75,11 +75,11 @@ logic is required. Use `slot="cta"` instead of `ctaLabel` when custom button opt
 			gap: var(--space-ml);
 		}
 
-		& * {
+		* {
 			margin-bottom: 0;
 		}
 
-		& .symbol {
+		.symbol {
 			--icon-size: var(--content-tile-icon-size, 1.75rem);
 			border-radius: 100%;
 			display: flex;
@@ -92,7 +92,7 @@ logic is required. Use `slot="cta"` instead of `ctaLabel` when custom button opt
 			}
 		}
 
-		& :global h3 {
+		:global h3 {
 			font: var(--f-heading-lg-medium);
 
 			@media (--viewport-xs) {
@@ -100,7 +100,7 @@ logic is required. Use `slot="cta"` instead of `ctaLabel` when custom button opt
 			}
 		}
 
-		& .description {
+		.description {
 			flex: 1;
 			font: var(--f-ui-lg-roman);
 			letter-spacing: var(--f-ui-lg-spacing, normal);
@@ -110,7 +110,7 @@ logic is required. Use `slot="cta"` instead of `ctaLabel` when custom button opt
 				letter-spacing: var(--f-ui-sm-spacing, normal);
 			}
 
-			& :global(p) {
+			:global(p) {
 				margin-bottom: 1.25em;
 				font: inherit;
 				letter-spacing: inherit;
@@ -124,7 +124,7 @@ logic is required. Use `slot="cta"` instead of `ctaLabel` when custom button opt
 
 	.cta {
 		@media (--viewport-sm-down) {
-			& :global .button {
+			:global .button {
 				width: 100%;
 			}
 		}

--- a/src/lib/components/ContentCardsSection.svelte
+++ b/src/lib/components/ContentCardsSection.svelte
@@ -41,7 +41,7 @@ A section component to display a collection of ContentCards in a responsive grid
 			--grid-gap: var(--space-ls);
 		}
 
-		& h2 {
+		h2 {
 			font: var(--f-heading-lg-medium);
 			letter-spacing: var(--f-heading-lg-spacing, normal);
 

--- a/src/lib/components/ContentTile.svelte
+++ b/src/lib/components/ContentTile.svelte
@@ -91,10 +91,12 @@ A `ctaLabel` or `cta` slot may also be provided to include an explicit button ta
 	.content {
 		--content-gap: var(--space-sl);
 		--content-padding: var(--space-ll) var(--space-lg);
+
 		@media (--viewport-sm-down) {
 			--content-gap: var(--space-ss);
 			--content-padding: var(--space-ls) var(--space-ml);
 		}
+
 		display: grid;
 		gap: var(--content-gap);
 		padding: var(--content-padding);
@@ -105,19 +107,19 @@ A `ctaLabel` or `cta` slot may also be provided to include an explicit button ta
 		display: grid;
 		gap: var(--content-gap);
 
-		& :global time {
+		:global time {
 			font: var(--f-ui-sm-medium);
 			letter-spacing: var(--f-ui-sm-spacing, normal);
 			color: hsl(var(--hsl-text-extra-light));
 		}
 
-		& h3 {
+		h3 {
 			margin: 0;
 			font: var(--f-heading-md-medium);
 			letter-spacing: var(--f-heading-md-spacing, normal);
 		}
 
-		& p {
+		p {
 			font: var(--f-ui-md-roman);
 			letter-spacing: var(--f-ui-md-spacing, normal);
 			color: hsl(var(--hsl-text-light));
@@ -127,14 +129,5 @@ A `ctaLabel` or `cta` slot may also be provided to include an explicit button ta
 	.cta {
 		margin-top: var(--space-sm);
 		display: grid;
-	}
-
-	/* display CTA button as hovered/focused when tile is hovered/focused */
-	.content-tile:hover,
-	.content-tile:focus {
-		& .cta :global .button {
-			--c-accent: var(--hsl-text), 1;
-			color: hsla(var(--hsl-text-inverted));
-		}
 	}
 </style>

--- a/src/lib/components/CopyWidget.svelte
+++ b/src/lib/components/CopyWidget.svelte
@@ -45,7 +45,7 @@ a `copier` store with a `copy` method – bind this to a variable and call `copi
 	.copy-widget {
 		display: grid;
 
-		& span {
+		span {
 			grid-area: 1 / -1;
 		}
 	}

--- a/src/lib/components/DataBadge.svelte
+++ b/src/lib/components/DataBadge.svelte
@@ -21,13 +21,13 @@
 		display: inline-grid;
 		transition: var(--transition-1);
 
-		& span {
+		span {
 			align-items: center;
 			display: flex;
 			gap: 0.375rem;
 		}
 
-		& .additional-value {
+		.additional-value {
 			margin-top: var(--badge-gap);
 		}
 

--- a/src/lib/components/DataBox.svelte
+++ b/src/lib/components/DataBox.svelte
@@ -129,7 +129,7 @@ Uses together with SummaryBox or DataBoxes to display a set of properties / stat
 			}
 		}
 
-		& :global a {
+		:global a {
 			font: inherit;
 			text-decoration: underline;
 		}

--- a/src/lib/components/DataBox.svelte
+++ b/src/lib/components/DataBox.svelte
@@ -89,7 +89,7 @@ Uses together with SummaryBox or DataBoxes to display a set of properties / stat
 	}
 
 	.value {
-		@nest .xs & {
+		.xs & {
 			font: var(--f-ui-lg-medium);
 			letter-spacing: var(--f-ui-lg-spacing, normal);
 
@@ -99,7 +99,7 @@ Uses together with SummaryBox or DataBoxes to display a set of properties / stat
 			}
 		}
 
-		@nest .sm & {
+		.sm & {
 			font: var(--f-ui-xl-medium);
 			letter-spacing: var(--f-ui-xl-spacing, normal);
 
@@ -109,7 +109,7 @@ Uses together with SummaryBox or DataBoxes to display a set of properties / stat
 			}
 		}
 
-		@nest .md & {
+		.md & {
 			font: var(--f-ui-xxl-medium);
 			letter-spacing: var(--f-ui-xxl-spacing, normal);
 
@@ -119,7 +119,7 @@ Uses together with SummaryBox or DataBoxes to display a set of properties / stat
 			}
 		}
 
-		@nest .lg & {
+		.lg & {
 			font: var(--f-ui-xxxl-medium);
 			letter-spacing: var(--f-ui-xxxl-spacing, normal);
 

--- a/src/lib/components/Dialog.svelte
+++ b/src/lib/components/Dialog.svelte
@@ -99,13 +99,13 @@ Modal dialog component. Dispatches `open` and `close` events when state changes
 		margin-bottom: var(--space-ss);
 		color: var(--c-text-4-v1);
 
-		& h5 {
+		h5 {
 			font: var(--f-ui-lg-medium);
 			letter-spacing: var(--f-ui-lg-spacing, normal);
 			margin: 0;
 		}
 
-		& button {
+		button {
 			display: flex;
 			gap: var(--space-ss);
 			justify-content: center;

--- a/src/lib/components/EntitySymbol.svelte
+++ b/src/lib/components/EntitySymbol.svelte
@@ -30,12 +30,12 @@
 		align-items: center;
 		justify-content: flex-start;
 
-		& .icon {
+		.icon {
 			display: grid;
 			justify-items: center;
 			width: var(--image-size);
 
-			& img {
+			img {
 				height: var(--image-size);
 			}
 		}

--- a/src/lib/components/Footer.svelte
+++ b/src/lib/components/Footer.svelte
@@ -43,7 +43,7 @@
 			padding-block: 0;
 		}
 
-		& .icon-group {
+		.icon-group {
 			display: flex;
 			gap: inherit;
 		}

--- a/src/lib/components/HashAddress.svelte
+++ b/src/lib/components/HashAddress.svelte
@@ -15,7 +15,7 @@
 		overflow: hidden;
 		white-space: nowrap;
 
-		& span {
+		span {
 			text-decoration: underline;
 
 			&:first-child {

--- a/src/lib/components/HeroBanner.svelte
+++ b/src/lib/components/HeroBanner.svelte
@@ -66,7 +66,7 @@ Hero banner used as heading on various pages (Community, Trading data, Blog roll
 		gap: var(--space-sm);
 		place-content: center stretch;
 
-		& h1 {
+		h1 {
 			font: var(--f-heading-lg-medium);
 			letter-spacing: var(--f-heading-lg-spacing, normal);
 
@@ -76,7 +76,7 @@ Hero banner used as heading on various pages (Community, Trading data, Blog roll
 			}
 		}
 
-		& p {
+		p {
 			margin: 0;
 			font: var(--f-ui-xl-roman);
 			letter-spacing: var(--f-ui-xl-spacing, normal);
@@ -93,11 +93,11 @@ Hero banner used as heading on various pages (Community, Trading data, Blog roll
 			display: none;
 		}
 
-		& :global svg {
+		:global svg {
 			max-height: min(28rem, 64vw);
 			margin: auto;
 
-			& * {
+			* {
 				fill: currentColor;
 			}
 		}

--- a/src/lib/components/Icon.svelte
+++ b/src/lib/components/Icon.svelte
@@ -23,10 +23,10 @@
 		display: contents;
 		font-size: var(--icon-size, var(--size, auto));
 
-		& :global svg {
+		:global svg {
 			height: 1em;
 			width: 1em;
-			& path {
+			path {
 				stroke: var(--icon-color, currentcolor);
 
 				&.fill {

--- a/src/lib/components/Illustration.svelte
+++ b/src/lib/components/Illustration.svelte
@@ -31,7 +31,7 @@
 		height: var(--illustration-height);
 		width: var(--illustration-height);
 
-		& > * {
+		> * {
 			fill: currentColor;
 		}
 	}

--- a/src/lib/components/MoneyInput.svelte
+++ b/src/lib/components/MoneyInput.svelte
@@ -91,7 +91,7 @@ retained to avoid rounding errors and allow for conversion to `BigInt`.
 		max-width: var(--text-input-max-width, auto);
 		width: var(--text-input-width, auto);
 
-		& .inner {
+		.inner {
 			display: flex;
 			background: hsla(var(--input-background));
 			border: 1px hsla(var(--hsl-box), var(--a-box-c)) solid;
@@ -100,7 +100,7 @@ retained to avoid rounding errors and allow for conversion to `BigInt`.
 			overflow: hidden;
 		}
 
-		& .unit {
+		.unit {
 			background-image: linear-gradient(hsla(var(--hsl-box), var(--a-box-b)), hsla(var(--hsl-box), var(--a-box-b))),
 				linear-gradient(hsla(var(--hsl-body)), hsla(var(--hsl-body)));
 			display: grid;
@@ -115,14 +115,14 @@ retained to avoid rounding errors and allow for conversion to `BigInt`.
 			opacity: 0.65;
 		}
 
-		& .conversion-label {
+		.conversion-label {
 			display: flex;
 			justify-content: flex-end;
 			text-align: right;
 			gap: var(--space-md);
 		}
 
-		& input {
+		input {
 			background: transparent;
 			border: none;
 			color: var(--c-text-1-v1);

--- a/src/lib/components/PageHeader.svelte
+++ b/src/lib/components/PageHeader.svelte
@@ -36,16 +36,16 @@ strings) or named slots (for nested markup); `description` can be a prop or defa
 			grid-auto-flow: column;
 		}
 
-		& h1 {
+		h1 {
 			font: var(--f-h1-medium);
 		}
 
-		& .multiline {
+		.multiline {
 			display: grid;
 			font-weight: 700;
 		}
 
-		& small {
+		small {
 			font: var(--f-h4-medium);
 			color: var(--c-text-2-v1);
 		}

--- a/src/lib/components/PageHeading.svelte
+++ b/src/lib/components/PageHeading.svelte
@@ -12,20 +12,20 @@
 	}
 
 	.level-1 :global {
-		& h1 {
+		h1 {
 			font: var(--f-heading-xl-medium);
 			letter-spacing: var(--f-heading-xl-spacing, normal);
 			margin-bottom: var(--space-md);
 		}
 
-		& p {
+		p {
 			font: var(--fs-ui-xl-medium);
 			letter-spacing: var(--fs-ui-xl-spacing, normal);
 		}
 	}
 
 	.level-2 :global {
-		& h1 {
+		h1 {
 			color: var(--c-text-ultra-light);
 			font: var(--f-heading-md-medium);
 			letter-spacing: var(--f-heading-md-spacing, normal);
@@ -37,7 +37,7 @@
 				margin: 0 0 var(--space-sl);
 			}
 
-			& a {
+			a {
 				font: inherit;
 
 				&:hover {
@@ -46,7 +46,7 @@
 			}
 		}
 
-		& h2 {
+		h2 {
 			font: var(--f-heading-xxxl-medium);
 			letter-spacing: var(--f-heading-xxxl-spacing, normal);
 			margin: 0;

--- a/src/lib/components/Section.svelte
+++ b/src/lib/components/Section.svelte
@@ -93,8 +93,8 @@ CSS overrides: `--section-padding`, `--section-gap`, `--section-background`
 
 	/* TODO: move font settings somewhere else */
 	.section :global {
-		& > h2,
-		& > header > h2 {
+		> h2,
+		> header > h2 {
 			font: var(--f-heading-xl-medium);
 
 			@media (--viewport-sm-down) {
@@ -102,8 +102,8 @@ CSS overrides: `--section-padding`, `--section-gap`, `--section-background`
 			}
 		}
 
-		& > p,
-		& > header > p {
+		> p,
+		> header > p {
 			font: var(--f-ui-lg-roman);
 
 			@media (--viewport-xs) {

--- a/src/lib/components/SegmentedControl.svelte
+++ b/src/lib/components/SegmentedControl.svelte
@@ -46,7 +46,7 @@ button-like control with a segement for each possible value.
 		&:first-child {
 			border-radius: var(--radius-md) 0 0 var(--radius-md);
 
-			& span {
+			span {
 				padding-left: var(--space-xxs);
 			}
 		}
@@ -54,7 +54,7 @@ button-like control with a segement for each possible value.
 		&:last-child {
 			border-radius: 0 var(--radius-md) var(--radius-md) 0;
 
-			& span {
+			span {
 				padding-right: var(--space-xxs);
 			}
 		}

--- a/src/lib/components/Select.svelte
+++ b/src/lib/components/Select.svelte
@@ -32,7 +32,7 @@
 			outline: none;
 		}
 
-		& :global svg {
+		:global svg {
 			position: absolute;
 			right: var(--wrapper-padding);
 			pointer-events: none;

--- a/src/lib/components/SourceCode.svelte
+++ b/src/lib/components/SourceCode.svelte
@@ -29,7 +29,7 @@ See: https://github.com/metonym/svelte-highlight
 		border-radius: var(--radius-md);
 		background-color: var(--c-ink);
 
-		& :global(.hljs) {
+		:global(.hljs) {
 			background-color: transparent;
 		}
 	}

--- a/src/lib/components/SummaryBox.svelte
+++ b/src/lib/components/SummaryBox.svelte
@@ -60,18 +60,18 @@ Possible `ctaPosition` values include: top, bottom, toggle (default).
 			padding: var(--space-md);
 		}
 
-		& .main {
+		.main {
 			display: grid;
 			align-content: flex-start;
 			gap: var(--space-ls);
 
-			& :global(p) {
+			:global(p) {
 				font: var(--f-ui-lg-roman);
 				letter-spacing: var(--f-ui-lg-spacing, normal);
 			}
 		}
 
-		& :global header {
+		:global header {
 			display: grid;
 			grid-template-columns: 1fr auto;
 			gap: var(--space-sm) var(--space-lg);
@@ -82,13 +82,13 @@ Possible `ctaPosition` values include: top, bottom, toggle (default).
 				margin-bottom: var(--space-sm);
 			}
 
-			& h3 {
+			h3 {
 				align-self: center;
 				font: var(--f-heading-md-medium);
 				letter-spacing: var(--f-heading-md-spacing, normal);
 			}
 
-			& p {
+			p {
 				/* grid-area: 2 / 1 / auto / span 2; */
 				grid-column: 1 / span 2;
 				color: hsla(var(--hsl-text-extra-light));

--- a/src/lib/components/Tabs.svelte
+++ b/src/lib/components/Tabs.svelte
@@ -56,7 +56,7 @@ Display tabs and associated content panels. Optional `selected` prop defaults to
 		padding: var(--space-md);
 		font: var(--f-ui-lg-medium);
 
-		@nest input:checked + & {
+		input:checked + & {
 			background: var(--c-background-4);
 			color: var(--c-text-default);
 			cursor: auto;

--- a/src/lib/components/TextInput.svelte
+++ b/src/lib/components/TextInput.svelte
@@ -68,14 +68,14 @@ unknown props through to HTML input element.
 		max-width: var(--text-input-max-width, auto);
 		width: var(--text-input-width, auto);
 
-		& input {
+		input {
 			font: var(--text-input-font, var(--font));
 			height: var(--text-input-height, var(--height));
 			letter-spacing: var(--text-input-letter-spacing, var(--letter-spacing, normal));
 		}
 
-		& .label,
-		& [slot='label'] {
+		.label,
+		[slot='label'] {
 			font-weight: 500;
 		}
 
@@ -87,7 +87,7 @@ unknown props through to HTML input element.
 			text-indent: 1.125em;
 		}
 
-		& :global svg {
+		:global svg {
 			position: absolute;
 			top: 50%;
 			transform: translateY(-50%);
@@ -102,7 +102,7 @@ unknown props through to HTML input element.
 			--letter-spacing: var(--f-mono-sm-spacing);
 			font-weight: 600;
 
-			& input::placeholder {
+			input::placeholder {
 				font: var(--f-ui-sm-roman);
 				letter-spacing: var(--f-ui-sm-spacing, normal);
 			}
@@ -114,7 +114,7 @@ unknown props through to HTML input element.
 			--letter-spacing: var(--f-mono-md-spacing);
 			font-weight: 600;
 
-			& input::placeholder {
+			input::placeholder {
 				font: var(--f-ui-md-roman);
 				letter-spacing: var(--f-ui-md-spacing, normal);
 			}
@@ -126,7 +126,7 @@ unknown props through to HTML input element.
 			--letter-spacing: var(--f-mono-lg-spacing);
 			font-weight: 600;
 
-			& input::placeholder {
+			input::placeholder {
 				font: var(--f-ui-lg-roman);
 				letter-spacing: var(--f-ui-lg-spacing, normal);
 			}
@@ -138,13 +138,13 @@ unknown props through to HTML input element.
 			--letter-spacing: var(--f-mono-xl-spacing);
 			font-weight: 600;
 
-			& input::placeholder {
+			input::placeholder {
 				font: var(--f-ui-xl-roman);
 				letter-spacing: var(--f-ui-xl-roman, normal);
 			}
 		}
 
-		& input {
+		input {
 			width: inherit;
 			padding: 0 var(--space-sl);
 			border: 1px hsla(var(--hsl-text-ultra-light)) solid;
@@ -179,10 +179,10 @@ unknown props through to HTML input element.
 			}
 		}
 
-		& .cancel-btn {
+		.cancel-btn {
 			display: none;
 
-			& :global svg {
+			:global svg {
 				left: auto;
 				right: var(--space-md);
 				font-size: 1rem;
@@ -190,7 +190,7 @@ unknown props through to HTML input element.
 		}
 
 		&:is(:hover, :focus-within) {
-			& :global .cancel-btn {
+			:global .cancel-btn {
 				display: contents;
 			}
 		}

--- a/src/lib/components/TextInput.svelte
+++ b/src/lib/components/TextInput.svelte
@@ -189,8 +189,7 @@ unknown props through to HTML input element.
 			}
 		}
 
-		&:has(:focus),
-		&:hover {
+		&:is(:hover, :focus-within) {
 			& :global .cancel-btn {
 				display: contents;
 			}

--- a/src/lib/components/Tooltip.svelte
+++ b/src/lib/components/Tooltip.svelte
@@ -36,17 +36,17 @@ For more information see:
 
 <style lang="postcss">
 	.tooltip {
-		& .trigger {
+		.trigger {
 			font-style: normal;
 			cursor: pointer;
 
 			/* Utility class to provide affordance that the trigger is interactive */
-			& :global(.underline) {
+			:global(.underline) {
 				border-bottom: 1px dotted hsla(var(--hsl-text-light));
 			}
 		}
 
-		& .popup {
+		.popup {
 			display: none;
 			position: absolute;
 			contain: content;
@@ -65,7 +65,7 @@ For more information see:
 				padding: 0;
 			}
 
-			& .inner {
+			.inner {
 				padding: 1.125rem;
 				border: 1px solid hsla(var(--hsl-box-3));
 				border-radius: var(--radius-md);
@@ -76,11 +76,11 @@ For more information see:
 				text-align: left;
 			}
 
-			& :global(a) {
+			:global(a) {
 				text-decoration: underline;
 			}
 
-			& :global(p) {
+			:global(p) {
 				margin-bottom: 0.5em;
 			}
 		}

--- a/src/lib/components/TradingDataInfo.svelte
+++ b/src/lib/components/TradingDataInfo.svelte
@@ -21,7 +21,7 @@ Container for displaying a set of trading data key/value pairs. Use with <Tradin
 		gap: var(--space-sl);
 		margin: 0;
 
-		& :global > * {
+		:global > * {
 			margin: 0;
 			overflow: hidden;
 			text-overflow: ellipsis;

--- a/src/lib/components/UpDownCell.svelte
+++ b/src/lib/components/UpDownCell.svelte
@@ -34,7 +34,7 @@ or other contexts where a stronger visual representation is desired.
 		display: flex;
 		justify-content: flex-end;
 
-		& :global(.up-down-indicator) {
+		:global(.up-down-indicator) {
 			background: hsla(var(--hsl-box), var(--a-box-b));
 			border-radius: var(--radius-sm);
 			display: grid;
@@ -46,7 +46,7 @@ or other contexts where a stronger visual representation is desired.
 			transition: all var(--time-sm) ease-out;
 		}
 
-		& :global(.bullish) {
+		:global(.bullish) {
 			background: hsla(var(--hsl-bullish), 0.12);
 
 			&:hover {
@@ -54,7 +54,7 @@ or other contexts where a stronger visual representation is desired.
 			}
 		}
 
-		& :global(.bearish) {
+		:global(.bearish) {
 			background: hsla(var(--hsl-bearish), 0.12);
 
 			&:hover {

--- a/src/lib/components/css/breakpoints.css
+++ b/src/lib/components/css/breakpoints.css
@@ -1,0 +1,31 @@
+/**
+ * Custom media queries for responsive breakpoints
+ *
+ * This file is loaded using the PostCSS Global Data plugin (postcss.config.js)
+ * to ensure the defs are available in all CSS contexts. See:
+ * https://github.com/csstools/postcss-plugins/tree/main/plugins/postcss-global-data
+ *
+ * ## Breakpoints:
+ *
+ *   xs       <=   576px  <  sm-up
+ *   sm-down  <=   768px  <  md-up
+ *   md-down  <=  1024px  <  lg-up
+ *   lg-down  <=  1260px  <  xl-up
+ *   xl-down  <=  1440px  <  xxl
+ *
+ * ## Usage:
+ *
+ *   @media(--viewport-md-up) {
+ *     [CSS rules]
+ *   }
+ */
+@custom-media --viewport-xs (width <= 576px);
+@custom-media --viewport-sm-up (width > 576px);
+@custom-media --viewport-sm-down (width <= 768px);
+@custom-media --viewport-md-up (width > 768px);
+@custom-media --viewport-md-down (width <= 1024px);
+@custom-media --viewport-lg-up (width > 1024px);
+@custom-media --viewport-lg-down (width <= 1260px);
+@custom-media --viewport-xl-up (width > 1260px);
+@custom-media --viewport-xl-down (width <= 1440px);
+@custom-media --viewport-xxl (width > 1440px);

--- a/src/lib/components/css/table-old.css
+++ b/src/lib/components/css/table-old.css
@@ -6,14 +6,14 @@ table.table {
 	width: 100%;
 	margin-bottom: 1rem;
 
-	& :is(th, td) {
+	:is(th, td) {
 		padding: 1rem;
 		border-block: 1px solid #a9a9b2;
 		vertical-align: top;
 		text-align: left;
 	}
 
-	& th {
+	th {
 		border-bottom-width: 2px;
 	}
 }

--- a/src/lib/components/css/table.css
+++ b/src/lib/components/css/table.css
@@ -25,18 +25,18 @@ table:not(.table) {
 		--table-letter-spacing: var(--f-ui-xs-spacing, normal);
 	}
 
-	& thead tr:first-child {
+	thead tr:first-child {
 		background-color: hsla(var(--hsl-body));
 		position: sticky;
 		top: 0;
 		z-index: 1;
 	}
 
-	& thead.sticky th {
+	thead.sticky th {
 		border-radius: 0;
 	}
 
-	& th {
+	th {
 		background: hsla(var(--hsl-body));
 		border-radius: var(--radius-md);
 		color: hsla(var(--hsl-text-extra-light));
@@ -60,12 +60,12 @@ table:not(.table) {
 				color: hsla(var(--hsl-text-light));
 			}
 
-			& .icon svg {
+			.icon svg {
 				position: absolute;
 				right: var(--space-ls);
 				top: var(--space-ls);
 
-				& path {
+				path {
 					stroke-width: 0.1875rem;
 				}
 			}
@@ -77,8 +77,8 @@ table:not(.table) {
 		}
 	}
 
-	& tbody tr {
-		& td {
+	tbody tr {
+		td {
 			background: hsla(var(--hsl-box), var(--a-box-b));
 			height: 3.25rem;
 			font: var(--table-font);
@@ -105,16 +105,16 @@ table:not(.table) {
 		}
 
 		&:is(:hover, :focus, :focus-within) {
-			& td {
+			td {
 				background: hsla(var(--hsl-box), var(--a-box-d));
 			}
 
-			& .button {
+			.button {
 				--c-accent: var(--hsl-text);
 				color: hsla(var(--hsl-text-inverted));
 			}
 
-			& .up-down-cell .up-down-indicator {
+			.up-down-cell .up-down-indicator {
 				&.bearish {
 					background: hsla(var(--hsl-bearish), 0.24) !important;
 				}
@@ -125,7 +125,7 @@ table:not(.table) {
 		}
 	}
 
-	& :is(th, td).right {
+	:is(th, td).right {
 		text-align: right;
 	}
 
@@ -140,16 +140,16 @@ table:not(.table) {
 			width: 100%;
 
 			&,
-			& tbody {
+			tbody {
 				display: grid;
 				gap: var(--space-md);
 			}
 
-			& thead {
+			thead {
 				display: none !important;
 			}
 
-			& tbody tr {
+			tbody tr {
 				background: hsla(var(--hsl-box), var(--a-box-b));
 				border-radius: var(--radius-md);
 				display: grid;
@@ -175,7 +175,7 @@ table:not(.table) {
 					}
 				}
 
-				& td {
+				td {
 					align-content: start;
 					background: transparent;
 					border-radius: 0;
@@ -199,25 +199,25 @@ table:not(.table) {
 				}
 			}
 
-			& tfoot,
-			& tfoot tr {
+			tfoot,
+			tfoot tr {
 				display: grid;
 			}
 
-			& .up-down-cell {
+			.up-down-cell {
 				justify-content: flex-start;
 				margin-top: var(--space-sm);
 			}
 		}
 	}
 
-	& .button {
+	.button {
 		white-space: nowrap;
 	}
 }
 
 table.loading {
-	& :not(thead, tfoot) tr td {
+	:not(thead, tfoot) tr td {
 		color: transparent;
 
 		&::before {
@@ -232,16 +232,16 @@ table.loading {
 			top: var(--space-sm);
 		}
 
-		& * {
+		* {
 			color: transparent;
 			background: transparent !important;
 		}
 	}
 
-	& .button {
+	.button {
 		cursor: loading;
 
-		& span {
+		span {
 			color: transparent;
 
 			&::before {

--- a/src/lib/components/css/table.css
+++ b/src/lib/components/css/table.css
@@ -20,7 +20,7 @@ table:not(.table) {
 		--table-letter-spacing: var(--f-ui-sm-spacing, normal);
 	}
 
-	@media (width <= 768px) {
+	@media (--viewport-sm-down) {
 		--table-font: var(--f-ui-xs-medium) !important;
 		--table-letter-spacing: var(--f-ui-xs-spacing, normal);
 	}
@@ -89,7 +89,7 @@ table:not(.table) {
 			vertical-align: middle;
 			--button-width: 100%;
 
-			@media (width > 1024px) {
+			@media (--viewport-lg-up) {
 				height: 3.825rem !important;
 			}
 
@@ -130,7 +130,7 @@ table:not(.table) {
 	}
 
 	&.responsive {
-		@media (width <= 768px) {
+		@media (--viewport-sm-down) {
 			--table-font: var(--f-ui-md-medium) !important;
 			--table-letter-spacing: var(--f-ui-xs-spacing, normal);
 

--- a/src/lib/components/css/tile.css
+++ b/src/lib/components/css/tile.css
@@ -25,16 +25,13 @@
 		background: hsla(var(--hsl-box), var(--a-box-d));
 	}
 
-	&:hover {
-		&,
-		& .tile {
-			background: var(--background-hover) !important;
-		}
+	&:hover,
+	&:hover & {
+		background: var(--background-hover) !important;
 	}
 
-	&:hover,
-	&:focus {
-		& .button {
+	&:is(:hover, :focus) {
+		.button {
 			background: hsla(var(--hsl-text), 1) !important;
 			color: hsla(var(--hsl-text-inverted)) !important;
 		}

--- a/src/lib/components/css/typography.css
+++ b/src/lib/components/css/typography.css
@@ -188,7 +188,7 @@
 }
 
 /* DEPRECATED Font Pairings - Desktop */
-@media (width >= 768px) {
+@media (--viewport-md-up) {
 	:root {
 		--f-h1-bold: 700 var(--fs-heading-xxl);
 		--f-h1-medium: 600 var(--fs-heading-xxl);

--- a/src/lib/components/datatable/PageButton.svelte
+++ b/src/lib/components/datatable/PageButton.svelte
@@ -30,7 +30,7 @@
 			color: hsla(var(--hsl-text));
 		}
 
-		@nest :global(nav:hover) &:not(:hover) {
+		:global(nav:hover) &:not(:hover) {
 			color: hsla(var(--hsl-text-extra-light));
 		}
 	}

--- a/src/lib/components/datatable/TableFooter.svelte
+++ b/src/lib/components/datatable/TableFooter.svelte
@@ -90,7 +90,7 @@
 			max-width: calc(100vw - 3 * var(--space-md));
 		}
 
-		& nav {
+		nav {
 			display: flex;
 
 			&:hover .gap-indicator {

--- a/src/lib/explorer/ExchangeTable.svelte
+++ b/src/lib/explorer/ExchangeTable.svelte
@@ -67,31 +67,31 @@
 <style lang="postcss">
 	.exchange-table :global {
 		@media (--viewport-md-up) {
-			& table {
+			table {
 				table-layout: fixed;
 			}
 
-			& .exchange_name {
+			.exchange_name {
 				width: 45%;
 				white-space: nowrap;
 
-				& :global * {
+				:global * {
 					overflow: hidden;
 					text-overflow: ellipsis;
 				}
 			}
 
-			& .pair_count {
+			.pair_count {
 				width: 25%;
 				text-align: right;
 			}
 
-			& .volume_30d {
+			.volume_30d {
 				width: 30%;
 				text-align: right;
 			}
 
-			& .cta {
+			.cta {
 				width: 15rem;
 				padding-left: 2em;
 			}

--- a/src/lib/explorer/LendingReserveTable.svelte
+++ b/src/lib/explorer/LendingReserveTable.svelte
@@ -84,27 +84,27 @@
 <style lang="postcss">
 	.reserve-table :global {
 		@media (--viewport-md-up) {
-			& table {
+			table {
 				table-layout: fixed;
 			}
 
-			& .asset_name {
+			.asset_name {
 				width: 40%;
 				white-space: nowrap;
 				overflow: hidden;
 				text-overflow: ellipsis;
 			}
 
-			& .asset_symbol {
+			.asset_symbol {
 				width: 20%;
 			}
 
-			& :is(.tvl, .supply_apr_latest, .variable_borrow_apr_latest) {
+			:is(.tvl, .supply_apr_latest, .variable_borrow_apr_latest) {
 				width: 20%;
 				text-align: right;
 			}
 
-			& .cta {
+			.cta {
 				width: 12rem;
 			}
 		}

--- a/src/lib/explorer/PairTable.svelte
+++ b/src/lib/explorer/PairTable.svelte
@@ -116,23 +116,23 @@
 		overflow-y: hidden;
 
 		@media (--viewport-md-up) {
-			& tr:hover td {
+			tr:hover td {
 				position: relative;
 				overflow: visible;
 			}
 
-			& :is(.usd_price_latest, .price_change_24h, .volume_30d, .liquidity, .liquidity_change_24h, .tvl) {
+			:is(.usd_price_latest, .price_change_24h, .volume_30d, .liquidity, .liquidity_change_24h, .tvl) {
 				max-width: 12ch;
 				text-align: right;
 				overflow: hidden;
 				text-overflow: ellipsis;
 			}
 
-			& .pair_symbol {
+			.pair_symbol {
 				min-width: 12rem;
 			}
 
-			& .exchange_name {
+			.exchange_name {
 				min-width: 6rem;
 				white-space: nowrap;
 			}

--- a/src/lib/explorer/TokenTable.svelte
+++ b/src/lib/explorer/TokenTable.svelte
@@ -74,32 +74,32 @@
 <style lang="postcss">
 	.token-table :global {
 		@media (--viewport-md-up) {
-			& table {
+			table {
 				table-layout: fixed;
 			}
 
-			& .name {
+			.name {
 				width: 35%;
 				white-space: nowrap;
 				overflow: hidden;
 				text-overflow: ellipsis;
 			}
 
-			& .symbol {
+			.symbol {
 				width: 15%;
 			}
 
-			& .volume_24h {
+			.volume_24h {
 				width: 25%;
 				text-align: right;
 			}
 
-			& .liquidity_latest {
+			.liquidity_latest {
 				width: 25%;
 				text-align: right;
 			}
 
-			& .cta {
+			.cta {
 				width: 12rem;
 				padding-left: 1rem;
 			}

--- a/src/lib/newsletter/OptInBanner.svelte
+++ b/src/lib/newsletter/OptInBanner.svelte
@@ -50,11 +50,11 @@
 			max-width: 60rem;
 		}
 
-		& :global .subscribe-form {
+		:global .subscribe-form {
 			grid-template-columns: repeat(auto-fit, minmax(17rem, auto));
 		}
 
-		& .artwork {
+		.artwork {
 			display: grid;
 			place-items: center;
 
@@ -62,7 +62,7 @@
 				padding: 2rem;
 			}
 
-			& :global svg {
+			:global svg {
 				@media (--viewport-md-down) {
 					max-width: min(36vw, 24rem);
 					max-height: min(36vw, 24rem);
@@ -74,17 +74,17 @@
 			}
 		}
 
-		& .form {
+		.form {
 			display: grid;
 			gap: var(--space-sm);
 		}
 
-		& :global [slot='title'],
-		& h2 {
+		:global [slot='title'],
+		h2 {
 			margin-bottom: var(--space-lg);
 		}
 
-		& :global h2 {
+		:global h2 {
 			font: var(--f-heading-lg-medium);
 			letter-spacing: var(--f-heading-lg-spacing, normal);
 
@@ -99,7 +99,7 @@
 			}
 		}
 
-		& :global p {
+		:global p {
 			font: var(--f-ui-xl-roman);
 
 			@media (--viewport-xs) {

--- a/src/lib/search/components/Search.svelte
+++ b/src/lib/search/components/Search.svelte
@@ -98,7 +98,7 @@ Display site-wide search box for use in top-nav.
 			</form>
 
 			{#if hasQuery}
-				<ul id="search-results">
+				<ul>
 					{#each hits as { document } (document.id)}
 						<SearchHit {document} />
 					{/each}
@@ -204,14 +204,6 @@ Display site-wide search box for use in top-nav.
 		}
 	}
 
-	/**
-	 * Prevent body scrolling when search dialog is open and has results on mobile
-	 * NOTE: using CSS ids as work-around for :has pseudo-selector flakiness
-	 */
-	:global body:has(#search-input-mobile:focus):has(#search-results) {
-		overflow: hidden;
-	}
-
 	ul {
 		padding: 0;
 		flex: 1;
@@ -219,6 +211,7 @@ Display site-wide search box for use in top-nav.
 		gap: var(--space-sm);
 		align-content: start;
 		overflow-y: auto;
+		overscroll-behavior: contain;
 	}
 
 	footer {

--- a/src/lib/search/components/Search.svelte
+++ b/src/lib/search/components/Search.svelte
@@ -169,7 +169,7 @@ Display site-wide search box for use in top-nav.
 		transition: opacity 0.25s;
 
 		/* NOTE: don't use native :focus-within due to timing issues (see toggleFocus) */
-		@nest :not(.hasFocus) & {
+		:not(.hasFocus) & {
 			opacity: 0;
 			pointer-events: none;
 		}
@@ -188,7 +188,7 @@ Display site-wide search box for use in top-nav.
 			left: 0;
 			top: 0;
 
-			@nest .hasQuery & .inner {
+			.hasQuery & .inner {
 				height: var(--viewport-height);
 				gap: var(--space-sm);
 			}
@@ -227,7 +227,7 @@ Display site-wide search box for use in top-nav.
 			--button-font: var(--f-ui-sm-medium);
 		}
 
-		@nest .hasQuery & {
+		.hasQuery & {
 			grid-template-columns: 1fr 1fr;
 		}
 	}

--- a/src/lib/search/components/Search.svelte
+++ b/src/lib/search/components/Search.svelte
@@ -179,7 +179,7 @@ Display site-wide search box for use in top-nav.
 			margin-top: var(--space-xxs);
 			width: 450px;
 
-			& .inner {
+			.inner {
 				max-height: calc(var(--viewport-height) - var(--space-xl) - var(--header-height, 5rem) / 2);
 			}
 		}
@@ -194,7 +194,7 @@ Display site-wide search box for use in top-nav.
 			}
 		}
 
-		& .inner {
+		.inner {
 			background: hsla(var(--hsl-box), var(--a-box-a));
 			box-shadow: var(--shadow-sm);
 			display: flex;

--- a/src/lib/search/components/SearchHit.svelte
+++ b/src/lib/search/components/SearchHit.svelte
@@ -98,7 +98,7 @@ props.
 		display: grid;
 		list-style-type: none;
 
-		& a {
+		a {
 			display: grid;
 			gap: var(--search-hit-gap, var(--space-md));
 			grid-template-columns: auto 1fr auto;
@@ -120,7 +120,7 @@ props.
 			}
 
 			&:hover {
-				& :global .up-down-indicator {
+				:global .up-down-indicator {
 					&.bearish {
 						background: hsla(var(--hsl-bearish), 0.24) !important;
 					}
@@ -135,12 +135,12 @@ props.
 				background: var(--background-hover); /* see tile.css */
 			}
 
-			& :global .up-down-cell {
+			:global .up-down-cell {
 				max-width: min(20vw, 12rem);
 			}
 		}
 
-		& .badge {
+		.badge {
 			position: relative;
 			display: grid;
 			align-content: center;
@@ -154,7 +154,7 @@ props.
 			text-align: center;
 		}
 
-		& .chain-icon {
+		.chain-icon {
 			position: absolute;
 			right: 0;
 			bottom: 0;
@@ -167,7 +167,7 @@ props.
 			box-shadow: 0 0 1px 1px var(--c-shadow-1-v1);
 		}
 
-		& .info {
+		.info {
 			display: grid;
 			gap: var(--space-xxs);
 			width: 100%;

--- a/src/lib/search/components/SearchHitDescription.svelte
+++ b/src/lib/search/components/SearchHitDescription.svelte
@@ -30,11 +30,11 @@
 		font: var(--search-hit-description-font, var(--f-ui-md-medium));
 		letter-spacing: var(--search-hit-description-spacing, var(--f-ui-md-spacing, normal));
 
-		& .swap-fee {
+		.swap-fee {
 			color: var(--c-text-extra-light);
 		}
 
-		& .warning-icon {
+		.warning-icon {
 			display: inline-block;
 			transform: translate(0.25em, -0.1em);
 		}

--- a/src/lib/wallet/WalletInfo.svelte
+++ b/src/lib/wallet/WalletInfo.svelte
@@ -12,7 +12,7 @@
 		width: 100%;
 		overflow: hidden;
 
-		& ul {
+		ul {
 			display: grid;
 			gap: var(--space-md);
 			padding: 0;

--- a/src/lib/wallet/WalletInfoItem.svelte
+++ b/src/lib/wallet/WalletInfoItem.svelte
@@ -34,13 +34,13 @@
 			--value-spacing: var(--f-ui-lg-spacing);
 		}
 
-		& > span {
+		> span {
 			@container (width >= 420px) {
 				padding: 0;
 			}
 		}
 
-		& .label {
+		.label {
 			margin-top: var(--space-xxs);
 			font: var(--label-font);
 			letter-spacing: var(--label-spacing);
@@ -50,7 +50,7 @@
 			}
 		}
 
-		& .value {
+		.value {
 			font: var(--value-font);
 			letter-spacing: var(--value-spacing);
 

--- a/src/lib/wallet/WalletSummary.svelte
+++ b/src/lib/wallet/WalletSummary.svelte
@@ -46,7 +46,7 @@
 		gap: var(--space-sm);
 		align-items: center;
 
-		& img {
+		img {
 			width: 1.75rem;
 		}
 	}
@@ -62,7 +62,7 @@
 		font: var(--f-ui-sm-medium);
 		color: hsla(var(--hsl-success));
 
-		& .dot {
+		.dot {
 			animation: pulse-opacity 1.5s ease-out infinite;
 			background: hsla(var(--hsl-success));
 			border-radius: 100%;

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -52,21 +52,6 @@
 <SiteMode />
 
 <style global lang="postcss">
-	/**
-	 * Custom media declarations (via PostCSS Custom Media plugin) - enables `@media (--var-name) {}`
-	 * Must be declared in __layout to ensure proper CSS load order in SSR.
-	 */
-	@custom-media --viewport-xs (width <= 576px);
-	@custom-media --viewport-sm-up (width > 576px);
-	@custom-media --viewport-sm-down (width <= 768px);
-	@custom-media --viewport-md-up (width > 768px);
-	@custom-media --viewport-md-down (width <= 1024px);
-	@custom-media --viewport-lg-up (width > 1024px);
-	@custom-media --viewport-lg-down (width <= 1260px);
-	@custom-media --viewport-xl-up (width > 1260px);
-	@custom-media --viewport-xl-down (width <= 1440px);
-	@custom-media --viewport-xxl (width > 1440px);
-
 	a.body-link {
 		border-bottom: 1px solid currentColor;
 		font-weight: 500;

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -129,7 +129,7 @@
 			padding: var(--space-5xl);
 		}
 
-		& h2 {
+		h2 {
 			font: var(--f-heading-lg-medium);
 			letter-spacing: var(--f-heading-lg-spacing, normal);
 			@media (--viewport-md-up) {
@@ -138,7 +138,7 @@
 			}
 		}
 
-		& .coming-soon {
+		.coming-soon {
 			font: var(--f-ui-sm-medium);
 			letter-spacing: var(--f-ui-sm-spacing, normal);
 			color: var(--c-text-2-v1);
@@ -148,12 +148,12 @@
 			border-radius: var(--radius-xxl);
 		}
 
-		& p {
+		p {
 			font: var(--f-ui-xl-roman);
 			letter-spacing: var(--f-ui-xl-spacing, normal);
 		}
 
-		& .ctas {
+		.ctas {
 			display: flex;
 			gap: var(--space-lg);
 			width: 100%;
@@ -164,7 +164,7 @@
 		}
 
 		/* hide on small displays due to label wrapping */
-		& .newsletter-cta {
+		.newsletter-cta {
 			display: grid;
 
 			@media (width < 390px) {

--- a/src/routes/ErrorPageInfo.svelte
+++ b/src/routes/ErrorPageInfo.svelte
@@ -29,7 +29,7 @@
 		overflow-y: auto;
 		text-align: center;
 
-		& h1 {
+		h1 {
 			font: 900 160px var(--ff-display);
 
 			@media (--viewport-sm-down) {
@@ -37,11 +37,11 @@
 			}
 		}
 
-		& h2 {
+		h2 {
 			font: var(--f-h3-roman);
 		}
 
-		& p {
+		p {
 			margin-top: var(--space-md);
 			max-width: 50ch;
 			font: var(--f-ui-large-roman);

--- a/src/routes/HomeHeroBanner.svelte
+++ b/src/routes/HomeHeroBanner.svelte
@@ -66,7 +66,7 @@ Home page hero banner.
 		}
 
 		@media (--viewport-xl-down) {
-			& br {
+			br {
 				display: none;
 			}
 		}

--- a/src/routes/about/Audience.svelte
+++ b/src/routes/about/Audience.svelte
@@ -69,7 +69,7 @@
 	header {
 		text-align: center;
 
-		& p {
+		p {
 			margin: 1rem 0;
 			font: var(--f-ui-xl-roman);
 			letter-spacing: var(--f-ui-xl-spacing);

--- a/src/routes/about/Feature.svelte
+++ b/src/routes/about/Feature.svelte
@@ -38,7 +38,7 @@
 				flex-direction: row-reverse;
 			}
 
-			& > * {
+			> * {
 				flex: 1;
 			}
 		}
@@ -54,22 +54,22 @@
 			gap: var(--space-xl);
 		}
 
-		& h3 {
+		h3 {
 			font: var(--f-heading-md-medium);
 			letter-spacing: var(--f-heading-md-spacing, normal);
 		}
 
-		& ul {
+		ul {
 			display: grid;
 			gap: var(--space-lg);
 		}
 
-		& :global li {
+		:global li {
 			font: var(--f-ui-xl-roman);
 			letter-spacing: var(--f-ui-xl-spacing, normal);
 		}
 
-		& .cta {
+		.cta {
 			display: grid;
 
 			@media (--viewport-md-up) {
@@ -86,7 +86,7 @@
 		display: flex;
 		justify-content: center;
 
-		& svg {
+		svg {
 			width: 100%;
 			max-width: 480px;
 
@@ -94,11 +94,11 @@
 				width: 80%;
 			}
 
-			& .bg {
+			.bg {
 				fill: hsla(var(--hsl-body));
 			}
 
-			& :not(.bg) {
+			:not(.bg) {
 				fill: currentColor;
 			}
 		}

--- a/src/routes/about/Platform.svelte
+++ b/src/routes/about/Platform.svelte
@@ -119,12 +119,12 @@
 			letter-spacing: var(--f-heading-xs-spacing);
 			text-align: left;
 
-			& br {
+			br {
 				display: none;
 			}
 		}
 
-		& a {
+		a {
 			font-weight: 600;
 			text-decoration: underline;
 		}

--- a/src/routes/blog/BlogPostContent.svelte
+++ b/src/routes/blog/BlogPostContent.svelte
@@ -31,14 +31,14 @@
 	.blog-post-content :global {
 		overflow: auto;
 
-		& h1 {
+		h1 {
 			font: var(--f-heading-lg-medium);
 			margin: var(--space-2xl) 0 !important;
 			text-transform: capitalize;
 		}
 
 		&,
-		& :is(p, li) {
+		:is(p, li) {
 			font: var(--f-text-md-regular);
 			letter-spacing: var(--f-text-lg-spacing, normal);
 
@@ -47,11 +47,11 @@
 			}
 		}
 
-		& p:not(:first-of-type) {
+		p:not(:first-of-type) {
 			margin-top: var(--space-lg);
 		}
 
-		& > h2 {
+		> h2 {
 			font: var(--f-heading-lg-medium);
 			letter-spacing: var(--f-heading-lg-spacing, normal);
 			margin: var(--space-5xl) 0 var(--space-lg);
@@ -60,7 +60,7 @@
 			}
 		}
 
-		& > h3 {
+		> h3 {
 			font: var(--f-heading-md-medium);
 			letter-spacing: var(--f-heading-md-spacing, normal);
 			margin: var(--space-xl) 0 var(--space-md) 0;
@@ -68,7 +68,7 @@
 				font: var(--f-heading-sm-medium);
 			}
 		}
-		& > h4 {
+		> h4 {
 			font: var(--f-heading-sm-medium);
 			letter-spacing: var(--f-heading-sm-spacing, normal);
 			margin: var(--space-xl) 0 var(--space-md) 0;
@@ -77,64 +77,64 @@
 			}
 		}
 
-		& :is(ol, ul) {
+		:is(ol, ul) {
 			margin: 0;
 		}
 
-		& li {
+		li {
 			margin: 0.5em 0 0 0;
 			padding-left: var(--space-xxs);
 		}
 
-		& a,
-		& a:hover {
+		a,
+		a:hover {
 			text-decoration: underline;
 			color: inherit;
 		}
 
-		& :is(strong, b) {
+		:is(strong, b) {
 			font-weight: 600;
 		}
 
-		& figure {
+		figure {
 			display: grid;
 			margin: var(--space-3xl) 0 var(--space-5xl);
 
-			& img {
+			img {
 				height: 100%;
 				width: 100%;
 			}
 		}
 
-		& figcaption {
+		figcaption {
 			font: var(--f-ui-sm-roman);
 			letter-spacing: var(--f-ui-sm-spacing, normal);
 			text-align: center;
 			margin: var(--space-md) 0;
 
-			& a {
+			a {
 				font-weight: 500;
 			}
 		}
 
-		& iframe {
+		iframe {
 			border: 0;
 			width: 100%;
 			min-height: 450px;
 		}
 
-		& .kg-image-card {
+		.kg-image-card {
 			text-align: center;
 		}
 
-		& .kg-image {
+		.kg-image {
 			width: 100%;
 			height: auto;
 			max-width: 100%;
 			display: inline-block;
 		}
 
-		& pre {
+		pre {
 			margin: var(--space-lg) 0;
 			padding: var(--space-lg);
 			background: var(--c-background-7-v1);
@@ -143,7 +143,7 @@
 			color: var(--c-parchment);
 		}
 
-		& blockquote {
+		blockquote {
 			margin: var(--space-lg) 0 var(--space-lg) var(--space-sl);
 			padding: var(--space-lg);
 			font: var(--f-text-lg-regular);
@@ -153,17 +153,17 @@
 			box-shadow: -0.75rem 0.75rem 0 var(--c-background-4-v1);
 		}
 
-		& .table-responsive {
+		.table-responsive {
 			width: 100%;
 			overflow-x: auto;
 		}
 
-		& table {
+		table {
 			margin: var(--space-lg) 0;
 			color: inherit;
 			border-collapse: collapse;
 
-			& :is(td, th) {
+			:is(td, th) {
 				vertical-align: top;
 				padding: var(--space-ss);
 				border-top: 1px solid var(--c-border-1-v1);
@@ -178,14 +178,14 @@
 				}
 			}
 
-			& th {
+			th {
 				background: var(--c-background-1-v1);
 				font-weight: 600;
 			}
 		}
 
 		/* JavaScript generated TOC */
-		& #table-of-contents {
+		#table-of-contents {
 			display: contents;
 		}
 	}

--- a/src/routes/blog/SocialLinks.svelte
+++ b/src/routes/blog/SocialLinks.svelte
@@ -21,7 +21,7 @@
 			flex-direction: column;
 		}
 
-		& :global .button {
+		:global .button {
 			--icon-size: 1.125rem !important;
 		}
 	}

--- a/src/routes/blog/TableOfContents.svelte
+++ b/src/routes/blog/TableOfContents.svelte
@@ -14,14 +14,14 @@
 
 <style lang="postcss">
 	.table-of-contents {
-		& a {
+		a {
 			font: var(--f-heading-xs-medium);
 			letter-spacing: var(--f-heading-xs-spacing, normal);
 			padding: var(--space-sm) var(--space-md);
 			text-decoration: none !important;
 		}
 
-		& .toc-entry-h3 {
+		.toc-entry-h3 {
 			margin-left: 1em;
 		}
 	}

--- a/src/routes/blog/[slug]/+page.svelte
+++ b/src/routes/blog/[slug]/+page.svelte
@@ -39,7 +39,7 @@
 		display: grid;
 		gap: var(--space-ls);
 
-		& h1 {
+		h1 {
 			font: var(--f-heading-xl-medium);
 			letter-spacing: var(--f-heading-xl-spacing, normal);
 			margin-top: var(--space-xl);
@@ -51,7 +51,7 @@
 			}
 		}
 
-		& :global(time) {
+		:global(time) {
 			font: var(--timestamp-font, var(--f-ui-md-roman));
 			color: var(--c-text-2-v1);
 		}

--- a/src/routes/glossary/+page.svelte
+++ b/src/routes/glossary/+page.svelte
@@ -78,7 +78,7 @@
 		gap: var(--space-3xl) var(--space-2xl);
 		overflow: auto;
 
-		& h2 {
+		h2 {
 			font: var(--f-heading-lg-medium);
 			letter-spacing: var(--f-heading-lg-spacing, normal);
 

--- a/src/routes/glossary/[slug]/+page.svelte
+++ b/src/routes/glossary/[slug]/+page.svelte
@@ -92,14 +92,14 @@
 		letter-spacing: var(--f-ui-lg-spacing, normal);
 
 		/* Format tags in HTML output */
-		& a,
-		& a:hover {
+		a,
+		a:hover {
 			color: inherit;
 			font-weight: 700;
 			text-decoration: underline;
 		}
 
-		& p {
+		p {
 			margin-bottom: 0.5rem;
 		}
 	}

--- a/src/routes/search/+page.svelte
+++ b/src/routes/search/+page.svelte
@@ -87,7 +87,7 @@ Advanced Search page
 			gap: var(--space-ss);
 		}
 
-		& :global .page-header {
+		:global .page-header {
 			padding-block: var(--space-lg);
 
 			@media (--viewport-md-down) {

--- a/src/routes/search/Filter.svelte
+++ b/src/routes/search/Filter.svelte
@@ -120,7 +120,7 @@ Display filter options as checkboxes search queries.
 		stroke: transparent;
 		stroke-width: 3;
 
-		@nest input:checked + & {
+		input:checked + & {
 			stroke: currentColor;
 		}
 	}

--- a/src/routes/search/FilterPanel.svelte
+++ b/src/routes/search/FilterPanel.svelte
@@ -136,12 +136,12 @@
 			display: none;
 		}
 
-		& h4 {
+		h4 {
 			font: var(--f-ui-xl-medium);
 			letter-spacing: var(--f-ui-xl-spacing, normal);
 		}
 
-		& button {
+		button {
 			border: none;
 			background: transparent;
 			padding: 0;

--- a/src/routes/search/SearchHitAdvanced.svelte
+++ b/src/routes/search/SearchHitAdvanced.svelte
@@ -75,11 +75,11 @@
 			--search-hit-description-spacing: var(--f-ui-lg-spacing, normal);
 		}
 
-		& .truncate {
+		.truncate {
 			white-space: nowrap;
 		}
 
-		& .secondary {
+		.secondary {
 			display: flex;
 			flex-wrap: wrap;
 			gap: var(--space-xs);
@@ -91,13 +91,13 @@
 				letter-spacing: var(--f-ui-xs-spacing, normal);
 			}
 
-			& dt {
+			dt {
 				display: inline-block;
 				font-weight: 400;
 				white-space: nowrap;
 			}
 
-			& dd {
+			dd {
 				display: inline-block;
 				margin: 0;
 				font-weight: 700;

--- a/src/routes/search/SearchPanel.svelte
+++ b/src/routes/search/SearchPanel.svelte
@@ -73,7 +73,7 @@
 			--text-input-height: 100%;
 		}
 
-		& :global input:not(:placeholder-shown) {
+		:global input:not(:placeholder-shown) {
 			font-weight: 700;
 		}
 	}

--- a/src/routes/slow-load/+page.svelte
+++ b/src/routes/slow-load/+page.svelte
@@ -41,7 +41,7 @@ by default. Increment the `?page=n` param to delay by n * 2 seconds.
 			flex-direction: column;
 		}
 
-		& :global .button {
+		:global .button {
 			min-width: 10rem;
 		}
 	}

--- a/src/routes/strategies/ChartThumbnail.svelte
+++ b/src/routes/strategies/ChartThumbnail.svelte
@@ -74,7 +74,7 @@
 			height: 11rem;
 		}
 
-		& :global(.chart-container) {
+		:global(.chart-container) {
 			transform: scale(1.015, 1);
 			width: 100%;
 			height: 100%;
@@ -87,12 +87,12 @@
 		top: var(--y);
 		transform: translate(-50%, calc(-100% - var(--space-md)));
 
-		& .date {
+		.date {
 			font: var(--f-ui-sm-medium);
 			color: hsla(var(--hsl-text-extra-light));
 		}
 
-		& .value {
+		.value {
 			font: var(--f-ui-md-medium);
 		}
 	}

--- a/src/routes/strategies/StrategyDataSummary.svelte
+++ b/src/routes/strategies/StrategyDataSummary.svelte
@@ -86,17 +86,17 @@
 			grid-template-columns: repeat(4, auto);
 
 			/* 1st and 2nd of 4 columns */
-			& :global(.tooltip:is(:nth-of-type(4n + 1), :nth-of-type(4n + 2)) .popup) {
+			:global(.tooltip:is(:nth-of-type(4n + 1), :nth-of-type(4n + 2)) .popup) {
 				right: 12.5%;
 			}
 
 			/* 3rd and 4th of 4 columns */
-			& :global(.tooltip:is(:nth-of-type(4n + 3), :nth-of-type(4n + 4)) .popup) {
+			:global(.tooltip:is(:nth-of-type(4n + 3), :nth-of-type(4n + 4)) .popup) {
 				left: 12.5%;
 			}
 		}
 
-		& :global(.popup) {
+		:global(.popup) {
 			left: 0;
 			right: 0;
 		}

--- a/src/routes/strategies/StrategyTile.svelte
+++ b/src/routes/strategies/StrategyTile.svelte
@@ -116,21 +116,21 @@
 			z-index: 9999999;
 		}
 
-		& .errors {
+		.errors {
 			margin-block: 0.625rem;
 			position: relative;
 
-			& :global(.tooltip .popup) {
+			:global(.tooltip .popup) {
 				width: 22rem;
 				right: 0;
 			}
 
-			& :global(.alert-item) {
+			:global(.alert-item) {
 				container-type: unset;
 			}
 		}
 
-		& .visuals {
+		.visuals {
 			padding-top: 2rem;
 			display: grid;
 			position: relative;
@@ -138,7 +138,7 @@
 				padding-top: 4rem;
 			}
 
-			& .top {
+			.top {
 				align-items: flex-start;
 				display: flex;
 				gap: 1rem;
@@ -149,7 +149,7 @@
 				right: 0;
 				top: 0;
 
-				& .tokens {
+				.tokens {
 					display: flex;
 					gap: 0.5rem;
 					--token-size: 2.5rem;
@@ -157,7 +157,7 @@
 						--token-size: 2rem;
 					}
 
-					& :global(.entity-symbol) {
+					:global(.entity-symbol) {
 						border-radius: 100%;
 						box-shadow: var(--shadow-1);
 					}
@@ -169,7 +169,7 @@
 			}
 		}
 
-		& .content {
+		.content {
 			container-type: inline-size;
 			display: grid;
 			gap: 0.75rem;
@@ -178,7 +178,7 @@
 				padding: 1rem;
 			}
 
-			& header {
+			header {
 				--avatar-size: 6rem;
 				align-items: center;
 				display: grid;
@@ -189,7 +189,7 @@
 					gap: 0.5rem;
 				}
 
-				& .avatar {
+				.avatar {
 					background: hsla(var(--hsla-box-3));
 					border-radius: 100%;
 					font: var(--f-ui-sm-roman);
@@ -199,11 +199,11 @@
 					position: relative;
 					width: var(--avatar-size);
 
-					& :global(.tooltip .popup) {
+					:global(.tooltip .popup) {
 						min-width: 20rem;
 					}
 
-					& img {
+					img {
 						border-radius: 100%;
 						height: 100%;
 						object-fit: cover;
@@ -213,7 +213,7 @@
 						place-items: center;
 					}
 
-					& .chain-icon {
+					.chain-icon {
 						border-radius: 100%;
 						bottom: -0.5rem;
 						box-shadow: var(--shadow-1);
@@ -223,24 +223,24 @@
 						position: absolute;
 						right: -0.5rem;
 
-						& strong {
+						strong {
 							text-transform: capitalize;
 						}
 					}
 				}
 
-				& .description {
+				.description {
 					align-items: center;
 					justify-items: start;
 					display: grid;
 					gap: 0.25rem;
 
-					& :where(h3, p) {
+					:where(h3, p) {
 						margin: 0;
 					}
 				}
 
-				& h3 {
+				h3 {
 					font: var(--f-ui-xxl-medium);
 
 					@container (width <= 520px) {
@@ -252,17 +252,17 @@
 					}
 				}
 
-				& p {
+				p {
 					font: var(--f-ui-md-medium);
 					color: hsla(var(--hsl-text-extra-light));
 				}
 			}
 
-			& .data {
+			.data {
 				position: relative;
 			}
 
-			& .backtest-data-badge {
+			.backtest-data-badge {
 				align-items: center;
 				border-radius: var(--radius-sl);
 				color: hsla(var(--hsl-text-extra-light));
@@ -274,7 +274,7 @@
 				text-transform: uppercase;
 			}
 
-			& .actions {
+			.actions {
 				display: grid;
 			}
 		}

--- a/src/routes/strategies/[strategy]/(nav)/+layout.svelte
+++ b/src/routes/strategies/[strategy]/(nav)/+layout.svelte
@@ -49,16 +49,16 @@
 		display: grid;
 		gap: var(--space-md);
 
-		& :global(> .alert-list) {
+		:global(> .alert-list) {
 			width: 100%;
 			margin-top: var(--space-lg);
 		}
 
-		& .page-heading p {
+		.page-heading p {
 			font: var(--f-ui-md-roman);
 		}
 
-		& .subpage :global {
+		.subpage :global {
 			display: grid;
 			gap: var(--space-ls);
 

--- a/src/routes/strategies/[strategy]/(nav)/StrategyNav.svelte
+++ b/src/routes/strategies/[strategy]/(nav)/StrategyNav.svelte
@@ -184,7 +184,7 @@
 		color: var(--c-text-default);
 		background: var(--c-background-3);
 
-		@nest :global(a:not([href]):not([tabindex])) & {
+		:global(a:not([href]):not([tabindex])) & {
 			background: var(--c-background-1);
 			color: var(--c-text-inverted);
 		}
@@ -206,14 +206,14 @@
 			display: none;
 		}
 
-		@nest .open & {
+		.open & {
 			opacity: 0.4;
 		}
 
 		button svg {
 			transition: transform 0.25s ease-out;
 
-			@nest .open & {
+			.open & {
 				transform: rotate(180deg);
 			}
 
@@ -234,7 +234,7 @@
 			height: 0;
 			transition: height 0.25s ease-out;
 
-			@nest .open & {
+			.open & {
 				height: var(--menu-height);
 			}
 

--- a/src/routes/strategies/[strategy]/(nav)/StrategyNav.svelte
+++ b/src/routes/strategies/[strategy]/(nav)/StrategyNav.svelte
@@ -210,14 +210,14 @@
 			opacity: 0.4;
 		}
 
-		& button svg {
+		button svg {
 			transition: transform 0.25s ease-out;
 
 			@nest .open & {
 				transform: rotate(180deg);
 			}
 
-			& path {
+			path {
 				stroke-width: 3px;
 			}
 		}
@@ -238,7 +238,7 @@
 				height: var(--menu-height);
 			}
 
-			& :global menu {
+			:global menu {
 				padding-top: var(--space-ls);
 			}
 		}

--- a/src/routes/strategies/[strategy]/(nav)/[status=positionStatus]-positions/PositionTable.svelte
+++ b/src/routes/strategies/[strategy]/(nav)/[status=positionStatus]-positions/PositionTable.svelte
@@ -144,25 +144,25 @@
 	}
 
 	.position-table :global {
-		& :is(td, th) {
+		:is(td, th) {
 			font-size: 14px !important;
 			height: auto !important;
 			padding: var(--space-ss) var(--space-ss);
 		}
 
-		& .sortable .icon svg {
+		.sortable .icon svg {
 			top: var(--space-sl);
 		}
 
-		& .button {
+		.button {
 			height: 2.5rem;
 		}
 
-		& .ticker {
+		.ticker {
 			white-space: pre;
 		}
 
-		& :is(.profitability, .value, .value_at_open, .frozen_value, .opened_at, .closed_at, .frozen_at) {
+		:is(.profitability, .value, .value_at_open, .frozen_value, .opened_at, .closed_at, .frozen_at) {
 			text-align: right;
 		}
 

--- a/src/routes/strategies/[strategy]/(nav)/decision-making/+page.svelte
+++ b/src/routes/strategies/[strategy]/(nav)/decision-making/+page.svelte
@@ -64,7 +64,7 @@
 	img {
 		width: 100%;
 
-		@nest .hasError & {
+		.hasError & {
 			max-width: 20rem;
 		}
 	}

--- a/src/routes/strategies/[strategy]/(nav)/logs/LogEntry.svelte
+++ b/src/routes/strategies/[strategy]/(nav)/logs/LogEntry.svelte
@@ -29,14 +29,14 @@
 			border-block: 1px solid var(--c-ink-light);
 		}
 
-		& .message {
+		.message {
 			/* display: inline-flex; */
 			overflow-x: auto;
 			white-space: pre-line;
 			font: var(--f-mono-xs-regular);
 		}
 
-		& :global time {
+		:global time {
 			display: flex;
 			font: var(--f-mono-sm-regular);
 			flex-direction: column;

--- a/src/routes/strategies/[strategy]/(nav)/performance/PortfolioPerformanceChart.svelte
+++ b/src/routes/strategies/[strategy]/(nav)/performance/PortfolioPerformanceChart.svelte
@@ -119,13 +119,13 @@ Render the portfolio performance chart using ChartIQ.
 			--chart-aspect-ratio: 1.25;
 		}
 
-		& header {
+		header {
 			display: grid;
 			grid-template-columns: 1fr auto;
 			align-items: center;
 		}
 
-		& h2 {
+		h2 {
 			font: var(--f-heading-md-medium);
 			letter-spacing: var(--f-heading-md-spacing, normal);
 
@@ -135,7 +135,7 @@ Render the portfolio performance chart using ChartIQ.
 			}
 		}
 
-		& p {
+		p {
 			color: hsla(var(--hsl-text-extra-light));
 			font: var(--f-ui-md-medium);
 			letter-spacing: var(--f-ui-md-spacing, normal);
@@ -155,14 +155,14 @@ Render the portfolio performance chart using ChartIQ.
 		border-radius: var(--radius-sm);
 		transform: translate(-50%, calc(-100% - var(--space-md)));
 
-		& .date {
+		.date {
 			font: var(--f-ui-xs-bold);
 			letter-spacing: var(--f-ui-xs-spacing);
 			color: hsla(var(--hsl-text), 0.4);
 			white-space: nowrap;
 		}
 
-		& .value {
+		.value {
 			font: var(--f-ui-md-roman);
 			letter-spacing: var(--f-ui-md-spacing);
 		}

--- a/src/routes/strategies/[strategy]/(nav)/status/+page.svelte
+++ b/src/routes/strategies/[strategy]/(nav)/status/+page.svelte
@@ -56,7 +56,7 @@
 <style lang="postcss">
 	.instance-status {
 		&,
-		& .inner {
+		.inner {
 			display: grid;
 			gap: var(--space-lg);
 			place-content: stretch;
@@ -67,7 +67,7 @@
 			}
 		}
 
-		& .inner {
+		.inner {
 			grid-template-columns: repeat(auto-fit, minmax(18rem, 1fr));
 		}
 	}

--- a/src/routes/strategies/[strategy]/(nav)/vault/+page.svelte
+++ b/src/routes/strategies/[strategy]/(nav)/vault/+page.svelte
@@ -78,7 +78,7 @@
 			flex-direction: column;
 		}
 
-		& img {
+		img {
 			width: 1.5rem;
 		}
 	}

--- a/src/routes/strategies/[strategy]/[status=positionStatus]-positions/[position]/+page.svelte
+++ b/src/routes/strategies/[strategy]/[status=positionStatus]-positions/[position]/+page.svelte
@@ -322,7 +322,7 @@
 	.error-details a {
 		font-weight: 500;
 
-		& .hash-wrapper {
+		.hash-wrapper {
 			display: inline-grid;
 		}
 	}
@@ -330,7 +330,7 @@
 	.position-page :global .data-box {
 		align-content: flex-start;
 
-		& .value {
+		.value {
 			display: grid;
 			gap: var(--space-sm);
 		}

--- a/src/routes/strategies/[strategy]/[status=positionStatus]-positions/[position]/TradeTable.svelte
+++ b/src/routes/strategies/[strategy]/[status=positionStatus]-positions/[position]/TradeTable.svelte
@@ -58,7 +58,7 @@
 		overflow-x: auto;
 		overflow-y: hidden;
 
-		& h2 {
+		h2 {
 			margin-bottom: var(--space-md);
 			font: var(--f-heading-xl-medium);
 			letter-spacing: var(--f-heading-xl-spacing, normal);
@@ -71,7 +71,7 @@
 	}
 
 	.trade-table :global {
-		& :is(, .quantity, .price, .value) {
+		:is(, .quantity, .price, .value) {
 			text-align: right;
 		}
 	}

--- a/src/routes/strategies/[strategy]/[status=positionStatus]-positions/[position]/trade-[trade]/+page.svelte
+++ b/src/routes/strategies/[strategy]/[status=positionStatus]-positions/[position]/trade-[trade]/+page.svelte
@@ -90,7 +90,7 @@
 	.error-details a {
 		font-weight: 500;
 
-		& .hash-wrapper {
+		.hash-wrapper {
 			display: inline-grid;
 		}
 	}

--- a/src/routes/strategies/[strategy]/[status=positionStatus]-positions/[position]/trade-[trade]/TransactionTable.svelte
+++ b/src/routes/strategies/[strategy]/[status=positionStatus]-positions/[position]/trade-[trade]/TransactionTable.svelte
@@ -43,7 +43,7 @@
 		overflow-x: auto;
 		overflow-y: hidden;
 
-		& h2 {
+		h2 {
 			margin-bottom: var(--space-md);
 			font: var(--f-heading-xl-medium);
 			letter-spacing: var(--f-heading-xl-spacing, normal);
@@ -56,7 +56,7 @@
 	}
 
 	.transaction-table :global {
-		& .status {
+		.status {
 			text-align: right;
 		}
 	}

--- a/src/routes/trading-view/[chain]/+page.svelte
+++ b/src/routes/trading-view/[chain]/+page.svelte
@@ -134,7 +134,7 @@
 	}
 
 	.trading-entities {
-		& h2 {
+		h2 {
 			margin-block: var(--space-lg);
 			font: var(--f-heading-lg-medium);
 			letter-spacing: var(--f-heading-lg-spacing, normal);

--- a/src/routes/trading-view/[chain]/ChainHeader.svelte
+++ b/src/routes/trading-view/[chain]/ChainHeader.svelte
@@ -36,7 +36,7 @@
 			flex-direction: column;
 			margin-top: var(--space-ms);
 
-			& :global .button {
+			:global .button {
 				width: 100%;
 			}
 		}
@@ -53,7 +53,7 @@
 			font: var(--f-heading-md-medium);
 		}
 
-		& span {
+		span {
 			display: flex;
 			align-items: center;
 			min-height: var(--logo-height);
@@ -61,7 +61,7 @@
 			line-height: 1.2em;
 		}
 
-		& img {
+		img {
 			height: var(--logo-height);
 		}
 	}

--- a/src/routes/trading-view/[chain]/SummaryDataTile.svelte
+++ b/src/routes/trading-view/[chain]/SummaryDataTile.svelte
@@ -29,7 +29,7 @@
 			padding: var(--space-ls);
 		}
 
-		& h3 {
+		h3 {
 			font: var(--f-h2-bold);
 
 			@media (--viewport-md-down) {
@@ -37,7 +37,7 @@
 			}
 		}
 
-		& h4 {
+		h4 {
 			margin-block: var(--space-xxs) var(--space-sm);
 			font: var(--f-h4-medium);
 
@@ -48,7 +48,7 @@
 			}
 		}
 
-		& p {
+		p {
 			font: var(--f-ui-small-roman);
 			letter-spacing: 0.01em;
 

--- a/src/routes/trading-view/[chain]/TopEntities.svelte
+++ b/src/routes/trading-view/[chain]/TopEntities.svelte
@@ -46,7 +46,7 @@
 		gap: var(--space-md);
 		align-items: flex-end;
 
-		& h4 {
+		h4 {
 			padding: 0 var(--space-md) var(--space-xxs) 0;
 			font: var(--f-ui-md-bold);
 			letter-spacing: var(--f-ui-md-spacing);

--- a/src/routes/trading-view/[chain]/TradingEntitiesTable.svelte
+++ b/src/routes/trading-view/[chain]/TradingEntitiesTable.svelte
@@ -25,7 +25,7 @@
 	.trading-entities-table {
 		table-layout: fixed;
 
-		& :global(td) {
+		:global(td) {
 			white-space: nowrap;
 			overflow: hidden;
 			text-overflow: ellipsis;

--- a/src/routes/trading-view/[chain]/[exchange]/+page.svelte
+++ b/src/routes/trading-view/[chain]/[exchange]/+page.svelte
@@ -122,7 +122,7 @@
 			gap: var(--space-6xl);
 		}
 
-		& .ds-2-col {
+		.ds-2-col {
 			row-gap: var(--space-xl);
 		}
 	}
@@ -158,7 +158,7 @@
 		font: var(--f-ui-large-roman);
 		text-align: center;
 
-		& a {
+		a {
 			font-weight: 700;
 			text-decoration: underline;
 			white-space: nowrap;

--- a/src/routes/trading-view/[chain]/[exchange]/[pair]/+page.svelte
+++ b/src/routes/trading-view/[chain]/[exchange]/[pair]/+page.svelte
@@ -181,7 +181,7 @@ Render the pair trading page
 			gap: var(--space-6xl);
 		}
 
-		& .ds-2-col {
+		.ds-2-col {
 			row-gap: var(--space-xl);
 			align-items: start;
 		}
@@ -213,16 +213,16 @@ Render the pair trading page
 			gap: var(--space-7xl);
 		}
 
-		& header {
+		header {
 			display: grid;
 			gap: var(--space-sl);
 		}
 
-		& h2 {
+		h2 {
 			font: var(--f-h1-medium);
 		}
 
-		& p {
+		p {
 			font: var(--f-h4-roman);
 		}
 	}

--- a/src/routes/trading-view/[chain]/[exchange]/[pair]/ChartSection.svelte
+++ b/src/routes/trading-view/[chain]/[exchange]/[pair]/ChartSection.svelte
@@ -134,7 +134,7 @@ for the same hovered date. Also displays a time-bucket selector.
 			flex-direction: column;
 		}
 
-		& h2 {
+		h2 {
 			flex: 1;
 			font: var(--f-h2-medium);
 			white-space: nowrap;
@@ -151,7 +151,7 @@ for the same hovered date. Also displays a time-bucket selector.
 		align-items: baseline;
 		border-bottom: 1px solid #999;
 
-		& h3 {
+		h3 {
 			flex: 1;
 			font: var(--f-h5-medium);
 			text-transform: uppercase;
@@ -162,7 +162,7 @@ for the same hovered date. Also displays a time-bucket selector.
 			}
 		}
 
-		& .help {
+		.help {
 			font: var(--f-ui-small-roman);
 			color: var(--c-text-2-v1);
 			text-align: right;
@@ -171,11 +171,11 @@ for the same hovered date. Also displays a time-bucket selector.
 			overflow: hidden;
 			text-overflow: ellipsis;
 
-			& a:hover {
+			a:hover {
 				color: var(--c-text-1-v1);
 			}
 
-			& .prefix {
+			.prefix {
 				@media (--viewport-xs) {
 					display: none;
 				}

--- a/src/routes/trading-view/[chain]/[exchange]/[pair]/TimePeriodSummaryTable.svelte
+++ b/src/routes/trading-view/[chain]/[exchange]/[pair]/TimePeriodSummaryTable.svelte
@@ -59,13 +59,13 @@ Display summary performance table for various periods.
 			grid-template-columns: repeat(5, 1fr);
 		}
 
-		& ul {
+		ul {
 			list-style-type: none;
 			padding: 0;
 			display: grid;
 		}
 
-		& li {
+		li {
 			--skeleton-width: 5ch;
 			--skeleton-height: 1.2em;
 			font: var(--f-ui-xl-roman);
@@ -96,16 +96,16 @@ Display summary performance table for various periods.
 			}
 		}
 
-		& .row-heading li {
+		.row-heading li {
 			font-weight: 500;
 			padding-inline: 0;
 		}
 
-		& .loading li.col-heading {
+		.loading li.col-heading {
 			color: var(--c-text-7-v1);
 		}
 
-		& .time-period-col:not(.active) {
+		.time-period-col:not(.active) {
 			@media (--viewport-md-down) {
 				display: none;
 			}

--- a/src/routes/trading-view/[chain]/[exchange]/[pair]/api-and-historical-data/APIExamples.svelte
+++ b/src/routes/trading-view/[chain]/[exchange]/[pair]/api-and-historical-data/APIExamples.svelte
@@ -58,17 +58,17 @@ Trading pair API examples. Display inline curl examples for retreiving trading p
 		display: grid;
 		gap: var(--space-md);
 
-		& h2 {
+		h2 {
 			margin-top: var(--space-lg);
 			font: var(--f-h2-medium);
 		}
 
-		& h3 {
+		h3 {
 			margin-top: var(--space-sm);
 			font: var(--f-h4-medium);
 		}
 
-		& pre {
+		pre {
 			background: var(--c-background-7-v1);
 			border: 1px solid var(--c-border-1-v1);
 			border-radius: var(--radius-xxs);

--- a/src/routes/trading-view/[chain]/lending/[protocol]/[reserve]/+page.svelte
+++ b/src/routes/trading-view/[chain]/lending/[protocol]/[reserve]/+page.svelte
@@ -108,7 +108,7 @@
 			gap: var(--space-6xl);
 		}
 
-		& .ds-2-col {
+		.ds-2-col {
 			row-gap: var(--space-xl);
 			align-items: start;
 		}
@@ -122,7 +122,7 @@
 		border-bottom: 1px solid #999;
 		padding-bottom: 0.5rem;
 
-		& h3 {
+		h3 {
 			flex: 1;
 			font: var(--f-h5-medium);
 			margin: 0;

--- a/src/routes/trading-view/[chain]/tokens/[token]/+page.svelte
+++ b/src/routes/trading-view/[chain]/tokens/[token]/+page.svelte
@@ -108,12 +108,12 @@
 	}
 
 	aside {
-		& p {
+		p {
 			margin-top: 0;
 			font: var(--f-ui-large-roman);
 		}
 
-		& a {
+		a {
 			font-weight: 700;
 			text-decoration: underline;
 		}

--- a/src/routes/trading-view/api/+page.svelte
+++ b/src/routes/trading-view/api/+page.svelte
@@ -116,7 +116,7 @@
 	}
 
 	header {
-		& h1 {
+		h1 {
 			margin-block: var(--space-5xl) var(--space-md);
 			font: var(--f-heading-xl-medium);
 			letter-spacing: var(--f-heading-xl-spacing, normal);
@@ -127,7 +127,7 @@
 			}
 		}
 
-		& p {
+		p {
 			font: var(--f-ui-lg-roman);
 			letter-spacing: var(--f-ui-lg-spacing, normal);
 		}

--- a/src/routes/trading-view/backtesting/+page.svelte
+++ b/src/routes/trading-view/backtesting/+page.svelte
@@ -186,16 +186,16 @@
 		display: grid;
 		gap: var(--space-lg);
 
-		& h2 {
+		h2 {
 			font: var(--f-heading-lg-medium);
 			margin-bottom: var(--space-xl);
 		}
 
-		& :is(p, li) {
+		:is(p, li) {
 			margin-bottom: 1em;
 		}
 
-		& form {
+		form {
 			margin-bottom: var(--space-lg);
 			display: flex;
 			align-items: flex-end;
@@ -205,11 +205,11 @@
 			--button-height: auto;
 		}
 
-		& :global .svelte-spinner {
+		:global .svelte-spinner {
 			align-self: center;
 		}
 
-		& .action-link {
+		.action-link {
 			display: inline-block;
 			text-transform: uppercase;
 			font-size: 0.8em;

--- a/src/routes/wizard/+layout.svelte
+++ b/src/routes/wizard/+layout.svelte
@@ -79,7 +79,7 @@
 			grid-auto-rows: auto 1fr;
 		}
 
-		& :is(h1, h2) {
+		:is(h1, h2) {
 			font: var(--f-heading-md-medium);
 			margin-bottom: var(--space-2xl);
 		}
@@ -102,14 +102,14 @@
 			justify-content: space-between;
 		}
 
-		& h1 {
+		h1 {
 			@media (--viewport-sm-down) {
 				font: var(--f-heading-xs-medium);
 				margin: 0;
 			}
 		}
 
-		& menu {
+		menu {
 			display: grid;
 			gap: var(--space-ms);
 			margin: 0;
@@ -120,7 +120,7 @@
 			}
 		}
 
-		& .pagination {
+		.pagination {
 			@media (--viewport-md-up) {
 				display: none;
 			}

--- a/src/routes/wizard/WizardNavItem.svelte
+++ b/src/routes/wizard/WizardNavItem.svelte
@@ -20,7 +20,7 @@
 	.wizard-nav-item {
 		display: contents;
 
-		& button {
+		button {
 			display: flex;
 			align-items: center;
 			gap: var(--space-sm);

--- a/src/routes/wizard/deposit/payment/+page.svelte
+++ b/src/routes/wizard/deposit/payment/+page.svelte
@@ -305,34 +305,34 @@
 		display: grid;
 		gap: var(--space-3xl);
 
-		& section {
+		section {
 			display: grid;
 			gap: var(--space-ls);
 		}
 
-		& h3 {
+		h3 {
 			color: hsla(var(--hsl-text-light));
 			font: var(--f-ui-lg-medium);
 			margin: 0;
 		}
 
-		& .deposit-header {
+		.deposit-header {
 			container-type: inline-size;
 			display: grid;
 			grid-template-columns: 1fr auto;
 			align-items: center;
 		}
 
-		& .payment-form {
+		.payment-form {
 			display: grid;
 			gap: var(--space-xl);
 		}
 
-		& progress {
+		progress {
 			width: 100%;
 		}
 
-		& .transaction-id {
+		.transaction-id {
 			display: grid;
 			gap: var(--space-ss);
 			justify-content: flex-start;

--- a/src/routes/wizard/redeem/shares-redemption/+page.svelte
+++ b/src/routes/wizard/redeem/shares-redemption/+page.svelte
@@ -243,33 +243,33 @@
 		display: grid;
 		gap: var(--space-xl);
 
-		& section {
+		section {
 			display: grid;
 			gap: var(--space-ls);
 		}
 
-		& h3 {
+		h3 {
 			color: hsla(var(--hsl-text-light));
 			font: var(--f-ui-lg-medium);
 			margin: 0;
 		}
 
-		& .redeem-header {
+		.redeem-header {
 			display: grid;
 			grid-template-columns: 1fr auto;
 			align-items: center;
 		}
 
-		& .redemption-form {
+		.redemption-form {
 			display: grid;
 			gap: var(--space-xl);
 		}
 
-		& progress {
+		progress {
 			width: 100%;
 		}
 
-		& .transaction-id {
+		.transaction-id {
 			display: grid;
 			gap: var(--space-ss);
 			justify-content: flex-start;


### PR DESCRIPTION
close #582

- upgrade postcss-preset-env to 9.1.3
- use PostCSS Global Data to load custom media defs
- remove `&` CSS nesting selector (when not required)
- remove deprecated `@nest` selector
