### PR TITLE
feat: Add Twitter card and Telegram link previews to all vault pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,1 +1,3 @@
 # Weblog of stuff
+
+- Added Twitter card and Telegram link previews to all vault pages (2026-02-10)

--- a/src/routes/strategies/[strategy]/vault/+page.svelte
+++ b/src/routes/strategies/[strategy]/vault/+page.svelte
@@ -2,6 +2,7 @@
 	Page to display vault information.
 -->
 <script lang="ts">
+	import { page } from '$app/state';
 	import Button from '$lib/components/Button.svelte';
 	import CryptoAddressWidget from '$lib/components/CryptoAddressWidget.svelte';
 	import DataBox from '$lib/components/DataBox.svelte';
@@ -9,16 +10,24 @@
 	import SummaryBox from '$lib/components/SummaryBox.svelte';
 	import { getLogoUrl } from '$lib/helpers/assets';
 	import { getExplorerUrl } from '$lib/helpers/chain';
+	import { MetaTags } from 'svelte-meta-tags';
 	import IconArrowRightUp from '~icons/local/arrow-right-up';
 
 	let { data } = $props();
 	let { chain, strategy, vault } = $derived(data);
+
+	let title = $derived(`Enzyme vault | ${strategy.name} | Trading Strategy`);
+	let description = $derived(`Enzyme vault information for ${strategy.name} strategy`);
+	let pageUrl = $derived(new URL(page.url.pathname, page.url.origin).href);
 </script>
 
-<svelte:head>
-	<title>Enzyme vault | {strategy.name} | Trading Strategy</title>
-	<meta name="description" content="Enzyme vault information for {strategy.name} strategy" />
-</svelte:head>
+<MetaTags
+	{title}
+	{description}
+	canonical={pageUrl}
+	openGraph={{ siteName: 'Trading Strategy', url: pageUrl, title, description, type: 'website' }}
+	twitter={{ site: '@TradingProtocol', cardType: 'summary', title, description }}
+/>
 
 <section class="vault">
 	<SummaryBox title="Vault information" ctaPosition="top">

--- a/src/routes/trading-view/vaults/+page.svelte
+++ b/src/routes/trading-view/vaults/+page.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
+	import { page } from '$app/state';
 	import type { TopVaults } from '$lib/top-vaults/schemas.js';
 	import TopVaultsPage from '$lib/top-vaults/TopVaultsPage.svelte';
