### PR TITLE
Fix TVL filtering on new vaults page

### DIFF
--- a/src/routes/trading-view/vaults/new-vaults/+page.svelte
+++ b/src/routes/trading-view/vaults/new-vaults/+page.svelte
@@ -19,4 +19,5 @@
 	title="New DeFi stablecoin vaults"
 	subtitle="The best performing DeFi stablecoin vaults that started within the last {maxAgeDays} days"
 	tvlThreshold={10_000}
+	filterTvl
 />


### PR DESCRIPTION
## Summary
- Adds missing `filterTvl` prop to enable the $10K TVL filtering on the new vaults page
- Previously, vaults with TVL below the threshold were still displayed even though the UI showed "Min. TVL $10K"

## Test plan
- [ ] Visit `/trading-view/vaults/new-vaults`
- [ ] Verify all listed vaults have TVL >= $10K
- [ ] Verify vault count is reduced (from ~80 to ~58)

🤖 Generated with [Claude Code](https://claude.com/claude-code)