### PR TITLE
Increase vault pagination from 50 to 150 items per page

### DIFF
--- a/src/lib/top-vaults/VaultGroupTable.svelte
+++ b/src/lib/top-vaults/VaultGroupTable.svelte
@@ -64,7 +64,7 @@
 			toggleOrder: ['desc', 'asc']
 		}),
 		page: addPagination({
-			initialPageSize: 50,
+			initialPageSize: 150,
 			initialPageIndex: pageIndex
 		})
 	});


### PR DESCRIPTION
Changes the pagination for vault listing pages (protocols, chains, and stablecoins) from 50 to 150 items per page for better user experience when browsing vaults.