### PR TITLE
feat: Reduce Docker image size with production-only dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Weblog of stuff
 
+- Reduce Docker image size by installing only production dependencies in serve stage (2026-02-18)
 - Add short and long descriptions to vault detail pages with metadata support (2026-02-18)
 - Hide deposit/wallet connect box on strategy page when deposits_disabled tag is set, unless user is admin (2026-02-15)
 - Add current/peak TVL scatter plot page comparing vault current TVL against historical peak (2026-02-13)

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,8 +31,15 @@ FROM node:20.19-slim
 
 WORKDIR /app
 
-COPY --from=builder /app/package.json .
-COPY --from=builder /app/node_modules ./node_modules
+# Install pnpm
+ENV PNPM_HOME="/pnpm"
+ENV PATH="$PNPM_HOME:$PATH"
+RUN corepack enable
+
+# Install production dependencies only
+COPY --from=builder /app/package.json /app/pnpm-lock.yaml /app/pnpm-workspace.yaml ./
+RUN --mount=type=ssh pnpm install --prod --frozen-lockfile
+
 COPY --from=builder /app/build ./build
 COPY --from=builder /app/scripts/server.js ./scripts/
 


### PR DESCRIPTION
## Summary

- Replace full `node_modules` copy from builder stage with a fresh `pnpm install --prod --frozen-lockfile` in the serve stage
- This excludes all devDependencies (vite, svelte, typescript, eslint, prettier, playwright, vitest, etc.) from the final image
- Estimated savings: ~200 MB

## Changes

The serve stage now installs pnpm and runs a production-only install instead of copying the entire `node_modules` directory from the builder. Only packages listed under `dependencies` in `package.json` are included in the final image.

🤖 Generated with [Claude Code](https://claude.com/claude-code)