### PR TITLE
Pair details refresh (part 1)

### DIFF
--- a/src/routes/trading-view/[chain]/[exchange]/[pair]/+page.svelte
+++ b/src/routes/trading-view/[chain]/[exchange]/[pair]/+page.svelte
@@ -6,10 +6,9 @@ Render the pair trading page
   be moved to SvelteKit routing query parameter
 -->
 <script lang="ts">
-	import type { ComponentProps } from 'svelte';
 	import { getTokenTaxInformation } from '$lib/helpers/tokentax';
 	import { formatSwapFee } from '$lib/helpers/formatters';
-	import { AlertList, Button, CopyWidget, EntitySymbol, PageHeader } from '$lib/components';
+	import { AlertList, Button, EntitySymbol, PageHeader } from '$lib/components';
 	import Breadcrumbs from '$lib/breadcrumb/Breadcrumbs.svelte';
 	import InfoTable from './InfoTable.svelte';
 	import InfoSummary from './InfoSummary.svelte';
@@ -36,23 +35,6 @@ Render the pair trading page
 		[summary.exchange_slug]: summary.exchange_name,
 		[summary.pair_slug]: summary.pair_name
 	};
-
-	let copier: ComponentProps<CopyWidget>['copier'];
-
-	// Construct and copy identifier used in Python code (such as Jupyter notebooks); e.g.:
-	// (ChainId.ethereum, "uniswap-v3", "WETH", "USDC", 0.0005) # Ether-USD Coin http://localhost:5173/trading-view/ethereum/uniswap-v3/eth-usdc-fee-5
-	function copyPythonIdentifier(this: HTMLButtonElement) {
-		const parts = [
-			`ChainId.${summary.chain_slug}`,
-			`"${summary.exchange_slug}"`,
-			`"${summary.base_token_symbol}"`,
-			`"${summary.quote_token_symbol}"`,
-			summary.pool_swap_fee
-		];
-		const identifier = `(${parts.join(', ')}) # ${summary.pair_name} ${$page.url}`;
-		copier?.copy(identifier);
-		this.blur();
-	}
 </script>
 
 <svelte:head>
@@ -89,7 +71,7 @@ Render the pair trading page
 	<section class="ds-container info" data-testid="pair-info">
 		<div class="ds-2-col">
 			<InfoTable {summary} {details} />
-			<InfoSummary {summary} {details} />
+			<InfoSummary {summary} {details} pageUrl={$page.url.toString()} />
 		</div>
 
 		{#if isUniswapIncompatible || tokenTax.broken || ridiculousPrice}
@@ -118,16 +100,6 @@ Render the pair trading page
 				{/if}
 			</AlertList>
 		{/if}
-
-		<div class="trade-actions">
-			<Button
-				label="{summary.pair_symbol} API and historical data"
-				href="./{summary.pair_slug}/api-and-historical-data"
-			/>
-			<Button label="Copy Python identifier" on:click={copyPythonIdentifier}>
-				<CopyWidget slot="icon" bind:copier --icon-size="1rem" />
-			</Button>
-		</div>
 	</section>
 
 	<section class="ds-container charts">
@@ -184,19 +156,6 @@ Render the pair trading page
 		.ds-2-col {
 			row-gap: var(--space-xl);
 			align-items: start;
-		}
-	}
-
-	.trade-actions {
-		display: flex;
-		flex-wrap: wrap;
-		justify-content: center;
-		gap: var(--space-ls) var(--space-xl);
-		padding-block: var(--space-lg);
-
-		@media (--viewport-xs) {
-			flex-direction: column;
-			padding-block: 0;
 		}
 	}
 

--- a/src/routes/trading-view/[chain]/[exchange]/[pair]/+page.svelte
+++ b/src/routes/trading-view/[chain]/[exchange]/[pair]/+page.svelte
@@ -9,7 +9,7 @@ Render the pair trading page
 	import type { ComponentProps } from 'svelte';
 	import { getTokenTaxInformation } from '$lib/helpers/tokentax';
 	import { formatSwapFee } from '$lib/helpers/formatters';
-	import { AlertList, Button, CopyWidget, PageHeader } from '$lib/components';
+	import { AlertList, Button, CopyWidget, EntitySymbol, PageHeader } from '$lib/components';
 	import Breadcrumbs from '$lib/breadcrumb/Breadcrumbs.svelte';
 	import InfoTable from './InfoTable.svelte';
 	import InfoSummary from './InfoSummary.svelte';
@@ -68,10 +68,14 @@ Render the pair trading page
 <Breadcrumbs labels={breadcrumbs} />
 
 <main>
