### PR TITLE
Add "Beta" badge to strategies (universal)

### DIFF
--- a/src/lib/components/DataBadge.svelte
+++ b/src/lib/components/DataBadge.svelte
@@ -19,8 +19,8 @@ The color and background color may be overridden with CSS props.
 
 <style lang="postcss">
 	[data-css-props] {
-		--data-badge-background: var(--hsla-box-2);
-		--data-badge-color: var(--hsl-text);
+		--data-badge-background: hsl(var(--hsla-box-2));
+		--data-badge-color: hsl(var(--hsl-text));
 		--data-badge-height: auto;
 	}
 
@@ -31,8 +31,8 @@ The color and background color may be overridden with CSS props.
 		padding: 0.5em 0.625em;
 		border-radius: 0.75em;
 		font-weight: 500;
-		color: hsl(var(--data-badge-color));
-		background: hsl(var(--data-badge-background));
+		color: var(--data-badge-color);
+		background: var(--data-badge-background);
 		transition: var(--transition-1);
 
 		&.bullish {
@@ -46,18 +46,18 @@ The color and background color may be overridden with CSS props.
 		}
 
 		&.error {
-			color: color-mix(in srgb, hsl(var(--hsl-text)), hsl(var(--hsl-error)) 50%);
-			background: hsl(var(--hsl-error) / 25%);
+			color: color-mix(in srgb, hsl(var(--hsl-text)), hsl(var(--hsl-error)) 25%);
+			background: hsl(var(--hsl-error) / 35%);
 		}
 
 		&.success {
-			color: color-mix(in srgb, hsl(var(--hsl-text)), hsl(var(--hsl-success)) 50%);
-			background: hsl(var(--hsl-success) / 25%);
+			color: color-mix(in srgb, hsl(var(--hsl-text)), hsl(var(--hsl-success)) 25%);
+			background: hsl(var(--hsl-success) / 35%);
 		}
 
 		&.warning {
-			color: color-mix(in srgb, hsl(var(--hsl-text)), hsl(var(--hsl-warning)) 35%);
-			background: hsl(var(--hsl-warning) / 25%);
+			color: color-mix(in srgb, hsl(var(--hsl-text)), hsl(var(--hsl-warning)) 25%);
+			background: hsl(var(--hsl-warning) / 40%);
 		}
 	}
 </style>

