### PR TITLE
Update chain vault listing minimum TVL to k

### DIFF
--- a/src/routes/trading-view/vaults/chains/[chain=slug]/+page.svelte
+++ b/src/routes/trading-view/vaults/chains/[chain=slug]/+page.svelte
@@ -15,7 +15,7 @@
 	{topVaults}
 	breadcrumbs={{ chains: 'Chains', [chainSlug]: chainName }}
 	title="Top {chainName} vaults"
-	subtitle="The best performing stablecoin vaults on {chainName} with minimum $50k USD TVL"
-	tvlThreshold={50000}
+	subtitle="The best performing stablecoin vaults on {chainName} with minimum $10k USD TVL"
+	tvlThreshold={10000}
 	filterTvl={true}
 />


### PR DESCRIPTION
## Summary
- Updated minimum TVL threshold for per-chain vault listings from $50k to $10k
- Updated subtitle text to reflect the new $10k minimum

## Context
The protocol and stablecoin vault listing pages were already using $10k minimum TVL, but the chain vault listing page was still using $50k. This PR brings consistency across all vault listing pages.

## Changes
- Modified [chains/[chain=slug]/+page.svelte](src/routes/trading-view/vaults/chains/[chain=slug]/+page.svelte):
  - Changed `tvlThreshold` from `50000` to `10000`
  - Updated subtitle text from "$50k USD TVL" to "$10k USD TVL"

## Test plan
- [ ] Verify that chain vault listing pages (e.g., `/trading-view/vaults/chains/hyperliquid`) now display "$10k USD TVL" in the subtitle
- [ ] Confirm that vaults with TVL between $10k-$50k are now visible on chain listing pages
- [ ] Check that the filtering behaviour is consistent with protocol and stablecoin listing pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)