-	<PageHeader subtitle="token pair on {details.exchange_name} on {details.chain_name}">
+	<PageHeader>
 		<span slot="title">
 			{summary.pair_symbol}
 			<span class="swap-fee">{swapFee}</span>
+		</span>
+		<span slot="subtitle" class="subtitle">
+			token pair on {details.exchange_name} on
+			<EntitySymbol type="blockchain" slug={summary.chain_slug} label={summary.chain_name} size="0.875em" />
 		</span>
 	</PageHeader>
 
@@ -161,6 +165,12 @@ Render the pair trading page
 		@media (--viewport-lg-up) {
 			gap: 5rem;
 		}
+	}
+
+	.subtitle {
+		display: flex;
+		align-items: center;
+		gap: 0.5ex;
 	}
 
 	.swap-fee {

--- a/src/routes/trading-view/[chain]/[exchange]/[pair]/+page.svelte
+++ b/src/routes/trading-view/[chain]/[exchange]/[pair]/+page.svelte
@@ -19,15 +19,13 @@ Render the pair trading page
 
 	export let data;
 
-	let copier: ComponentProps<CopyWidget>['copier'];
-
 	$: summary = data.pair.summary;
 	$: details = data.pair.additional_details;
 
 	$: tokenTax = getTokenTaxInformation(details);
 	$: isUniswapV3 = summary.exchange_type === 'uniswap_v3';
 	$: isUniswapIncompatible = summary.exchange_type === 'uniswap_v2_incompatible';
-	$: swapFee = formatSwapFee(summary.pool_swap_fee);
+	$: swapFee = formatSwapFee(summary.pair_swap_fee);
 
 	// Ridiculous token price warning: it is common with scam tokens to price the
 	// token super low so that prices are not readable when converted to USD.
@@ -39,11 +37,7 @@ Render the pair trading page
 		[summary.pair_slug]: summary.pair_name
 	};
 
-	$: pageTitle = [
-		summary.pair_symbol,
-		isUniswapV3 ? `${swapFee} pool` : 'token price',
-		`on ${details.exchange_name}`
-	].join(' ');
+	let copier: ComponentProps<CopyWidget>['copier'];
 
 	// Construct and copy identifier used in Python code (such as Jupyter notebooks); e.g.:
 	// (ChainId.ethereum, "uniswap-v3", "WETH", "USDC", 0.0005) # Ether-USD Coin http://localhost:5173/trading-view/ethereum/uniswap-v3/eth-usdc-fee-5
@@ -62,7 +56,9 @@ Render the pair trading page
 </script>
 
 <svelte:head>
-	<title>{pageTitle}</title>
+	<title>
+		{summary.pair_symbol} ({swapFee}) token price on {details.exchange_name}
+	</title>
 	<meta
 		name="description"
 		content="Price and liquidity for {summary.pair_symbol} on {details.exchange_name} on {details.chain_name}"
@@ -75,9 +71,7 @@ Render the pair trading page
 	<PageHeader subtitle="token pair on {details.exchange_name} on {details.chain_name}">
 		<span slot="title">
 			{summary.pair_symbol}
-			{#if isUniswapV3}
-				<span class="pool-swap-fee">{swapFee}</span>
-			{/if}
+			<span class="swap-fee">{swapFee}</span>
 		</span>
 	</PageHeader>
 
@@ -169,7 +163,7 @@ Render the pair trading page
 		}
 	}
 
