### PR TITLE
Fetch Lagoon vault fees from smart contract

### DIFF
--- a/src/lib/trade-executor/vaults/base.ts
+++ b/src/lib/trade-executor/vaults/base.ts
@@ -3,6 +3,13 @@ import type { Chain } from '$lib/helpers/chain';
 import type { Config } from '@wagmi/core';
 import type { TokenBalance } from '$lib/eth-defi/schemas/token';
 
+export type VaultFees = {
+	managementFee: number;
+	totalPerformanceFee: number;
+	tradingStrategyProtocolFee?: number;
+	strategyDeveloperFee?: number;
+};
+
 export const DepositMethod = {
 	INTERNAL: 'internal',
 	EXTERNAL: 'external'
@@ -58,12 +65,12 @@ export abstract class BaseVault<Contracts extends SmartContracts> extends BaseAs
 
 	// Common properties set in the constructor
 	readonly contracts: Contracts;
-	#feeData: StrategyFees;
+	protected readonly feeData: StrategyFees;
 
 	constructor(chain: Chain, contracts: Contracts, feeData: StrategyFees) {
 		super(chain);
 		this.contracts = contracts;
-		this.#feeData = feeData;
+		this.feeData = feeData;
 	}
 
 	// Return a given vault's URL on vault provider's website
@@ -86,13 +93,13 @@ export abstract class BaseVault<Contracts extends SmartContracts> extends BaseAs
 
 	// By default, vault adapters return the fees defined in metadata payload. This
 	// can be overridden at the adapter level (e.g., see lagoon vault adapter).
-	async getFees() {
-		const fees = this.#feeData;
+	async getFees(_config: Config): Promise<VaultFees> {
+		const fees = this.feeData;
 		return {
 			managementFee: fees.management_fee,
+			totalPerformanceFee: fees.trading_strategy_protocol_fee + fees.strategy_developer_fee,
 			tradingStrategyProtocolFee: fees.trading_strategy_protocol_fee,
-			strategyDeveloperFee: fees.strategy_developer_fee,
-			totalPerformanceFee: fees.trading_strategy_protocol_fee + fees.strategy_developer_fee
+			strategyDeveloperFee: fees.strategy_developer_fee
 		};
 	}
 }

--- a/src/lib/trade-executor/vaults/enzyme/index.ts
+++ b/src/lib/trade-executor/vaults/enzyme/index.ts
@@ -9,14 +9,21 @@ export class EnzymeVault extends BaseVault<EnzymeSmartContracts> {
 	type = 'enzyme';
 	label = 'Enzyme';
 	logoUrl = '/logos/tokens/enzyme';
-
+	address = this.contracts.vault;
 	depositMethod = DepositMethod.INTERNAL;
+
+	// Enzyme protocol fee and info; see:
+	// https://docs.enzyme.finance/what-is-enzyme/faq#fees-performance-and-accounting
+	protocolFee = 0.0025;
+	protocolFeeTooltip = `
+		The Enzyme protocol fee rate applied to the vault is 0.50%. Shares accrued can be bought
+		back with MLN at a 50% discount, leading to an effective protocol fee rate of 0.25%.
+	`;
+	protocolFeeUrl = 'https://docs.enzyme.finance/what-is-enzyme/faq#fees-performance-and-accounting';
 
 	get externalProviderUrl() {
 		return `https://app.enzyme.finance/vault/${this.contracts.vault}?network=${this.chain.slug}`;
 	}
-
-	address = this.contracts.vault;
 
 	async getShareValueUSD(config: Config, address: Address): Promise<TokenBalance> {
 		const { default: abi } = await import('./abi/FundValueCalculator.json');

--- a/src/lib/trade-executor/vaults/hot_wallet/index.ts
+++ b/src/lib/trade-executor/vaults/hot_wallet/index.ts
@@ -1,4 +1,4 @@
-import { BaseAssetManager, DepositMethod } from '../base';
+import { BaseAssetManager } from '../base';
 
 export class HotWallet extends BaseAssetManager {
 	type = 'hot_wallet';

--- a/src/lib/trade-executor/vaults/index.ts
+++ b/src/lib/trade-executor/vaults/index.ts
@@ -2,7 +2,7 @@
  * Vault adapter abstract classes and factory
  *
  */
-import type { OnChainData, VaultOnChainData, SmartContracts } from '../schemas/summary';
+import type { OnChainData, VaultOnChainData, SmartContracts, StrategyFees } from '../schemas/summary';
 import type { BaseAssetManager, BaseVault } from './base';
 import { EnzymeVault } from './enzyme';
 import { VelvetVault } from './velvet';
@@ -11,18 +11,17 @@ import { HotWallet } from './hot_wallet';
 import { getChain } from '$lib/helpers/chain';
 
 // Overload signatures (helps TS know that vault input -> vault output)
-export function createVaultAdapter(data: VaultOnChainData): BaseVault<SmartContracts>;
-export function createVaultAdapter(data: OnChainData): BaseAssetManager;
+export function createVaultAdapter(onChainData: VaultOnChainData, feeData: StrategyFees): BaseVault<SmartContracts>;
+export function createVaultAdapter(onChainData: OnChainData, feeData: StrategyFees): BaseAssetManager;
 
 /**
  * Vault adapter factory - returns the correct vault adapter instance
  * based on the `asset_management_mode` supplied by the strategy metadata.
  */
-export function createVaultAdapter({
-	asset_management_mode: mode,
-	chain_id: chainId,
-	smart_contracts: contracts
-}: OnChainData): BaseAssetManager {
+export function createVaultAdapter(
+	{ asset_management_mode: mode, chain_id: chainId, smart_contracts: contracts }: OnChainData,
+	feeData: StrategyFees
+): BaseAssetManager {
 	const chain = getChain(chainId);
 
 	if (!chain) {
@@ -31,11 +30,11 @@ export function createVaultAdapter({
 
 	switch (mode) {
 		case 'enzyme':
-			return new EnzymeVault(chain, contracts);
+			return new EnzymeVault(chain, contracts, feeData);
 		case 'velvet':
-			return new VelvetVault(chain, contracts);
+			return new VelvetVault(chain, contracts, feeData);
 		case 'lagoon':
-			return new LagoonVault(chain, contracts);
+			return new LagoonVault(chain, contracts, feeData);
 		case 'hot_wallet':
 			return new HotWallet(chain);
 		default:

--- a/src/lib/trade-executor/vaults/lagoon/index.ts
+++ b/src/lib/trade-executor/vaults/lagoon/index.ts
@@ -15,7 +15,7 @@ export class LagoonVault extends BaseVault<LagoonSmartContracts> {
 	// Lagoon protocol fee and info
 	protocolFee = 0;
 	protocolFeeTooltip = `During the introductory period, Lagoon is not charging a protocol fee.`;
-	protocolFeeUrl = undefined;
+	protocolFeeUrl = 'https://docs.lagoon.finance/vault-creators/fees-and-economics';
 
 	get externalProviderUrl() {
 		return `https://app.lagoon.finance/vault/${this.chain.id}/${this.contracts.address}`;
@@ -46,5 +46,21 @@ export class LagoonVault extends BaseVault<LagoonSmartContracts> {
 			functionName: 'convertToAssets',
 			args: [vaultBalance.value]
 		}) as Promise<bigint>;
+	}
+
+	// Get Lagoon vault fees from vault smart contract
+	async getFees(config: Config) {
+		const fees = (await readContract(config, {
+			abi: (await import('./abi/Vault.json')).default,
+			chainId: this.chain.id,
+			address: this.contracts.address,
+			functionName: 'feeRates'
+		})) as { managementRate: number; performanceRate: number };
+
+		// convert basis point values to decimal percentage values
+		return {
+			managementFee: fees.managementRate / 10_000,
+			totalPerformanceFee: fees.performanceRate / 10_000
+		};
 	}
 }

--- a/src/lib/trade-executor/vaults/lagoon/index.ts
+++ b/src/lib/trade-executor/vaults/lagoon/index.ts
@@ -9,14 +9,17 @@ export class LagoonVault extends BaseVault<LagoonSmartContracts> {
 	type = 'lagoon';
 	label = 'Lagoon';
 	logoUrl = '/logos/tokens/lagoon';
-
+	address = this.contracts.address;
 	depositMethod = DepositMethod.EXTERNAL;
+
+	// Lagoon protocol fee and info
+	protocolFee = 0;
+	protocolFeeTooltip = `During the introductory period, Lagoon is not charging a protocol fee.`;
+	protocolFeeUrl = undefined;
 
 	get externalProviderUrl() {
 		return `https://app.lagoon.finance/vault/${this.chain.id}/${this.contracts.address}`;
 	}
-
-	address = this.contracts.address;
 
 	async getShareValueUSD(config: Config, address: Address): Promise<TokenBalance> {
 		const [denominationToken, value] = await Promise.all([

--- a/src/lib/trade-executor/vaults/velvet/index.ts
+++ b/src/lib/trade-executor/vaults/velvet/index.ts
@@ -5,18 +5,21 @@ export class VelvetVault extends BaseVault<VelvetSmartContracts> {
 	type = 'velvet';
 	label = 'Velvet Capital';
 	logoUrl = '/logos/tokens/velvet';
+	address = this.contracts.portfolio;
+	depositMethod = DepositMethod.EXTERNAL;
+
+	// Velvet Capital protocol fee and info
+	protocolFee = 0;
+	protocolFeeTooltip = 'Velvet Capital protocol fee info TBD.';
+	protocolFeeUrl = undefined;
 
 	get shortLabel() {
 		return 'Velvet';
 	}
 
-	depositMethod = DepositMethod.EXTERNAL;
-
 	get externalProviderUrl() {
 		return `https://dapp.velvet.capital/VaultDetails/${this.contracts.portfolio}`;
 	}
-
-	address = this.contracts.portfolio;
 
 	async getShareValueUSD() {
 		throw new Error('Velvet deposit value not yet available.');

--- a/src/lib/trade-executor/vaults/velvet/index.ts
+++ b/src/lib/trade-executor/vaults/velvet/index.ts
@@ -9,9 +9,13 @@ export class VelvetVault extends BaseVault<VelvetSmartContracts> {
 	depositMethod = DepositMethod.EXTERNAL;
 
 	// Velvet Capital protocol fee and info
-	protocolFee = 0;
-	protocolFeeTooltip = 'Velvet Capital protocol fee info TBD.';
-	protocolFeeUrl = undefined;
+	protocolFee = 0.002;
+	protocolFeeTooltip = `
+		To support further development & future token buy-backs Velvet Capital DeFi execution engine
+		takes a 0.2% transaction fee. The fee can be further reduced by staking Velvet tokens (please
+		refer to the Tokenomics section).
+	`;
+	protocolFeeUrl = 'https://docs.velvet.capital/product/fees';
 
 	get shortLabel() {
 		return 'Velvet';

--- a/src/routes/strategies/StrategyDataSummary.svelte
+++ b/src/routes/strategies/StrategyDataSummary.svelte
@@ -11,7 +11,7 @@
 
 	const backtestLink = `/strategies/${strategy.id}/backtest`;
 	const keyMetrics = strategy.summary_statistics?.key_metrics ?? {};
-	const vault = strategy.on_chain_data ? createVaultAdapter(strategy.on_chain_data) : undefined;
+	const vault = strategy.connected ? createVaultAdapter(strategy.on_chain_data, strategy.fees) : undefined;
 
 	function formatTvl(value: MaybeNumber) {
 		const digits = value && value < 1000 ? 2 : 1;

--- a/src/routes/strategies/[strategy]/+layout.ts
+++ b/src/routes/strategies/[strategy]/+layout.ts
@@ -38,7 +38,7 @@ export async function load({ params, fetch, parent }) {
 
 	const chain = getChain(strategy.on_chain_data.chain_id)!;
 
-	const vault = createVaultAdapter(strategy.on_chain_data);
+	const vault = createVaultAdapter(strategy.on_chain_data, strategy.fees);
 
 	return {
 		chain,

--- a/src/routes/strategies/[strategy]/StrategyNav.svelte
+++ b/src/routes/strategies/[strategy]/StrategyNav.svelte
@@ -98,6 +98,7 @@
 			case currentOption?.slug : return true;
 			case 'frozen-positions'  : return hasFrozenPositions;
 			case 'vault'             : return hasVault;
+			case 'fees'              : return hasVault;
 			case 'backtest'          : return backtestAvailable;
 			default                  : return true;
 		}

--- a/src/routes/strategies/[strategy]/fees/+page.svelte
+++ b/src/routes/strategies/[strategy]/fees/+page.svelte
@@ -4,12 +4,8 @@
 	import { formatPercent } from '$lib/helpers/formatters';
 
 	export let data;
-	const { strategy } = data;
+	const { strategy, vault, fees } = data;
 
-	const { fees } = strategy;
-	const totalPerformanceFee = fees.trading_strategy_protocol_fee + fees.strategy_developer_fee;
-
-	const hasEnzymeVault = strategy.on_chain_data.asset_management_mode === 'enzyme';
 	const enzymeFeeUrl = 'https://docs.enzyme.finance/what-is-enzyme/faq#fees-performance-and-accounting';
 	const enzymeProtocolFee = 0.0025;
 </script>
@@ -31,7 +27,7 @@
 					<p><a href="/glossary/management-fee" target="_blank">Learn more about management fees</a>.</p>
 				</div>
 			</Tooltip>
-			<span>{formatPercent(fees.management_fee, 2)}</span>
+			<span>{formatPercent(fees.managementFee, 2)}</span>
 		</div>
 
 		<div class="fees-group">
@@ -43,7 +39,7 @@
 						<p><a href="/glossary/performance-fee" target="_blank">Learn more about performance fees</a>.</p>
 					</div>
 				</Tooltip>
-				<span>{formatPercent(totalPerformanceFee, 2)}</span>
+				<span>{formatPercent(fees.totalPerformanceFee, 2)}</span>
 			</header>
 
 			<div class="fees-list">
@@ -52,22 +48,22 @@
 						<span slot="trigger">Trading Strategy protocol fee <IconQuestionCircle /></span>
 						<div slot="popup">
 							Percent of strategy's profits distributed to the Trading Strategy protocol.
-							{#if fees.trading_strategy_protocol_fee === 0}
+							{#if fees.tradingStrategyProtocolFee === 0}
 								During the beta period, Trading Strategy is not charging a protocol fee.
-							{:else if fees.trading_strategy_protocol_fee <= 0.02}
+							{:else if fees.tradingStrategyProtocolFee <= 0.02}
 								For early users, Trading Strategy is offering a discounted protocol fee of
-								<strong>{formatPercent(fees.trading_strategy_protocol_fee)}</strong>.
+								<strong>{formatPercent(fees.tradingStrategyProtocolFee)}</strong>.
 							{/if}
 						</div>
 					</Tooltip>
-					<span>{formatPercent(fees.trading_strategy_protocol_fee, 2)}</span>
+					<span>{formatPercent(fees.tradingStrategyProtocolFee, 2)}</span>
 				</div>
 				<div class="row">
 					<Tooltip>
 						<span slot="trigger">Strategy developer fee <IconQuestionCircle /></span>
 						<div slot="popup">Percent of strategy's profits earned by the strategy developer.</div>
 					</Tooltip>
-					<span>{formatPercent(fees.strategy_developer_fee, 2)}</span>
+					<span>{formatPercent(fees.strategyDeveloperFee, 2)}</span>
 				</div>
 			</div>
 
@@ -78,11 +74,12 @@
 						Percentage of strategy profits allocated to depositors, after deducting performance fees.
 					</div>
 				</Tooltip>
-				<span>{formatPercent(1 - totalPerformanceFee, 2)}</span>
+				<span>{formatPercent(1 - fees.totalPerformanceFee, 2)}</span>
 			</footer>
 		</div>
 
-		{#if hasEnzymeVault}
+		<!-- TODO: use vault.providerProtocolFee plus property for description -->
+		{#if vault.type === 'enzyme'}
 			<div class="row">
 				<Tooltip>
 					<span slot="trigger">Enzyme Protocol fee <IconQuestionCircle /></span>

--- a/src/routes/strategies/[strategy]/fees/+page.svelte
+++ b/src/routes/strategies/[strategy]/fees/+page.svelte
@@ -41,30 +41,32 @@
 				<span>{formatPercent(fees.totalPerformanceFee, 2)}</span>
 			</header>
 
-			<div class="fees-list">
-				<div class="row">
-					<Tooltip>
-						<span slot="trigger">Trading Strategy protocol fee <IconQuestionCircle /></span>
-						<div slot="popup">
-							Percent of strategy's profits distributed to the Trading Strategy protocol.
-							{#if fees.tradingStrategyProtocolFee === 0}
-								During the beta period, Trading Strategy is not charging a protocol fee.
-							{:else if fees.tradingStrategyProtocolFee <= 0.02}
-								For early users, Trading Strategy is offering a discounted protocol fee of
-								<strong>{formatPercent(fees.tradingStrategyProtocolFee)}</strong>.
-							{/if}
-						</div>
-					</Tooltip>
-					<span>{formatPercent(fees.tradingStrategyProtocolFee, 2)}</span>
+			{#if fees.tradingStrategyProtocolFee && fees.strategyDeveloperFee}
+				<div class="fees-list">
+					<div class="row">
+						<Tooltip>
+							<span slot="trigger">Trading Strategy protocol fee <IconQuestionCircle /></span>
+							<div slot="popup">
+								Percent of strategy's profits distributed to the Trading Strategy protocol.
+								{#if fees.tradingStrategyProtocolFee === 0}
+									During the beta period, Trading Strategy is not charging a protocol fee.
+								{:else if fees.tradingStrategyProtocolFee <= 0.02}
+									For early users, Trading Strategy is offering a discounted protocol fee of
+									<strong>{formatPercent(fees.tradingStrategyProtocolFee)}</strong>.
+								{/if}
+							</div>
+						</Tooltip>
+						<span>{formatPercent(fees.tradingStrategyProtocolFee, 2)}</span>
+					</div>
+					<div class="row">
+						<Tooltip>
+							<span slot="trigger">Strategy developer fee <IconQuestionCircle /></span>
+							<div slot="popup">Percent of strategy's profits earned by the strategy developer.</div>
+						</Tooltip>
+						<span>{formatPercent(fees.strategyDeveloperFee, 2)}</span>
+					</div>
 				</div>
-				<div class="row">
-					<Tooltip>
-						<span slot="trigger">Strategy developer fee <IconQuestionCircle /></span>
-						<div slot="popup">Percent of strategy's profits earned by the strategy developer.</div>
-					</Tooltip>
-					<span>{formatPercent(fees.strategyDeveloperFee, 2)}</span>
-				</div>
-			</div>
+			{/if}
 
 			<footer class="row">
 				<Tooltip>
@@ -165,6 +167,10 @@
 
 				footer {
 					border-radius: 0 0 var(--radius-md) var(--radius-md);
+				}
+
+				header + footer {
+					border-top: 4px solid var(--c-body);
 				}
 			}
 		}

--- a/src/routes/strategies/[strategy]/fees/+page.svelte
+++ b/src/routes/strategies/[strategy]/fees/+page.svelte
@@ -7,7 +7,6 @@
 	const { strategy, vault, fees } = data;
 
 	const enzymeFeeUrl = 'https://docs.enzyme.finance/what-is-enzyme/faq#fees-performance-and-accounting';
-	const enzymeProtocolFee = 0.0025;
 </script>
 
 <svelte:head>
@@ -78,24 +77,22 @@
 			</footer>
 		</div>
 
-		<!-- TODO: use vault.providerProtocolFee plus property for description -->
-		{#if vault.type === 'enzyme'}
-			<div class="row">
-				<Tooltip>
-					<span slot="trigger">Enzyme Protocol fee <IconQuestionCircle /></span>
-					<div slot="popup">
+		<div class="row">
+			<Tooltip>
+				<span slot="trigger">{vault.label} Protocol fee <IconQuestionCircle /></span>
+				<div slot="popup">
+					<p>{@html vault.protocolFeeTooltip}</p>
+					{#if vault.protocolFeeUrl}
 						<p>
-							The Enzyme protocol fee rate applied to the vault is 0.50%. Shares accrued can be bought back with MLN at
-							a 50% discount, leading to an effective protocol fee rate of 0.25%.
+							<a href={vault.protocolFeeUrl} target="_blank" rel="noreferrer">
+								Learn more about {vault.shortLabel} protocol fees
+							</a>.
 						</p>
-						<p>
-							<a href={enzymeFeeUrl} target="_blank" rel="noreferrer">Learn more about Enzyme protocol fees</a>.
-						</p>
-					</div>
-				</Tooltip>
-				<span>{formatPercent(enzymeProtocolFee, 2)}</span>
-			</div>
-		{/if}
+					{/if}
+				</div>
+			</Tooltip>
+			<span>{formatPercent(vault.protocolFee, 2)}</span>
+		</div>
 	</div>
 </section>
 
@@ -182,6 +179,13 @@
 			max-width: 50ch;
 			font: var(--f-ui-md-roman);
 			letter-spacing: var(--ls-ui-md-roman);
+
+			p {
+				margin: 0;
+				& + p {
+					margin-top: 0.75em;
+				}
+			}
 		}
 	}
 </style>

--- a/src/routes/strategies/[strategy]/fees/+page.ts
+++ b/src/routes/strategies/[strategy]/fees/+page.ts
@@ -1,0 +1,14 @@
+import { error } from '@sveltejs/kit';
+
+export async function load({ parent }) {
+	const { vault } = await parent();
+
+	if (!vault.depositEnabled()) {
+		error(404, 'Not found');
+	}
+
+	return {
+		vault, // type-narrowed vault
+		fees: await vault.getFees()
+	};
+}

--- a/src/routes/strategies/[strategy]/fees/+page.ts
+++ b/src/routes/strategies/[strategy]/fees/+page.ts
@@ -1,4 +1,5 @@
 import { error } from '@sveltejs/kit';
+import { config } from '$lib/wallet/client.js';
 
 export async function load({ parent }) {
 	const { vault } = await parent();
@@ -9,6 +10,6 @@ export async function load({ parent }) {
 
 	return {
 		vault, // type-narrowed vault
-		fees: await vault.getFees()
+		fees: await vault.getFees(config)
 	};
 }


### PR DESCRIPTION
close #889
toward #868

- modify /fees page to get fees from vault adapter
- add Lagoon protocol fee and tooltip/link
- get Lagoon vault fees from vault smart contract
- add Velvet Capital protocol fee and tooltip/link
