### PR TITLE
More share price updates

### DIFF
--- a/src/routes/strategies/[strategy]/period-performance/+server.ts
+++ b/src/routes/strategies/[strategy]/period-performance/+server.ts
@@ -44,8 +44,8 @@ function getPerformanceSummary(data: [number, number][], end: Date, timeBucket: 
 	const startTs = dateToTs(start);
 	const endTs = dateToTs(end);
 
-	const first = data.findLast(([ts]) => ts < startTs)!;
-	const last = data.findLast(([ts]) => ts < endTs)!;
+	const first = data.findLast(([ts]) => ts <= startTs)!;
+	const last = data.findLast(([ts]) => ts <= endTs)!;
 
 	const performance = relativeReturn(first?.[1], last?.[1]);
 	const annualized = performance && annualizedReturn(start, end, performance);

--- a/src/routes/strategies/[strategy]/period-performance/+server.ts
+++ b/src/routes/strategies/[strategy]/period-performance/+server.ts
@@ -1,39 +1,42 @@
+import { error, json } from '@sveltejs/kit';
 import { dateToTs, timeBucketToIntervalParts } from '$lib/charts/helpers';
-import { parseDate } from '$lib/helpers/date.js';
+import { getDateParam } from '$lib/helpers/url-params.js';
 import { relativeReturn, annualizedReturn } from '$lib/helpers/financial.js';
 import { timeBucketEnum } from '$lib/schemas/utility.js';
-import { error, json } from '@sveltejs/kit';
-import { getStrategyInfo } from 'trade-executor/client/strategy-info.js';
+import { fetchChartData } from 'trade-executor/client/chart.js';
 import { configuredStrategies } from 'trade-executor/schemas/configuration';
 
 const periodTimeBuckets = timeBucketEnum.exclude(['1m', '5m', '15m']).options;
 
 type PeriodTimeBucket = (typeof periodTimeBuckets)[number];
 
-// return an array of period performance summaries
+/**
+ * Return an array of period performance summaries
+ */
 export async function GET({ fetch, params, url }) {
-	const strategyConf = configuredStrategies.get(params.strategy);
-	if (!strategyConf) error(404, 'Not found');
+	// verify strategy is configured
+	const strategy = configuredStrategies.get(params.strategy);
+	if (!strategy) error(404, 'Not found');
 
-	const strategy = await getStrategyInfo(fetch, strategyConf);
+	// parse `end` param, default to current date
+	const endDate = getDateParam(url.searchParams, 'end') ?? new Date();
 
-	// parse `end` param (if provided) and set `endDate` to provided value or current date
-	const end = url.searchParams.get('end');
-	const endDate = end ? parseDate(end) : new Date();
-
-	// return error if invalid `end` param supplied
-	if (!endDate) {
-		error(400, 'param `end` must be a valid date string or timestamp (or omitted for current date)');
-	}
+	// get performance data
+	const { data } = await fetchChartData(fetch, strategy.url, {
+		source: 'live_trading',
+		type: strategy.useSharePrice ? 'share_price_based_return' : 'compounding_unrealised_trading_profitability_sampled'
+	});
 
 	// get performance summaries for specified time buckets
-	const data = strategy.summary_statistics?.compounding_unrealised_trading_profitability ?? [];
 	const performanceSummaries = periodTimeBuckets.map((timeBucket) => getPerformanceSummary(data, endDate, timeBucket));
 
+	// return JSON response object
 	return json(performanceSummaries);
 }
 
-// check performance of strategy over time interval
+/**
+ * Summarize performance of strategy for a given time interval
+ */
 function getPerformanceSummary(data: [number, number][], end: Date, timeBucket: PeriodTimeBucket) {
 	const [interval, duration] = timeBucketToIntervalParts(timeBucket);
 	const start = interval.offset(end, -duration);

--- a/src/routes/strategies/[strategy]/period-performance/+server.ts
+++ b/src/routes/strategies/[strategy]/period-performance/+server.ts
@@ -1,14 +1,18 @@
+import type { PerformanceTuple } from 'trade-executor/schemas/utility-types';
 import { error, json } from '@sveltejs/kit';
 import { timeBucketEnum } from '$lib/schemas/utility.js';
 import { configuredStrategies } from 'trade-executor/schemas/configuration';
 import { getDateParam } from '$lib/helpers/url-params.js';
 import { fetchChartData } from 'trade-executor/client/chart.js';
-import { dateToTs, timeBucketToIntervalParts } from '$lib/charts/helpers';
+import { timeBucketToIntervalParts, dateToTs, tsToDate } from '$lib/charts/helpers';
 import { relativeReturn } from '$lib/helpers/financial.js';
 
 const periodTimeBuckets = timeBucketEnum.exclude(['1m', '5m', '15m']).options;
 
 type PeriodTimeBucket = (typeof periodTimeBuckets)[number];
+
+// Used to a add a buffer to time periods when checking for entries in-range
+const PERIOD_BUFFER_MINUTES = 5;
 
 /**
  * Return an array of period performance summaries
@@ -18,7 +22,7 @@ export async function GET({ fetch, params, url }) {
 	const strategy = configuredStrategies.get(params.strategy);
 	if (!strategy) error(404, 'Not found');
 
-	// parse `end` param, default to current date
+	// parse `end` param (default to current date)
 	const endDate = getDateParam(url.searchParams, 'end') ?? new Date();
 
 	// get performance data
@@ -27,8 +31,18 @@ export async function GET({ fetch, params, url }) {
 		type: strategy.useSharePrice ? 'share_price_based_return' : 'compounding_unrealised_trading_profitability_sampled'
 	});
 
+	// find the last entry prior to requested end date and use this as end target instead
+	// (this helps maximize the data points found per period since strategies run on regular cycles)
+	const endTs = dateToTs(endDate);
+	const lastEntry = data.findLast(([ts]) => ts <= endTs);
+
+	// return empty JSON array response if no lastEntry found
+	if (!lastEntry) return json([]);
+
 	// get performance summaries for specified time buckets
-	const performanceSummaries = periodTimeBuckets.map((timeBucket) => getPerformanceSummary(data, endDate, timeBucket));
+	const performanceSummaries = periodTimeBuckets.map((timeBucket) => {
+		return getPerformanceSummary(data, timeBucket, lastEntry);
+	});
 
 	// return JSON response object
 	return json(performanceSummaries);
@@ -37,27 +51,31 @@ export async function GET({ fetch, params, url }) {
 /**
  * Summarize performance of strategy for a given time interval
  */
-function getPerformanceSummary(data: [number, number][], end: Date, timeBucket: PeriodTimeBucket) {
+function getPerformanceSummary(data: PerformanceTuple[], timeBucket: PeriodTimeBucket, lastEntry: PerformanceTuple) {
+	// get the last entry date
+	const end = tsToDate(lastEntry[0]);
+
 	// find the start time based on end and interval
 	const [interval, duration] = timeBucketToIntervalParts(timeBucket);
 	const start = interval.offset(end, -duration);
+
+	// add a small buffer to the start time due to variability in cycle times
+	start.setUTCMinutes(start.getUTCMinutes() - PERIOD_BUFFER_MINUTES);
 
 	// get the start and end timestamps as they are needed for iterator comparisions
 	const startTs = dateToTs(start);
 	const endTs = dateToTs(end);
 
-	// find the first and last data point within the interval time window
-	const first = data.find(([ts]) => ts >= startTs && ts <= endTs);
-	const last = data.findLast(([ts]) => ts <= endTs && ts >= startTs);
+	// find the first entry within the interval time window
+	const firstEntry = data.find(([ts]) => ts >= startTs && ts <= endTs);
 
-	const performance = first !== last ? relativeReturn(first?.[1], last?.[1]) : undefined;
+	const performance = firstEntry !== lastEntry ? relativeReturn(firstEntry?.[1], lastEntry?.[1]) : undefined;
 
 	return {
 		timeBucket,
 		start,
 		end,
-		first: first ?? null,
-		last: last ?? null,
+		first: firstEntry ? tsToDate(firstEntry?.[0]) : null,
 		performance: performance ?? null
 	};
 }

--- a/src/routes/strategies/[strategy]/snapshot/+page.ts
+++ b/src/routes/strategies/[strategy]/snapshot/+page.ts
@@ -20,14 +20,14 @@ export async function load({ fetch, params, url }) {
 		error(400, 'start and end query params required');
 	}
 
-	const resp = await fetchChartData(fetch, strategy.url, {
-		type: 'compounding_unrealised_trading_profitability_sampled',
-		source: 'live_trading'
+	const { data } = await fetchChartData(fetch, strategy.url, {
+		source: 'live_trading',
+		type: strategy.useSharePrice ? 'share_price_based_return' : 'compounding_unrealised_trading_profitability_sampled'
 	});
 
 	return {
 		strategy,
-		chartData: normalizeDataForInterval(resp.data, utcHour),
+		chartData: normalizeDataForInterval(data, utcHour),
 		dateRange: [startDate, endDate] as [Date, Date],
 		// remove unneeded layout items (page used only for generating social media image)
 		skipNavbar: true,

--- a/src/routes/strategies/[strategy]/snapshot/+page.ts
+++ b/src/routes/strategies/[strategy]/snapshot/+page.ts
@@ -1,10 +1,10 @@
+import type { SimpleDataItem } from '$lib/charts/types.js';
 import { error } from '@sveltejs/kit';
 import { configuredStrategies } from 'trade-executor/schemas/configuration';
 import { getStrategyInfo } from 'trade-executor/client/strategy-info';
 import { fetchChartData } from 'trade-executor/client/chart';
 import { getDateParam } from '$lib/helpers/url-params.js';
-import { normalizeDataForInterval } from '$lib/charts/helpers';
-import { utcHour } from 'd3-time';
+import { dateToTs } from '$lib/charts/helpers';
 
 export async function load({ fetch, params, url }) {
 	const strategyConf = configuredStrategies.get(params.strategy);
@@ -20,15 +20,27 @@ export async function load({ fetch, params, url }) {
 		error(400, 'start and end query params required');
 	}
 
+	const range = {
+		from: dateToTs(startDate),
+		to: dateToTs(endDate)
+	};
+
 	const { data } = await fetchChartData(fetch, strategy.url, {
 		source: 'live_trading',
 		type: strategy.useSharePrice ? 'share_price_based_return' : 'compounding_unrealised_trading_profitability_sampled'
 	});
 
+	const chartData = data
+		// exclude records with duplicate or or out-of-order timestamps
+		.filter(([ts], index) => !(ts >= data[index + 1]?.[0]))
+		// map to TvChart SimpleDataItem records
+		.map(([time, value]) => ({ time, value })) as SimpleDataItem[];
+
 	return {
 		strategy,
-		chartData: normalizeDataForInterval(data, utcHour),
-		dateRange: [startDate, endDate] as [Date, Date],
+		chartData,
+		range,
+
 		// remove unneeded layout items (page used only for generating social media image)
 		skipNavbar: true,
 		skipFooter: true


### PR DESCRIPTION
- Use share price data on period-performance endpoint and performance snapshot page
- Don't resample data when calculating period performance or rendering performance snapshot chart
- Use last entry prior to requested end date for period performance periods

close #971 
close #972 