### PR TITLE
tv-chart: improve DataFeed fetch logic

### DIFF
--- a/src/lib/charts/Series.svelte
+++ b/src/lib/charts/Series.svelte
@@ -106,16 +106,14 @@
 
 		if (!children) return;
 
-		// push to event loop to allow TradingView to first create the series pane elements
-		setTimeout(() => {
-			try {
-				const target = series.getPane().getHTMLElement().querySelector('td:nth-child(2)');
-				if (!target) throw new Error('No series target HTML element found.');
+		// Use requestAnimationFrame to push to event loop and only run when window is in foreground
+		// (allows TradingView to first create the series pane elements)
+		requestAnimationFrame(() => {
+			const target = series.getPane().getHTMLElement().querySelector('td:nth-child(2)');
+			if (target) {
 				seriesContent = mount(SeriesContent, { target, props: { children } });
-			} catch (e) {
-				console.error(e);
 			}
-		}, 100);
+		});
 	});
 
 	// subscribe range changes (due to pan/zoom interactions)

--- a/src/lib/charts/Series.svelte
+++ b/src/lib/charts/Series.svelte
@@ -12,7 +12,7 @@
 	import SeriesContent from './SeriesContent.svelte';
 	import { getChartContext } from './TvChart.svelte';
 
-	const LOGICAL_RANGE_THRESHOLD = 50;
+	const LOGICAL_RANGE_THRESHOLD = 100;
 
 	const { chart, colors } = getChartContext();
 
@@ -75,11 +75,8 @@
 	function handleRangeChange(range: LogicalRange | null) {
 		visibileLogicalRange = range;
 
-		if (!dataFeed?.hasMoreData || !range) return;
-
-		if (range.from < LOGICAL_RANGE_THRESHOLD) {
-			const ticksVisible = Math.round(range.to - range.from) + 1;
-			dataFeed.fetchData(ticksVisible * 2);
+		if (dataFeed?.hasMoreData && range && range.from < LOGICAL_RANGE_THRESHOLD) {
+			dataFeed.fetchData();
 		}
 	}
 


### PR DESCRIPTION
- use endDate field to determine next fetch endDate
- fetch consistent number of ticks (seems to reduce TV error)
