### PR TITLE
fix error on Velvet strategy overview page

### DIFF
--- a/src/lib/trade-executor/vaults/velvet/index.ts
+++ b/src/lib/trade-executor/vaults/velvet/index.ts
@@ -1,6 +1,8 @@
 import type { VelvetSmartContracts } from 'trade-executor/schemas/summary';
+import type { Config } from '@wagmi/core';
 import type { TokenBalance } from '$lib/eth-defi/schemas/token';
 import { BaseVault } from '../base';
+import { getTokenInfo } from '$lib/eth-defi/helpers';
 
 export class VelvetVault extends BaseVault<VelvetSmartContracts> {
 	readonly type = 'velvet';
@@ -25,8 +27,22 @@ export class VelvetVault extends BaseVault<VelvetSmartContracts> {
 		return `https://dapp.velvet.capital/VaultDetails/${this.contracts.portfolio}`;
 	}
 
-	// TODO: implement!
-	getShareValueUSD(): Promise<TokenBalance> {
-		throw new Error('Method not implemented');
+	// TODO: this is a temporary stub that only returns if share balance is 0
+	async getShareValueUSD(config: Config, address: Address): Promise<TokenBalance> {
+		// hard-code USDC for now
+		const usdcAddress = '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913';
+
+		const [usdcInfo, shareBalance] = await Promise.all([
+			getTokenInfo(config, { chainId: this.chain.id, address: usdcAddress }),
+			this.getShareBalance(config, address)
+		]);
+
+		// if share balance is 0, we know the value is 0
+		if (shareBalance.value === 0n) {
+			return { ...usdcInfo, value: 0n };
+		}
+
+		// otherwise, TBD (need to determine how to get share price or convert to share value)
+		throw new Error('Unable to calculate share value.');
 	}
 }

--- a/src/lib/wallet/MyDeposits.svelte
+++ b/src/lib/wallet/MyDeposits.svelte
@@ -81,6 +81,8 @@
 							<div class="vault-balance">
 								{formatDollar(formatBalance(balance))}
 							</div>
+						{:catch e}
+							<div class="vault-balance">---</div>
 						{/await}
 					{/if}
 				</div>


### PR DESCRIPTION
- getShareValueUSD currently throws error (not implemented)
- this was unhandled on MyDeposits - added `catch` branch to template
- implemented stub getShareValueUSD - returns when share balance is 0