+	import { MetaTags } from 'svelte-meta-tags';
 
 	function filterByMinTvl(topVaults: TopVaults, tvlThreshold: number) {
 		const vaults = topVaults.vaults.filter((vault) => {
@@ -12,12 +14,19 @@
 
 	let { data } = $props();
 	let topVaults = $derived(filterByMinTvl(data.topVaults, 50_000));
+
+	const title = 'Top DeFi stablecoin vaults';
+	const description = 'The best DeFi vaults for all blockchains.';
+	let pageUrl = $derived(new URL(page.url.pathname, page.url.origin).href);
 </script>
 
-<svelte:head>
-	<title>Top DeFi stablecoin vaults</title>
-	<meta name="description" content="The best DeFi vaults for all blockchains." />
-</svelte:head>
+<MetaTags
+	{title}
+	{description}
+	canonical={pageUrl}
+	openGraph={{ siteName: 'Trading Strategy', url: pageUrl, title, description, type: 'website' }}
+	twitter={{ site: '@TradingProtocol', cardType: 'summary', title, description }}
+/>
 
 <TopVaultsPage
 	{topVaults}

--- a/src/routes/trading-view/vaults/[vault=slug]/SocialMetaTags.svelte
+++ b/src/routes/trading-view/vaults/[vault=slug]/SocialMetaTags.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
 	import { page } from '$app/state';
+	import { vaultSparklinesUrl } from '$lib/config';
 	import type { Chain } from '$lib/helpers/chain';
+	import { formatDollar, formatPercent } from '$lib/helpers/formatters';
 	import type { VaultInfo } from '$lib/top-vaults/schemas';
 	import { MetaTags, JsonLd } from 'svelte-meta-tags';
 
@@ -11,9 +13,19 @@
 
 	let { vault, chain }: Props = $props();
 
-	let description = $derived(`Vault details for ${vault.name} vault on ${vault.protocol} on ${chain.name}`);
+	let description = $derived.by(() => {
+		const parts = [`${vault.name} on ${vault.protocol} on ${chain.name}`];
+		if (vault.current_nav != null) {
+			parts.push(`TVL: ${formatDollar(vault.current_nav, 0)}`);
+		}
+		if (vault.one_month_returns != null) {
+			parts.push(`1M return: ${formatPercent(vault.one_month_returns)}`);
+		}
+		return parts.join(' | ');
+	});
+
 	let pageUrl = $derived(new URL(page.url.pathname, page.url.origin).href);
-	let imageUrl = $derived(`https://vault-sparklines.tradingstrategy.ai/sparkline-90d-${vault.id}.png`);
+	let imageUrl = $derived(`${vaultSparklinesUrl}/sparkline-90d-${vault.id}.png`);
 </script>
 
 <MetaTags

--- a/src/routes/trading-view/vaults/all/+page.svelte
+++ b/src/routes/trading-view/vaults/all/+page.svelte
@@ -2,19 +2,28 @@
 All vaults listing including problematic/blacklisted vaults
 -->
 <script lang="ts">
+	import { page } from '$app/state';
 	import TopVaultsPage from '$lib/top-vaults/TopVaultsPage.svelte';
 	import { formatDollar } from '$lib/helpers/formatters.js';
+	import { MetaTags } from 'svelte-meta-tags';
 
 	let { data } = $props();
 	let { topVaults, tvlThreshold } = $derived(data);
 
 	let minTvlString = $derived(formatDollar(tvlThreshold, 0));
+
+	const title = 'All DeFi stablecoin vaults';
+	const description = 'All stablecoin vaults, including ones with stuck funds and oracle problems.';
+	let pageUrl = $derived(new URL(page.url.pathname, page.url.origin).href);
 </script>
 
-<svelte:head>
-	<title>All DeFi stablecoin vaults</title>
-	<meta name="description" content="All stablecoin vaults, including ones with stuck funds and oracle problems." />
-</svelte:head>
+<MetaTags
+	{title}
+	{description}
+	canonical={pageUrl}
+	openGraph={{ siteName: 'Trading Strategy', url: pageUrl, title, description, type: 'website' }}
+	twitter={{ site: '@TradingProtocol', cardType: 'summary', title, description }}
+/>
 
 <TopVaultsPage
 	{topVaults}

--- a/src/routes/trading-view/vaults/chains/+page.svelte
+++ b/src/routes/trading-view/vaults/chains/+page.svelte
@@ -2,12 +2,14 @@
 	import type { ComponentProps } from 'svelte';
 	import { goto } from '$app/navigation';
 	import { resolve } from '$app/paths';
+	import { page } from '$app/state';
 	import DataBadge from '$lib/components/DataBadge.svelte';
 	import HeroBanner from '$lib/components/HeroBanner.svelte';
 	import Section from '$lib/components/Section.svelte';
 	import VaultGroupTable from '$lib/top-vaults/VaultGroupTable.svelte';
 	import VaultListingsSelector from '$lib/top-vaults/VaultListingsSelector.svelte';
 	import { getLogoUrl } from '$lib/helpers/assets';
+	import { MetaTags } from 'svelte-meta-tags';
 
 	let { data } = $props();
 	let { chains, options } = $derived(data);
@@ -21,12 +23,19 @@
 	function getHref(slug: string) {
 		return resolve(`/trading-view/vaults/chains/${slug}`);
 	}
+
+	const title = 'DeFi stablecoin vaults by chain';
+	const description = 'Top DeFi vaults, grouped by blockchain';
+	let pageUrl = $derived(new URL(page.url.pathname, page.url.origin).href);
 </script>
 
-<svelte:head>
-	<title>DeFi stablecoin vaults by chain</title>
-	<meta name="description" content="Top DeFi vaults, grouped by blockchain" />
-</svelte:head>
+<MetaTags
+	{title}
+	{description}
+	canonical={pageUrl}
+	openGraph={{ siteName: 'Trading Strategy', url: pageUrl, title, description, type: 'website' }}
+	twitter={{ site: '@TradingProtocol', cardType: 'summary', title, description }}
+/>
 
 <main class="chain-index-page">
 	<Section tag="header">

--- a/src/routes/trading-view/vaults/chains/[chain=slug]/+page.svelte
+++ b/src/routes/trading-view/vaults/chains/[chain=slug]/+page.svelte
@@ -1,14 +1,23 @@
 <script lang="ts">
+	import { page } from '$app/state';
 	import TopVaultsPage from '$lib/top-vaults/TopVaultsPage.svelte';
+	import { MetaTags } from 'svelte-meta-tags';
 
 	let { data } = $props();
 	let { chain, chainSlug, chainName, topVaults } = $derived(data);
+
+	let title = $derived(`${chainName} top vaults`);
+	let description = $derived(`Top stablecoin vaults on ${chainName} blockchain ranked by performance.`);
+	let pageUrl = $derived(new URL(page.url.pathname, page.url.origin).href);
 </script>
 
-<svelte:head>
-	<title>{chainName} top vaults</title>
-	<meta name="description" content="Top stablecoin vaults on {chainName} blockchain ranked by performance." />
-</svelte:head>
+<MetaTags
+	{title}
+	{description}
+	canonical={pageUrl}
+	openGraph={{ siteName: 'Trading Strategy', url: pageUrl, title, description, type: 'website' }}
+	twitter={{ site: '@TradingProtocol', cardType: 'summary', title, description }}
+/>
 
 <TopVaultsPage
 	{chain}

--- a/src/routes/trading-view/vaults/high-tvl/+page.svelte
+++ b/src/routes/trading-view/vaults/high-tvl/+page.svelte
@@ -1,17 +1,26 @@
 <script lang="ts">
+	import { page } from '$app/state';
 	import TopVaultsPage from '$lib/top-vaults/TopVaultsPage.svelte';
 	import { formatDollar } from '$lib/helpers/formatters.js';
+	import { MetaTags } from 'svelte-meta-tags';
 
 	let { data } = $props();
 	let { topVaults, tvlThreshold } = $derived(data);
 
 	let minTvlString = $derived(formatDollar(tvlThreshold, 0));
+
+	const title = 'High TVL DeFi stablecoin vaults';
+	let description = $derived(`The best performing DeFi stablecoin vaults with more than ${minTvlString} TVL.`);
+	let pageUrl = $derived(new URL(page.url.pathname, page.url.origin).href);
 </script>
 
-<svelte:head>
-	<title>High TVL DeFi stablecoin vaults</title>
-	<meta name="description" content="The best performing DeFi stablecoin vaults with more than {minTvlString} TVL." />
-</svelte:head>
+<MetaTags
+	{title}
+	{description}
+	canonical={pageUrl}
+	openGraph={{ siteName: 'Trading Strategy', url: pageUrl, title, description, type: 'website' }}
+	twitter={{ site: '@TradingProtocol', cardType: 'summary', title, description }}
+/>
 
 <TopVaultsPage
 	{topVaults}

--- a/src/routes/trading-view/vaults/new-vaults/+page.svelte
+++ b/src/routes/trading-view/vaults/new-vaults/+page.svelte
@@ -1,17 +1,25 @@
 <script lang="ts">
+	import { page } from '$app/state';
 	import TopVaultsPage from '$lib/top-vaults/TopVaultsPage.svelte';
+	import { MetaTags } from 'svelte-meta-tags';
 
 	let { data } = $props();
 	let { topVaults, maxAgeDays } = $derived(data);
+
+	const title = 'New DeFi stablecoin vaults';
+	let description = $derived(
+		`The best performing DeFi stablecoin vaults that started within the last ${maxAgeDays} days.`
+	);
+	let pageUrl = $derived(new URL(page.url.pathname, page.url.origin).href);
 </script>
 
-<svelte:head>
-	<title>New DeFi stablecoin vaults</title>
-	<meta
-		name="description"
-		content="The best performing DeFi stablecoin vaults that started within the last {maxAgeDays} days."
-	/>
-</svelte:head>
+<MetaTags
+	{title}
+	{description}
+	canonical={pageUrl}
+	openGraph={{ siteName: 'Trading Strategy', url: pageUrl, title, description, type: 'website' }}
+	twitter={{ site: '@TradingProtocol', cardType: 'summary', title, description }}
+/>
 
 <TopVaultsPage
 	{topVaults}

--- a/src/routes/trading-view/vaults/protocols/+page.svelte
+++ b/src/routes/trading-view/vaults/protocols/+page.svelte
@@ -1,12 +1,14 @@
 <script lang="ts">
 	import type { ComponentProps } from 'svelte';
 	import { goto } from '$app/navigation';
+	import { page } from '$app/state';
 	import DataBadge from '$lib/components/DataBadge.svelte';
 	import HeroBanner from '$lib/components/HeroBanner.svelte';
 	import Section from '$lib/components/Section.svelte';
 	import VaultGroupTable from '$lib/top-vaults/VaultGroupTable.svelte';
 	import VaultListingsSelector from '$lib/top-vaults/VaultListingsSelector.svelte';
 	import { getVaultProtocolLogoUrl } from '$lib/vault-protocol/helpers.js';
+	import { MetaTags } from 'svelte-meta-tags';
 
 	let { data } = $props();
 	let { protocols, options } = $derived(data);
@@ -16,12 +18,19 @@
 		await goto('?' + new URLSearchParams(params), { noScroll: true });
 		scrollToTop();
 	};
+
+	const title = 'DeFi stablecoin vault protocols | Trading Strategy';
+	const description = 'Top DeFi stablecoin vault protocols across all blockchains';
+	let pageUrl = $derived(new URL(page.url.pathname, page.url.origin).href);
 </script>
 
-<svelte:head>
-	<title>DeFi stablecoin vault protocols | Trading Strategy</title>
-	<meta name="description" content="Top DeFi stablecoin vault protocols across all blockchains" />
-</svelte:head>
+<MetaTags
+	{title}
+	{description}
+	canonical={pageUrl}
+	openGraph={{ siteName: 'Trading Strategy', url: pageUrl, title, description, type: 'website' }}
+	twitter={{ site: '@TradingProtocol', cardType: 'summary', title, description }}
+/>
 
 <main class="protocol-index-page">
 	<Section tag="header">

--- a/src/routes/trading-view/vaults/protocols/[protocol=slug]/+page.svelte
+++ b/src/routes/trading-view/vaults/protocols/[protocol=slug]/+page.svelte
@@ -1,13 +1,22 @@
 <script lang="ts">
+	import { page } from '$app/state';
 	import TopVaultsPage from '$lib/top-vaults/TopVaultsPage.svelte';
+	import { MetaTags } from 'svelte-meta-tags';
 
 	let { data } = $props();
 	let { protocolSlug, protocolName, topVaults, protocolMetadata } = $derived(data);
+
+	let title = $derived(`${protocolName} top vaults`);
+	let description = $derived(`Top stablecoin vaults on ${protocolName}`);
+	let pageUrl = $derived(new URL(page.url.pathname, page.url.origin).href);
 </script>
 
-<svelte:head>
-	<title>{protocolName} top vaults</title>
-	<meta name="description" content="Top stablecoin vaults on {protocolName}" />
-</svelte:head>
+<MetaTags
+	{title}
+	{description}
+	canonical={pageUrl}
+	openGraph={{ siteName: 'Trading Strategy', url: pageUrl, title, description, type: 'website' }}
+	twitter={{ site: '@TradingProtocol', cardType: 'summary', title, description }}
+/>
 
 <TopVaultsPage {topVaults} {protocolMetadata} title="Top {protocolName} vaults" tvlThreshold={10000} filterTvl={true} />

--- a/src/routes/trading-view/vaults/stablecoins/+page.svelte
+++ b/src/routes/trading-view/vaults/stablecoins/+page.svelte
@@ -1,11 +1,13 @@
 <script lang="ts">
 	import type { ComponentProps } from 'svelte';
 	import { goto } from '$app/navigation';
+	import { page } from '$app/state';
 	import DataBadge from '$lib/components/DataBadge.svelte';
 	import HeroBanner from '$lib/components/HeroBanner.svelte';
 	import Section from '$lib/components/Section.svelte';
 	import VaultGroupTable from '$lib/top-vaults/VaultGroupTable.svelte';
 	import VaultListingsSelector from '$lib/top-vaults/VaultListingsSelector.svelte';
+	import { MetaTags } from 'svelte-meta-tags';
 
 	let { data } = $props();
 	let { stablecoins, options } = $derived(data);
@@ -15,12 +17,19 @@
 		await goto('?' + new URLSearchParams(params), { noScroll: true });
 		scrollToTop();
 	};
+
+	const title = 'DeFi vault stablecoins | Trading Strategy';
+	const description = 'Top DeFi vault stablecoins across all blockchains';
+	let pageUrl = $derived(new URL(page.url.pathname, page.url.origin).href);
 </script>
 
-<svelte:head>
-	<title>DeFi vault stablecoins | Trading Strategy</title>
-	<meta name="description" content="Top DeFi vault stablecoins across all blockchains" />
-</svelte:head>
+<MetaTags
+	{title}
+	{description}
+	canonical={pageUrl}
+	openGraph={{ siteName: 'Trading Strategy', url: pageUrl, title, description, type: 'website' }}
+	twitter={{ site: '@TradingProtocol', cardType: 'summary', title, description }}
+/>
 
 <main class="stablecoin-index-page">
 	<Section tag="header">

--- a/src/routes/trading-view/vaults/stablecoins/[denomination=slug]/+page.svelte
+++ b/src/routes/trading-view/vaults/stablecoins/[denomination=slug]/+page.svelte
@@ -1,14 +1,23 @@
 <script lang="ts">
+	import { page } from '$app/state';
 	import TopVaultsPage from '$lib/top-vaults/TopVaultsPage.svelte';
+	import { MetaTags } from 'svelte-meta-tags';
 
 	let { data } = $props();
 	let { denominationSlug, denominationName, topVaults } = $derived(data);
+
+	let title = $derived(`${denominationName} top vaults | Trading Strategy`);
+	let description = $derived(`Top ${denominationName} DeFi vaults ranked by performance.`);
+	let pageUrl = $derived(new URL(page.url.pathname, page.url.origin).href);
 </script>
 
-<svelte:head>
-	<title>{denominationName} top vaults | Trading Strategy</title>
-	<meta name="description" content="Top {denominationName} DeFi vaults for ranked by performance." />
-</svelte:head>
+<MetaTags
+	{title}
+	{description}
+	canonical={pageUrl}
+	openGraph={{ siteName: 'Trading Strategy', url: pageUrl, title, description, type: 'website' }}
+	twitter={{ site: '@TradingProtocol', cardType: 'summary', title, description }}
+/>
 
 <TopVaultsPage
 	{topVaults}

--- a/tests/integration/trading-view/vaults/social-meta-tags.test.ts
+++ b/tests/integration/trading-view/vaults/social-meta-tags.test.ts
@@ -1,0 +1,58 @@
+import { expect, test } from '@playwright/test';
+
+test.describe('vault social meta tags', () => {
+	test.describe('vault index page', () => {
+		test.beforeEach(async ({ page }) => {
+			await page.goto('/trading-view/vaults');
+		});
+
+		test('has open graph meta tags', async ({ page }) => {
+			await expect(page.locator('meta[property="og:title"]')).toHaveAttribute('content', /.+/);
+			await expect(page.locator('meta[property="og:description"]')).toHaveAttribute('content', /.+/);
+			await expect(page.locator('meta[property="og:url"]')).toHaveAttribute('content', /.+/);
+			await expect(page.locator('meta[property="og:site_name"]')).toHaveAttribute('content', 'Trading Strategy');
+			await expect(page.locator('meta[property="og:type"]')).toHaveAttribute('content', 'website');
+		});
+
+		test('has twitter card meta tags', async ({ page }) => {
+			await expect(page.locator('meta[name="twitter:card"]')).toHaveAttribute('content', 'summary');
+			await expect(page.locator('meta[name="twitter:site"]')).toHaveAttribute('content', '@TradingProtocol');
+			await expect(page.locator('meta[name="twitter:title"]')).toHaveAttribute('content', /.+/);
+			await expect(page.locator('meta[name="twitter:description"]')).toHaveAttribute('content', /.+/);
+		});
+	});
+
+	test.describe('high TVL listing page', () => {
+		test.beforeEach(async ({ page }) => {
+			await page.goto('/trading-view/vaults/high-tvl');
+		});
+
+		test('has open graph meta tags', async ({ page }) => {
+			await expect(page.locator('meta[property="og:title"]')).toHaveAttribute('content', /.+/);
+			await expect(page.locator('meta[property="og:description"]')).toHaveAttribute('content', /.+/);
+			await expect(page.locator('meta[property="og:site_name"]')).toHaveAttribute('content', 'Trading Strategy');
+		});
+
+		test('has twitter card meta tags', async ({ page }) => {
+			await expect(page.locator('meta[name="twitter:card"]')).toHaveAttribute('content', 'summary');
+			await expect(page.locator('meta[name="twitter:site"]')).toHaveAttribute('content', '@TradingProtocol');
+		});
+	});
+
+	test.describe('new vaults listing page', () => {
+		test.beforeEach(async ({ page }) => {
+			await page.goto('/trading-view/vaults/new-vaults');
+		});
+
+		test('has open graph meta tags', async ({ page }) => {
+			await expect(page.locator('meta[property="og:title"]')).toHaveAttribute('content', /.+/);
+			await expect(page.locator('meta[property="og:description"]')).toHaveAttribute('content', /.+/);
+			await expect(page.locator('meta[property="og:site_name"]')).toHaveAttribute('content', 'Trading Strategy');
+		});
+
+		test('has twitter card meta tags', async ({ page }) => {
+			await expect(page.locator('meta[name="twitter:card"]')).toHaveAttribute('content', 'summary');
+			await expect(page.locator('meta[name="twitter:site"]')).toHaveAttribute('content', '@TradingProtocol');
+		});
+	});
+});

--- a/tests/mocks/top-vaults/list.mock.ts
+++ b/tests/mocks/top-vaults/list.mock.ts
@@ -33,7 +33,8 @@ const belowTvl = generateMockVaults('Below TVL', 50, {
 const aboveTvl = generateMockVaults('Above TVL', 250, {
 	get current_nav() {
 		return Math.random() * 1_000_000 + 50_000;
-	}
+	},
+	one_month_returns: 0.05
 });
 
 export default defineMock({


### PR DESCRIPTION
## Summary

- Enriched vault detail page social preview description with TVL and 1-month return metrics
- Replaced basic `<svelte:head>` with `MetaTags` component (from `svelte-meta-tags`) on all 10 vault listing pages and the strategy vault page, adding Open Graph and Twitter card meta tags
- Used `vaultSparklinesUrl` config instead of hardcoded sparkline URL for vault detail page image
- Added Playwright integration tests verifying OG and Twitter card meta tags on vault index, high TVL, and new vaults pages


🤖 Generated with [Claude Code](https://claude.com/claude-code)