### PR TITLE
Simplified strategy tile on front page

### DIFF
--- a/src/lib/components/Tooltip.svelte
+++ b/src/lib/components/Tooltip.svelte
@@ -67,12 +67,13 @@ For more information see:
 			}
 
 			.inner {
-				padding: 1.125rem;
+				padding: 1rem;
 				border: 1px solid var(--c-box-3);
-				border-radius: var(--radius-md);
+				border-radius: var(--radius-ms);
 				background: var(--c-text-inverted);
 				box-shadow: var(--shadow-3);
-				font: var(--f-ui-small-light);
+				font: var(--f-ui-sm-roman);
+				letter-spacing: var(--ls-ui-sm);
 				color: var(--c-text);
 				text-align: left;
 			}

--- a/src/lib/trade-executor/components/KeyMetric.svelte
+++ b/src/lib/trade-executor/components/KeyMetric.svelte
@@ -107,7 +107,6 @@ Display one key metric in a strategy tile.
 		white-space: nowrap;
 
 		:global(.icon) {
-			--icon-size: 1.1em;
 			transform: translateY(-0.1em);
 		}
 
@@ -127,6 +126,11 @@ Display one key metric in a strategy tile.
 			letter-spacing: 0.03em;
 			text-transform: uppercase;
 			color: color-mix(in srgb, var(--c-text-extra-light), var(--c-warning) 40%);
