### PR TITLE
Update vault chains page subtitle copy

### DIFF
--- a/src/routes/trading-view/vaults/chains/+page.svelte
+++ b/src/routes/trading-view/vaults/chains/+page.svelte
@@ -31,7 +31,7 @@
 <main class="chain-index-page">
 	<Section tag="header">
 		<VaultListingsSelector />
-		<HeroBanner subtitle="Browse DeFi vaults grouped by blockchain">
+		<HeroBanner subtitle="Browse DeFi stablecoin vaults by their blockchain">
 			{#snippet title()}
 				<span>DeFi vaults by chain</span>
 				<DataBadge class="badge" status="warning">Beta</DataBadge>


### PR DESCRIPTION
## Summary
- Updated HeroBanner subtitle on the vault chains page from "Browse DeFi vaults grouped by blockchain" to "Browse DeFi stablecoin vaults by their blockchain"

## Test plan
- [ ] Verify the updated subtitle renders correctly on the vault chains page

🤖 Generated with [Claude Code](https://claude.com/claude-code)