-	.pool-swap-fee {
+	.swap-fee {
 		margin-left: var(--space-xxs);
 		color: var(--c-text-extra-light);
 	}

--- a/src/routes/trading-view/[chain]/[exchange]/[pair]/+page.svelte
+++ b/src/routes/trading-view/[chain]/[exchange]/[pair]/+page.svelte
@@ -120,7 +120,6 @@ Render the pair trading page
 		{/if}
 
 		<div class="trade-actions">
-			<Button label="Blockchain explorer" href={details.explorer_link} />
 			<Button
 				label="{summary.pair_symbol} API and historical data"
 				href="./{summary.pair_slug}/api-and-historical-data"

--- a/src/routes/trading-view/[chain]/[exchange]/[pair]/+page.svelte
+++ b/src/routes/trading-view/[chain]/[exchange]/[pair]/+page.svelte
@@ -85,20 +85,12 @@ Render the pair trading page
 			<InfoSummary {summary} {details} />
 		</div>
 
-		{#if isUniswapV3 || isUniswapIncompatible || tokenTax.broken || ridiculousPrice}
+		{#if isUniswapIncompatible || tokenTax.broken || ridiculousPrice}
 			<AlertList status="warning" let:AlertItem>
-				{#if isUniswapV3}
-					<AlertItem title="Uniswap V3 beta">
-						We are in the process of integrating Uniswap V3 data. This page is available as a beta preview, but please
-						note that the data for this trading pair is currently incomplete.
-					</AlertItem>
-				{/if}
-
 				{#if isUniswapIncompatible}
 					<AlertItem title="Incompatible exchange">
 						{summary.exchange_name} is not fully compatible with Uniswap v2 protocols. Price, volume and liquidity data for
-						{summary.pair_symbol}
-						may be inaccurate.
+						{summary.pair_symbol} may be inaccurate.
 					</AlertItem>
 				{/if}
 

--- a/src/routes/trading-view/[chain]/[exchange]/[pair]/+page.svelte
+++ b/src/routes/trading-view/[chain]/[exchange]/[pair]/+page.svelte
@@ -67,7 +67,7 @@ Render the pair trading page
 
 <Breadcrumbs labels={breadcrumbs} />
 
-<main>
+<main class="ds-3">
 	<PageHeader>
 		<span slot="title">
 			{summary.pair_symbol}
@@ -77,6 +77,13 @@ Render the pair trading page
 			token pair on {details.exchange_name} on
 			<EntitySymbol type="blockchain" slug={summary.chain_slug} label={summary.chain_name} size="0.875em" />
 		</span>
+		<svelte:fragment slot="cta">
+			{#if details.trade_link}
+				<Button href={details.trade_link} target="_blank" rel="noreferrer">
+					Swap {summary.base_token_symbol_friendly}/{summary.quote_token_symbol_friendly}
+				</Button>
+			{/if}
+		</svelte:fragment>
 	</PageHeader>
 
 	<section class="ds-container info" data-testid="pair-info">
@@ -113,8 +120,6 @@ Render the pair trading page
 		{/if}
 
 		<div class="trade-actions">
-			<Button label="Buy {summary.base_token_symbol_friendly}" href={details.buy_link} />
-			<Button label="Sell {summary.base_token_symbol_friendly}" href={details.sell_link} />
 			<Button label="Blockchain explorer" href={details.explorer_link} />
 			<Button
 				label="{summary.pair_symbol} API and historical data"

--- a/src/routes/trading-view/[chain]/[exchange]/[pair]/InfoTable.svelte
+++ b/src/routes/trading-view/[chain]/[exchange]/[pair]/InfoTable.svelte
@@ -52,10 +52,6 @@
 
 	<TradingDataInfoRow label="Volume 24h" value={formatDollar(summary.usd_volume_24h)} />
 
-	{#if summary.liquidity_type === 'xyliquidity'}
-		<TradingDataInfoRow label="Liquidity" value={formatDollar(summary.usd_liquidity_latest)} />
-	{/if}
-
 	{#if Number.isFinite(summary.pair_tvl)}
 		<TradingDataInfoRow label="TVL">
 			<Tooltip slot="value">
@@ -86,8 +82,8 @@
 		<a slot="label" href={tokenTaxDocsUrl} rel="external">Token tax</a>
 	</TradingDataInfoRow>
 
-	{#if summary.pool_swap_fee}
-		<TradingDataInfoRow label="Swap fee" value={formatSwapFee(summary.pool_swap_fee)} />
+	{#if summary.pair_swap_fee}
+		<TradingDataInfoRow label="Trading fee" value={formatSwapFee(summary.pair_swap_fee)} />
 	{/if}
 
 	<TradingDataInfoRow label="Exchange">

--- a/src/routes/trading-view/[chain]/lending/[protocol]/[reserve]/+page.svelte
+++ b/src/routes/trading-view/[chain]/lending/[protocol]/[reserve]/+page.svelte
@@ -44,7 +44,7 @@
 
 <main class="ds-3">
 	<PageHeader title={reserve.asset_name}>
-		<span class="subtitle" slot="subtitle">
+		<span slot="subtitle" class="subtitle">
 			{reserve.protocol_name}
 			reserve on
 			<EntitySymbol type="blockchain" slug={reserve.chain_slug} label={reserve.chain_name} size="0.875em" />


### PR DESCRIPTION
close #642

- include swap fee in heading for all trading pairs
- *add blockchain logo to pair details subtitle
- update pair details page InfoTable
- remove Uniswap v3 beta warning from pair details
- replace buy/sell buttons with heading swap button
- remove "Blockchain explorer" button (redundant)
- move pair details secondary buttons into info summary
