### PR TITLE
update ChartIQ license key

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -73,7 +73,7 @@
         "node": "^20.11.0"
       },
       "optionalDependencies": {
-        "chartiq": "github:tradingstrategy-ai/chartiq-dist#v9.0.0"
+        "chartiq": "github:tradingstrategy-ai/chartiq-dist#v9.0.0-key2"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -8992,7 +8992,7 @@
     },
     "node_modules/chartiq": {
       "version": "9.0.0",
-      "resolved": "git+ssh://git@github.com/tradingstrategy-ai/chartiq-dist.git#36dfeb7eba529ffb53beeaf7b86c19d9ff0fdf80",
+      "resolved": "git+ssh://git@github.com/tradingstrategy-ai/chartiq-dist.git#d0f51626ad526565e289bcbfe302ea9a0fb01f6f",
       "license": "https://chartiq.com/developer-license-agreement/",
       "optional": true
     },

--- a/package.json
+++ b/package.json
@@ -83,6 +83,6 @@
     "zod": "^3.22.4"
   },
   "optionalDependencies": {
-    "chartiq": "github:tradingstrategy-ai/chartiq-dist#v9.0.0"
+    "chartiq": "github:tradingstrategy-ai/chartiq-dist#v9.0.0-key2"
   }
 }


### PR DESCRIPTION
update to v9.0.0-key2 with new key.js file