+
+			--icon-size: 1.1em;
+			:global(svg path) {
+				stroke-width: 2.5;
+			}
 		}
 
 		.backtest-tooltip {

--- a/src/lib/trade-executor/components/KeyMetricDescription.svelte
+++ b/src/lib/trade-executor/components/KeyMetricDescription.svelte
@@ -75,23 +75,17 @@
 
 <style lang="postcss">
 	h3 {
-		font: var(--f-ui-xl-medium);
-		margin-bottom: 0.75rem !important;
+		font: var(--f-ui-md-medium);
+		letter-spacing: var(--ls-ui-md);
 	}
 
 	ul {
+		display: grid;
+		gap: 0.625rem;
 		margin-block: 1rem;
 	}
 
-	ul li {
-		margin-bottom: 0.75rem;
-	}
-
-	strong {
-		font-weight: 700;
-	}
-
-	.timespan {
+	:is(strong, .timespan) {
 		font-weight: 700;
 	}
 </style>

--- a/src/lib/trade-executor/components/StrategyIcon.svelte
+++ b/src/lib/trade-executor/components/StrategyIcon.svelte
@@ -10,13 +10,14 @@
 </script>
 
 <div class="strategy-icon" class:outdated>
-	<object type="image/webp" data={dataUrl} aria-label="Strategy icon">
-		<img src={strategyIconUrl} alt="Strategy icon" />
-	</object>
 	{#if outdated}
 		<svg viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">
 			<text x="50" y="50">outdated</text>
 		</svg>
+	{:else}
+		<object type="image/webp" data={dataUrl} aria-label="Strategy icon">
+			<img src={strategyIconUrl} alt="Strategy icon" />
+		</object>
 	{/if}
 </div>
 
@@ -32,13 +33,8 @@
 			object-fit: cover;
 		}
 
-		> * {
-			grid-area: 1 / -1;
-		}
-
-		&.outdated object {
-			opacity: 0.85;
-			filter: blur(1.5px);
+		&.outdated {
+			background: hsl(100 0% 50% / 65%);
 		}
 
 		svg {
@@ -47,11 +43,9 @@
 			text {
 				font: var(--f-ui-md-bold);
 				fill: #fdfdfc;
-				stroke: #131211;
-				stroke-width: 0.25px;
 				text-anchor: middle;
 				alignment-baseline: middle;
-				filter: drop-shadow(0 0.25em 0.5em #131211);
+				filter: drop-shadow(0 0.375em 0.625em #131211);
 			}
 		}
 	}

--- a/src/routes/FeaturedStrategies.svelte
+++ b/src/routes/FeaturedStrategies.svelte
@@ -18,7 +18,7 @@
 	const chartDateRange = getStrategyChartDateRange(strategies);
 </script>
 
-<Section padding="xl">
+<Section padding="lg">
 	<h2>Open strategies</h2>
 	<p class="live-ago">
 		Open strategies have been live for {openLiveDays}.

--- a/src/routes/FeaturedStrategies.svelte
+++ b/src/routes/FeaturedStrategies.svelte
@@ -89,7 +89,6 @@
 		gap: var(--gap);
 		justify-content: center;
 		padding: 3rem 0;
-		overflow: hidden;
 
 		/* custom method to ensure equal width strategy tiles in flex layout */
 		--num-gaps: calc(var(--columns) - 1);

--- a/src/routes/FeaturedStrategies.svelte
+++ b/src/routes/FeaturedStrategies.svelte
@@ -39,7 +39,7 @@
 	</div>
 	<div class="strategies">
 		{#each strategies as strategy (strategy.id)}
-			<StrategyTile {strategy} {chartDateRange} />
+			<StrategyTile simplified {strategy} {chartDateRange} />
 		{:else}
 			<div class="fallback">
 				<Alert size="sm" status="info">Check back soon to see top-performing strategies.</Alert>

--- a/src/routes/strategies/ChartThumbnail.svelte
+++ b/src/routes/strategies/ChartThumbnail.svelte
@@ -98,7 +98,7 @@
 			bottom: 0;
 			width: 100%;
 			text-align: center;
-			font: var(--f-ui-md-roman);
+			font: var(--f-ui-sm-medium);
 			letter-spacing: var(--f-ui-md-spacing, normal);
 			color: var(--c-text-extra-light);
 			opacity: 0;

--- a/src/routes/strategies/StrategyDataSummary.svelte
+++ b/src/routes/strategies/StrategyDataSummary.svelte
@@ -2,19 +2,25 @@
 	import type { StrategyRuntimeState } from 'trade-executor/strategy/runtime-state';
 	import { EntitySymbol, UpDownIndicator } from '$lib/components';
 	import { KeyMetric } from 'trade-executor/components';
-	import { formatDaysAgo, formatNumber, formatPercent, formatPrice } from '$lib/helpers/formatters';
+	import { formatDaysAgo, formatNumber, formatPercent, formatDollar } from '$lib/helpers/formatters';
 	import { formatProfitability } from 'trade-executor/helpers/formatters';
 	import { metricDescriptions } from 'trade-executor/helpers/strategy-metric-help-texts';
 	import { getLogoUrl } from '$lib/helpers/assets';
 
+	export let simplified = false;
 	export let strategy: StrategyRuntimeState;
 
 	const backtestLink = `/strategies/${strategy.id}/backtest`;
 	const keyMetrics = strategy.summary_statistics?.key_metrics ?? {};
 	const assetManagementMode = strategy.on_chain_data?.asset_management_mode;
+
+	function formatTvl(value: MaybeNumber) {
+		const digits = value && value < 1000 ? 2 : 1;
+		return formatDollar(value, digits);
+	}
 </script>
 
-<div class="strategy-data-summary ds-3">
+<div class="strategy-data-summary ds-3" class:simplified>
 	{#if keyMetrics.cagr}
 		<KeyMetric
 			name="Annual return"
@@ -33,21 +39,24 @@
 	{/if}
 
 	<KeyMetric
-		name="Total value locked"
+		name="TVL"
+		tooltipName="Total value locked"
 		metric={keyMetrics.total_equity}
-		formatter={formatPrice}
+		formatter={formatTvl}
 		tooltipExtraDescription={metricDescriptions.tvl}
 		{backtestLink}
 	/>
 
-	<KeyMetric
-		name="Max drawdown"
-		tooltipName="Maximum drawdown"
-		metric={keyMetrics.max_drawdown}
-		formatter={formatPercent}
-		tooltipExtraDescription={metricDescriptions.maxDrawdown}
-		{backtestLink}
-	/>
+	{#if !simplified}
+		<KeyMetric
+			name="Max drawdown"
+			tooltipName="Maximum drawdown"
+			metric={keyMetrics.max_drawdown}
+			formatter={formatPercent}
+			tooltipExtraDescription={metricDescriptions.maxDrawdown}
+			{backtestLink}
+		/>
+	{/if}
 
 	<KeyMetric
 		name="Age"
@@ -66,25 +75,29 @@
 		{backtestLink}
 	/>
 
-	<KeyMetric
-		name="Sortino"
-		tooltipName="Sortino Ratio"
-		metric={keyMetrics.sortino}
-		formatter={formatNumber}
-		{backtestLink}
-	/>
+	{#if !simplified}
+		<KeyMetric
+			name="Sortino"
+			tooltipName="Sortino Ratio"
+			metric={keyMetrics.sortino}
+			formatter={formatNumber}
+			{backtestLink}
+		/>
+	{/if}
 
-	<KeyMetric name="Asset management" {backtestLink}>
-		<div class="asset-management">
-			{#if assetManagementMode === 'enzyme'}
-				<EntitySymbol label="Enzyme vault" logoUrl={getLogoUrl('token', 'enzyme')} />
-			{:else if assetManagementMode === 'hot_wallet'}
-				<EntitySymbol label="Hot wallet" logoUrl={getLogoUrl('wallet', 'metamask')} />
-			{:else}
-				---
-			{/if}
-		</div>
-	</KeyMetric>
+	{#if !simplified}
+		<KeyMetric name="Asset management" {backtestLink}>
+			<div class="asset-management">
+				{#if assetManagementMode === 'enzyme'}
+					<EntitySymbol label="Enzyme vault" logoUrl={getLogoUrl('token', 'enzyme')} />
+				{:else if assetManagementMode === 'hot_wallet'}
+					<EntitySymbol label="Hot wallet" logoUrl={getLogoUrl('wallet', 'metamask')} />
+				{:else}
+					---
+				{/if}
+			</div>
+		</KeyMetric>
+	{/if}
 </div>
 
 <style lang="postcss">
@@ -95,6 +108,12 @@
 		list-style: none;
 		margin-block: 1.25rem;
 		padding: 0;
+
+		&.simplified {
+			display: flex;
+			justify-content: space-between;
+			gap: 1rem 0.75rem;
+		}
 
 		@media (--viewport-sm-down) {
 			margin-block: 0.75rem;

--- a/src/routes/strategies/StrategyTile.svelte
+++ b/src/routes/strategies/StrategyTile.svelte
@@ -89,7 +89,7 @@
 			</div>
 		</header>
 		<div class="data">
-			<StrategyDataSummary {strategy} />
+			<StrategyDataSummary {simplified} {strategy} />
 		</div>
 		<div class="actions">
 			<Button size="md" {href}>View strategy</Button>

--- a/src/routes/strategies/StrategyTile.svelte
+++ b/src/routes/strategies/StrategyTile.svelte
@@ -14,6 +14,7 @@
 	import { getLogoUrl } from '$lib/helpers/assets';
 
 	export let admin = false;
+	export let simplified = false;
 	export let strategy: StrategyRuntimeState;
 	export let chartDateRange: [Date?, Date?];
 
@@ -37,7 +38,7 @@
 <!-- tile container element MUST NOT be an anchor tag; see StrategyTile.test.ts  -->
 <!-- svelte-ignore a11y-no-static-element-interactions a11y-click-events-have-key-events -->
 <div class="strategy-tile ds-3" on:click={handleClick}>
-	<div class="visuals">
+	<div class="visuals" class:simplified>
 		<div class="top">
 			<div>
 				{#if chain}
@@ -50,26 +51,28 @@
 				{/if}
 			</div>
 
-			<div class="badges">
-				{#if errorHtml}
-					<Tooltip>
-						<DataBadge slot="trigger" status="error">Error</DataBadge>
-						<svelte:fragment slot="popup">{@html errorHtml}</svelte:fragment>
-					</Tooltip>
-				{/if}
+			{#if !simplified}
+				<div class="badges">
+					{#if errorHtml}
+						<Tooltip>
+							<DataBadge slot="trigger" status="error">Error</DataBadge>
+							<svelte:fragment slot="popup">{@html errorHtml}</svelte:fragment>
+						</Tooltip>
+					{/if}
 
-				<StrategyBadges tags={strategy.tags ?? []} includeLive={admin} />
+					<StrategyBadges tags={strategy.tags ?? []} includeLive={admin} />
 
-				{#if strategy.new_version_id}
-					<Tooltip>
-						<DataBadge slot="trigger" status="error">Outdated</DataBadge>
-						<svelte:fragment slot="popup">
-							This is an outdated strategy. An updated version is available
-							<a href="/strategies/{strategy.new_version_id}">here</a>.
-						</svelte:fragment>
-					</Tooltip>
-				{/if}
-			</div>
+					{#if strategy.new_version_id}
+						<Tooltip>
+							<DataBadge slot="trigger" status="error">Outdated</DataBadge>
+							<svelte:fragment slot="popup">
+								This is an outdated strategy. An updated version is available
+								<a href="/strategies/{strategy.new_version_id}">here</a>.
+							</svelte:fragment>
+						</Tooltip>
+					{/if}
+				</div>
+			{/if}
 		</div>
 		<div class="chart">
 			<ChartThumbnail data={chartData} dateRange={chartDateRange} />
@@ -129,38 +132,42 @@
 				left: 0;
 				right: 0;
 				top: 0;
+			}
 
-				.chain-icon {
-					display: flex;
-					border-radius: 100%;
-					height: 2rem;
-					aspect-ratio: 1;
-					padding: 15%;
-					background: var(--c-text-inverted);
-					box-shadow: var(--shadow-1);
+			.chain-icon {
+				display: flex;
+				border-radius: 100%;
+				height: 2rem;
+				aspect-ratio: 1;
+				padding: 15%;
+				background: var(--c-text-inverted);
+				box-shadow: var(--shadow-1);
+			}
+
+			.badges {
+				display: flex;
+				gap: 0.375rem;
+				font: var(--f-ui-sm-medium);
+
+				:global([data-css-props]) {
+					--data-badge-height: 100%;
 				}
 
-				.badges {
-					display: flex;
-					gap: 0.375rem;
-					font: var(--f-ui-sm-medium);
-
-					:global([data-css-props]) {
-						--data-badge-height: 100%;
-					}
-
-					:global(.tooltip .popup) {
-						position: absolute;
-						max-width: 22rem;
-						right: 0;
-						left: auto;
-						bottom: auto;
-					}
+				:global(.tooltip .popup) {
+					position: absolute;
+					max-width: 22rem;
+					right: 0;
+					left: auto;
+					bottom: auto;
 				}
 			}
 
-			&:not(:hover) .chart {
+			.chart {
 				z-index: -1;
+			}
+
+			&.simplified .chart {
+				margin-top: -2rem;
 			}
 		}
 

--- a/src/routes/strategies/StrategyTile.svelte
+++ b/src/routes/strategies/StrategyTile.svelte
@@ -167,7 +167,11 @@
 			}
 
 			&.simplified .chart {
-				margin-top: -2rem;
+				margin-block: -2rem;
+
+				:global(figcaption) {
+					bottom: 1rem;
+				}
 			}
 		}
 

--- a/src/routes/strategies/StrategyTile.svelte
+++ b/src/routes/strategies/StrategyTile.svelte
@@ -32,16 +32,6 @@
 		if (target instanceof HTMLAnchorElement && target.href) return;
 		goto(href);
 	};
-
-	// FIXME: hack to infer list of tokens based on strategy ID;
-	// In the future this will come from the strategy configuration.
-	function getStrategyTokens({ id }: StrategyRuntimeState) {
-		const tokens: string[] = [];
-		for (const token of ['eth', 'btc', 'matic']) {
-			if (id.includes(token)) tokens.push(token);
-		}
-		return [...tokens, 'usdc'];
-	}
 </script>
 
 <!-- tile container element MUST NOT be an anchor tag; see StrategyTile.test.ts  -->
@@ -49,14 +39,15 @@
 <div class="strategy-tile ds-3" on:click={handleClick}>
 	<div class="visuals">
 		<div class="top">
-			<div class="tokens">
-				{#each getStrategyTokens(strategy) as slug}
-					{@const symbol = slug.toUpperCase()}
+			<div>
+				{#if chain}
 					<Tooltip>
-						<img slot="trigger" src={getLogoUrl('token', slug)} alt={symbol} />
-						<span slot="popup">This strategy trades <strong>{symbol}</strong></span>
+						<img class="chain-icon" slot="trigger" src={getLogoUrl('blockchain', chain.slug)} alt={chain.name} />
+						<span slot="popup">
+							This strategy runs on <strong>{chain.name}</strong> blockchain
+						</span>
 					</Tooltip>
-				{/each}
+				{/if}
 			</div>
 
 			<div class="badges">
@@ -88,20 +79,6 @@
 		<header>
 			<div class="avatar">
 				<StrategyIcon {strategy} />
-				{#if chain}
-					<div class="chain-icon">
-						<Tooltip>
-							<EntitySymbol
-								slot="trigger"
-								size="var(--chain-icon-size)"
-								logoUrl={getLogoUrl('blockchain', chain.slug)}
-							/>
-							<span slot="popup">
-								This strategy runs on <strong>{chain.name}</strong> blockchain
-							</span>
-						</Tooltip>
-					</div>
-				{/if}
 			</div>
 			<div class="description">
 				<h3 class="truncate">{strategy.name}</h3>
@@ -153,17 +130,14 @@
 				right: 0;
 				top: 0;
 
-				.tokens {
+				.chain-icon {
 					display: flex;
-					gap: 0.375rem;
-
-					img {
-						display: flex;
-						width: 1.75rem;
-						height: 1.75rem;
-						border-radius: 100%;
-						box-shadow: var(--shadow-1);
-					}
+					border-radius: 100%;
+					height: 2rem;
+					aspect-ratio: 1;
+					padding: 15%;
+					background: var(--c-text-inverted);
+					box-shadow: var(--shadow-1);
 				}
 
 				.badges {
@@ -227,22 +201,6 @@
 
 					:global(.tooltip .popup) {
 						min-width: 20rem;
-					}
-
-					.chain-icon {
-						display: flex;
-						position: absolute;
-						right: 0;
-						bottom: 0;
-						padding: 5%;
-						transform: translate(20%, 20%);
-						border-radius: 100%;
-						box-shadow: var(--shadow-1);
-						background: var(--c-text-inverted);
-
-						strong {
-							text-transform: capitalize;
-						}
 					}
 				}
 

--- a/src/routes/strategies/StrategyTile.svelte
+++ b/src/routes/strategies/StrategyTile.svelte
@@ -137,11 +137,11 @@
 			.chain-icon {
 				display: flex;
 				border-radius: 100%;
-				height: 2rem;
+				height: 1.875rem;
 				aspect-ratio: 1;
 				padding: 15%;
-				background: var(--c-text-inverted);
-				box-shadow: var(--shadow-1);
+				border: 1px solid var(--c-box-4);
+				background: var(--c-box-2);
 			}
 
 			.badges {


### PR DESCRIPTION
close #803

- replace strategy tile token icons with chain icon
- remove badges
- hide some metrics
- simplify "outdated" strategy icon
- improve tooltip styling
