### PR TITLE
Increase initial vault page size from 100 to 150

### DIFF
--- a/src/lib/top-vaults/TopVaultsTable.svelte
+++ b/src/lib/top-vaults/TopVaultsTable.svelte
@@ -21,7 +21,7 @@
 	import { getFormattedLockup, isBlacklisted, resolveVaultDetails } from './helpers';
 
 	const TVL_THRESHOLD_DEFAULT = 50_000;
-	const INITIAL_ROW_COUNT = 100;
+	const INITIAL_ROW_COUNT = 150;
 	const ROW_BATCH_SIZE = 50;
 
 	interface SortOptions {


### PR DESCRIPTION
## Summary
- Increase `INITIAL_ROW_COUNT` from 100 to 150 in the `TopVaultsTable` component
- This affects all vault breakdown pages (by chain, by protocol, and by stablecoin)

## Test plan
- [ ] Visit vault pages and verify 150 vaults load initially
- [ ] Verify infinite scroll still works for additional vaults

🤖 Generated with [Claude Code](https://claude.com/claude-code)