### PR TITLE
Add support for deprecated/outdated strategies

### DIFF
--- a/src/lib/components/AlertItem.svelte
+++ b/src/lib/components/AlertItem.svelte
@@ -4,7 +4,7 @@ Display a single alert item (should always be nested within AlertList).
 
 #### Usage:
 ```tsx
-	<AlertItem title="Optional title">
+	<AlertItem title="Optional title" displayWhen={optionalCondition}>
 		Warning message – e.g., data on this page may be incomplete!
 	</AlertItem>
 ```
@@ -13,24 +13,27 @@ Display a single alert item (should always be nested within AlertList).
 	import IconWarning from '~icons/local/warning';
 
 	export let title = '';
+	export let displayWhen: any = true;
 </script>
 
-<li class="alert-item">
-	<div class="icon">
-		<IconWarning />
-	</div>
-	<div class="inner">
-		<span class="content">
-			{#if title}
-				<strong>{title}</strong>
+{#if displayWhen}
+	<li class="alert-item">
+		<div class="icon">
+			<IconWarning />
+		</div>
+		<div class="inner">
+			<span class="content">
+				{#if title}
+					<strong>{title}</strong>
+				{/if}
+				<span><slot /></span>
+			</span>
+			{#if $$slots.cta}
+				<span class="cta"><slot name="cta" /></span>
 			{/if}
-			<span><slot /></span>
-		</span>
-		{#if $$slots.cta}
-			<span class="cta"><slot name="cta" /></span>
-		{/if}
-	</div>
-</li>
+		</div>
+	</li>
+{/if}
 
 <style lang="postcss">
 	.alert-item {

--- a/src/lib/trade-executor/components/StrategyIcon.svelte
+++ b/src/lib/trade-executor/components/StrategyIcon.svelte
@@ -6,20 +6,53 @@
 	const localIconUrl = `/avatars/${strategy.id}.webp`;
 	const strategyIconUrl = strategy.icon_url?.replace(/^http:/, 'https:');
 	const dataUrl = strategy.connected ? localIconUrl : strategyIconUrl;
+	const outdated = Boolean(strategy.new_version_id);
 </script>
 
-<object type="image/webp" data={dataUrl} aria-label="Strategy icon">
-	<img src={strategyIconUrl} alt="Strategy icon" />
-</object>
+<div class="strategy-icon" class:outdated>
+	<object type="image/webp" data={dataUrl} aria-label="Strategy icon">
+		<img src={strategyIconUrl} alt="Strategy icon" />
+	</object>
+	{#if outdated}
+		<svg viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">
+			<text x="50" y="50">outdated</text>
+		</svg>
+	{/if}
+</div>
 
 <style lang="postcss">
-	:is(img, object) {
-		display: grid;
-		place-items: center;
-		height: inherit;
-		width: inherit;
-		border-radius: 100%;
-		overflow: hidden;
-		object-fit: cover;
+	.strategy-icon {
+		:is(&, img, object) {
+			display: grid;
+			place-items: center;
+			height: inherit;
+			width: inherit;
+			border-radius: 100%;
+			overflow: hidden;
+			object-fit: cover;
+		}
+
+		> * {
+			grid-area: 1 / -1;
+		}
+
+		&.outdated object {
+			opacity: 0.85;
+			filter: blur(1.5px);
+		}
+
+		svg {
+			z-index: 1;
+
+			text {
+				font: var(--f-ui-md-bold);
+				fill: #fdfdfc;
+				stroke: #131211;
+				stroke-width: 0.25px;
+				text-anchor: middle;
+				alignment-baseline: middle;
+				filter: drop-shadow(0 0.25em 0.5em #131211);
+			}
+		}
 	}
 </style>

--- a/src/lib/trade-executor/strategy/configuration.ts
+++ b/src/lib/trade-executor/strategy/configuration.ts
@@ -14,7 +14,8 @@ export const strategyConfigurationSchema = z.object({
 	id: z.string(),
 	name: z.string(),
 	url: z.string().url(),
-	fees: strategyFeesSchema.default({})
+	fees: strategyFeesSchema.default({}),
+	new_version_id: z.string().nullish()
 });
 export type StrategyConfiguration = z.infer<typeof strategyConfigurationSchema>;
 

--- a/src/lib/wallet/MyDeposits.svelte
+++ b/src/lib/wallet/MyDeposits.svelte
@@ -40,6 +40,8 @@
 		contracts.fund_value_calculator
 	].every(Boolean);
 
+	const isOutdated = Boolean(strategy.new_version_id);
+
 	$: connected = $wallet.isConnected;
 	$: wrongNetwork = connected && $wallet.chain?.id !== chain?.id;
 	$: buttonsDisabled = geoBlocked || !depositEnabled || wrongNetwork;
@@ -145,7 +147,7 @@
 						<IconUnlink slot="icon" />
 					</Button>
 				{/if}
-				<Button label="Deposit" disabled={buttonsDisabled} on:click={() => launchWizard('deposit')} />
+				<Button label="Deposit" disabled={buttonsDisabled || isOutdated} on:click={() => launchWizard('deposit')} />
 				<Button secondary label="Redeem" disabled={buttonsDisabled} on:click={() => launchWizard('redeem')} />
 			</div>
 		</div>

--- a/src/routes/+page.server.ts
+++ b/src/routes/+page.server.ts
@@ -1,10 +1,14 @@
 import { getCachedStrategies } from 'trade-executor/strategy/runtime-state';
 
 export async function load({ fetch }) {
-	const strategies = await getCachedStrategies(fetch);
+	// get first 3 live strategies (excluding outdated)
+	const strategies = (await getCachedStrategies(fetch))
+		.filter((s) => {
+			const isLive = s.tags?.includes('live');
+			const isCurrent = !s.new_version_id;
+			return isLive && isCurrent;
+		})
+		.slice(0, 3);
 
-	// return first 3 live strategies
-	return {
-		strategies: strategies.filter((s) => s.tags?.includes('live')).slice(0, 3)
-	};
+	return { strategies };
 }

--- a/src/routes/strategies/StrategyTile.svelte
+++ b/src/routes/strategies/StrategyTile.svelte
@@ -66,7 +66,18 @@
 						<svelte:fragment slot="popup">{@html errorHtml}</svelte:fragment>
 					</Tooltip>
 				{/if}
+
 				<StrategyBadges tags={strategy.tags ?? []} includeLive={admin} />
+
+				{#if strategy.new_version_id}
+					<Tooltip>
+						<DataBadge slot="trigger" status="error">Outdated</DataBadge>
+						<svelte:fragment slot="popup">
+							This is an outdated strategy. An updated version is available
+							<a href="/strategies/{strategy.new_version_id}">here</a>.
+						</svelte:fragment>
+					</Tooltip>
+				{/if}
 			</div>
 		</div>
 		<div class="chart">

--- a/src/routes/strategies/[strategy]/+layout.svelte
+++ b/src/routes/strategies/[strategy]/+layout.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { page } from '$app/stores';
 	import Breadcrumbs from '$lib/breadcrumb/Breadcrumbs.svelte';
-	import { Alert, PageHeading } from '$lib/components';
+	import { AlertList, PageHeading } from '$lib/components';
 	import { StrategyIcon } from 'trade-executor/components';
 	import { menuOptions, default as StrategyNav } from './StrategyNav.svelte';
 	import StrategyBadges from '../StrategyBadges.svelte';
@@ -12,10 +12,11 @@
 
 	$: ({ strategy, deferred } = data);
 
-	// Get the error message HTML
+	$: isOverviewPage = $page.url.pathname.endsWith(strategy.id);
+
 	$: errorHtml = getTradeExecutorErrorHtml(strategy);
 
-	$: isOverviewPage = $page.url.pathname.endsWith(strategy.id);
+	$: isOutdated = Boolean(strategy.new_version_id);
 
 	$: breadcrumbs = {
 		[strategy.id]: strategy.name,
@@ -41,11 +42,19 @@
 			</div>
 		</PageHeading>
 
-		{#if errorHtml && isOverviewPage}
+		{#if isOverviewPage && (errorHtml || isOutdated)}
 			<div class="error-wrapper">
-				<Alert status="warning" size="sm" title="Ongoing execution issues">
-					{@html errorHtml}
-				</Alert>
+				<AlertList status="warning" size="md" let:AlertItem>
+					<AlertItem title="Outdated strategy" displayWhen={isOutdated}>
+						You are viewing an outdated version of this strategy. An updated version is available
+						<a href="/strategies/{strategy.new_version_id}" data-sveltekit-reload>here</a>. To maximize future returns,
+						participants should consider tranfering deposits to the latest version (though there is no guarantee of
+						better performance).
+					</AlertItem>
+					<AlertItem title="Ongoing execution issues" displayWhen={errorHtml}>
+						{@html errorHtml}
+					</AlertItem>
+				</AlertList>
 			</div>
 		{/if}
 

--- a/src/routes/trading-view/[chain=slug]/[exchange]/[pair]/+page.svelte
+++ b/src/routes/trading-view/[chain=slug]/[exchange]/[pair]/+page.svelte
@@ -84,28 +84,22 @@ Render the pair trading page
 
 		{#if isUniswapIncompatible || tokenTax.broken || ridiculousPrice}
 			<AlertList status="warning" let:AlertItem>
-				{#if isUniswapIncompatible}
-					<AlertItem title="Incompatible exchange">
-						{summary.exchange_name} is not fully compatible with Uniswap v2 protocols. Price, volume and liquidity data for
-						{summary.pair_symbol} may be inaccurate.
-					</AlertItem>
-				{/if}
+				<AlertItem title="Incompatible exchange" displayWhen={isUniswapIncompatible}>
+					{summary.exchange_name} is not fully compatible with Uniswap v2 protocols. Price, volume and liquidity data for
+					{summary.pair_symbol} may be inaccurate.
+				</AlertItem>
 
-				{#if tokenTax.broken}
-					<AlertItem>
-						This token is unlikely to be tradeable.
-						<a
-							href="https://tradingstrategy.ai/docs/programming/market-data/token-tax.html#honeypots-and-other-rug-pull-risks"
-							rel="external">Read more about transfer fees being broken or malicious in the token tax documentation</a
-						>. Error code <strong>{tokenTax.sellTax}</strong>.
-					</AlertItem>
-				{/if}
+				<AlertItem displayWhen={tokenTax.broken}>
+					This token is unlikely to be tradeable.
+					<a
+						href="https://tradingstrategy.ai/docs/programming/market-data/token-tax.html#honeypots-and-other-rug-pull-risks"
+						rel="external">Read more about transfer fees being broken or malicious in the token tax documentation</a
+					>. Error code <strong>{tokenTax.sellTax}</strong>.
+				</AlertItem>
 
-				{#if ridiculousPrice}
-					<AlertItem>
-						This trading pair is using low digit price units that may prevent displaying the price data properly.
-					</AlertItem>
-				{/if}
+				<AlertItem displayWhen={ridiculousPrice}>
+					This trading pair is using low digit price units that may prevent displaying the price data properly.
+				</AlertItem>
 			</AlertList>
 		{/if}
 	</section>


### PR DESCRIPTION
close #798

- add config option
- add "outdated" warning to overview page
- disable "Deposit" button on outdated strategies
- add "Outdated" badge to outdated strategies
- exclude outdated strategies from front page
