### PR TITLE
feat: Replace vault lockup Unicode clock emoji with SVG icon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # Weblog of stuff
 
+- Replace vault lockup Unicode clock emoji with consistent SVG icon (2026-02-11)
 - Replace breadcrumbs with vault listings selector on vault detail pages (2026-02-11)
 - Added Twitter card and Telegram link previews to all vault pages (2026-02-10)

--- a/src/lib/assets/icons/clock.svg
+++ b/src/lib/assets/icons/clock.svg
@@ -1,0 +1,4 @@
+<svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<circle cx="12" cy="12" r="10" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M12 6v6l4 2" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/src/lib/top-vaults/TopVaultsTable.svelte
+++ b/src/lib/top-vaults/TopVaultsTable.svelte
@@ -16,6 +16,7 @@
 	import RiskCell from './RiskCell.svelte';
 	import IconChevronUp from '~icons/local/chevron-up';
 	import IconChevronDown from '~icons/local/chevron-down';
+	import IconClock from '~icons/local/clock';
 	import { getChain } from '$lib/helpers/chain';
 	import { formatDollar, formatNumber, formatPercent, formatValue } from '$lib/helpers/formatters';
 	import {
@@ -405,7 +406,7 @@
 								<Tooltip>
 									<svelte:fragment slot="trigger">
 										<span class="status-wrapper">
-											<span class="status-bullet">🕒</span>{getFormattedLockup(vault)}
+											<IconClock />{getFormattedLockup(vault)}
 										</span>
 									</svelte:fragment>
 									<svelte:fragment slot="popup"
@@ -706,20 +707,16 @@
 					color: var(--c-text-light);
 				}
 
-				&:has(.status-bullet) {
+				&:has(:global(.icon)) {
 					color: var(--c-warning);
 				}
 
 				.status-wrapper {
+					display: inline-flex;
+					align-items: center;
+					gap: 0.25rem;
 					white-space: nowrap;
-				}
-
-				.status-bullet {
-					color: var(--c-warning);
-					margin-right: 0.375rem;
-					font-size: 0.875rem;
-					vertical-align: middle;
-					display: inline-block;
+					--icon-size: 0.875rem;
 				}
 			}
 


### PR DESCRIPTION
## Summary

- Replace the `🕒` Unicode clock emoji in the vault listing lockup column with a proper SVG clock icon that renders consistently across all platforms
- New `clock.svg` icon added to the local icon set, matching the existing style (24x24, stroke-based, currentColor, stroke-width 1.75)
- Updated CSS to use `inline-flex` alignment and the `--icon-size` CSS variable for consistent sizing

🤖 Generated with [Claude Code](https://claude.com/claude-code)