--- a/src/lib/components/DataBadge.svelte
+++ b/src/lib/components/DataBadge.svelte
@@ -10,10 +10,12 @@ The color and background color may be overridden with CSS props.
 ```
 -->
 <script lang="ts">
+	let className: string = '';
+	export { className as class };
 	export let status: 'bullish' | 'bearish' | 'error' | 'success' | 'warning' | 'default' = 'default';
 </script>
 
-<span class="data-badge {status}" data-css-props>
+<span class="data-badge {status} {className}" data-css-props>
 	<slot />
 </span>
 
@@ -30,7 +32,9 @@ The color and background color may be overridden with CSS props.
 		height: var(--data-badge-height);
 		padding: 0.5em 0.625em;
 		border-radius: 0.75em;
+		font-family: var(--ff-ui);
 		font-weight: 500;
+		line-height: var(--lh-ui, 125%);
 		color: var(--data-badge-color);
 		background: var(--data-badge-background);
 		text-transform: capitalize;

--- a/src/lib/components/DataBadge.svelte
+++ b/src/lib/components/DataBadge.svelte
@@ -33,6 +33,7 @@ The color and background color may be overridden with CSS props.
 		font-weight: 500;
 		color: var(--data-badge-color);
 		background: var(--data-badge-background);
+		text-transform: capitalize;
 		transition: var(--transition-1);
 
 		&.bullish {

--- a/src/lib/components/DataBadge.svelte
+++ b/src/lib/components/DataBadge.svelte
@@ -21,16 +21,18 @@ The color and background color may be overridden with CSS props.
 	[data-css-props] {
 		--data-badge-background: var(--hsla-box-2);
 		--data-badge-color: var(--hsl-text);
+		--data-badge-height: auto;
 	}
 
 	.data-badge {
 		display: inline-grid;
+		align-items: center;
+		height: var(--data-badge-height);
 		padding: 0.5em 0.625em;
 		border-radius: 0.75em;
 		font-weight: 500;
 		color: hsl(var(--data-badge-color));
 		background: hsl(var(--data-badge-background));
-		text-transform: uppercase;
 		transition: var(--transition-1);
 
 		&.bullish {

--- a/src/lib/explorer/TradingDescription.svelte
+++ b/src/lib/explorer/TradingDescription.svelte
@@ -35,7 +35,7 @@ Used in DataTable context (vs. standard svelte component context).
 	{/if}
 	{#if isTest}
 		<span class="test-badge">
-			<DataBadge status="warning">TEST</DataBadge>
+			<DataBadge status="warning">Test</DataBadge>
 		</span>
 	{/if}
 </div>

--- a/src/routes/strategies/+page.svelte
+++ b/src/routes/strategies/+page.svelte
@@ -36,7 +36,7 @@
 		{#if filteredStrategies.length}
 			<div class="strategy-tiles" data-testid="strategy-tiles">
 				{#each filteredStrategies as strategy (strategy.id)}
-					<StrategyTile {strategy} chain={chainInfo[strategy.on_chain_data?.chain_id ?? 0]} />
+					<StrategyTile {admin} {strategy} chain={chainInfo[strategy.on_chain_data?.chain_id ?? 0]} />
 				{/each}
 			</div>
 		{:else}

--- a/src/routes/strategies/StrategyBadges.svelte
+++ b/src/routes/strategies/StrategyBadges.svelte
@@ -1,0 +1,15 @@
+<script lang="ts">
+	import { DataBadge } from '$lib/components';
+
+	let className: string = '';
+	export { className as class };
+	export let tags: string[] = [];
+	export let includeLive = false;
+</script>
+
+{#each tags as tag}
+	{@const isLive = tag === 'live'}
+	{#if !isLive || includeLive}
+		<DataBadge class={className} status={isLive ? 'success' : 'warning'}>{tag}</DataBadge>
+	{/if}
+{/each}

--- a/src/routes/strategies/StrategyTile.svelte
+++ b/src/routes/strategies/StrategyTile.svelte
@@ -65,10 +65,9 @@
 						<svelte:fragment slot="popup">{@html errorHtml}</svelte:fragment>
 					</Tooltip>
 				{/if}
-				<Tooltip>
-					<DataBadge slot="trigger" status="warning">Beta</DataBadge>
-					<svelte:fragment slot="popup">This strategy is in beta.</svelte:fragment>
-				</Tooltip>
+				{#each strategy.tags ?? [] as tag}
+					<DataBadge status="warning">{tag}</DataBadge>
+				{/each}
 			</div>
 		</div>
 		<div class="chart">

--- a/src/routes/strategies/StrategyTile.svelte
+++ b/src/routes/strategies/StrategyTile.svelte
@@ -4,7 +4,7 @@
 	import type { StrategyRuntimeState } from 'trade-executor/strategy/runtime-state';
 	import { type RawTick, type Quote, rawTicksToQuotes } from '$lib/chart';
 	import { goto } from '$app/navigation';
-	import { Alert, Button, EntitySymbol, Tooltip } from '$lib/components';
+	import { Button, DataBadge, EntitySymbol, Tooltip } from '$lib/components';
 	import ChartThumbnail from './ChartThumbnail.svelte';
 	import StrategyDataSummary from './StrategyDataSummary.svelte';
 	import { getTradeExecutorErrorHtml } from 'trade-executor/strategy/error';
@@ -58,14 +58,18 @@
 				{/each}
 			</div>
 
-			{#if errorHtml}
-				<div class="errors">
+			<div class="badges">
+				{#if errorHtml}
 					<Tooltip>
-						<Alert slot="trigger" size="xs">Error occurred</Alert>
+						<DataBadge slot="trigger" status="error">Error</DataBadge>
 						<svelte:fragment slot="popup">{@html errorHtml}</svelte:fragment>
 					</Tooltip>
-				</div>
-			{/if}
+				{/if}
+				<Tooltip>
+					<DataBadge slot="trigger" status="warning">Beta</DataBadge>
+					<svelte:fragment slot="popup">This strategy is in beta.</svelte:fragment>
+				</Tooltip>
+			</div>
 		</div>
 		<div class="chart">
 			<ChartThumbnail data={chartData} />
@@ -120,23 +124,6 @@
 			z-index: 2;
 		}
 
-		.errors {
-			position: relative;
-			z-index: 1;
-
-			:global(.tooltip .popup) {
-				position: absolute;
-				width: 22rem;
-				right: 0;
-				left: auto;
-				bottom: auto;
-			}
-
-			:global(.alert-item) {
-				container-type: unset;
-			}
-		}
-
 		.visuals {
 			padding-top: 2rem;
 			display: grid;
@@ -146,7 +133,6 @@
 			}
 
 			.top {
-				align-items: flex-start;
 				display: flex;
 				gap: 1rem;
 				justify-content: space-between;
@@ -159,14 +145,29 @@
 				.tokens {
 					display: flex;
 					gap: 0.5rem;
-					--token-size: 2.5rem;
-					@media (--viewport-sm-down) {
-						--token-size: 2rem;
-					}
+					--token-size: 2rem;
 
 					:global(.entity-symbol) {
 						border-radius: 100%;
 						box-shadow: var(--shadow-1);
+					}
+				}
+
+				.badges {
+					display: flex;
+					gap: 0.5em;
+					font: var(--f-ui-sm-medium);
+
+					:global([data-css-props]) {
+						--data-badge-height: 100%;
+					}
+
+					:global(.tooltip .popup) {
+						position: absolute;
+						max-width: 22rem;
+						right: 0;
+						left: auto;
+						bottom: auto;
 					}
 				}
 			}

--- a/src/routes/strategies/StrategyTile.svelte
+++ b/src/routes/strategies/StrategyTile.svelte
@@ -5,10 +5,12 @@
 	import { type RawTick, type Quote, rawTicksToQuotes } from '$lib/chart';
 	import { goto } from '$app/navigation';
 	import { Button, DataBadge, EntitySymbol, Tooltip } from '$lib/components';
+	import StrategyBadges from './StrategyBadges.svelte';
 	import ChartThumbnail from './ChartThumbnail.svelte';
 	import StrategyDataSummary from './StrategyDataSummary.svelte';
 	import { getTradeExecutorErrorHtml } from 'trade-executor/strategy/error';
 
+	export let admin = false;
 	export let strategy: StrategyRuntimeState;
 	export let chain: ApiChain | undefined;
 
@@ -65,9 +67,7 @@
 						<svelte:fragment slot="popup">{@html errorHtml}</svelte:fragment>
 					</Tooltip>
 				{/if}
-				{#each strategy.tags ?? [] as tag}
-					<DataBadge status="warning">{tag}</DataBadge>
-				{/each}
+				<StrategyBadges tags={strategy.tags} includeLive={admin} />
 			</div>
 		</div>
 		<div class="chart">

--- a/src/routes/strategies/StrategyTile.test.ts
+++ b/src/routes/strategies/StrategyTile.test.ts
@@ -26,7 +26,7 @@ describe('StrategyTile component', () => {
 		test('should display error message', async () => {
 			const { getByText } = render(StrategyTile, { strategy, chain });
 			// check for tooltip trigger
-			getByText(/Error occurred/);
+			getByText(/Error/);
 			// check for tooltip popup content
 			const popup = getByText(/Trade executor offline/);
 		});

--- a/src/routes/strategies/[strategy]/(nav)/+layout.svelte
+++ b/src/routes/strategies/[strategy]/(nav)/+layout.svelte
@@ -1,7 +1,8 @@
 <script lang="ts">
 	import { page } from '$app/stores';
-	import { Alert, DataBadge, PageHeading } from '$lib/components';
+	import { Alert, PageHeading } from '$lib/components';
 	import StrategyNav from './StrategyNav.svelte';
+	import StrategyBadges from '../../StrategyBadges.svelte';
 	import { WalletWidget } from '$lib/wallet';
 	import { getTradeExecutorErrorHtml } from 'trade-executor/strategy/error';
 
@@ -18,9 +19,7 @@
 		<img slot="icon" src={strategy.icon_url} alt={strategy.name} />
 		<div class="title" slot="title">
 			{strategy.name}
-			{#each strategy.tags ?? [] as tag}
-				<DataBadge class="badge" status="warning">{tag}</DataBadge>
-			{/each}
+			<StrategyBadges class="badge" tags={strategy.tags} />
 		</div>
 		<div class="wallet-widget" slot="cta">
 			<WalletWidget {strategy} {chain} />

--- a/src/routes/strategies/[strategy]/(nav)/+layout.svelte
+++ b/src/routes/strategies/[strategy]/(nav)/+layout.svelte
@@ -18,9 +18,11 @@
 		<img slot="icon" src={strategy.icon_url} alt={strategy.name} />
 		<div class="title" slot="title">
 			{strategy.name}
-			<span class="badges">
-				<DataBadge status="warning">Beta</DataBadge>
-			</span>
+			{#each strategy.tags ?? [] as tag}
+				<span class="badge">
+					<DataBadge status="warning">{tag}</DataBadge>
+				</span>
+			{/each}
 		</div>
 		<div class="wallet-widget" slot="cta">
 			<WalletWidget {strategy} {chain} />
@@ -57,12 +59,13 @@
 		display: grid;
 		gap: var(--space-md);
 
-		.badges {
+		.badge {
 			display: inline-block;
 			font-family: var(--ff-ui);
 			font-size: clamp(11px, 0.45em, 16px);
 			line-height: var(--lh-ui);
-			transform: translate(0.25em, -0.375em);
+			margin-inline: 0.25em;
+			transform: translate(0, -0.375em);
 		}
 
 		:global(> .alert-list) {

--- a/src/routes/strategies/[strategy]/(nav)/+layout.svelte
+++ b/src/routes/strategies/[strategy]/(nav)/+layout.svelte
@@ -18,7 +18,7 @@
 		<img slot="icon" src={strategy.icon_url} alt={strategy.name} />
 		<div class="title" slot="title">
 			{strategy.name}
-			<span class="beta-badge">
+			<span class="badges">
 				<DataBadge status="warning">Beta</DataBadge>
 			</span>
 		</div>
@@ -57,7 +57,7 @@
 		display: grid;
 		gap: var(--space-md);
 
-		.beta-badge {
+		.badges {
 			display: inline-block;
 			font-family: var(--ff-ui);
 			font-size: clamp(11px, 0.45em, 16px);

--- a/src/routes/strategies/[strategy]/(nav)/+layout.svelte
+++ b/src/routes/strategies/[strategy]/(nav)/+layout.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { page } from '$app/stores';
-	import { Alert, PageHeading } from '$lib/components';
+	import { Alert, DataBadge, PageHeading } from '$lib/components';
 	import StrategyNav from './StrategyNav.svelte';
 	import { WalletWidget } from '$lib/wallet';
 	import { getTradeExecutorErrorHtml } from 'trade-executor/strategy/error';
@@ -14,8 +14,14 @@
 </script>
 
 <main class="strategy-layout ds-container">
-	<PageHeading title={strategy.name} description={strategy.short_description}>
+	<PageHeading description={strategy.short_description}>
 		<img slot="icon" src={strategy.icon_url} alt={strategy.name} />
+		<div class="title" slot="title">
+			{strategy.name}
+			<span class="beta-badge">
+				<DataBadge status="warning">Beta</DataBadge>
+			</span>
+		</div>
 		<div class="wallet-widget" slot="cta">
 			<WalletWidget {strategy} {chain} />
 		</div>
@@ -50,6 +56,14 @@
 	.strategy-layout {
 		display: grid;
 		gap: var(--space-md);
+
+		.beta-badge {
+			display: inline-block;
+			font-family: var(--ff-ui);
+			font-size: clamp(11px, 0.45em, 16px);
+			line-height: var(--lh-ui);
+			transform: translate(0.25em, -0.375em);
+		}
 
 		:global(> .alert-list) {
 			width: 100%;

--- a/src/routes/strategies/[strategy]/(nav)/+layout.svelte
+++ b/src/routes/strategies/[strategy]/(nav)/+layout.svelte
@@ -47,9 +47,6 @@
 		/>
 		<div>
 			<slot />
-			<p class="beta-notice">
-				<strong>Beta notice</strong>: Trade execution is currently in beta. Execution may contain issues.
-			</p>
 		</div>
 	</div>
 </main>
@@ -88,11 +85,6 @@
 		@media (--viewport-sm-down) {
 			display: none;
 		}
-	}
-
-	.beta-notice {
-		margin: var(--space-xl) 0;
-		color: hsl(var(--hsl-text-extra-light));
 	}
 
 	.error-wrapper {

--- a/src/routes/strategies/[strategy]/(nav)/+layout.svelte
+++ b/src/routes/strategies/[strategy]/(nav)/+layout.svelte
@@ -19,9 +19,7 @@
 		<div class="title" slot="title">
 			{strategy.name}
 			{#each strategy.tags ?? [] as tag}
-				<span class="badge">
-					<DataBadge status="warning">{tag}</DataBadge>
-				</span>
+				<DataBadge class="badge" status="warning">{tag}</DataBadge>
 			{/each}
 		</div>
 		<div class="wallet-widget" slot="cta">
@@ -56,21 +54,13 @@
 		display: grid;
 		gap: var(--space-md);
 
-		.badge {
-			display: inline-block;
-			font-family: var(--ff-ui);
+		:global(.badge) {
 			font-size: clamp(11px, 0.45em, 16px);
-			line-height: var(--lh-ui);
 			margin-inline: 0.25em;
 			transform: translate(0, -0.375em);
 		}
 
-		:global(> .alert-list) {
-			width: 100%;
-			margin-top: var(--space-lg);
-		}
-
-		.subpage :global {
+		.subpage {
 			display: grid;
 			gap: var(--space-ls);
 
@@ -79,16 +69,16 @@
 				grid-template-columns: 14rem auto;
 			}
 		}
-	}
 
-	.wallet-widget {
-		@media (--viewport-sm-down) {
-			display: none;
+		.wallet-widget {
+			@media (--viewport-sm-down) {
+				display: none;
+			}
 		}
-	}
 
-	.error-wrapper {
-		margin-top: calc(var(--space-md) * -1);
-		margin-bottom: var(--space-md);
+		.error-wrapper {
+			margin-top: -1rem;
+			margin-bottom: 1rem;
+		}
 	}
 </style>

--- a/src/routes/strategies/[strategy]/(nav)/[status=positionStatus]-positions/PositionFlag.svelte
+++ b/src/routes/strategies/[strategy]/(nav)/[status=positionStatus]-positions/PositionFlag.svelte
@@ -21,7 +21,7 @@
 <style lang="postcss">
 	.flag {
 		:global([data-css-props]) {
-			--data-badge-background: var(--hsla-box-4);
+			--data-badge-background: hsl(var(--hsla-box-4));
 		}
 
 		:global(*) {

--- a/src/routes/strategies/[strategy]/[status=positionStatus]-positions/[position=integer]/+page.svelte
+++ b/src/routes/strategies/[strategy]/[status=positionStatus]-positions/[position=integer]/+page.svelte
@@ -341,7 +341,7 @@
 
 	.data-badge {
 		:global([data-css-props]) {
-			--data-badge-background: var(--hsla-box-4);
+			--data-badge-background: hsl(var(--hsla-box-4));
 		}
 		font-size: 0.6em;
 		line-height: 125%;

--- a/src/routes/strategies/[strategy]/[status=positionStatus]-positions/[position=integer]/+page.svelte
+++ b/src/routes/strategies/[strategy]/[status=positionStatus]-positions/[position=integer]/+page.svelte
@@ -88,7 +88,7 @@
 				{#if position.stopLossTriggered}
 					<Tooltip>
 						<span slot="trigger" class="data-badge">
-							<DataBadge>stop loss</DataBadge>
+							<DataBadge>Stop loss</DataBadge>
 						</span>
 						<span slot="popup">
 							{position.tooltip.stopLossTriggered}

--- a/src/routes/strategies/[strategy]/[status=positionStatus]-positions/[position=integer]/trade-[trade=integer]/+page.svelte
+++ b/src/routes/strategies/[strategy]/[status=positionStatus]-positions/[position=integer]/trade-[trade=integer]/+page.svelte
@@ -8,10 +8,8 @@
 		formatTimeDiffMinutesSeconds
 	} from '$lib/helpers/formatters';
 	import { getExplorerUrl } from '$lib/helpers/chain';
-	import { Alert, Button, DataBox, PageHeading, Timestamp } from '$lib/components';
+	import { Alert, Button, DataBadge, DataBox, HashAddress, PageHeading, Timestamp } from '$lib/components';
 	import TransactionTable from './TransactionTable.svelte';
-	import HashAddress from '$lib/components/HashAddress.svelte';
-	import DataBadge from '$lib/components/DataBadge.svelte';
 
 	export let data;
 
@@ -24,12 +22,12 @@
 			Trade #{trade.trade_id}
 			{#if trade.isTest}
 				<span class="heading-badge">
-					<DataBadge status="warning">test</DataBadge>
+					<DataBadge status="warning">Test</DataBadge>
 				</span>
 			{/if}
 			{#if trade.trade_type === 'stop_loss'}
 				<span class="heading-badge">
-					<DataBadge>stop loss</DataBadge>
+					<DataBadge>Stop loss</DataBadge>
 				</span>
 			{/if}
 		</span>

--- a/tests/integration/strategies/index.test.ts
+++ b/tests/integration/strategies/index.test.ts
@@ -19,7 +19,7 @@ test.describe('strategy index page', () => {
 
 	test('should only display live strategies to admin user when live filter applied', async ({ page }) => {
 		await page.goto('/strategies?pw=secret');
-		await page.getByText('live', { exact: true }).click();
+		await page.locator('label:has-text("live")').click();
 
 		const rows = page.locator(`[data-testid="strategy-tiles"] > *`);
 		expect(await rows.count()).toBe(1);


### PR DESCRIPTION
towards #649

Add badges (based on `strategy.tags`) to strategy tiles and page heading.