### PR TITLE
improve color defs

### DIFF
--- a/postcss.config.js
+++ b/postcss.config.js
@@ -12,8 +12,7 @@ export default {
 
 		darkThemeClass({
 			darkSelector: '[data-color-mode="dark"]',
-			lightSelector: '[data-color-mode="light"]',
-			rootSelector: ['body']
+			lightSelector: '[data-color-mode="light"]'
 		})
 	]
 };

--- a/src/app.html
+++ b/src/app.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" data-color-mode="%ts:color-mode%">
 	<head>
 		<meta charset="utf-8" />
 		<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1" />
@@ -42,7 +42,7 @@
 		</script>
 		%sveltekit.head%
 	</head>
-	<body data-color-mode="%ts:color-mode%">
+	<body>
 		<div>%sveltekit.body%</div>
 	</body>
 </html>

--- a/src/lib/breadcrumb/Breadcrumbs.svelte
+++ b/src/lib/breadcrumb/Breadcrumbs.svelte
@@ -78,7 +78,7 @@ https://search.google.com/structured-data/testing-tool
 		margin-bottom: var(--space-sl);
 		margin-left: calc(-1 * var(--space-sm));
 		overflow: hidden;
-		color: hsl(var(--hsl-text-extra-light));
+		color: var(--c-text-extra-light);
 		font: var(--f-ui-xs-medium);
 		letter-spacing: var(--f-ui-xs-spacing, normal);
 
