### PR TITLE
Add minimum TVL threshold for vault group breakdown pages

### DIFF
--- a/src/lib/top-vaults/helpers.ts
+++ b/src/lib/top-vaults/helpers.ts
@@ -3,6 +3,9 @@ import { resolve } from '$app/paths';
 import { getChain } from '$lib/helpers/chain';
 import { isNumber } from '$lib/helpers/formatters';
 
+/** Minimum TVL threshold for vault group breakdown pages */
+export const MIN_TVL_THRESHOLD = 10_000;
+
 /**
  * Resolve path to vault datails page for a given vault
  */
@@ -20,6 +23,11 @@ export function isBlacklisted(vault: VaultInfo) {
 
 export function hasSupportedProtocol(vault: VaultInfo) {
 	return !vault.protocol.startsWith('<');
+}
+
+/** Check if vault meets minimum TVL threshold */
+export function meetsMinTvl(vault: VaultInfo, threshold = MIN_TVL_THRESHOLD) {
+	return (vault.current_nav ?? 0) >= threshold;
 }
 
 /**

--- a/src/routes/trading-view/vaults/chains/+page.ts
+++ b/src/routes/trading-view/vaults/chains/+page.ts
@@ -1,5 +1,5 @@
 import type { VaultGroup } from '$lib/top-vaults/schemas.js';
-import { isBlacklisted } from '$lib/top-vaults/helpers.js';
+import { isBlacklisted, meetsMinTvl } from '$lib/top-vaults/helpers.js';
 import { sortOptions } from '$lib/top-vaults/VaultGroupTable.svelte';
 import { getNumberParam, getStringParam } from '$lib/helpers/url-params';
 import { getChain } from '$lib/helpers/chain';
@@ -10,7 +10,7 @@ export async function load({ parent, url: { searchParams } }) {
 	type ChainAccumulator = VaultGroup & { weighted_apy_sum: number; tvl_with_apy: number };
 
 	const chains = topVaults.vaults.reduce<Record<string, ChainAccumulator>>((acc, vault) => {
-		if (isBlacklisted(vault)) return acc;
+		if (isBlacklisted(vault) || !meetsMinTvl(vault)) return acc;
 
 		const chain = getChain(vault.chain_id);
 		if (!chain) return acc;

--- a/src/routes/trading-view/vaults/protocols/+page.ts
+++ b/src/routes/trading-view/vaults/protocols/+page.ts
@@ -1,5 +1,5 @@
 import type { VaultGroup } from '$lib/top-vaults/schemas.js';
-import { isBlacklisted } from '$lib/top-vaults/helpers.js';
+import { isBlacklisted, meetsMinTvl } from '$lib/top-vaults/helpers.js';
 import { sortOptions } from '$lib/top-vaults/VaultGroupTable.svelte';
 import { getNumberParam, getStringParam } from '$lib/helpers/url-params';
 
@@ -9,7 +9,7 @@ export async function load({ parent, url: { searchParams } }) {
 	type ProtocolAccumulator = VaultGroup & { weighted_apy_sum: number; tvl_with_apy: number };
 
 	const protocols = topVaults.vaults.reduce<Record<string, ProtocolAccumulator>>((acc, vault) => {
-		if (isBlacklisted(vault)) return acc;
+		if (isBlacklisted(vault) || !meetsMinTvl(vault)) return acc;
 
 		const slug = vault.protocol_slug;
 

--- a/src/routes/trading-view/vaults/stablecoins/+page.ts
+++ b/src/routes/trading-view/vaults/stablecoins/+page.ts
@@ -1,5 +1,5 @@
 import type { VaultGroup } from '$lib/top-vaults/schemas.js';
-import { isBlacklisted } from '$lib/top-vaults/helpers.js';
+import { isBlacklisted, meetsMinTvl } from '$lib/top-vaults/helpers.js';
 import { sortOptions } from '$lib/top-vaults/VaultGroupTable.svelte';
 import { getNumberParam, getStringParam } from '$lib/helpers/url-params';
 
@@ -9,7 +9,7 @@ export async function load({ parent, url: { searchParams } }) {
 	type StablecoinAccumulator = VaultGroup & { weighted_apy_sum: number; tvl_with_apy: number };
 
 	const stablecoins = topVaults.vaults.reduce<Record<string, StablecoinAccumulator>>((acc, vault) => {
-		if (isBlacklisted(vault) || !vault.stablecoinish) return acc;
+		if (isBlacklisted(vault) || !vault.stablecoinish || !meetsMinTvl(vault)) return acc;
 
 		const slug = vault.denomination_slug;
 


### PR DESCRIPTION
## Summary
- Add `MIN_TVL_THRESHOLD` constant (10,000) and `meetsMinTvl` helper to vault utils
- Filter vaults with TVL < $10,000 from protocol, stablecoin, and chain breakdown pages
- Ensures only vaults with meaningful TVL are included in group calculations

## Test plan
- [ ] Visit `/trading-view/vaults/protocols` and verify low TVL vaults are excluded
- [ ] Visit `/trading-view/vaults/stablecoins` and verify low TVL vaults are excluded
- [ ] Visit `/trading-view/vaults/chains` and verify low TVL vaults are excluded

🤖 Generated with [Claude Code](https://claude.com/claude-code)