### PR TITLE
feat: Add HyperCore chain support and group with HyperEVM under Hyperliquid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Weblog of stuff
 
+- Add HyperCore chain support and group HyperEVM and HyperCore under Hyperliquid in listings and statistics (2026-02-20)
 - Add reusable DropdownMenu component and group chart links under a "Charts" dropdown in vault listings navigation (2026-02-20)
 - Reduce Docker image size by installing only production dependencies in serve stage (2026-02-18)
 - Add short and long descriptions to vault detail pages with metadata support (2026-02-18)

--- a/src/lib/helpers/chain.ts
+++ b/src/lib/helpers/chain.ts
@@ -1,3 +1,24 @@
+/**
+ * Blockchain network metadata used for routing, display and explorer links.
+ *
+ * Multiple chains may share the same slug to appear grouped in listings and
+ * statistics. For example, HyperEVM (999) and HyperCore (9999) both use slug
+ * `'hyperliquid'` so they appear as a single "Hyperliquid" entry in chain
+ * listings, while `getChain(chainId)` still returns chain-specific details
+ * (e.g. different explorer URLs).
+ *
+ * @param id - Numeric chain ID (e.g. 1 for Ethereum, 999 for HyperEVM)
+ * @param slug - URL-friendly identifier used in routes and logo lookup; chains
+ *   sharing a slug are grouped together in listings and statistics
+ * @param name - Human-readable display name
+ * @param homepage - Chain project homepage URL
+ * @param explorer - Block explorer base URL for address/transaction links
+ * @param nativeCurrency - Symbol of the chain's native token (e.g. 'ETH', 'HYPE')
+ * @param hasBackendData - Whether the chain has full backend oracle/price data;
+ *   `false` means only indexed vaults and logos are available
+ * @param sortOrder - Optional display ordering for fully supported chains;
+ *   chains without a sortOrder are sorted alphabetically after sorted chains
+ */
 type ChainData = {
 	id: number;
 	slug: string;
@@ -131,12 +152,23 @@ export const chains = (() => {
 			nativeCurrency: 'S',
 			hasBackendData: false
 		},
+		// HyperEVM: The EVM varient of Hyperliquid
 		{
 			id: 999,
 			slug: 'hyperliquid',
 			name: 'Hyperliquid',
 			homepage: 'https://hyperfoundation.org',
 			explorer: 'https://hyperevmscan.io',
+			nativeCurrency: 'HYPE',
+			hasBackendData: false
+		},
+		// HyperCore: Synthetic chain created in eth_defi for native Hyperliquid vaults
+		{
+			id: 9999,
+			slug: 'hyperliquid',
+			name: 'Hyperliquid',
+			homepage: 'https://hyperfoundation.org',
+			explorer: 'https://hypurrscan.io',
 			nativeCurrency: 'HYPE',
 			hasBackendData: false
 		},
@@ -230,6 +262,13 @@ export type Chain = (typeof chains)[number];
  */
 export function getChain(identifier: Maybe<number | string>) {
 	return chains.find(({ id, slug }) => id === identifier || slug === identifier);
+}
+
+/**
+ * Get all chains sharing a slug (e.g. both HyperEVM and HyperCore have slug 'hyperliquid').
+ */
+export function getChainsBySlug(slug: string): ChainData[] {
+	return chains.filter((c) => c.slug === slug);
 }
 
 /**

--- a/src/routes/trading-view/vaults/chains/+page.ts
+++ b/src/routes/trading-view/vaults/chains/+page.ts
@@ -9,11 +9,11 @@ export async function load({ parent, url: { searchParams } }) {
 
 	const eligibleVaults = topVaults.vaults.filter((v) => !isBlacklisted(v) && meetsMinTvl(v));
 
-	const chains = eligibleVaults.reduce<Record<string, VaultGroup & { chain_id: number }>>((acc, vault) => {
+	const chains = eligibleVaults.reduce<Record<string, VaultGroup & { chain_ids: Set<number> }>>((acc, vault) => {
 		const chain = getChain(vault.chain_id);
 		if (!chain) return acc;
 
-		const slug = chain.slug;
+		const { slug } = chain;
 
 		acc[slug] ??= {
 			slug,
@@ -21,18 +21,19 @@ export async function load({ parent, url: { searchParams } }) {
 			vault_count: 0,
 			tvl: 0,
 			avg_apy: null,
-			chain_id: vault.chain_id
+			chain_ids: new Set()
 		};
+		acc[slug].chain_ids.add(vault.chain_id);
 		acc[slug].vault_count++;
 		acc[slug].tvl += vault.current_nav ?? 0;
 
 		return acc;
 	}, {});
 
-	// Calculate TVL-weighted average APY for each chain
-	const chainGroups: VaultGroup[] = Object.values(chains).map(({ chain_id, ...group }) => ({
+	// Calculate TVL-weighted average APY for each chain group
+	const chainGroups: VaultGroup[] = Object.values(chains).map(({ chain_ids, ...group }) => ({
 		...group,
-		avg_apy: calculateTvlWeightedApy(eligibleVaults.filter((v) => v.chain_id === chain_id))
+		avg_apy: calculateTvlWeightedApy(eligibleVaults.filter((v) => chain_ids.has(v.chain_id)))
 	}));
 
 	const options = {

--- a/src/routes/trading-view/vaults/chains/[chain=slug]/+page.ts
+++ b/src/routes/trading-view/vaults/chains/[chain=slug]/+page.ts
@@ -1,5 +1,5 @@
 import { error } from '@sveltejs/kit';
-import { getChain } from '$lib/helpers/chain';
+import { getChain, getChainsBySlug } from '$lib/helpers/chain';
 
 export async function load({ params, parent }) {
 	const chainSlug = params.chain;
@@ -9,8 +9,11 @@ export async function load({ params, parent }) {
 
 	const { topVaults } = await parent();
 
+	// Include vaults from all chains sharing this slug (e.g. HyperEVM + HyperCore)
+	const chainIds = new Set(getChainsBySlug(chain.slug).map((c) => c.id));
+
 	const vaults = topVaults.vaults.filter((vault) => {
-		return vault.chain_id === chain.id;
+		return chainIds.has(vault.chain_id);
 	});
 
 	return {

--- a/src/routes/trading-view/vaults/current-peak-tvl/TvlScatterPlot.svelte
+++ b/src/routes/trading-view/vaults/current-peak-tvl/TvlScatterPlot.svelte
@@ -18,7 +18,7 @@ Plotly.js is loaded dynamically from CDN.
 	import type { VaultInfo } from '$lib/top-vaults/schemas';
 	import { isBlacklisted, hasSupportedProtocol } from '$lib/top-vaults/helpers';
 	import { resolveVaultDetails } from '$lib/top-vaults/helpers';
-	import { getChain } from '$lib/helpers/chain';
+	import { getChain, getChainsBySlug } from '$lib/helpers/chain';
 	import {
 		loadPlotly,
 		buildMarker,
@@ -98,28 +98,34 @@ Plotly.js is loaded dynamically from CDN.
 	 * Chains with <= 2 vaults become "Other" (grey).
 	 */
 	function buildChainTraces(currentVaults: VaultInfo[]): any[] {
-		const chainCounts = new Map<number, number>();
+		const slugCounts = new Map<string, number>();
 		for (const v of currentVaults) {
-			chainCounts.set(v.chain_id, (chainCounts.get(v.chain_id) ?? 0) + 1);
+			const chain = getChain(v.chain_id);
+			if (!chain) continue;
+			slugCounts.set(chain.slug, (slugCounts.get(chain.slug) ?? 0) + 1);
 		}
 
-		const sortedChains = [...chainCounts.entries()]
-			.map(([chainId, count]) => ({ chainId, name: getChain(chainId)!.name, count }))
+		const sortedGroups = [...slugCounts.entries()]
+			.map(([slug, count]) => ({ slug, name: getChain(slug)!.name, count }))
 			.sort((a, b) => b.count - a.count || a.name.localeCompare(b.name));
 
-		const majorChains = sortedChains.filter(({ count }) => count > 2);
-		const otherChainIds = new Set(sortedChains.filter(({ count }) => count <= 2).map(({ chainId }) => chainId));
+		const majorGroups = sortedGroups.filter(({ count }) => count > 2);
+		const otherSlugs = new Set(sortedGroups.filter(({ count }) => count <= 2).map(({ slug }) => slug));
 
 		const traces: any[] = [];
 
-		for (let i = 0; i < majorChains.length; i++) {
-			const { chainId, name } = majorChains[i];
+		for (let i = 0; i < majorGroups.length; i++) {
+			const { slug, name } = majorGroups[i];
 			const color = protocolPalette[i % protocolPalette.length];
-			const group = currentVaults.filter((v) => v.chain_id === chainId);
+			const chainIds = new Set(getChainsBySlug(slug).map((c) => c.id));
+			const group = currentVaults.filter((v) => chainIds.has(v.chain_id));
 			traces.push(buildTvlTrace(group, name, color));
 		}
 
-		const otherVaults = currentVaults.filter((v) => otherChainIds.has(v.chain_id));
+		const otherVaults = currentVaults.filter((v) => {
+			const chain = getChain(v.chain_id);
+			return chain && otherSlugs.has(chain.slug);
+		});
 		if (otherVaults.length > 0) {
 			traces.push(buildTvlTrace(otherVaults, 'Other', greyColor));
 		}


### PR DESCRIPTION
## Summary
- Add HyperCore (chain ID 9999) to the chain registry so HyperCore vault pages load correctly instead of returning 404
- Both HyperEVM (999) and HyperCore (9999) share slug `hyperliquid` so they appear as a single "Hyperliquid" entry in chain listings, scatter plots, and statistics while retaining distinct explorer URLs (`hyperevmscan.io` vs `hypurrscan.io`)
- Add `getChainsBySlug()` helper and update chain grouping/filtering logic to aggregate by slug

🤖 Generated with [Claude Code](https://claude.com/claude-code)