### PR TITLE
feat: Add vault yield / chain scatter plot page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Weblog of stuff
 
+- Add vault yield / chain scatter plot page grouping vaults by blockchain (2026-02-11)
 - Add vault yield / protocol scatter plot page and refactor shared scatter plot components (2026-02-11)
 - Add vault yield / risk scatter plot page with Plotly.js (2026-02-11)
 - Replace vault lockup Unicode clock emoji with consistent SVG icon (2026-02-11)

--- a/src/lib/scatter-plot/ScatterPlotSelector.svelte
+++ b/src/lib/scatter-plot/ScatterPlotSelector.svelte
@@ -13,7 +13,8 @@ Selector linking between vault scatter plot chart pages.
 
 	const charts = [
 		{ href: '/trading-view/vaults/yield-risk', label: 'Yield / Risk' },
-		{ href: '/trading-view/vaults/yield-protocol', label: 'Yield / Protocol' }
+		{ href: '/trading-view/vaults/yield-protocol', label: 'Yield / Protocol' },
+		{ href: '/trading-view/vaults/yield-chain', label: 'Yield / Chain' }
 	] as const;
 
 	function isActive(href: string): boolean {

--- a/src/lib/top-vaults/VaultListingsSelector.svelte
+++ b/src/lib/top-vaults/VaultListingsSelector.svelte
@@ -11,7 +11,8 @@
 		{ href: '/trading-view/vaults/protocols', label: 'By protocol' },
 		{ href: '/trading-view/vaults/all', label: 'All' },
 		{ href: '/trading-view/vaults/yield-risk', label: 'Yield / Risk' },
-		{ href: '/trading-view/vaults/yield-protocol', label: 'Yield / Protocol' }
+		{ href: '/trading-view/vaults/yield-protocol', label: 'Yield / Protocol' },
+		{ href: '/trading-view/vaults/yield-chain', label: 'Yield / Chain' }
 	] as const;
 
 	function isActive(href: string): boolean {

--- a/src/routes/trading-view/vaults/yield-chain/+page.svelte
+++ b/src/routes/trading-view/vaults/yield-chain/+page.svelte
@@ -1,0 +1,77 @@
+<!--
+Scatter plot page showing vault TVL vs three-month annualised returns, coloured by blockchain.
+-->
+<script lang="ts">
+	import { page } from '$app/state';
+	import DataBadge from '$lib/components/DataBadge.svelte';
+	import HeroBanner from '$lib/components/HeroBanner.svelte';
+	import Section from '$lib/components/Section.svelte';
+	import Alert from '$lib/components/Alert.svelte';
+	import VaultListingsSelector from '$lib/top-vaults/VaultListingsSelector.svelte';
+	import TopVaultsOptIn from '$lib/top-vaults/TopVaultsOptIn.svelte';
+	import ScatterPlotSelector from '$lib/scatter-plot/ScatterPlotSelector.svelte';
+	import ChainScatterPlot from './ChainScatterPlot.svelte';
+	import { MetaTags } from 'svelte-meta-tags';
+
+	let { data } = $props();
+	let { topVaults } = $derived(data);
+
+	const title = 'Vault yield vs chain';
+	const description =
+		'Scatter plot of DeFi vault TVL versus three-month annualised returns, grouped by blockchain. Adjust the minimum TVL filter to focus on larger vaults.';
+	let pageUrl = $derived(new URL(page.url.pathname, page.url.origin).href);
+</script>
+
+<MetaTags
+	{title}
+	{description}
+	canonical={pageUrl}
+	openGraph={{ siteName: 'Trading Strategy', url: pageUrl, title, description, type: 'website' }}
+	twitter={{ site: '@TradingProtocol', cardType: 'summary', title, description }}
+/>
+
+<main class="yield-chain-page">
+	<div class="mobile-notice">
+		<Alert size="sm" status="warning">This chart is best viewed on a large screen.</Alert>
+	</div>
+
+	<Section tag="header">
+		<VaultListingsSelector />
+		<HeroBanner
+			subtitle="Explore vault TVL versus three-month annualised returns, coloured by blockchain. Adjust the minimum TVL filter to focus on larger vaults."
+		>
+			{#snippet title()}
+				<span>Vault yield / chain scatter plot</span>
+				<DataBadge class="badge" status="warning">Beta</DataBadge>
+			{/snippet}
+		</HeroBanner>
+	</Section>
+
+	<Section padding="sm">
+		<ChainScatterPlot vaults={topVaults.vaults} />
+		<ScatterPlotSelector />
+	</Section>
+
+	<Section>
+		<TopVaultsOptIn />
+	</Section>
+</main>
+
+<style>
+	.yield-chain-page {
+		:global(.badge) {
+			font-size: 0.5em;
+			margin-inline: 0.25em;
+			transform: translate(0, -0.375em);
+		}
+	}
+
+	.mobile-notice {
+		display: none;
+
+		@media (max-width: 768px) {
+			display: block;
+			padding: 1rem var(--container-padding, 1rem);
+		}
+	}
+</style>

--- a/src/routes/trading-view/vaults/yield-chain/+page.ts
+++ b/src/routes/trading-view/vaults/yield-chain/+page.ts
@@ -1,0 +1,6 @@
+export const ssr = false;
+
+export async function load({ parent }) {
+	const { topVaults } = await parent();
+	return { topVaults };
+}

--- a/src/routes/trading-view/vaults/yield-chain/ChainScatterPlot.svelte
+++ b/src/routes/trading-view/vaults/yield-chain/ChainScatterPlot.svelte
@@ -1,0 +1,211 @@
+<!--
+@component
+Scatter plot of vault TVL (Y, logarithmic) versus three-month returns (X),
+coloured by blockchain. Plotly.js is loaded dynamically from CDN.
+
+- Vaults with unrecognised chain IDs are excluded
+- Chains with two or fewer vaults are grouped as "Other" in grey
+- Each supported chain is a separate Plotly trace for legend toggling
+
+@example
+```svelte
+  <ChainScatterPlot vaults={topVaults.vaults} />
+```
+-->
+<script lang="ts">
+	import type { VaultInfo } from '$lib/top-vaults/schemas';
+	import { isBlacklisted } from '$lib/top-vaults/helpers';
+	import { getChain } from '$lib/helpers/chain';
+	import {
+		loadPlotly,
+		computeScatterRanges,
+		buildBaseHoverLines,
+		buildTrace,
+		buildChartLayout,
+		buildChartConfig,
+		protocolPalette,
+		greyColor
+	} from '$lib/scatter-plot/helpers';
+	import { goto } from '$app/navigation';
+	import ScatterPlotShell from '$lib/scatter-plot/ScatterPlotShell.svelte';
+
+	interface Props {
+		vaults: VaultInfo[];
+	}
+
+	let { vaults }: Props = $props();
+
+	let chartContainer = $state<HTMLDivElement>(undefined as unknown as HTMLDivElement);
+	let loading = $state(true);
+	let error = $state<string | null>(null);
+	let minTvl = $state(50_000);
+
+	/** Vaults that pass base eligibility (not blacklisted, have TVL + 3-month return). */
+	let baseEligible = $derived(
+		vaults.filter(
+			(v) => !isBlacklisted(v) && v.current_nav != null && v.current_nav >= minTvl && v.three_months_cagr != null
+		)
+	);
+
+	/** Vaults excluded because chain is unrecognised. */
+	let excludedCount = $derived(baseEligible.filter((v) => !getChain(v.chain_id)).length);
+
+	/** Vaults included in the chart (known chain only). */
+	let eligibleVaults = $derived(baseEligible.filter((v) => getChain(v.chain_id)));
+
+	function formatHoverText(v: VaultInfo): string {
+		const lines = buildBaseHoverLines(v);
+		const chainName = getChain(v.chain_id)?.name ?? `Chain ${v.chain_id}`;
+		lines.splice(3, 0, `Chain: ${chainName}`);
+		return lines.join('<br>');
+	}
+
+	/**
+	 * Group vaults by chain, assign colours by vault count descending.
+	 * Chains with <= 2 vaults become "Other" (grey).
+	 */
+	function buildChainTraces(currentVaults: VaultInfo[]): any[] {
+		const chainCounts = new Map<number, number>();
+		for (const v of currentVaults) {
+			chainCounts.set(v.chain_id, (chainCounts.get(v.chain_id) ?? 0) + 1);
+		}
+
+		const sortedChains = [...chainCounts.entries()]
+			.map(([chainId, count]) => ({ chainId, name: getChain(chainId)!.name, count }))
+			.sort((a, b) => b.count - a.count || a.name.localeCompare(b.name));
+
+		const majorChains = sortedChains.filter(({ count }) => count > 2);
+		const otherChainIds = new Set(sortedChains.filter(({ count }) => count <= 2).map(({ chainId }) => chainId));
+
+		const traces: any[] = [];
+
+		for (let i = 0; i < majorChains.length; i++) {
+			const { chainId, name } = majorChains[i];
+			const color = protocolPalette[i % protocolPalette.length];
+			const group = currentVaults.filter((v) => v.chain_id === chainId);
+			traces.push(buildTrace(group, name, color, formatHoverText));
+		}
+
+		const otherVaults = currentVaults.filter((v) => otherChainIds.has(v.chain_id));
+		if (otherVaults.length > 0) {
+			traces.push(buildTrace(otherVaults, 'Other', greyColor, formatHoverText));
+		}
+
+		return traces;
+	}
+
+	$effect(() => {
+		const currentVaults = eligibleVaults;
+		let destroyed = false;
+
+		(async () => {
+			try {
+				loading = true;
+				error = null;
+
+				const Plotly = await loadPlotly();
+				if (destroyed) return;
+
+				if (currentVaults.length === 0) {
+					error = 'No vaults with both TVL and three-month return data available.';
+					loading = false;
+					return;
+				}
+
+				const traces = buildChainTraces(currentVaults);
+
+				const { xRange, yRange } = computeScatterRanges(currentVaults, minTvl);
+				const layout = buildChartLayout('Chain', xRange, yRange);
+				// Disable default legend click — we handle it ourselves below
+				layout.legend.itemclick = false;
+				layout.legend.itemdoubleclick = false;
+				const config = buildChartConfig();
+
+				if (destroyed) return;
+
+				await Plotly.newPlot(chartContainer, traces, layout, config);
+
+				(chartContainer as any).on('plotly_click', (data: any) => {
+					const point = data.points?.[0];
+					if (point?.customdata) {
+						goto(point.customdata);
+					}
+				});
+
+				// Custom legend click: first click isolates, subsequent clicks toggle additional chains
+				(chartContainer as any).on('plotly_legendclick', (event: any) => {
+					const traceCount = traces.length;
+					const clicked = event.curveNumber;
+					const currentData = (chartContainer as any).data;
+
+					const visibleStates: (boolean | string)[] = currentData.map((t: any) => t.visible ?? true);
+					const allVisible = visibleStates.every((v: boolean | string) => v === true);
+					const visibleCount = visibleStates.filter((v: boolean | string) => v === true).length;
+
+					const update: (boolean | string)[] = new Array(traceCount);
+
+					if (allVisible) {
+						// All visible → isolate the clicked chain
+						for (let i = 0; i < traceCount; i++) {
+							update[i] = i === clicked ? true : 'legendonly';
+						}
+					} else if (visibleStates[clicked] === true) {
+						// Clicked one is visible → hide it; if last visible, restore all
+						if (visibleCount <= 1) {
+							update.fill(true);
+						} else {
+							for (let i = 0; i < traceCount; i++) {
+								update[i] = i === clicked ? 'legendonly' : visibleStates[i];
+							}
+						}
+					} else {
+						// Clicked one is hidden → show it too
+						for (let i = 0; i < traceCount; i++) {
+							update[i] = i === clicked ? true : visibleStates[i];
+						}
+						// If all would now be visible, just set all to true
+						if (update.every((v) => v === true)) {
+							update.fill(true);
+						}
+					}
+
+					Plotly.restyle(chartContainer, { visible: update });
+					return false;
+				});
+
+				loading = false;
+			} catch (e) {
+				if (!destroyed) {
+					error = e instanceof Error ? e.message : 'Failed to load chart';
+					loading = false;
+				}
+			}
+		})();
+
+		return () => {
+			destroyed = true;
+			if (chartContainer && (window as any).Plotly) {
+				(window as any).Plotly.purge(chartContainer);
+			}
+		};
+	});
+</script>
+
+<ScatterPlotShell bind:chartContainer {loading} {error} bind:minTvl>
+	{#snippet belowChart()}
+		{#if excludedCount > 0}
+			<p class="excluded-notice">
+				{excludedCount} vault{excludedCount === 1 ? '' : 's'} with unknown chain not included in this chart.
+			</p>
+		{/if}
+	{/snippet}
+</ScatterPlotShell>
+
+<style>
+	.excluded-notice {
+		text-align: center;
+		font: var(--f-ui-sm-roman);
+		color: var(--c-text-extra-light);
+		margin-top: 0.75rem;
+	}
+</style>

--- a/tests/integration/trading-view/vaults/yield-chain.test.ts
+++ b/tests/integration/trading-view/vaults/yield-chain.test.ts
@@ -1,0 +1,35 @@
+import { expect, test } from '@playwright/test';
+
+test.describe('vault yield / chain scatter plot page', () => {
+	test.beforeEach(async ({ page }) => {
+		await page.goto('/trading-view/vaults/yield-chain');
+	});
+
+	test('renders scatter plot grouped by chain with navigation', async ({ page }) => {
+		// Page title
+		await expect(page.locator('h1')).toContainText('scatter plot');
+
+		// Vault listings navigation with active link
+		const nav = page.locator('.vault-listings-selector');
+		await expect(nav).toBeVisible();
+		const activeLink = nav.locator('a.active');
+		await expect(activeLink).toHaveText('Yield / Chain');
+
+		// Scatter plot selector links (risk, protocol, chain)
+		const selector = page.locator('.scatter-plot-selector');
+		await expect(selector).toBeVisible();
+		await expect(selector.locator('a')).toHaveCount(3);
+
+		// Chart renders with Plotly
+		const plotWrapper = page.getByTestId('vault-scatter-plot');
+		await expect(plotWrapper).toBeVisible();
+		const plotlyChart = plotWrapper.locator('.js-plotly-plot');
+		await expect(plotlyChart).toBeVisible({ timeout: 15000 });
+
+		// Legend is present with chain entries
+		const legend = plotWrapper.locator('.legend');
+		await expect(legend).toBeVisible();
+		const legendText = await legend.textContent();
+		expect(legendText?.length).toBeGreaterThan(0);
+	});
+});

--- a/tests/integration/trading-view/vaults/yield-protocol.test.ts
+++ b/tests/integration/trading-view/vaults/yield-protocol.test.ts
@@ -42,6 +42,6 @@ test.describe('vault yield / protocol scatter plot page', () => {
 	test('displays scatter plot selector with both chart links', async ({ page }) => {
 		const selector = page.locator('.scatter-plot-selector');
 		await expect(selector).toBeVisible();
-		await expect(selector.locator('a')).toHaveCount(2);
+		await expect(selector.locator('a')).toHaveCount(3);
 	});
 });


### PR DESCRIPTION
## Summary
- Add new scatter plot page at `/trading-view/vaults/yield-chain` grouping vaults by blockchain name
- Chains with >2 vaults get distinct colours; smaller chains grouped as "Other"
- Custom legend interaction (click to isolate/toggle chains), same as protocol scatter
- Add navigation links in ScatterPlotSelector and VaultListingsSelector
- Add integration test and update existing protocol test for new link count

🤖 Generated with [Claude Code](https://claude.com/claude-code)