### PR TITLE
feat: Add short and long descriptions to vault detail pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Weblog of stuff
 
+- Add short and long descriptions to vault detail pages with metadata support (2026-02-18)
 - Hide deposit/wallet connect box on strategy page when deposits_disabled tag is set, unless user is admin (2026-02-15)
 - Add current/peak TVL scatter plot page comparing vault current TVL against historical peak (2026-02-13)
 - Add vault yield / chain scatter plot page grouping vaults by blockchain (2026-02-11)

--- a/src/lib/top-vaults/schemas.ts
+++ b/src/lib/top-vaults/schemas.ts
@@ -119,6 +119,8 @@ export const vaultInfoSchema = z.object({
 	features: z.string().array(),
 	flags: z.string().array(),
 	notes: z.string().nullable(),
+	short_description: z.string().nullable().optional(),
+	description: z.string().nullable().optional(),
 	/** Reason deposits are closed, null if deposits are open */
 	deposit_closed_reason: z.string().nullable(),
 	/** Reason redemptions are closed, null if redemptions are open */

--- a/src/routes/trading-view/vaults/[vault=slug]/+page.svelte
+++ b/src/routes/trading-view/vaults/[vault=slug]/+page.svelte
@@ -55,6 +55,12 @@
 
 		<VaultMetrics {vault} />
 
+		{#if vault.description}
+			<MetricsBox class="description" title="Description">
+				<Markdown content={vault.description} />
+			</MetricsBox>
+		{/if}
+
 		{#if vault.notes}
 			<MetricsBox class="notes" title="Notes">
 				<Markdown content={vault.notes} />

--- a/src/routes/trading-view/vaults/[vault=slug]/SocialMetaTags.svelte
+++ b/src/routes/trading-view/vaults/[vault=slug]/SocialMetaTags.svelte
@@ -13,7 +13,7 @@
 
 	let { vault, chain }: Props = $props();
 
-	let description = $derived.by(() => {
+	let generatedDescription = $derived.by(() => {
 		const parts = [`${vault.name} on ${vault.protocol} on ${chain.name}`];
 		if (vault.current_nav != null) {
 			parts.push(`TVL: ${formatDollar(vault.current_nav, 0)}`);
@@ -23,6 +23,8 @@
 		}
 		return parts.join(' | ');
 	});
+
+	let description = $derived(vault.short_description ?? generatedDescription);
 
 	let pageUrl = $derived(new URL(page.url.pathname, page.url.origin).href);
 	let imageUrl = $derived(`${vaultSparklinesUrl}/sparkline-90d-${vault.id}.png`);

--- a/src/routes/trading-view/vaults/[vault=slug]/VaultPageHeader.svelte
+++ b/src/routes/trading-view/vaults/[vault=slug]/VaultPageHeader.svelte
@@ -37,7 +37,17 @@
 	{/snippet}
 </PageHeader>
 
+{#if vault.short_description}
+	<p class="vault-description ds-container">{vault.short_description}</p>
+{/if}
+
 <style>
+	.vault-description {
+		margin: 0;
+		font: var(--f-ui-lg-roman);
+		color: var(--c-text-light);
+	}
+
 	.page-title {
 		display: inline-flex;
 		flex-wrap: wrap;


### PR DESCRIPTION
## Summary

- Display `short_description` below the vault heading when available
- Display `description` in a "Description" box below "Other metrics" when available
- Use `short_description` as page meta description (OpenGraph, Twitter) when available, falling back to the generated description

🤖 Generated with [Claude Code](https://claude.com/claude-code)