### PR TITLE
Use share price metric when available

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -41,7 +41,8 @@ TS_PUBLIC_STRATEGIES=`[
     "id": "base-ath",
     "name": "All-time high on Base",
     "url": "https://base-ath.tradingstrategy.ai",
-    "frontpage": true
+    "frontpage": true,
+    "useSharePrice": true
   },
   {
     "id": "enzyme-polygon-eth-rolling-ratio",

--- a/src/lib/trade-executor/schemas/configuration.ts
+++ b/src/lib/trade-executor/schemas/configuration.ts
@@ -10,7 +10,8 @@ export const strategyConfigurationSchema = z.object({
 	hiddenPositions: primaryKey.array().default([]),
 	frontpage: z.boolean().default(false),
 	microsite: z.boolean().default(false),
-	depositExternal: z.boolean().default(false)
+	depositExternal: z.boolean().default(false),
+	useSharePrice: z.boolean().default(false)
 });
 export type StrategyConfiguration = z.infer<typeof strategyConfigurationSchema>;
 

--- a/src/lib/trade-executor/schemas/summary.ts
+++ b/src/lib/trade-executor/schemas/summary.ts
@@ -16,7 +16,7 @@ import {
 	duration,
 	hexString,
 	percent,
-	unixTimestamp,
+	performanceData,
 	unixTimestampToDate,
 	usDollarAmount
 } from './utility-types';
@@ -93,9 +93,6 @@ export type VaultOnChainData = OnChainData & {
 	asset_management_mode: Exclude<OnChainData['asset_management_mode'], 'hot_wallet'>;
 };
 
-export const performanceTupleSchema = z.tuple([unixTimestamp, usDollarAmount]);
-export type PerformanceTuple = z.infer<typeof performanceTupleSchema>;
-
 // See `calculate_key_metrics` in:
 // https://github.com/tradingstrategy-ai/trade-executor/blob/master/tradeexecutor/statistics/key_metric.py
 export const summaryKeyMetricKind = z.enum([
@@ -133,8 +130,8 @@ export const strategySummaryStatisticsSchema = z.object({
 	profitability_90_days: percent.nullish(),
 	return_all_time: percent.nullish(),
 	return_annualised: percent.nullish(),
-	compounding_unrealised_trading_profitability: performanceTupleSchema.array().nullish(),
-	performance_chart_90_days: performanceTupleSchema.array().nullish(),
+	compounding_unrealised_trading_profitability: performanceData.nullish(),
+	performance_chart_90_days: performanceData.nullish(),
 	key_metrics: summaryKeyMetricsSchema,
 	backtest_metrics_cut_off_period: duration.nullish()
 });

--- a/src/lib/trade-executor/schemas/summary.ts
+++ b/src/lib/trade-executor/schemas/summary.ts
@@ -127,11 +127,14 @@ export const strategySummaryStatisticsSchema = z.object({
 	last_trade_at: unixTimestampToDate.nullish(),
 	enough_data: z.boolean().nullish(),
 	current_value: usDollarAmount.nullish(),
-	profitability_90_days: percent.nullish(),
+	// Deprecated - remove when this is no longer in trade-executor
+	// profitability_90_days: percent.nullish(),
 	return_all_time: percent.nullish(),
 	return_annualised: percent.nullish(),
 	compounding_unrealised_trading_profitability: performanceData.nullish(),
-	performance_chart_90_days: performanceData.nullish(),
+	// Deprecated - remove when this is no longer in trade-executor
+	// performance_chart_90_days: performanceData.nullish(),
+	share_price_returns_90_days: performanceData.nullish(),
 	key_metrics: summaryKeyMetricsSchema,
 	backtest_metrics_cut_off_period: duration.nullish()
 });

--- a/src/lib/trade-executor/schemas/utility-types.ts
+++ b/src/lib/trade-executor/schemas/utility-types.ts
@@ -48,3 +48,9 @@ export type USDollarAmount = z.infer<typeof usDollarAmount>;
 
 export const usDollarPrice = z.coerce.number();
 export type USDollarPrice = z.infer<typeof usDollarPrice>;
+
+export const performanceTuple = z.tuple([unixTimestamp, decimalToNumber]);
+export type PerformanceTuple = z.infer<typeof performanceTuple>;
+
+export const performanceData = performanceTuple.array();
+export type PerformanceData = z.infer<typeof performanceData>;

--- a/src/lib/trade-executor/schemas/web-chart.ts
+++ b/src/lib/trade-executor/schemas/web-chart.ts
@@ -1,0 +1,31 @@
+/**
+ * zod schemas for Trade Executor web chart endpoint
+ *
+ * Based on Python classes found in:
+ * https://github.com/tradingstrategy-ai/trade-executor/blob/master/tradeexecutor/visual/web_chart.py
+ *
+ */
+import { z } from 'zod';
+import { performanceData } from './utility-types';
+
+export const webChartType = z.enum([
+	'compounding_unrealised_trading_profitability_sampled',
+	'compounding_realised_profitability',
+	'realised_profitability',
+	'netflow',
+	'total_equity',
+	'share_price',
+	'share_price_based_return'
+]);
+export type WebChartType = z.infer<typeof webChartType>;
+
+export const webChartSource = z.enum(['live_trading', 'backtest']);
+export type WebChartSource = z.infer<typeof webChartSource>;
+
+export const webChartSchema = z.object({
+	data: performanceData,
+	title: z.string(),
+	help_link: z.string(),
+	source: webChartSource
+});
+export type WebChart = z.infer<typeof webChartSchema>;

--- a/src/routes/strategies/StrategyTile.svelte
+++ b/src/routes/strategies/StrategyTile.svelte
@@ -33,10 +33,11 @@
 
 	const href = `/strategies/${strategy.id}`;
 
-	const chartData = normalizeDataForInterval(
-		strategy.summary_statistics?.compounding_unrealised_trading_profitability ?? [],
-		utcDay
-	);
+	const rawChartData = strategy.useSharePrice
+		? strategy.summary_statistics?.share_price_returns_90_days
+		: strategy.summary_statistics?.compounding_unrealised_trading_profitability;
+
+	const chartData = normalizeDataForInterval(rawChartData ?? [], utcDay);
 </script>
 
 <div class="strategy-tile ds-3 targetable">

--- a/src/routes/strategies/[strategy]/StrategyPerformanceChart.svelte
+++ b/src/routes/strategies/[strategy]/StrategyPerformanceChart.svelte
@@ -16,6 +16,10 @@
 
 	let chartClient = $derived(getChartClient(fetch, strategy.url));
 
+	let chartDataType = $derived(
+		strategy.useSharePrice ? 'share_price_based_return' : 'compounding_unrealised_trading_profitability_sampled'
+	);
+
 	let benchmarkTokens = $derived(getBenchmarkTokens(strategy));
 
 	let loading = $derived($chartClient.loading || benchmarkTokens.some((t) => t.loading));
@@ -37,7 +41,7 @@
 	// fetch chart data (initial load or when chartClient is updated)
 	$effect(() => {
 		chartClient.fetch({
-			type: 'compounding_unrealised_trading_profitability_sampled',
+			type: chartDataType,
 			source: 'live_trading'
 		});
 	});

--- a/src/routes/strategies/[strategy]/performance/+page.svelte
+++ b/src/routes/strategies/[strategy]/performance/+page.svelte
@@ -20,11 +20,15 @@
 
 	let tableData = $derived(strategyState.stats.long_short_metrics_latest?.[dataSource.table]);
 
+	let chartDataType = $derived(
+		strategy.useSharePrice ? 'share_price_based_return' : 'compounding_unrealised_trading_profitability_sampled'
+	);
+
 	const chartClient = getChartClient(fetch, strategy.url);
 
 	$effect(() => {
 		chartClient.fetch({
-			type: 'compounding_unrealised_trading_profitability_sampled',
+			type: chartDataType,
 			source: dataSource.chart
 		});
 	});


### PR DESCRIPTION
- Add new `useSharePrice` config option (temporary)
- Use `share_price_returns_90_days` when `useSharePrice=true` on strategy tile (index views)
- Use `share_price_based_return` chart type when `useSharePrice=true` (overview and performance tab)

close #968