@@ -104,7 +104,7 @@ https://search.google.com/structured-data/testing-tool
 		}
 
 		> span {
-			color: hsl(var(--hsl-text));
+			color: var(--c-text);
 		}
 
 		&:not(:last-child)::after {

--- a/src/lib/chart/ChartContainer.svelte
+++ b/src/lib/chart/ChartContainer.svelte
@@ -75,8 +75,8 @@ Display a chart container with title, description and timespan selector.
 	.chart-container {
 		display: grid;
 		gap: var(--space-sm);
-		background: hsl(var(--hsla-box-1));
-		border: 1px solid hsl(var(--hsla-box-3));
+		background: var(--c-box-1);
+		border: 1px solid var(--c-box-3);
 		border-radius: var(--radius-md);
 		padding-block: var(--chart-container-padding);
 

--- a/src/lib/chart/ChartIQ.svelte
+++ b/src/lib/chart/ChartIQ.svelte
@@ -208,7 +208,7 @@ Dynamically ChartIQ modules (if available) and render chart element.
 <div class="chart-iq" data-css-props>
 	{#if loading || updating}
 		<div class="loading" transition:fade={{ duration: 250 }}>
-			<Spinner size="60" color="hsl(var(--hsl-text-extra-light))" />
+			<Spinner size="60" color="var(--c-text-extra-light)" />
 		</div>
 	{/if}
 

--- a/src/lib/chart/HudMetric.svelte
+++ b/src/lib/chart/HudMetric.svelte
@@ -34,7 +34,7 @@ Use in conjunction with HudRow to display chart HUD (heads-up-display) data.
 		margin: 0;
 
 		dt {
-			color: hsl(var(--hsl-text-light));
+			color: var(--c-text-light);
 		}
 	}
 </style>

--- a/src/lib/chart/PairCandleChart.svelte
+++ b/src/lib/chart/PairCandleChart.svelte
@@ -131,7 +131,7 @@ Display trading pair candles (ohlc+v) charts, with attached quoteFeed for chart 
 
 <style lang="postcss">
 	.pair-candle-chart-hud {
-		background: hsl(var(--hsla-box-3));
+		background: var(--c-box-3);
 		display: inline-grid;
 		gap: var(--space-ss);
 		padding: var(--space-md);

--- a/src/lib/chart/PerformanceChart.svelte
+++ b/src/lib/chart/PerformanceChart.svelte
@@ -130,7 +130,7 @@ Display a peformance line chart for a given (static) dataset.
 			transform: translate(-50%, calc(-100% - var(--space-md)));
 
 			:global(time) {
-				color: hsl(var(--hsl-text-extra-light));
+				color: var(--c-text-extra-light);
 			}
 
 			.value {

--- a/src/lib/chart/ReserveInterestChart.svelte
+++ b/src/lib/chart/ReserveInterestChart.svelte
@@ -116,7 +116,7 @@
 
 <style lang="postcss">
 	.reserve-interest-rate-hud {
-		background: hsl(var(--hsla-box-3));
+		background: var(--c-box-3);
 		display: inline-grid;
 		gap: var(--space-ss);
 		padding: var(--space-md);

--- a/src/lib/chart/chart.css
+++ b/src/lib/chart/chart.css
@@ -4,33 +4,33 @@
  */
 .stx_candle_up,
 .stx_candle_shadow_up {
-	color: hsl(var(--hsl-bullish));
-	border-left-color: hsl(var(--hsl-bullish));
+	color: var(--c-bullish);
+	border-left-color: var(--c-bullish);
 }
 
 .stx_candle_down,
 .stx_candle_shadow_down {
-	color: hsl(var(--hsl-bearish));
-	border-left-color: hsl(var(--hsl-bearish));
+	color: var(--c-bearish);
+	border-left-color: var(--c-bearish);
 }
 
 .stx_current_hr_up {
-	background-color: hsl(var(--hsl-bullish));
+	background-color: var(--c-bullish);
 }
 
 .stx_current_hr_down {
-	background-color: hsl(var(--hsl-bearish));
+	background-color: var(--c-bearish);
 }
 
 .stx_volume_underlay_up,
 .stx_volume_underlay_down {
-	border-left-color: hsl(var(--hsl-body));
+	border-left-color: var(--c-body);
 	opacity: 0.3;
 }
 
 .stx_grid,
 .stx_grid_dark {
-	color: hsl(var(--hsla-box-3));
+	color: var(--c-box-3);
 	border-style: solid;
 }
 
@@ -44,18 +44,18 @@
 
 .stx_yaxis,
 .stx_xaxis {
-	color: hsl(var(--hsl-text-light));
+	color: var(--c-text-light);
 }
 
 .stx_xaxis_dark {
-	color: hsl(var(--hsl-text));
+	color: var(--c-text);
 }
 
 .stx-float-date,
 .stx-float-price {
-	color: hsl(var(--hsl-text));
+	color: var(--c-text);
 	/* this needs to be a solid bg color (no transparency) */
-	background: color-mix(in srgb, hsl(var(--hsl-body)), hsl(var(--hsl-box)) 36%);
+	background: color-mix(in srgb, var(--c-body), hsl(var(--hsl-box)) var(--box-3-alpha));
 }
 
 .stx-float-date {
@@ -77,13 +77,13 @@
 }
 
 .stx_jump_today {
-	background: hsl(var(--hsla-box-2));
+	background: var(--c-box-2);
 }
 
 .crossY,
 .stx_crosshair_y {
 	height: 0px;
-	border-bottom: dashed hsl(var(--hsl-text)) 1px;
+	border-bottom: dashed var(--c-text) 1px;
 	background-color: transparent;
 	margin-top: 1px !important; /* since we're using border-bottom to draw the actual line */
 	opacity: 0.5;
@@ -92,7 +92,7 @@
 .crossX,
 .stx_crosshair_x {
 	width: 0px;
-	border-left: dashed hsl(var(--hsl-text)) 1px;
+	border-left: dashed var(--c-text) 1px;
 	background-color: transparent;
 	opacity: 0.5;
 }
@@ -103,36 +103,36 @@
 
 /* default line chart styles */
 .stx_line_chart {
-	--hsl-chart-line: var(--hsl-text-extra-light);
-	color: hsl(var(--hsl-chart-line));
+	--c-chart-line: var(--c-text-extra-light);
+	color: var(--c-chart-line);
 	width: 2px;
 }
 
 /* bullish line chart styles */
 :is(.bullish, [data-direction='bullish']) .stx_line_chart {
-	--hsl-chart-line: var(--hsl-bullish);
+	--c-chart-line: var(--c-bullish);
 }
 
 /* bearish line chart styles */
 :is(.bearish, [data-direction='bearish']) .stx_line_chart {
-	--hsl-chart-line: var(--hsl-bearish);
+	--c-chart-line: var(--c-bearish);
 }
 
 /* default mountain chart styles */
 .stx_mountain_chart {
-	--hsl-chart-mountain: var(--hsl-text-extra-light);
-	border: hsl(var(--hsl-chart-mountain)); /* line */
-	background-color: hsl(var(--hsl-chart-mountain) / 25%); /* gradient dark */
-	color: hsl(var(--hsl-chart-mountain) / 0%); /* gradient light */
+	--c-chart-mountain: var(--c-text-extra-light);
+	border: var(--c-chart-mountain); /* line */
+	background-color: color-mix(in srgb, var(--c-chart-mountain), transparent 75%); /* gradient dark */
+	color: color-mix(in srgb, var(--c-chart-mountain), transparent 99.9%); /* gradient light */
 	width: 2px;
 }
 
 /* bullish mountain chart styles */
 :is(.bullish, [data-direction='bullish']) .stx_mountain_chart {
-	--hsl-chart-mountain: var(--hsl-bullish);
+	--c-chart-mountain: var(--c-bullish);
 }
 
 /* bearish mountain chart styles */
 :is(.bearish, [data-direction='bearish']) .stx_mountain_chart {
-	--hsl-chart-mountain: var(--hsl-bearish);
+	--c-chart-mountain: var(--c-bearish);
 }

--- a/src/lib/components/AlertList.svelte
+++ b/src/lib/components/AlertList.svelte
@@ -30,27 +30,27 @@ component instead.
 		border-radius: var(--radius-sm);
 		margin-inline: auto;
 		list-style: none;
-		color: hsl(var(--hsl-text));
+		color: var(--c-text);
 	}
 
 	.error {
-		background: hsl(var(--hsl-error) / 10%);
-		border-color: hsl(var(--hsl-error));
+		background: color-mix(in srgb, transparent, var(--c-error) 10%);
+		border-color: var(--c-error);
 	}
 
 	.success {
-		background: hsl(var(--hsl-success) / 10%);
-		border-color: hsl(var(--hsl-success));
+		background: color-mix(in srgb, transparent, var(--c-success) 10%);
+		border-color: var(--c-success);
 	}
 
 	.warning {
-		background: hsl(var(--hsl-warning) / 10%);
-		border-color: hsl(var(--hsl-warning));
+		background: color-mix(in srgb, transparent, var(--c-warning) 10%);
+		border-color: var(--c-warning);
 	}
 
 	.info {
-		background: hsl(var(--hsla-box-1));
-		border-color: hsl(var(--hsla-box-3));
+		background: var(--c-box-1);
+		border-color: var(--c-box-3);
 	}
 
 	.lg {

--- a/src/lib/components/Banner.svelte
+++ b/src/lib/components/Banner.svelte
@@ -24,7 +24,7 @@
 <style lang="postcss">
 	.banner {
 		display: contents;
-		--section-background: hsl(var(--hsla-background-accent-1));
+		--section-background: var(--c-background-accent-1);
 
 		:is(h2, footer) {
 			text-align: center;

--- a/src/lib/components/Button.svelte
+++ b/src/lib/components/Button.svelte
@@ -94,41 +94,41 @@ using flags: primary (default), secondary, ternary, quarternary.
 	}
 
 	.primary {
-		--c-accent: var(--hsla-box-4);
-		background: hsl(var(--c-accent));
-		color: hsl(var(--hsl-text));
+		--c-accent: var(--c-box-4);
+		background: var(--c-accent);
+		color: var(--c-text);
 		outline-color: var(--c-accent);
 		outline-offset: -1px;
 
 		&:is(:hover, :focus):not([disabled]) {
-			--c-accent: var(--hsl-text);
-			color: hsl(var(--hsl-text-inverted));
+			--c-accent: var(--c-text);
+			color: var(--c-text-inverted);
 		}
 	}
 
 	.secondary {
 		background: transparent;
-		color: hsl(var(--hsl-text));
-		border-color: hsl(var(--hsl-text));
+		color: var(--c-text);
+		border-color: var(--c-text);
 
 		&:is(:hover, :focus):not([disabled]) {
-			background: hsl(var(--hsl-text));
-			color: hsl(var(--hsl-text-inverted));
+			background: var(--c-text);
+			color: var(--c-text-inverted);
 		}
 	}
 
 	.tertiary {
-		background: hsl(var(--hsla-box-2));
-		color: hsl(var(--hsl-text));
+		background: var(--c-box-2);
+		color: var(--c-text);
 		border-color: transparent;
 
 		&:is(:hover, :focus):not([disabled]) {
-			background: hsl(var(--hsla-box-4));
+			background: var(--c-box-4);
 		}
 	}
 
 	.quarternary {
-		background: hsl(var(--hsla-box-2));
+		background: var(--c-box-2);
 	}
 
 	.ghost {

--- a/src/lib/components/ContentTile.svelte
+++ b/src/lib/components/ContentTile.svelte
@@ -79,7 +79,7 @@ A `ctaLabel` or `cta` slot may also be provided to include an explicit button ta
 		height: 100%;
 		aspect-ratio: 1;
 		object-fit: cover;
-		background: hsl(var(--hsla-box-2));
+		background: var(--c-box-2);
 
 		@media (--viewport-sm-up) {
 			max-height: 20rem;
@@ -112,7 +112,7 @@ A `ctaLabel` or `cta` slot may also be provided to include an explicit button ta
 		:global time {
 			font: var(--f-ui-sm-medium);
 			letter-spacing: var(--f-ui-sm-spacing, normal);
-			color: hsl(var(--hsl-text-extra-light));
+			color: var(--c-text-extra-light);
 		}
 
 		h3 {
@@ -124,7 +124,7 @@ A `ctaLabel` or `cta` slot may also be provided to include an explicit button ta
 		p {
 			font: var(--f-ui-md-roman);
 			letter-spacing: var(--f-ui-md-spacing, normal);
-			color: hsl(var(--hsl-text-light));
+			color: var(--c-text-light);
 		}
 	}
 

--- a/src/lib/components/DataBadge.svelte
+++ b/src/lib/components/DataBadge.svelte
@@ -21,8 +21,8 @@ The color and background color may be overridden with CSS props.
 
 <style lang="postcss">
 	[data-css-props] {
-		--data-badge-background: hsl(var(--hsla-box-2));
-		--data-badge-color: hsl(var(--hsl-text));
+		--data-badge-background: var(--c-box-2);
+		--data-badge-color: var(--c-text);
 		--data-badge-height: auto;
 	}
 
@@ -41,28 +41,28 @@ The color and background color may be overridden with CSS props.
 		transition: var(--transition-1);
 
 		&.bullish {
-			color: hsl(var(--hsl-bullish));
-			background: hsl(var(--hsl-bullish) / 25%);
+			color: var(--c-bullish);
+			background: color-mix(in srgb, currentColor, transparent 75%);
 		}
 
 		&.bearish {
-			color: hsl(var(--hsl-bearish));
-			background: hsl(var(--hsl-bearish) / 25%);
+			color: var(--c-bearish);
+			background: color-mix(in srgb, currentColor, transparent 75%);
 		}
 
 		&.error {
-			color: color-mix(in srgb, hsl(var(--hsl-text)), hsl(var(--hsl-error)) 25%);
-			background: hsl(var(--hsl-error) / 35%);
+			color: color-mix(in srgb, var(--c-text), var(--c-error) 25%);
+			background: color-mix(in srgb, transparent, var(--c-error) 35%);
 		}
 
 		&.success {
-			color: color-mix(in srgb, hsl(var(--hsl-text)), hsl(var(--hsl-success)) 25%);
-			background: hsl(var(--hsl-success) / 35%);
+			color: color-mix(in srgb, var(--c-text), var(--c-success) 25%);
+			background: color-mix(in srgb, transparent, var(--c-success) 35%);
 		}
 
 		&.warning {
-			color: color-mix(in srgb, hsl(var(--hsl-text)), hsl(var(--hsl-warning)) 25%);
-			background: hsl(var(--hsl-warning) / 40%);
+			color: color-mix(in srgb, var(--c-text), var(--c-warning) 25%);
+			background: color-mix(in srgb, transparent, var(--c-warning) 40%);
 		}
 	}
 </style>

--- a/src/lib/components/DataBox.svelte
+++ b/src/lib/components/DataBox.svelte
@@ -27,7 +27,7 @@ Uses together with SummaryBox (or any grid layout) to display a set of propertie
 <style lang="postcss">
 	.data-box {
 		border-radius: var(--radius-md);
-		background: hsl(var(--hsla-box-2));
+		background: var(--c-box-2);
 		display: grid;
 
 		&.xs {
@@ -80,7 +80,7 @@ Uses together with SummaryBox (or any grid layout) to display a set of propertie
 	.label {
 		font: var(--f-ui-md-medium);
 		letter-spacing: var(--f-ui-md-spacing, normal);
-		color: hsl(var(--hsl-text-extra-light));
+		color: var(--c-text-extra-light);
 
 		@media (--viewport-sm-down) {
 			font: var(--f-ui-sm-medium);

--- a/src/lib/components/Dialog.svelte
+++ b/src/lib/components/Dialog.svelte
@@ -76,6 +76,7 @@ Modal dialog component. Dispatches `open` and `close` events when state changes
 		border: none;
 		border-radius: var(--radius-xs);
 		background: var(--c-body);
+		color: var(--c-text);
 	}
 
 	dialog::backdrop {

--- a/src/lib/components/Dialog.svelte
+++ b/src/lib/components/Dialog.svelte
@@ -75,11 +75,11 @@ Modal dialog component. Dispatches `open` and `close` events when state changes
 		padding: var(--space-xl);
 		border: none;
 		border-radius: var(--radius-xs);
-		background: hsl(var(--hsl-body));
+		background: var(--c-body);
 	}
 
 	dialog::backdrop {
-		background: hsl(var(--hsl-backdrop));
+		background: var(--c-backdrop);
 		opacity: 0.25;
 	}
 
@@ -89,7 +89,7 @@ Modal dialog component. Dispatches `open` and `close` events when state changes
 		gap: var(--space-ss);
 		align-items: center;
 		margin-bottom: var(--space-ss);
-		color: hsl(var(--hsl-text-extra-light));
+		color: var(--c-text-extra-light);
 
 		h5 {
 			font: var(--f-ui-lg-medium);

--- a/src/lib/components/HeroBanner.svelte
+++ b/src/lib/components/HeroBanner.svelte
@@ -106,7 +106,7 @@ Hero banner used as heading on various pages (Community, Trading data, Blog roll
 	hr {
 		width: 100%;
 		margin: var(--space-lg) 0;
-		border: 1px solid hsl(var(--hsl-text));
+		border: 1px solid var(--c-text);
 
 		@media (--viewport-lg-down) {
 			margin: var(--space-md) 0;

--- a/src/lib/components/MenuItem.svelte
+++ b/src/lib/components/MenuItem.svelte
@@ -33,12 +33,12 @@
 		border-radius: var(--menu-item-border-radius, var(--radius-xs));
 
 		&:not([href]):not([tabindex]) {
-			background: hsl(var(--hsla-box-3));
+			background: var(--c-box-3);
 			color: var(--menu-item-active-color, inherit);
 		}
 
 		&:hover {
-			background: hsl(var(--hsla-box-2));
+			background: var(--c-box-2);
 		}
 	}
 

--- a/src/lib/components/MoneyInput.svelte
+++ b/src/lib/components/MoneyInput.svelte
@@ -101,8 +101,9 @@ retained to avoid rounding errors and allow for conversion to `BigInt`.
 		}
 
 		.unit {
-			background-image: linear-gradient(hsl(var(--hsla-box-2)), hsl(var(--hsla-box-2))),
-				linear-gradient(hsl(var(--hsl-body)), hsl(var(--hsl-body)));
+			/* layer box-2 on top of body color instead of white */
+			background-color: hsl(var(--hsl-body));
+			background-image: linear-gradient(hsl(var(--hsla-box-2)), hsl(var(--hsla-box-2)));
 			display: grid;
 			font: var(--f-ui-lg-bold);
 			height: 100%;

--- a/src/lib/components/MoneyInput.svelte
+++ b/src/lib/components/MoneyInput.svelte
@@ -93,8 +93,8 @@ retained to avoid rounding errors and allow for conversion to `BigInt`.
 
 		.inner {
 			display: flex;
-			background: hsl(var(--hsla-input-background));
-			border: 1px hsl(var(--hsla-input-border)) solid;
+			background: var(--c-input-background);
+			border: 1px var(--c-input-border) solid;
 			border-radius: var(--radius-sm);
 			height: 4.25rem;
 			overflow: hidden;
@@ -102,8 +102,8 @@ retained to avoid rounding errors and allow for conversion to `BigInt`.
 
 		.unit {
 			/* layer box-2 on top of body color instead of white */
-			background-color: hsl(var(--hsl-body));
-			background-image: linear-gradient(hsl(var(--hsla-box-2)), hsl(var(--hsla-box-2)));
+			background-color: var(--c-body);
+			background-image: linear-gradient(var(--c-box-2), var(--c-box-2));
 			display: grid;
 			font: var(--f-ui-lg-bold);
 			height: 100%;
@@ -136,20 +136,20 @@ retained to avoid rounding errors and allow for conversion to `BigInt`.
 			width: 100%;
 
 			&::placeholder {
-				color: hsl(var(--hsl-text-extra-light));
+				color: var(--c-text-extra-light);
 			}
 
 			&:disabled {
-				background: hsl(var(--hsla-box-1));
+				background: var(--c-box-1);
 			}
 
 			&:focus,
 			&:hover {
-				background: hsl(var(--hsla-input-background-focus));
+				background: var(--c-input-background-focus);
 			}
 
 			&:focus {
-				border-color: hsl(var(--hsla-input-border-focus));
+				border-color: var(--c-input-border-focus);
 				outline: none;
 			}
 		}

--- a/src/lib/components/NavPanel.svelte
+++ b/src/lib/components/NavPanel.svelte
@@ -40,7 +40,7 @@
 		display: grid;
 		gap: var(--space-lg);
 		grid-auto-rows: min-content;
-		background: hsl(var(--hsl-body));
+		background: var(--c-body);
 		box-shadow: var(--shadow-1);
 		transform: translateX(calc(100% + var(--space-xl)));
 		transition: transform 0.25s;

--- a/src/lib/components/PageHeader.svelte
+++ b/src/lib/components/PageHeader.svelte
@@ -47,7 +47,7 @@ strings) or named slots (for nested markup); `description` can be a prop or defa
 
 		small {
 			font: var(--f-h4-medium);
-			color: hsl(var(--hsl-text-extra-light));
+			color: var(--c-text-extra-light);
 		}
 	}
 </style>

--- a/src/lib/components/PageHeading.svelte
+++ b/src/lib/components/PageHeading.svelte
@@ -74,7 +74,7 @@
 	}
 
 	.icon {
-		background: hsl(var(--hsla-box-1));
+		background: var(--c-box-1);
 		border-radius: 100%;
 		height: var(--icon-size);
 		width: var(--icon-size);
@@ -98,7 +98,7 @@
 	:is(.prefix, .description) {
 		font: var(--secondary-font);
 		letter-spacing: var(--secondary-spacing, normal);
-		color: hsl(var(--hsl-text-extra-light));
+		color: var(--c-text-extra-light);
 	}
 
 	.prefix :global(a:hover) {

--- a/src/lib/components/SegmentedControl.svelte
+++ b/src/lib/components/SegmentedControl.svelte
@@ -29,9 +29,9 @@ button-like control with a segement for each possible value.
 	.primary {
 		--gap: 1px;
 		--padding: var(--space-sm) var(--space-md);
-		--background-default: hsl(var(--hsla-box-4));
-		--background-selected: hsl(var(--hsl-text));
-		--color-selected: hsl(var(--hsl-text-inverted));
+		--background-default: var(--c-box-4);
+		--background-selected: var(--c-text);
+		--color-selected: var(--c-text-inverted);
 
 		@media (--viewport-sm-down) {
 			--padding: var(--space-ss) var(--space-sl);
@@ -41,7 +41,7 @@ button-like control with a segement for each possible value.
 	.secondary {
 		--gap: 2px;
 		--padding: 0.75em;
-		--background-selected: hsl(var(--hsla-box-3));
+		--background-selected: var(--c-box-3);
 		--border-radius: 2em;
 	}
 

--- a/src/lib/components/Select.svelte
+++ b/src/lib/components/Select.svelte
@@ -19,8 +19,8 @@
 	.select {
 		--wrapper-padding: var(--space-sl);
 		align-items: center;
-		border: 1px hsl(var(--hsla-input-border)) solid;
-		background: hsl(var(--hsla-input-background));
+		border: 1px var(--c-input-border) solid;
+		background: var(--c-input-background);
 		border-radius: var(--radius-sm);
 		display: flex;
 		justify-content: space-between;
@@ -29,11 +29,11 @@
 
 		&:focus-within,
 		&:hover {
-			background: hsl(var(--hsla-input-background-focus));
+			background: var(--c-input-background-focus);
 		}
 
 		&:focus-within {
-			border-color: hsl(var(--hsla-input-border-focus));
+			border-color: var(--c-input-border-focus);
 			outline: none;
 		}
 

--- a/src/lib/components/SocialIcon.svelte
+++ b/src/lib/components/SocialIcon.svelte
@@ -27,8 +27,8 @@
 		width: var(--social-icon-size);
 		border: none;
 		border-radius: calc(var(--social-icon-size) / 2);
-		background: hsl(var(--hsl-text));
-		color: hsl(var(--hsl-body));
+		background: var(--c-text);
+		color: var(--c-body);
 		transition: opacity 0.15s;
 
 		@media (--viewport-sm-down) {

--- a/src/lib/components/SourceCode.svelte
+++ b/src/lib/components/SourceCode.svelte
@@ -27,7 +27,7 @@ See: https://github.com/metonym/svelte-highlight
 		display: grid;
 		padding: var(--space-xxs);
 		border-radius: var(--radius-md);
-		background: hsl(var(--hsl-terminal-bg));
+		background: var(--c-terminal-bg);
 
 		:global(.hljs) {
 			background-color: transparent;

--- a/src/lib/components/SummaryBox.svelte
+++ b/src/lib/components/SummaryBox.svelte
@@ -52,7 +52,7 @@ Possible `ctaPosition` values include: top, bottom, toggle (default).
 		container-type: inline-size;
 		display: grid;
 		grid-template-rows: auto 1fr auto;
-		background: hsl(var(--hsla-box-1));
+		background: var(--c-box-1);
 		border-radius: var(--radius-md);
 		padding: var(--space-lg) var(--space-lg);
 
@@ -91,7 +91,7 @@ Possible `ctaPosition` values include: top, bottom, toggle (default).
 			p {
 				/* grid-area: 2 / 1 / auto / span 2; */
 				grid-column: 1 / span 2;
-				color: hsl(var(--hsl-text-extra-light));
+				color: var(--c-text-extra-light);
 				font: var(--f-ui-md-medium);
 				letter-spacing: var(--f-ui-md-spacing, normal);
 			}

--- a/src/lib/components/Tabs.svelte
+++ b/src/lib/components/Tabs.svelte
@@ -51,14 +51,14 @@ Display tabs and associated content panels. Optional `selected` prop defaults to
 	label {
 		display: inline-block;
 		border-radius: var(--radius-md);
-		color: hsl(var(--hsl-text-extra-light));
+		color: var(--c-text-extra-light);
 		cursor: pointer;
 		padding: var(--space-md);
 		font: var(--f-ui-lg-medium);
 
 		input:checked + & {
-			background: hsl(var(--hsla-box-2));
-			color: hsl(var(--hsl-text));
+			background: var(--c-box-2);
+			color: var(--c-text);
 			cursor: auto;
 		}
 	}

--- a/src/lib/components/TextInput.svelte
+++ b/src/lib/components/TextInput.svelte
@@ -68,7 +68,7 @@ unknown props through to HTML input element.
 		width: var(--text-input-width, auto);
 		font: var(--text-input-font, var(--font));
 		letter-spacing: var(--text-input-letter-spacing, var(--letter-spacing, normal));
-		color: hsl(var(--hsl-text));
+		color: var(--c-text);
 
 		.label,
 		[slot='label'] {
@@ -144,29 +144,29 @@ unknown props through to HTML input element.
 			width: inherit;
 			height: var(--text-input-height, var(--height));
 			padding: 0 var(--space-sl);
-			border: 1px hsl(var(--hsla-input-border)) solid;
+			border: 1px var(--c-input-border) solid;
 			border-radius: var(--border-radius);
-			background: hsl(var(--hsla-input-background));
+			background: var(--c-input-background);
 			font: inherit;
 			letter-spacing: inherit;
 			color: inherit;
 			transition: background var(--time-sm) ease-out;
 
 			&::placeholder {
-				color: hsl(var(--hsl-text-extra-light));
+				color: var(--c-text-extra-light);
 			}
 
 			&:disabled {
-				background: hsl(var(--hsla-box-1));
+				background: var(--c-box-1);
 			}
 
 			&:focus,
 			&:hover {
-				background: hsl(var(--hsla-input-background-focus));
+				background: var(--c-input-background-focus);
 			}
 
 			&:focus {
-				border-color: hsl(var(--hsla-input-border-focus));
+				border-color: var(--c-input-border-focus);
 				outline: none;
 			}
 

--- a/src/lib/components/Tooltip.svelte
+++ b/src/lib/components/Tooltip.svelte
@@ -42,7 +42,7 @@ For more information see:
 
 			/* Utility class to provide affordance that the trigger is interactive */
 			:global(.underline) {
-				border-bottom: 1px dotted hsl(var(--hsl-text-light));
+				border-bottom: 1px dotted var(--c-text-light);
 			}
 		}
 
@@ -68,12 +68,12 @@ For more information see:
 
 			.inner {
 				padding: 1.125rem;
-				border: 1px solid hsl(var(--hsl-box-3));
+				border: 1px solid var(--c-box-3);
 				border-radius: var(--radius-md);
-				background: hsl(var(--hsl-text-inverted));
+				background: var(--c-text-inverted);
 				box-shadow: var(--shadow-3);
 				font: var(--f-ui-small-light);
-				color: hsl(var(--hsl-text));
+				color: var(--c-text);
 				text-align: left;
 			}
 

--- a/src/lib/components/UpDownCell.svelte
+++ b/src/lib/components/UpDownCell.svelte
@@ -35,7 +35,7 @@ or other contexts where a stronger visual representation is desired.
 		justify-content: flex-end;
 
 		:global(.up-down-indicator) {
-			background: hsl(var(--hsla-box-2));
+			background: var(--c-box-2);
 			border-radius: var(--radius-sm);
 			display: grid;
 			font: var(--up-down-font, var(--f-ui-sm-medium));
@@ -46,19 +46,13 @@ or other contexts where a stronger visual representation is desired.
 			transition: all var(--time-sm) ease-out;
 		}
 
-		:global(.bullish) {
-			background: hsl(var(--hsl-bullish) / 12%);
+		:global(:is(.bullish, .bearish)) {
+			transition: none;
+			background: color-mix(in srgb, transparent, currentColor 12%);
+			--background-hover: color-mix(in srgb, transparent, currentColor 24%);
 
 			&:hover {
-				background: hsl(var(--hsl-bullish) / 24%) !important;
-			}
-		}
-
-		:global(.bearish) {
-			background: hsl(var(--hsl-bearish) / 12%);
-
-			&:hover {
-				background: hsl(var(--hsl-bearish) / 24%) !important;
+				background: var(--background-hover);
 			}
 		}
 	}

--- a/src/lib/components/UpDownIndicator.svelte
+++ b/src/lib/components/UpDownIndicator.svelte
@@ -29,14 +29,14 @@ a lightweight visual representation is needed. See `UpDownCell.svelte` for a mor
 
 <style lang="postcss">
 	.up-down-indicator {
-		color: hsl(var(--hsl-text-light));
+		color: var(--c-text-light);
 
 		&.bullish {
-			color: hsl(var(--hsl-bullish));
+			color: var(--c-bullish);
 		}
 
 		&.bearish {
-			color: hsl(var(--hsl-bearish));
+			color: var(--c-bearish);
 		}
 	}
 </style>

--- a/src/lib/components/UspTile.svelte
+++ b/src/lib/components/UspTile.svelte
@@ -34,7 +34,7 @@
 	}
 
 	span {
-		color: hsl(var(--hsl-text-extra-light));
+		color: var(--c-text-extra-light);
 		font: var(--f-ui-xl-medium);
 	}
 </style>

--- a/src/lib/components/css/bullish-bearish.css
+++ b/src/lib/components/css/bullish-bearish.css
@@ -1,0 +1,7 @@
+:is(.bullish, [data-direction='bullish']) {
+	color: var(--c-bullish);
+}
+
+:is(.bearish, [data-direction='bearish']) {
+	color: var(--c-bearish);
+}

--- a/src/lib/components/css/color.css
+++ b/src/lib/components/css/color.css
@@ -1,21 +1,30 @@
-/* Global color values (not theme-specific) */
 :root {
+	/* Supported color schemes */
+	color-scheme: light dark;
+
+	/* Global color hues */
 	--hue-1: 36;
 	--hue-2: 60;
 	--hue-bearish: 0;
 	--hue-bullish: 140;
 
+	/* Common/shared color definitions */
 	--c-console: hsl(120 93% 79%);
 	--c-error: hsl(358 56% 55%);
 	--c-success: hsl(149 64% 44%);
 	--c-warning: hsl(43 92% 50%);
 
-	/* Color schemes */
-	color-scheme: light dark;
-}
+	/* Box shading levels; see theme-specific hsl-box and alpha values */
+	--c-box-1: hsl(var(--hsl-box) / var(--box-1-alpha));
+	--c-box-2: hsl(var(--hsl-box) / var(--box-2-alpha));
+	--c-box-3: hsl(var(--hsl-box) / var(--box-3-alpha));
+	--c-box-4: hsl(var(--hsl-box) / var(--box-4-alpha));
 
-/* Light theme (default) */
-body {
+	/**
+	 * Light theme
+	 *
+	 * This is the default if no system or user-selected theme specified.
+	 */
 	--c-body: hsl(var(--hue-1) 100% 96%);
 
 	--c-text: hsl(var(--hue-1) 9% 7%);
@@ -34,11 +43,6 @@ body {
 	--box-2-alpha: 24%;
 	--box-3-alpha: 36%;
 	--box-4-alpha: 48%;
-
-	--c-box-1: hsl(var(--hsl-box) / var(--box-1-alpha));
-	--c-box-2: hsl(var(--hsl-box) / var(--box-2-alpha));
-	--c-box-3: hsl(var(--hsl-box) / var(--box-3-alpha));
-	--c-box-4: hsl(var(--hsl-box) / var(--box-4-alpha));
 
 	--c-background-accent-1: var(--c-box-2);
 
@@ -59,11 +63,14 @@ body {
 	/* see: https://stackoverflow.com/questions/70845195#answer-70934827 */
 	--cm-light: initial;
 	--cm-dark: ;
-}
 
-/* Dark theme */
-@media (prefers-color-scheme: dark) {
-	body {
+	/**
+	 * Dark theme
+   *
+	 * Media query is applied to both system theme and user-selected
+	 * theme via postcss plugin (see postcss.config.js)
+ 	 */
+	@media (prefers-color-scheme: dark) {
 		--c-body: hsl(var(--hue-2) 2% 10%);
 
 		--c-text: hsl(var(--hue-1) 12% 99%);
@@ -106,6 +113,7 @@ body {
 	}
 }
 
+/* Global text and background values (defined in light/dark themes above) */
 body {
 	color: var(--c-text);
 	background-color: var(--c-body);

--- a/src/lib/components/css/color.css
+++ b/src/lib/components/css/color.css
@@ -5,12 +5,10 @@
 	--hue-bearish: 0;
 	--hue-bullish: 140;
 
-	--hsl-black: 0 0% 0%;
-	--hsl-white: 0 0% 100%;
-	--hsl-console: 120 93% 79%;
-	--hsl-error: 358 56% 55%;
-	--hsl-success: 149 64% 44%;
-	--hsl-warning: 43 92% 50%;
+	--c-console: hsl(120 93% 79%);
+	--c-error: hsl(358 56% 55%);
+	--c-success: hsl(149 64% 44%);
+	--c-warning: hsl(43 92% 50%);
 
 	/* Color schemes */
 	color-scheme: light dark;
@@ -18,38 +16,43 @@
 
 /* Light theme (default) */
 body {
-	--hsl-body: var(--hue-1) 100% 96%;
+	--c-body: hsl(var(--hue-1) 100% 96%);
 
-	--hsl-text: var(--hue-1) 9% 7%;
-	--hsl-text-light: var(--hue-1) 4% 24%;
-	--hsl-text-extra-light: var(--hue-1) 6% 56%;
-	--hsl-text-ultra-light: var(--hue-1) 12% 68%;
-	--hsl-text-inverted: var(--hue-2) 20% 99%;
+	--c-text: hsl(var(--hue-1) 9% 7%);
+	--c-text-light: hsl(var(--hue-1) 4% 24%);
+	--c-text-extra-light: hsl(var(--hue-1) 6% 56%);
+	--c-text-ultra-light: hsl(var(--hue-1) 12% 68%);
+	--c-text-inverted: hsl(var(--hue-2) 20% 99%);
 
-	--hsl-bullish: var(--hue-bullish) 68% 42%;
-	--hsl-bearish: var(--hue-bearish) 92% 57%;
+	--c-bullish: hsl(var(--hue-bullish) 68% 42%);
+	--c-bearish: hsl(var(--hue-bearish) 92% 57%);
 
-	--hsl-shadow: var(--hsl-black);
+	--c-shadow: black;
 
 	--hsl-box: var(--hue-1) 32% 72%;
-	--hsla-box-1: var(--hsl-box) / 12%;
-	--hsla-box-2: var(--hsl-box) / 24%;
-	--hsla-box-3: var(--hsl-box) / 36%;
-	--hsla-box-4: var(--hsl-box) / 48%;
+	--box-1-alpha: 12%;
+	--box-2-alpha: 24%;
+	--box-3-alpha: 36%;
+	--box-4-alpha: 48%;
 
-	--hsla-background-accent-1: var(--hsla-box-2);
+	--c-box-1: hsl(var(--hsl-box) / var(--box-1-alpha));
+	--c-box-2: hsl(var(--hsl-box) / var(--box-2-alpha));
+	--c-box-3: hsl(var(--hsl-box) / var(--box-3-alpha));
+	--c-box-4: hsl(var(--hsl-box) / var(--box-4-alpha));
 
-	--hsla-input-background: var(--hsl-white) / 95%;
-	--hsla-input-background-focus: var(--hsl-white);
-	--hsla-input-border: var(--hsla-box-4);
-	--hsla-input-border-focus: var(--hsl-text-extra-light);
+	--c-background-accent-1: var(--c-box-2);
 
-	--hsla-quoteblock-background: var(--hsl-white);
-	--hsla-quoteblock-backdrop: var(--hsla-box-4);
+	--c-input-background: color-mix(in srgb, white, transparent 5%);
+	--c-input-background-focus: white;
+	--c-input-border: var(--c-box-4);
+	--c-input-border-focus: var(--c-text-extra-light);
+
+	--c-quoteblock-background: white;
+	--c-quoteblock-backdrop: var(--c-box-4);
 
 	/* must use raw values since ::backdrop does not inherit from anything */
 	::backdrop {
-		--hsl-backdrop: 0 0% 0%;
+		--c-backdrop: black;
 	}
 
 	/* color mode utility properties */
@@ -61,38 +64,39 @@ body {
 /* Dark theme */
 @media (prefers-color-scheme: dark) {
 	body {
-		--hsl-body: var(--hue-2) 2% 10%;
+		--c-body: hsl(var(--hue-2) 2% 10%);
 
-		--hsl-text: var(--hue-1) 12% 99%;
-		--hsl-text-light: var(--hue-1) 4% 88%;
-		--hsl-text-extra-light: var(--hue-1) 3% 64%;
-		--hsl-text-ultra-light: var(--hue-1) 2% 36%;
-		--hsl-text-inverted: var(--hue-1) 9% 7%;
+		--c-text: hsl(var(--hue-1) 12% 99%);
+		--c-text-light: hsl(var(--hue-1) 4% 88%);
+		--c-text-extra-light: hsl(var(--hue-1) 3% 64%);
+		--c-text-ultra-light: hsl(var(--hue-1) 2% 36%);
+		--c-text-inverted: hsl(var(--hue-1) 9% 7%);
 
-		--hsl-bullish: var(--hue-bullish) 68% 42%;
-		--hsl-bearish: var(--hue-bearish) 92% 72%;
+		--c-bullish: hsl(var(--hue-bullish) 68% 42%);
+		--c-bearish: hsl(var(--hue-bearish) 92% 72%);
 
-		--hsl-shadow: var(--hsl-white);
+		--c-shadow: white;
 
+		/* see --c-box-n values above */
 		--hsl-box: var(--hue-1) 2% 92%;
-		--hsla-box-1: var(--hsl-box) / 5%;
-		--hsla-box-2: var(--hsl-box) / 8%;
-		--hsla-box-3: var(--hsl-box) / 14%;
-		--hsla-box-4: var(--hsl-box) / 20%;
+		--box-1-alpha: 5%;
+		--box-2-alpha: 8%;
+		--box-3-alpha: 14%;
+		--box-4-alpha: 20%;
 
-		--hsla-background-accent-1: 0 0% 0% / 20%;
+		--c-background-accent-1: hsl(0 0% 0% / 20%);
 
-		--hsla-input-background: var(--hsla-box-2);
-		--hsla-input-background-focus: var(--hsla-box-3);
-		--hsla-input-border: var(--hsla-box-4);
-		--hsla-input-border-focus: var(--hsl-text-extra-light);
+		--c-input-background: var(--c-box-2);
+		--c-input-background-focus: var(--c-box-3);
+		--c-input-border: var(--c-box-4);
+		--c-input-border-focus: var(--c-text-extra-light);
 
-		--hsla-quoteblock-background: var(--hsla-box-4);
-		--hsla-quoteblock-backdrop: var(--hsla-box-2);
+		--c-quoteblock-background: var(--c-box-4);
+		--c-quoteblock-backdrop: var(--c-box-2);
 
 		/* must use raw values since ::backdrop does not inherit from anything */
 		::backdrop {
-			--hsl-backdrop: 0 0% 100%;
+			--c-backdrop: white;
 		}
 
 		/* color mode utility properties */
@@ -103,8 +107,8 @@ body {
 }
 
 body {
-	color: hsl(var(--hsl-text));
-	background-color: hsl(var(--hsl-body));
+	color: var(--c-text);
+	background-color: var(--c-body);
 	transition-property: background-color, color;
 	transition-duration: var(--time-md);
 }

--- a/src/lib/components/css/datatable.css
+++ b/src/lib/components/css/datatable.css
@@ -41,7 +41,7 @@ table.datatable {
 	}
 
 	thead tr:first-child {
-		background-color: hsl(var(--hsl-body));
+		background: var(--c-body);
 		position: sticky;
 		top: 0;
 		z-index: 1;
@@ -52,9 +52,8 @@ table.datatable {
 	}
 
 	th {
-		background: hsl(var(--hsl-body));
-		border-radius: var(--table-border-radius);
-		color: hsl(var(--hsl-text-extra-light));
+		background: var(--c-body);
+		color: var(--c-text-extra-light);
 		font: var(--table-font);
 		letter-spacing: var(--table-letter-spacing, normal);
 		overflow: hidden;
@@ -71,8 +70,9 @@ table.datatable {
 			user-select: none;
 
 			&:hover {
-				background: hsl(var(--hsla-box-1));
-				color: hsl(var(--hsl-text-light));
+				background: var(--c-box-1);
+				color: var(--c-text-light);
+				border-radius: var(--table-border-radius);
 			}
 
 			.icon svg {
@@ -87,14 +87,14 @@ table.datatable {
 		}
 
 		&.sorted {
-			color: hsl(var(--hsl-text));
+			color: var(--c-text);
 			padding-right: var(--space-5xl);
 		}
 	}
 
 	tbody tr {
 		td {
-			background: hsl(var(--hsla-box-2));
+			background: var(--c-box-2);
 			height: var(--body-cell-height);
 			font: var(--table-font);
 			letter-spacing: var(--table-letter-spacing, normal);
@@ -119,21 +119,16 @@ table.datatable {
 
 		&:is(:hover, :focus, :focus-within) {
 			td {
-				background: hsl(var(--hsla-box-4));
+				background: var(--c-box-4);
 			}
 
 			.button {
-				--c-accent: var(--hsl-text);
-				color: hsl(var(--hsl-text-inverted));
+				--c-accent: var(--c-text);
+				color: var(--c-text-inverted);
 			}
 
-			.up-down-cell .up-down-indicator {
-				&.bearish {
-					background: hsl(var(--hsl-bearish) / 24%) !important;
-				}
-				&.bullish {
-					background: hsl(var(--hsl-bullish) / 24%) !important;
-				}
+			.up-down-indicator:is(.bullish, .bearish) {
+				background: var(--background-hover);
 			}
 		}
 	}
@@ -163,7 +158,7 @@ table.datatable {
 			}
 
 			tbody tr {
-				background: hsl(var(--hsla-box-2));
+				background: var(--c-box-2);
 				border-radius: var(--table-border-radius);
 				display: grid;
 				grid-template-columns: 1fr 1fr;
@@ -235,7 +230,7 @@ table.loading {
 
 		&::before {
 			animation: pulse-opacity 1s infinite ease-out;
-			background: hsl(var(--hsla-box-3));
+			background: var(--c-box-3);
 			bottom: var(--space-sm);
 			border-radius: var(--radius-sm);
 			content: '';
@@ -259,7 +254,7 @@ table.loading {
 
 			&::before {
 				animation: pulse-opacity 1s infinite ease-out;
-				background: hsl(var(--hsla-box-3));
+				background: var(--c-box-3);
 				bottom: var(--space-lg);
 				border-radius: var(--radius-sm);
 				content: '';

--- a/src/lib/components/css/index.css
+++ b/src/lib/components/css/index.css
@@ -1,5 +1,6 @@
-@import './animations.css';
 @import './reset.css';
+@import './animations.css';
+@import './bullish-bearish.css';
 @import './color.css';
 @import './datatable.css';
 @import './input.css';
@@ -7,12 +8,12 @@
 @import './progress.css';
 @import './radius.css';
 @import './radius-new.css';
+@import './shadows.css';
 @import './space.css';
 @import './terminal.css';
 @import './tile.css';
 @import './time.css';
+@import './transitions.css';
 @import './truncate.css';
 @import './typography.css';
 @import './typography-new.css';
-@import './transitions.css';
-@import './shadows.css';

--- a/src/lib/components/css/progress.css
+++ b/src/lib/components/css/progress.css
@@ -1,6 +1,6 @@
 progress {
-	--background-color: hsl(var(--hsla-box-1));
-	--progress-color: hsl(var(--hsl-success));
+	--background-color: var(--c-box-1);
+	--progress-color: var(--c-success);
 	--border-radius: var(--progress-border-radius, var(--radius-xs));
 	appearance: none;
 	background: var(--background-color);

--- a/src/lib/components/css/shadows.css
+++ b/src/lib/components/css/shadows.css
@@ -1,5 +1,5 @@
 body {
-	--shadow-1: 0 0 4px 0 hsl(var(--hsl-shadow) / 20%);
-	--shadow-2: 0 0 6px 0 hsl(var(--hsl-shadow) / 10%);
-	--shadow-3: 0 0 6px 0 hsl(var(--hsl-shadow) / 5%);
+	--shadow-1: 0 0 4px 0 color-mix(in srgb, transparent, var(--c-shadow) 20%);
+	--shadow-2: 0 0 6px 0 color-mix(in srgb, transparent, var(--c-shadow) 10%);
+	--shadow-3: 0 0 6px 0 color-mix(in srgb, transparent, var(--c-shadow) 5%);
 }

--- a/src/lib/components/css/terminal.css
+++ b/src/lib/components/css/terminal.css
@@ -1,14 +1,14 @@
 body {
-	--hsl-terminal-bg: 239, 31%, 6%;
-	--hsl-terminal: var(--hue-1), 4%, 86%;
-	--hsl-terminal-light: var(--hue-1), 3%, 72%;
+	--c-terminal-bg: hsl(239, 31%, 6%);
+	--c-terminal: hsl(var(--hue-1), 4%, 86%);
+	--c-terminal-light: hsl(var(--hue-1), 3%, 72%);
 }
 
 :where(.terminal-viewport) {
 	border-radius: var(--radius-md);
 	padding: var(--space-md) var(--space-lg);
-	background: hsl(var(--hsl-terminal-bg));
-	color: hsl(var(--hsl-terminal));
+	background: var(--c-terminal-bg);
+	color: var(--c-terminal);
 	font: var(--f-mono-md-regular);
 	letter-spacing: var(--f-mono-md-spacing, normal);
 

--- a/src/lib/components/css/tile.css
+++ b/src/lib/components/css/tile.css
@@ -7,22 +7,22 @@
 	transition: background var(--time-sm) ease-out;
 
 	&.a {
-		background: hsl(var(--hsla-box-1));
-		--background-hover: hsl(var(--hsla-box-2));
+		background: var(--c-box-1);
+		--background-hover: var(--c-box-2);
 	}
 
 	&.b {
-		background: hsl(var(--hsla-box-2));
-		--background-hover: hsl(var(--hsla-box-4));
+		background: var(--c-box-2);
+		--background-hover: var(--c-box-4);
 	}
 
 	&.c {
-		background: hsl(var(--hsla-box-3));
-		--background-hover: hsl(var(--hsla-box-4));
+		background: var(--c-box-3);
+		--background-hover: var(--c-box-4);
 	}
 
 	&.d {
-		background: hsl(var(--hsla-box-4));
+		background: var(--c-box-4);
 	}
 
 	&:hover,
@@ -32,8 +32,8 @@
 
 	&:is(:hover, :focus) {
 		.button {
-			background: hsl(var(--hsl-text)) !important;
-			color: hsl(var(--hsl-text-inverted)) !important;
+			background: var(--c-text) !important;
+			color: var(--c-text-inverted) !important;
 		}
 	}
 }

--- a/src/lib/components/datatable/MobileSortSelect.svelte
+++ b/src/lib/components/datatable/MobileSortSelect.svelte
@@ -38,7 +38,7 @@
 
 <style lang="postcss">
 	.mobile-sorting {
-		background: hsl(var(--hsl-body));
+		background: var(--c-body);
 		padding: var(--space-md) 0;
 		position: sticky;
 		top: 0;

--- a/src/lib/components/datatable/PageButton.svelte
+++ b/src/lib/components/datatable/PageButton.svelte
@@ -22,16 +22,16 @@
 	button {
 		background: none;
 		border: none;
-		color: hsl(var(--hsl-text-extra-light));
+		color: var(--c-text-extra-light);
 		cursor: pointer;
 		transition: color var(--time-xs) ease-out;
 
 		&:hover {
-			color: hsl(var(--hsl-text));
+			color: var(--c-text);
 		}
 
 		:global(nav:hover) &:not(:hover) {
-			color: hsl(var(--hsl-text-extra-light));
+			color: var(--c-text-extra-light);
 		}
 	}
 
@@ -39,11 +39,11 @@
 		cursor: not-allowed;
 
 		&.active {
-			color: hsl(var(--hsl-text));
+			color: var(--c-text);
 		}
 
 		&.disabled {
-			color: hsl(var(--hsl-text-extra-light));
+			color: var(--c-text-extra-light);
 		}
 	}
 </style>

--- a/src/lib/components/datatable/TableFooter.svelte
+++ b/src/lib/components/datatable/TableFooter.svelte
@@ -94,7 +94,7 @@
 			display: flex;
 
 			&:hover .gap-indicator {
-				color: hsl(var(--hsl-text-extra-light));
+				color: var(--c-text-extra-light);
 			}
 		}
 	}

--- a/src/lib/explorer/PairSymbolCell.svelte
+++ b/src/lib/explorer/PairSymbolCell.svelte
@@ -23,6 +23,6 @@
 	}
 
 	span {
-		color: hsl(var(--hsl-text-extra-light));
+		color: var(--c-text-extra-light);
 	}
 </style>

--- a/src/lib/explorer/TradingDescription.svelte
+++ b/src/lib/explorer/TradingDescription.svelte
@@ -48,7 +48,7 @@ Used in DataTable context (vs. standard svelte component context).
 		white-space: nowrap;
 
 		.modifier {
-			color: hsl(var(--hsl-text-extra-light));
+			color: var(--c-text-extra-light);
 		}
 
 		.test-badge {

--- a/src/lib/header/ColorModePicker.svelte
+++ b/src/lib/header/ColorModePicker.svelte
@@ -17,12 +17,12 @@
 	};
 
 	function openDialog() {
-		currentMode = document.body.getAttribute('data-color-mode') ?? 'system';
+		currentMode = document.documentElement.dataset.colorMode ?? 'system';
 		open = true;
 	}
 
 	function setMode(mode: string) {
-		document.body.setAttribute('data-color-mode', mode);
+		document.documentElement.dataset.colorMode = mode;
 		document.cookie = cookies.serialize('color-mode', mode, {
 			secure: false,
 			path: '/',
@@ -37,7 +37,9 @@
 <Dialog title="Color Mode" bind:open>
 	<menu>
 		{#each Object.entries(modes) as [mode, label]}
-			<li class={mode} class:active={mode === currentMode} on:click={() => setMode(mode)}>{label}</li>
+			<li class={mode} class:active={mode === currentMode}>
+				<button on:click={() => setMode(mode)}>{label}</button>
+			</li>
 		{/each}
 	</menu>
 </Dialog>
@@ -45,36 +47,39 @@
 <style lang="postcss">
 	menu {
 		display: grid;
-		margin-block: var(--space-md) 0;
+		margin-block: 1rem 0;
 		padding: 0;
-		list-style-type: none;
 	}
 
 	li {
+		display: contents;
+	}
+
+	button {
+		border: none;
 		border-radius: var(--radius-xs);
-		padding-block: var(--space-ss);
+		padding-block: 0.5rem;
+		background: inherit;
 		font: var(--f-ui-lg-medium);
 		letter-spacing: var(--f-ui-lg-spacing, normal);
 		color: var(--c-text);
-		text-align: center;
 		cursor: pointer;
 
-		&.light:hover {
+		.light &:hover {
 			background: var(--cm-light, var(--c-background-accent-1)) var(--cm-dark, var(--c-text));
 			color: var(--cm-light, var(--c-text)) var(--cm-dark, var(--c-text-inverted));
 		}
 
-		&.dark:hover {
+		.dark &:hover {
 			background: var(--cm-dark, var(--c-background-accent-1)) var(--cm-light, var(--c-text));
 			color: var(--cm-dark, var(--c-text)) var(--cm-light, var(--c-text-inverted));
 		}
 
-		&.system:hover {
+		.system &:hover {
 			background: var(--c-background-accent-1);
 		}
 
-		&.active,
-		&.active:hover {
+		.active :is(&, &:hover) {
 			background: var(--c-box-3);
 		}
 	}

--- a/src/lib/header/ColorModePicker.svelte
+++ b/src/lib/header/ColorModePicker.svelte
@@ -55,27 +55,27 @@
 		padding-block: var(--space-ss);
 		font: var(--f-ui-lg-medium);
 		letter-spacing: var(--f-ui-lg-spacing, normal);
-		color: hsl(var(--hsl-text));
+		color: var(--c-text);
 		text-align: center;
 		cursor: pointer;
 
 		&.light:hover {
-			background: var(--cm-light, hsl(var(--hsla-background-accent-1))) var(--cm-dark, hsl(var(--hsl-text)));
-			color: var(--cm-light, hsl(var(--hsl-text))) var(--cm-dark, hsl(var(--hsl-text-inverted)));
+			background: var(--cm-light, var(--c-background-accent-1)) var(--cm-dark, var(--c-text));
+			color: var(--cm-light, var(--c-text)) var(--cm-dark, var(--c-text-inverted));
 		}
 
 		&.dark:hover {
-			background: var(--cm-dark, hsl(var(--hsla-background-accent-1))) var(--cm-light, hsl(var(--hsl-text)));
-			color: var(--cm-dark, hsl(var(--hsl-text))) var(--cm-light, hsl(var(--hsl-text-inverted)));
+			background: var(--cm-dark, var(--c-background-accent-1)) var(--cm-light, var(--c-text));
+			color: var(--cm-dark, var(--c-text)) var(--cm-light, var(--c-text-inverted));
 		}
 
 		&.system:hover {
-			background: hsl(var(--hsla-background-accent-1));
+			background: var(--c-background-accent-1);
 		}
 
 		&.active,
 		&.active:hover {
-			background: hsl(var(--hsla-box-3));
+			background: var(--c-box-3);
 		}
 	}
 </style>

--- a/src/lib/momentum/MomentumTable.svelte
+++ b/src/lib/momentum/MomentumTable.svelte
@@ -67,7 +67,7 @@
 		.position {
 			width: 3.5em;
 			padding-right: 0;
-			color: hsl(var(--hsl-text-extra-light));
+			color: var(--c-text-extra-light);
 		}
 
 		.price-change {

--- a/src/lib/newsletter/OptInBanner.svelte
+++ b/src/lib/newsletter/OptInBanner.svelte
@@ -35,7 +35,7 @@
 <style lang="postcss">
 	.newsletter-opt-in-banner {
 		--newsletter-banner-padding: var(--space-xl);
-		background-color: hsl(var(--hsla-box-2));
+		background-color: var(--c-box-2);
 		border-radius: var(--radius-lg);
 		display: grid;
 		gap: var(--space-8xl);

--- a/src/lib/search/components/Search.svelte
+++ b/src/lib/search/components/Search.svelte
@@ -165,8 +165,8 @@ Display site-wide search box for use in top-nav.
 	.results {
 		--text-input-height: 2.875rem;
 
-		background: hsl(var(--hsl-body));
-		border: 1px hsl(var(--hsla-box-3)) solid;
+		background: var(--c-body);
+		border: 1px var(--c-box-3) solid;
 		box-shadow: var(--shadow-3);
 		overflow: hidden;
 		position: absolute;
@@ -202,7 +202,7 @@ Display site-wide search box for use in top-nav.
 		}
 
 		.inner {
-			background: hsl(var(--hsla-box-1));
+			background: var(--c-box-1);
 			display: flex;
 			flex-direction: column;
 			gap: var(--space-md);
@@ -225,7 +225,7 @@ Display site-wide search box for use in top-nav.
 			margin-bottom: var(--space-sl);
 			font: var(--f-ui-md-medium);
 			letter-spacing: var(--f-ui-md-spacing, normal);
-			color: hsl(var(--hsl-text-extra-light));
+			color: var(--c-text-extra-light);
 			text-align: center;
 
 			@media (--search-layout-mobile) {

--- a/src/lib/search/components/SearchHit.svelte
+++ b/src/lib/search/components/SearchHit.svelte
@@ -79,10 +79,10 @@ props.
 
 <style lang="postcss">
 	.search-hit {
-		--hsl-exchange: 36, 68%, 35%;
-		--hsl-token: 36, 21%, 54%;
-		--hsl-trading-pair: 239, 6%, 36%;
-		--hsl-lending-reserve: 291, 16%, 43%;
+		--c-exchange: hsl(36, 68%, 35%);
+		--c-token: hsl(36, 21%, 54%);
+		--c-trading-pair: hsl(239, 6%, 36%);
+		--c-lending-reserve: hsl(291, 16%, 43%);
 
 		display: grid;
 		list-style-type: none;
@@ -105,20 +105,10 @@ props.
 				opacity: 0.35;
 			}
 
-			&:hover {
-				:global .up-down-indicator {
-					&.bearish {
-						background: hsl(var(--hsl-bearish) / 24%) !important;
-					}
-
-					&.bullish {
-						background: hsl(var(--hsl-bullish) / 24%) !important;
-					}
-				}
-			}
-
-			&:focus {
-				background: var(--background-hover); /* see tile.css */
+			/* see tile.css and UpDownCell.svelte */
+			&:focus,
+			&:is(:hover, :focus) :global(.up-down-indicator) {
+				background: var(--background-hover);
 			}
 
 			:global .up-down-cell {
@@ -135,24 +125,24 @@ props.
 			width: 5.625em;
 			font: var(--search-hit-badge-font, var(--f-ui-xs-medium));
 			letter-spacing: var(--search-hit-badge-spacing, var(--f-ui-xs-spacing, normal));
-			color: var(--cm-light, hsl(var(--hsl-text-inverted))) var(--cm-dark, hsl(var(--hsl-text)));
+			color: var(--cm-light, var(--c-text-inverted)) var(--cm-dark, var(--c-text));
 			text-transform: capitalize;
 			text-align: center;
 
 			&.exchange {
-				background: hsl(var(--hsl-exchange));
+				background: var(--c-exchange);
 			}
 
 			&.token {
-				background: hsl(var(--hsl-token));
+				background: var(--c-token);
 			}
 
 			&.pair {
-				background: hsl(var(--hsl-trading-pair));
+				background: var(--c-trading-pair);
 			}
 
 			&.lending_reserve {
-				background: hsl(var(--hsl-lending-reserve));
+				background: var(--c-lending-reserve);
 			}
 		}
 
@@ -165,7 +155,7 @@ props.
 			padding: 0.15em;
 			border-radius: 1em;
 			transform: translate(50%, 50%);
-			background: hsl(var(--hsl-text-inverted));
+			background: var(--c-text-inverted);
 			box-shadow: var(--shadow-1);
 		}
 

--- a/src/lib/search/components/SearchHitDescription.svelte
+++ b/src/lib/search/components/SearchHitDescription.svelte
@@ -31,7 +31,7 @@
 		letter-spacing: var(--search-hit-description-spacing, var(--f-ui-md-spacing, normal));
 
 		.swap-fee {
-			color: hsl(var(--hsl-text-extra-light));
+			color: var(--c-text-extra-light);
 		}
 
 		.warning-icon {

--- a/src/lib/trade-executor/components/KeyMetric.svelte
+++ b/src/lib/trade-executor/components/KeyMetric.svelte
@@ -72,7 +72,7 @@ Display one key metric in a strategy tile.
 			align-items: center;
 			font: var(--key-metric-label-font);
 			letter-spacing: var(--key-metric-label-letter-spacing, normal);
-			color: hsl(var(--hsl-text-light));
+			color: var(--c-text-light);
 
 			&.backtesting > span::after {
 				content: '*';

--- a/src/lib/wallet/DepositBalance.svelte
+++ b/src/lib/wallet/DepositBalance.svelte
@@ -43,7 +43,7 @@
 		.symbol {
 			font: var(--f-ui-md-medium);
 			letter-spacing: var(--ls-ui-md);
-			color: hsl(var(--hsl-text-extra-light));
+			color: var(--c-text-extra-light);
 		}
 	}
 </style>

--- a/src/lib/wallet/MyDeposits.svelte
+++ b/src/lib/wallet/MyDeposits.svelte
@@ -147,7 +147,7 @@
 
 		display: grid;
 		grid-template-rows: auto 1fr;
-		border: 1px solid hsl(var(--hsl-text-light));
+		border: 1px solid var(--c-text-light);
 		border-radius: var(--radius-md);
 		--padding: 1.25rem;
 		--gap: 1rem;
@@ -225,7 +225,7 @@
 		font-size: 1rem;
 		letter-spacing: 0.06em;
 		text-transform: uppercase;
-		color: hsl(var(--hsl-text-ultra-light));
+		color: var(--c-text-ultra-light);
 		white-space: nowrap;
 
 		.mobile & {

--- a/src/lib/wallet/TokenBalance.svelte
+++ b/src/lib/wallet/TokenBalance.svelte
@@ -9,7 +9,7 @@
 
 {#await data}
 	<slot skeleton={true} value="---" symbol="---">
-		<Spinner size="2rem" color="hsl(var(--hsl-text-light))" />
+		<Spinner size="2rem" color="var(--c-text-light)" />
 	</slot>
 {:then balance}
 	{@const { symbol } = balance}

--- a/src/lib/wallet/WalletBalance.svelte
+++ b/src/lib/wallet/WalletBalance.svelte
@@ -42,7 +42,7 @@
 	<WalletInfoItem>
 		<EntitySymbol slot="label" type="token" label={chainCurrency} slug={chainCurrency?.toLowerCase()} />
 		{#await fetchNativeCurrency(address)}
-			<Spinner size="30" color="hsl(var(--hsl-text-light))" />
+			<Spinner size="30" color="var(--c-text-light)" />
 		{:then balance}
 			{formatBalance(balance, 2, 4)}
 		{/await}
@@ -52,7 +52,7 @@
 		<WalletInfoItem>
 			<EntitySymbol slot="label" type="token" label="USDC" slug="usdc" />
 			{#await fetchDenominationToken(address)}
-				<Spinner size="30" color="hsl(var(--hsl-text-light))" />
+				<Spinner size="30" color="var(--c-text-light)" />
 			{:then balance}
 				{formatBalance(balance, 2, 4)}
 			{:catch}

--- a/src/lib/wallet/WalletInfoItem.svelte
+++ b/src/lib/wallet/WalletInfoItem.svelte
@@ -17,7 +17,7 @@
 		display: grid;
 		gap: var(--space-md);
 		align-items: center;
-		background: hsl(var(--hsla-box-2));
+		background: var(--c-box-2);
 		border-radius: var(--radius-md);
 		padding: var(--space-md) var(--space-ml);
 

--- a/src/lib/wallet/WalletSummary.svelte
+++ b/src/lib/wallet/WalletSummary.svelte
@@ -63,13 +63,13 @@
 		margin-left: var(--space-sm);
 		padding: var(--space-xs) var(--space-sl);
 		border-radius: var(--space-md);
-		background: hsl(var(--hsl-success) / 20%);
 		font: var(--f-ui-sm-medium);
-		color: hsl(var(--hsl-success));
+		color: var(--c-success);
+		background: color-mix(in srgb, transparent, currentColor 20%);
 
 		.dot {
 			animation: pulse-opacity 1.5s ease-out infinite;
-			background: hsl(var(--hsl-success));
+			background: currentColor;
 			border-radius: 100%;
 			height: 0.625rem;
 			width: 0.625rem;

--- a/src/lib/wallet/WalletTile.svelte
+++ b/src/lib/wallet/WalletTile.svelte
@@ -15,7 +15,7 @@
 
 <style lang="postcss">
 	.wallet-tile {
-		border: 2px hsl(var(--hsla-box-1)) solid;
+		border: 2px var(--c-box-1) solid;
 		border-radius: var(--radius-sm);
 		cursor: pointer;
 		display: grid;
@@ -27,8 +27,8 @@
 		outline: none;
 
 		&:focus {
-			background: hsl(var(--hsla-box-3));
-			--background-hover: hsl(var(--hsla-box-4));
+			background: var(--c-box-3);
+			--background-hover: var(--c-box-4);
 		}
 	}
 

--- a/src/lib/wallet/WalletWidget.svelte
+++ b/src/lib/wallet/WalletWidget.svelte
@@ -69,7 +69,7 @@
 		justify-content: center;
 		font: var(--f-ui-sm-medium);
 		letter-spacing: var(--ls-ui-sm);
-		color: hsl(var(--hsl-text-extra-light));
+		color: var(--c-text-extra-light);
 		opacity: 0;
 		transition: opacity var(--time-xs) ease-out;
 

--- a/src/routes/+error.svelte
+++ b/src/routes/+error.svelte
@@ -68,7 +68,7 @@
 		left: 0;
 		right: 0;
 		min-height: 100vh;
-		background: hsl(var(--hsl-body));
+		background: var(--c-body);
 		display: grid;
 		grid-template-rows: 1fr auto 1fr;
 		gap: var(--space-4xl);

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -59,20 +59,11 @@
 		font-weight: 500;
 	}
 
-	/* Price action and candle colors */
-	:is(.bullish, [data-direction='bullish']) {
-		color: hsl(var(--hsl-bullish));
-	}
-
-	:is(.bearish, [data-direction='bearish']) {
-		color: hsl(var(--hsl-bearish));
-	}
-
 	/* global skeleton class */
 	.skeleton {
 		color: transparent !important;
 		position: relative;
-		--skeleton-background: hsl(var(--hsla-box-3));
+		--skeleton-background: var(--c-box-3);
 
 		&::before {
 			width: var(--skeleton-width, 100%);

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -73,7 +73,7 @@
 		</Section>
 	{/if}
 
-	<Section padding="lg" --section-background="hsl(var(--hsla-background-accent-1))">
+	<Section padding="lg" --section-background="var(--c-background-accent-1)">
 		<div class="strategies">
 			<h2>Strategies</h2>
 			<div class="coming-soon">Coming soon</div>
@@ -114,7 +114,7 @@
 	}
 
 	.strategies {
-		background: hsl(var(--hsla-box-2));
+		background: var(--c-box-2);
 		border-radius: var(--radius-xl);
 		display: grid;
 		gap: var(--space-3xl);
@@ -141,10 +141,10 @@
 		.coming-soon {
 			font: var(--f-ui-sm-medium);
 			letter-spacing: var(--f-ui-sm-spacing, normal);
-			color: hsl(var(--hsl-text-light));
+			color: var(--c-text-light);
 			text-transform: uppercase;
 			padding: var(--space-sl) var(--space-ls);
-			border: 1px solid hsl(var(--hsl-text-extra-light));
+			border: 1px solid var(--c-text-extra-light);
 			border-radius: var(--radius-xxl);
 		}
 

--- a/src/routes/HomeHeroBanner.svelte
+++ b/src/routes/HomeHeroBanner.svelte
@@ -38,7 +38,7 @@ Home page hero banner.
 
 <style lang="postcss">
 	.home-hero-banner {
-		background: hsl(var(--hsla-background-accent-1));
+		background: var(--c-background-accent-1);
 		padding: var(--space-xl) 0;
 		@media (--viewport-md-up) {
 			padding: var(--space-10xl) var(--space-3xl);
@@ -86,7 +86,7 @@ Home page hero banner.
 	}
 
 	hr {
-		border: 1px solid hsl(var(--hsl-text));
+		border: 1px solid var(--c-text);
 		margin-block: var(--space-lg);
 	}
 </style>

--- a/src/routes/about/Feature.svelte
+++ b/src/routes/about/Feature.svelte
@@ -94,7 +94,7 @@
 			}
 
 			.bg {
-				fill: hsl(var(--hsl-body));
+				fill: var(--c-body);
 			}
 
 			:not(.bg) {

--- a/src/routes/blog/+page.svelte
+++ b/src/routes/blog/+page.svelte
@@ -50,7 +50,7 @@
 	<Section>
 		{#if page.loading}
 			<div style:text-align="center">
-				<Spinner size="4rem" color="hsl(var(--hsl-text))" />
+				<Spinner size="4rem" color="var(--c-text)" />
 			</div>
 		{:else if page.error}
 			<Alert title="Error loading blog posts">

--- a/src/routes/blog/[slug]/+page.svelte
+++ b/src/routes/blog/[slug]/+page.svelte
@@ -57,7 +57,7 @@
 		:global(time) {
 			font: var(--f-ui-md-medium);
 			letter-spacing: var(--f-ui-md-spacing, normal);
-			color: hsl(var(--hsl-text-extra-light));
+			color: var(--c-text-extra-light);
 		}
 	}
 

--- a/src/routes/blog/[slug]/BlogPostContent.svelte
+++ b/src/routes/blog/[slug]/BlogPostContent.svelte
@@ -138,8 +138,8 @@
 			margin: var(--space-lg) 0;
 			border-radius: var(--radius-sm);
 			padding: var(--space-ms) var(--space-ls);
-			background: hsl(var(--hsl-terminal-bg));
-			color: hsl(var(--hsl-terminal));
+			background: var(--c-terminal-bg);
+			color: var(--c-terminal);
 			font: var(--f-mono-sm-regular);
 			letter-spacing: var(--f-mono-sm-spacing, normal);
 
@@ -156,8 +156,8 @@
 			padding: var(--space-lg);
 			font: var(--f-text-lg-regular);
 			letter-spacing: var(--f-text-lg-spacing, normal);
-			background: hsl(var(--hsla-quoteblock-background));
-			box-shadow: -0.75rem 0.75rem 0 hsl(var(--hsla-quoteblock-backdrop));
+			background: var(--c-quoteblock-background);
+			box-shadow: -0.75rem 0.75rem 0 var(--c-quoteblock-backdrop);
 		}
 
 		.table-wrapper {
@@ -172,7 +172,7 @@
 
 			:is(td, th) {
 				padding: var(--space-ss);
-				border-block: 1px solid hsl(var(--hsl-text-extra-light));
+				border-block: 1px solid var(--c-text-extra-light);
 				vertical-align: top;
 
 				&:first-child {
@@ -185,7 +185,7 @@
 			}
 
 			th {
-				background: hsl(var(--hsla-box-2));
+				background: var(--c-box-2);
 				font-weight: 600;
 			}
 		}

--- a/src/routes/glossary/+page.svelte
+++ b/src/routes/glossary/+page.svelte
@@ -105,7 +105,7 @@
 
 	hr {
 		margin: var(--space-lg) 0;
-		border: 1px solid hsl(var(--hsl-text));
+		border: 1px solid var(--c-text);
 
 		@media (--viewport-lg-down) {
 			margin: var(--space-lg) 0 var(--space-xl);

--- a/src/routes/newsletter/+page.svelte
+++ b/src/routes/newsletter/+page.svelte
@@ -11,6 +11,6 @@
 
 <style lang="postcss">
 	.newsletter-page {
-		--section-background: hsl(var(--hsla-background-accent-1));
+		--section-background: var(--c-background-accent-1);
 	}
 </style>

--- a/src/routes/search/Filter.svelte
+++ b/src/routes/search/Filter.svelte
@@ -87,7 +87,7 @@ Display filter options as checkboxes search queries.
 
 		&:is(:hover, :focus-within)::before {
 			--offset: calc(-1 * var(--space-sm));
-			background: hsl(var(--hsla-box-3));
+			background: var(--c-box-3);
 			border-radius: var(--radius-sm);
 			bottom: var(--offset);
 			content: '';
@@ -98,7 +98,7 @@ Display filter options as checkboxes search queries.
 		}
 
 		&:focus-within::before {
-			outline: 2px solid hsl(var(--hsl-text-extra-light));
+			outline: 2px solid var(--c-text-extra-light);
 		}
 	}
 
@@ -106,9 +106,9 @@ Display filter options as checkboxes search queries.
 		appearance: none;
 		width: 1.5rem;
 		height: 1.5rem;
-		border: 2px solid hsl(var(--hsl-text));
+		border: 2px solid var(--c-text);
 		border-radius: var(--radius-xxs);
-		background: hsl(var(--hsl-body));
+		background: var(--c-body);
 		outline: none;
 	}
 
@@ -129,7 +129,7 @@ Display filter options as checkboxes search queries.
 	.count {
 		padding: var(--space-xxs);
 		border-radius: var(--radius-xxs);
-		background-color: hsl(var(--hsla-box-2));
+		background-color: var(--c-box-2);
 		font: var(--f-ui-sm-medium);
 		letter-spacing: var(--f-ui-sm-spacing, normal);
 	}

--- a/src/routes/search/FilterPanel.svelte
+++ b/src/routes/search/FilterPanel.svelte
@@ -119,7 +119,7 @@
 			bottom: 0;
 			z-index: 10;
 			overflow-y: scroll;
-			background: hsl(var(--hsl-body));
+			background: var(--c-body);
 			box-shadow: var(--shadow-1);
 			transition: transform var(--time-xl);
 
@@ -170,7 +170,7 @@
 		bottom: 0;
 		padding: var(--space-sl);
 		display: grid;
-		background: hsl(var(--hsl-body));
+		background: var(--c-body);
 		box-shadow: var(--shadow-1);
 
 		@media (--viewport-lg-up) {

--- a/src/routes/strategies/ChartThumbnail.svelte
+++ b/src/routes/strategies/ChartThumbnail.svelte
@@ -86,7 +86,7 @@
 			text-align: center;
 			font: var(--f-ui-md-roman);
 			letter-spacing: var(--f-ui-md-spacing, normal);
-			color: hsl(var(--hsl-text-extra-light));
+			color: var(--c-text-extra-light);
 			opacity: 0;
 			transition: var(--transition-1);
 
@@ -104,7 +104,7 @@
 		transform: translate(-50%, calc(-100% - var(--space-md)));
 
 		:global(time) {
-			color: hsl(var(--hsl-text-extra-light));
+			color: var(--c-text-extra-light);
 		}
 
 		.value {

--- a/src/routes/strategies/StrategyTile.svelte
+++ b/src/routes/strategies/StrategyTile.svelte
@@ -111,15 +111,15 @@
 	.strategy-tile {
 		display: grid;
 		grid-template-columns: repeat(auto-fit, minmax(min(90vw, 24rem), 1fr));
-		background: hsl(var(--hsla-box-1));
-		border: 1px hsl(var(--hsla-box-3)) solid;
+		background: var(--c-box-1);
+		border: 1px var(--c-box-3) solid;
 		border-radius: var(--radius-lg);
-		color: hsl(var(--hsl-text));
+		color: var(--c-text);
 		cursor: pointer;
 		transition: var(--transition-1);
 
 		&:hover {
-			background: hsl(var(--hsla-box-2));
+			background: var(--c-box-2);
 			z-index: 2;
 		}
 
@@ -197,7 +197,7 @@
 				}
 
 				.avatar {
-					background: hsl(var(--hsla-box-3));
+					background: var(--c-box-3);
 					border-radius: 100%;
 					font: var(--f-ui-sm-roman);
 					text-align: center;
@@ -224,7 +224,7 @@
 						border-radius: 100%;
 						bottom: -0.5rem;
 						box-shadow: var(--shadow-1);
-						background: hsl(var(--hsl-text-inverted));
+						background: var(--c-text-inverted);
 						display: flex;
 						padding: 0.25rem;
 						position: absolute;
@@ -261,7 +261,7 @@
 
 				p {
 					font: var(--f-ui-md-medium);
-					color: hsl(var(--hsl-text-extra-light));
+					color: var(--c-text-extra-light);
 				}
 			}
 
@@ -272,7 +272,7 @@
 			.backtest-indicator {
 				font: var(--f-ui-xs-bold);
 				letter-spacing: 0.03em;
-				color: hsl(var(--hsl-text-extra-light));
+				color: var(--c-text-extra-light);
 				text-transform: uppercase;
 			}
 
@@ -283,8 +283,8 @@
 
 		&:is(:hover, :focus) {
 			.actions :global(.button) {
-				background: hsl(var(--hsl-text));
-				color: hsl(var(--hsl-text-inverted));
+				background: var(--c-text);
+				color: var(--c-text-inverted);
 			}
 
 			.chart :global(figcaption) {

--- a/src/routes/strategies/[strategy]/(nav)/+page.svelte
+++ b/src/routes/strategies/[strategy]/(nav)/+page.svelte
@@ -180,7 +180,7 @@
 			}
 
 			:global(.stx_xaxis_dark) {
-				color: hsl(var(--hsl-text-extra-light));
+				color: var(--c-text-extra-light);
 			}
 		}
 
@@ -200,7 +200,7 @@
 			align-items: center;
 			font: var(--f-ui-sm-medium);
 			letter-spacing: var(--ls-ui-sm);
-			color: hsl(var(--hsl-text-extra-light));
+			color: var(--c-text-extra-light);
 		}
 
 		.description p {

--- a/src/routes/strategies/[strategy]/(nav)/StrategyNav.svelte
+++ b/src/routes/strategies/[strategy]/(nav)/StrategyNav.svelte
@@ -146,8 +146,8 @@
 <style lang="postcss">
 	.strategy-nav {
 		--menu-gap: var(--space-sl);
-		--menu-item-active-color: hsl(var(--hsl-text));
-		--menu-item-color: hsl(var(--hsl-text-extra-light));
+		--menu-item-active-color: var(--c-text);
+		--menu-item-color: var(--c-text-extra-light);
 		--menu-item-border-radius: var(--radius-md);
 		--menu-item-padding: 0 var(--space-md);
 
@@ -181,12 +181,12 @@
 		border-radius: var(--radius-lg);
 		font: var(--f-ui-md-bold);
 		letter-spacing: var(--f-ui-md-spacing, normal);
-		color: hsl(var(--hsl-text));
-		background: hsl(var(--hsla-box-3));
+		color: var(--c-text);
+		background: var(--c-box-3);
 
 		:global(a:not([href]):not([tabindex])) & {
-			background: hsl(var(--hsl-text));
-			color: hsl(var(--hsl-text-inverted));
+			background: var(--c-text);
+			color: var(--c-text-inverted);
 		}
 
 		@media (--viewport-md-down) {

--- a/src/routes/strategies/[strategy]/(nav)/SummaryBox.svelte
+++ b/src/routes/strategies/[strategy]/(nav)/SummaryBox.svelte
@@ -18,8 +18,8 @@
 	.summary-box {
 		display: grid;
 		gap: 1rem;
-		background: hsl(var(--hsla-box-1));
-		border: 1px solid hsl(var(--hsla-box-3));
+		background: var(--c-box-1);
+		border: 1px solid var(--c-box-3);
 		border-radius: var(--radius-md);
 		padding: 1.25rem;
 	}
@@ -29,7 +29,7 @@
 		grid-auto-flow: column;
 		grid-template-columns: 1fr;
 		align-items: center;
-		color: hsl(var(--hsl-text-ultra-light));
+		color: var(--c-text-ultra-light);
 	}
 
 	h2 {

--- a/src/routes/strategies/[strategy]/(nav)/[status=positionStatus]-positions/PositionFlag.svelte
+++ b/src/routes/strategies/[strategy]/(nav)/[status=positionStatus]-positions/PositionFlag.svelte
@@ -21,7 +21,7 @@
 <style lang="postcss">
 	.flag {
 		:global([data-css-props]) {
-			--data-badge-background: hsl(var(--hsla-box-4));
+			--data-badge-background: var(--c-box-4);
 		}
 
 		:global(*) {

--- a/src/routes/strategies/[strategy]/(nav)/backtest/+page.svelte
+++ b/src/routes/strategies/[strategy]/(nav)/backtest/+page.svelte
@@ -67,7 +67,7 @@ Page to display the strategy backtest results.
 
 		{#if !iframeLoaded}
 			<div class="spinner-wrapper">
-				<Spinner size="2rem" color="hsl(var(--hsl-text-light))" />
+				<Spinner size="2rem" color="var(--c-text-light)" />
 			</div>
 		{/if}
 

--- a/src/routes/strategies/[strategy]/(nav)/logs/LogEntry.svelte
+++ b/src/routes/strategies/[strategy]/(nav)/logs/LogEntry.svelte
@@ -36,7 +36,7 @@
 		}
 
 		&:not(:first-of-type) {
-			border-bottom: 1px solid hsl(var(--hsl-terminal-light) / 15%);
+			border-bottom: 1px solid color-mix(in srgb, transparent, var(--c-terminal-light) 15%);
 		}
 
 		.message {
@@ -65,7 +65,7 @@
 		:global(time) {
 			display: flex;
 			flex-direction: column;
-			color: hsl(var(--hsl-terminal-light));
+			color: var(--c-terminal-light);
 
 			@media (--viewport-sm-up) {
 				text-align: right;
@@ -73,20 +73,20 @@
 		}
 
 		&.trade {
-			color: hsl(var(--hsl-success));
+			color: var(--c-success);
 		}
 
 		&.warning {
-			color: hsl(var(--hsl-warning));
+			color: var(--c-warning);
 		}
 
 		&.error {
-			color: hsl(var(--hsl-error));
+			color: var(--c-error);
 		}
 
 		&.critical {
-			background: hsl(var(--hsl-error) / 65%);
-			color: hsl(var(--hsl-white));
+			background: color-mix(in srgb, transparent, var(--c-error) 65%);
+			color: white;
 		}
 	}
 </style>

--- a/src/routes/strategies/[strategy]/(nav)/performance/+page.svelte
+++ b/src/routes/strategies/[strategy]/(nav)/performance/+page.svelte
@@ -68,7 +68,7 @@
 		}
 
 		.chart-subtitle {
-			color: hsl(var(--hsl-text-extra-light));
+			color: var(--c-text-extra-light);
 			font: var(--f-ui-md-medium);
 			letter-spacing: var(--ls-ui-md, normal);
 		}

--- a/src/routes/strategies/[strategy]/(nav)/performance/LongShortTable.svelte
+++ b/src/routes/strategies/[strategy]/(nav)/performance/LongShortTable.svelte
@@ -83,7 +83,7 @@
 			display: grid;
 			width: 100%;
 			margin-bottom: 1rem;
-			border-bottom: 2px solid hsl(var(--hsl-text-ultra-light));
+			border-bottom: 2px solid var(--c-text-ultra-light);
 			white-space: nowrap;
 			font: var(--f-ui-md-roman);
 			letter-spacing: var(--ls-ui-md);
@@ -100,7 +100,7 @@
 
 			/* zebra-striped rows */
 			tr:nth-child(odd) td {
-				background: hsl(var(--hsla-box-2));
+				background: var(--c-box-2);
 			}
 
 			:is(th, td) {
@@ -111,23 +111,22 @@
 				position: sticky;
 				top: -1px;
 				padding-block: 1em;
-				border-bottom: 2px solid hsl(var(--hsl-text-ultra-light));
+				border-bottom: 2px solid var(--c-text-ultra-light);
 				text-align: left;
 
-				color: hsl(var(--hsl-text-extra-light));
+				color: var(--c-text-extra-light);
 				/* using color-mix to prevent layered transparency */
-				/* FIXME: % value is off for dark-mode (switch to color-mix in colors.css) */
-				background: color-mix(in srgb, hsl(var(--hsl-body)), hsl(var(--hsl-box)) 12%);
+				background: color-mix(in srgb, var(--c-body), hsl(var(--hsl-box)) var(--box-1-alpha));
 			}
 
 			td {
 				&.name {
 					font-weight: 500;
-					color: hsl(var(--hsl-text-light));
+					color: var(--c-text-light);
 				}
 
 				&.no-match {
-					color: hsl(var(--hsl-text-extra-light));
+					color: var(--c-text-extra-light);
 				}
 			}
 

--- a/src/routes/strategies/[strategy]/[status=positionStatus]-positions/[position=integer]/+page.svelte
+++ b/src/routes/strategies/[strategy]/[status=positionStatus]-positions/[position=integer]/+page.svelte
@@ -336,12 +336,12 @@
 	}
 
 	.position-kind {
-		color: hsl(var(--hsl-text-extra-light));
+		color: var(--c-text-extra-light);
 	}
 
 	.data-badge {
 		:global([data-css-props]) {
-			--data-badge-background: hsl(var(--hsla-box-4));
+			--data-badge-background: var(--c-box-4);
 		}
 		font-size: 0.6em;
 		line-height: 125%;

--- a/src/routes/strategies/[strategy]/[status=positionStatus]-positions/[position=integer]/TradeTable.svelte
+++ b/src/routes/strategies/[strategy]/[status=positionStatus]-positions/[position=integer]/TradeTable.svelte
@@ -75,7 +75,7 @@
 
 	.trade-table :global {
 		.trade_id {
-			color: hsl(var(--hsl-text-extra-light));
+			color: var(--c-text-extra-light);
 			width: 2em;
 			padding-right: 0;
 		}

--- a/src/routes/strategies/[strategy]/[status=positionStatus]-positions/[position=integer]/trade-[trade=integer]/+page.svelte
+++ b/src/routes/strategies/[strategy]/[status=positionStatus]-positions/[position=integer]/trade-[trade=integer]/+page.svelte
@@ -192,7 +192,7 @@
 		}
 
 		.position-impact {
-			color: hsl(var(--hsl-text-extra-light));
+			color: var(--c-text-extra-light);
 			font: var(--f-heading-xl-medium);
 			letter-spacing: var(--f-heading-xl-spacing);
 
@@ -219,7 +219,7 @@
 		.trading-pair {
 			font-weight: bold;
 			& .swap-fee {
-				color: hsl(var(--hsl-text-extra-light));
+				color: var(--c-text-extra-light);
 			}
 		}
 
@@ -260,7 +260,7 @@
 
 				&:first-child {
 					padding-left: 0.75rem;
-					color: hsl(var(--hsl-text-extra-light));
+					color: var(--c-text-extra-light);
 				}
 
 				&:last-child {

--- a/src/routes/strategies/[strategy]/[status=positionStatus]-positions/[position=integer]/trade-[trade=integer]/TransactionStatus.svelte
+++ b/src/routes/strategies/[strategy]/[status=positionStatus]-positions/[position=integer]/trade-[trade=integer]/TransactionStatus.svelte
@@ -13,6 +13,6 @@
 
 <style lang="postcss">
 	.failure {
-		color: hsl(var(--hsl-error));
+		color: var(--c-error);
 	}
 </style>

--- a/src/routes/trading-view/[chain]/BlockInfoTile.svelte
+++ b/src/routes/trading-view/[chain]/BlockInfoTile.svelte
@@ -34,13 +34,13 @@
 	time {
 		margin-bottom: var(--space-sm);
 		font: var(--f-ui-large-medium);
-		color: hsl(var(--hsl-text-light));
+		color: var(--c-text-light);
 
 		@media (--viewport-md-down) {
 			margin-bottom: var(--space-xxs);
 			font: var(--f-ui-body-medium);
 			letter-spacing: 0.01em;
-			color: hsl(var(--hsl-text));
+			color: var(--c-text);
 		}
 	}
 
@@ -50,7 +50,7 @@
 
 		@media (--viewport-md-down) {
 			font: var(--f-h4-bold);
-			color: hsl(var(--hsl-text-light));
+			color: var(--c-text-light);
 		}
 	}
 

--- a/src/routes/trading-view/[chain]/ChainHeader.svelte
+++ b/src/routes/trading-view/[chain]/ChainHeader.svelte
@@ -22,7 +22,7 @@
 	.inner {
 		--logo-height: 5rem;
 		align-items: center;
-		background: hsl(var(--hsla-box-1));
+		background: var(--c-box-1);
 		border-radius: var(--radius-xl);
 		display: flex;
 		gap: var(--space-md);

--- a/src/routes/trading-view/[chain]/SummaryDataTile.svelte
+++ b/src/routes/trading-view/[chain]/SummaryDataTile.svelte
@@ -45,7 +45,7 @@
 			@media (--viewport-md-down) {
 				margin-block: 0;
 				font: var(--f-h5-medium);
-				color: hsl(var(--hsl-text-light));
+				color: var(--c-text-light);
 			}
 		}
 

--- a/src/routes/trading-view/[chain]/TopEntities.svelte
+++ b/src/routes/trading-view/[chain]/TopEntities.svelte
@@ -50,7 +50,7 @@
 			padding: 0 var(--space-md) var(--space-xxs) 0;
 			font: var(--f-ui-md-bold);
 			letter-spacing: var(--f-ui-md-spacing);
-			color: hsl(var(--hsl-text-light));
+			color: var(--c-text-light);
 
 			@media (--viewport-md-down) {
 				font: var(--f-ui-sm-bold);

--- a/src/routes/trading-view/[chain]/[exchange]/[pair]/+page.svelte
+++ b/src/routes/trading-view/[chain]/[exchange]/[pair]/+page.svelte
@@ -171,7 +171,7 @@ Render the pair trading page
 
 	.pool-swap-fee {
 		margin-left: var(--space-xxs);
-		color: hsl(var(--hsl-text-extra-light));
+		color: var(--c-text-extra-light);
 	}
 
 	.info {

--- a/src/routes/trading-view/[chain]/[exchange]/[pair]/TimePeriodPicker.svelte
+++ b/src/routes/trading-view/[chain]/[exchange]/[pair]/TimePeriodPicker.svelte
@@ -33,7 +33,7 @@ Radio button options to select a time period.
 		flex: 1;
 		margin: 0;
 		padding-block: var(--space-md);
-		background: hsl(var(--hsla-box-4));
+		background: var(--c-box-4);
 		font: var(--f-ui-md-medium);
 		text-align: center;
 		text-transform: capitalize;
@@ -56,8 +56,8 @@ Radio button options to select a time period.
 		}
 
 		&.selected {
-			background: hsl(var(--hsl-text));
-			color: hsl(var(--hsl-text-inverted));
+			background: var(--c-text);
+			color: var(--c-text-inverted);
 		}
 	}
 

--- a/src/routes/trading-view/[chain]/[exchange]/[pair]/TimePeriodSummaryTable.svelte
+++ b/src/routes/trading-view/[chain]/[exchange]/[pair]/TimePeriodSummaryTable.svelte
@@ -90,7 +90,7 @@ Display summary performance table for various periods.
 					padding-block: var(--space-md);
 
 					&:not(:last-child) {
-						border-bottom: 1px solid hsl(var(--hsl-text-ultra-light));
+						border-bottom: 1px solid var(--c-text-ultra-light);
 					}
 				}
 			}
@@ -102,7 +102,7 @@ Display summary performance table for various periods.
 		}
 
 		.loading li.col-heading {
-			color: hsl(var(--hsl-text-extra-light));
+			color: var(--c-text-extra-light);
 		}
 
 		.time-period-col:not(.active) {

--- a/src/routes/trading-view/top-list/+page.svelte
+++ b/src/routes/trading-view/top-list/+page.svelte
@@ -20,7 +20,7 @@
 			ctaLabel="View daily up"
 			href="/trading-view/top-list/daily-up"
 			icon="trend-up"
-			--icon-color="hsl(var(--hsl-bullish))"
+			--icon-color="var(--c-bullish)"
 		>
 			<h3 slot="title">Top daily up</h3>
 			<p>
@@ -33,7 +33,7 @@
 			ctaLabel="View daily down"
 			href="/trading-view/top-list/daily-down"
 			icon="trend-down"
-			--icon-color="hsl(var(--hsl-bearish))"
+			--icon-color="var(--c-bearish)"
 		>
 			<h3 slot="title">Top daily down</h3>
 			<p>

--- a/src/routes/wizard/+layout.svelte
+++ b/src/routes/wizard/+layout.svelte
@@ -83,7 +83,7 @@
 	}
 
 	.inner nav {
-		background: hsl(var(--hsla-box-1));
+		background: var(--c-box-1);
 		border-radius: var(--radius-md);
 		display: grid;
 		align-content: start;

--- a/src/routes/wizard/WizardNavItem.svelte
+++ b/src/routes/wizard/WizardNavItem.svelte
@@ -33,21 +33,21 @@
 			transition: all var(--time-sm) ease-out;
 
 			&.active {
-				background: hsl(var(--hsla-box-4));
+				background: var(--c-box-4);
 				cursor: default;
 			}
 
 			&.disabled {
-				color: hsl(var(--hsl-text-extra-light));
+				color: var(--c-text-extra-light);
 				cursor: not-allowed;
 				&:hover {
-					background: hsl(var(--hsla-box-2));
+					background: var(--c-box-2);
 				}
 			}
 
 			&.completed {
-				background: hsl(var(--hsl-success) / 10%);
-				color: hsl(var(--hsl-success));
+				color: var(--c-success);
+				background: color-mix(in srgb, transparent, currentColor 10%);
 			}
 		}
 	}

--- a/src/routes/wizard/deposit/payment/+page.svelte
+++ b/src/routes/wizard/deposit/payment/+page.svelte
@@ -316,7 +316,7 @@
 		}
 
 		h3 {
-			color: hsl(var(--hsl-text-light));
+			color: var(--c-text-light);
 			font: var(--f-ui-lg-medium);
 			margin: 0;
 		}

--- a/src/routes/wizard/deposit/tos/+page.svelte
+++ b/src/routes/wizard/deposit/tos/+page.svelte
@@ -186,7 +186,7 @@
 				margin: 0;
 				font: var(--f-ui-sm-medium);
 				letter-spacing: var(--f-ui-sm-spacing, normal);
-				color: hsl(var(--hsl-text-light));
+				color: var(--c-text-light);
 				white-space: nowrap;
 			}
 
@@ -213,8 +213,8 @@
 			min-height: 18rem;
 			max-height: 28rem;
 			white-space: pre-line;
-			background: hsl(var(--hsla-input-background));
-			border: 2px solid hsl(var(--hsla-input-border));
+			background: var(--c-input-background);
+			border: 2px solid var(--c-input-border);
 			overflow-y: auto;
 			font: var(--f-text-md-regular);
 			letter-spacing: var(--f-text-md-spacing, normal);
@@ -239,7 +239,7 @@
 		.no-file {
 			font: var(--f-mono-md-regular);
 			letter-spacing: var(--f-mono-md-spacing, normal);
-			color: color-mix(in srgb, hsl(var(--hsl-text)), hsl(var(--hsl-error)) 50%);
+			color: color-mix(in srgb, var(--c-text), var(--c-error));
 		}
 
 		form {
@@ -255,7 +255,7 @@
 				bottom: -2rem;
 				width: 100%;
 				font-weight: bold;
-				color: hsl(var(--hsl-error));
+				color: var(--c-error);
 				text-align: center;
 			}
 		}

--- a/src/routes/wizard/redeem/deposit-status/+page.svelte
+++ b/src/routes/wizard/redeem/deposit-status/+page.svelte
@@ -36,7 +36,7 @@
 			<WalletInfoItem>
 				<EntitySymbol slot="label" type="token" label={chainCurrency} slug={chainCurrency?.toLowerCase()} />
 				{#await getNativeCurrency(address)}
-					<Spinner size="30" color="hsl(var(--hsl-text-light))" />
+					<Spinner size="30" color="var(--c-text-light)" />
 				{:then balance}
 					{formatBalance(balance, 2, 4)}
 				{/await}
@@ -71,7 +71,7 @@
 
 <style lang="postcss">
 	h3 {
-		color: hsl(var(--hsl-text-light));
+		color: var(--c-text-light);
 		font: var(--f-ui-lg-medium);
 	}
 </style>

--- a/src/routes/wizard/redeem/shares-redemption/+page.svelte
+++ b/src/routes/wizard/redeem/shares-redemption/+page.svelte
@@ -254,7 +254,7 @@
 		}
 
 		h3 {
-			color: hsl(var(--hsl-text-light));
+			color: var(--c-text-light);
 			font: var(--f-ui-lg-medium);
 			margin: 0;
 		}

--- a/src/routes/wizard/redeem/success/+page.svelte
+++ b/src/routes/wizard/redeem/success/+page.svelte
@@ -41,7 +41,7 @@
 	}
 
 	h3 {
-		color: hsl(var(--hsl-text-light));
+		color: var(--c-text-light);
 		font: var(--f-ui-lg-medium);
 	}
 </style>


### PR DESCRIPTION
Various improvements to colors.css before starting work on trading
entity page refresh.

- refactor colors.css - replace `--hsl-` props with `--c-`
- fix dialog text color bug
- refactor color themes to use root element
