### PR TITLE
tv-chart: use color-mix instead of relative color syntax

### DIFF
--- a/src/lib/charts/ChartTooltip.svelte
+++ b/src/lib/charts/ChartTooltip.svelte
@@ -41,7 +41,7 @@
 		z-index: 3;
 		padding: 1.125rem;
 		border-radius: var(--radius-md);
-		background: hsl(from var(--c-text-inverted) h s l / 80%);
+		background: color-mix(in srgb, transparent, var(--c-text-inverted) 80%);
 		box-shadow: var(--shadow-3);
 		white-space: nowrap;
 		pointer-events: none;

--- a/src/lib/charts/PairCandleChart.svelte
+++ b/src/lib/charts/PairCandleChart.svelte
@@ -169,7 +169,7 @@
 		:is(h3, .no-tvl-data) {
 			position: absolute;
 			padding: 0.125em 0.25em;
-			background: hsl(from var(--c-body) h s l / 60%);
+			background: color-mix(in srgb, transparent, var(--c-body) 60%);
 		}
 
 		h3 {

--- a/src/lib/charts/TvChart.svelte
+++ b/src/lib/charts/TvChart.svelte
@@ -271,13 +271,13 @@
 	}
 
 	.tv-chart {
-		--c-bullish-0: hsl(from var(--c-bullish) h s l / 0%);
-		--c-bearish-0: hsl(from var(--c-bearish) h s l / 0%);
-		--c-bullish-30: hsl(from var(--c-bullish) h s l / 30%);
-		--c-bearish-30: hsl(from var(--c-bearish) h s l / 30%);
+		--c-bullish-0: color-mix(in srgb, transparent, var(--c-bullish) 0.1%);
+		--c-bullish-30: color-mix(in srgb, transparent, var(--c-bullish) 30%);
+		--c-bearish-0: color-mix(in srgb, transparent, var(--c-bearish) 0.1%);
+		--c-bearish-30: color-mix(in srgb, transparent, var(--c-bearish) 30%);
 		--c-neutral: var(--c-text-ultra-light);
-		--c-neutral-0: hsl(from var(--c-text-ultra-light) h s l / 0%);
-		--c-neutral-30: hsl(from var(--c-text-ultra-light) h s l / 30%);
+		--c-neutral-0: color-mix(in srgb, transparent, var(--c-neutral) 0.1%);
+		--c-neutral-30: color-mix(in srgb, transparent, var(--c-neutral) 30%);
 		--c-axis-border: var(--cm-light, var(--c-text-light)) var(--cm-dark, var(--c-text-extra-light));
 		--c-grid-lines: var(--cm-light, var(--c-box-3)) var(--cm-dark, var(--c-box-1));
 		--c-pane-separator: var(--cm-light, var(--c-text-extra-light)) var(--cm-dark, var(--c-text-ultra-light));

--- a/src/routes/strategies/[strategy]/StrategyPerformanceChart.svelte
+++ b/src/routes/strategies/[strategy]/StrategyPerformanceChart.svelte
@@ -207,6 +207,8 @@
 				align-items: center;
 				font: var(--f-ui-sm-medium);
 				letter-spacing: var(--ls-ui-sm);
+				/* NOTE: There's no way to remove alpha-channel with color-mix, so have to use */
+				/* relative color syntax here (not supported by Mobile Safari < 16.4 ) */
 				color: hsl(from var(--color) h s l / 100%);
 			}
 


### PR DESCRIPTION
fixes #948
