### PR TITLE
feat: Replace breadcrumbs with vault listings selector on vault detail pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
 # Weblog of stuff
 
+- Replace breadcrumbs with vault listings selector on vault detail pages (2026-02-11)
 - Added Twitter card and Telegram link previews to all vault pages (2026-02-10)

--- a/src/routes/trading-view/vaults/[vault=slug]/+page.svelte
+++ b/src/routes/trading-view/vaults/[vault=slug]/+page.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { discordUrl } from '$lib/config';
-	import Breadcrumbs from '$lib/breadcrumb/Breadcrumbs.svelte';
+	import VaultListingsSelector from '$lib/top-vaults/VaultListingsSelector.svelte';
 	import Alert from '$lib/components/Alert.svelte';
 	import Button from '$lib/components/Button.svelte';
 	import Markdown from '$lib/components/Markdown.svelte';
@@ -24,9 +24,11 @@
 
 <SocialMediaTags {vault} {chain} />
 
-<Breadcrumbs labels={{ vaults: 'Top vaults', [vault.vault_slug]: vault.name }} />
-
 <main class="vault-details ds-3">
+	<Section tag="header">
+		<VaultListingsSelector />
+	</Section>
+
 	<VaultPageHeader {vault} />
 
 	<Section padding="md" --section-gap="var(--gap)">


### PR DESCRIPTION
## Summary
- Replace breadcrumb navigation with the vault listings selector (`VaultListingsSelector`) on individual vault detail pages, matching the navigation pattern used on vault listing pages
- Wrap the selector in a `<Section>` component to ensure proper left alignment with page content

🤖 Generated with [Claude Code](https://claude.com/claude-code)