### PR TITLE
feat: Refine vault listing table filters and blacklist display

### DIFF
--- a/src/lib/top-vaults/TopVaultsTable.svelte
+++ b/src/lib/top-vaults/TopVaultsTable.svelte
@@ -70,18 +70,10 @@
 		return topVaults.vaults.filter((v) => !isBlacklisted(v));
 	});
 
-	const HYPERCORE_CHAIN_ID = 9999;
-	const TVL_THRESHOLD_HYPERCORE = 1_000_000;
-
-	function getVaultTvlThreshold(vault: VaultInfo) {
-		if (chain) return tvlThreshold;
-		return vault.chain_id === HYPERCORE_CHAIN_ID ? TVL_THRESHOLD_HYPERCORE : tvlThreshold;
-	}
-
 	// Get vaults hidden due to TVL threshold (only when filterTvl is enabled)
 	let hiddenVaults = $derived.by(() => {
 		if (!filterTvl) return [];
-		return baseVaults.filter((v) => (v.current_nav ?? 0) < getVaultTvlThreshold(v));
+		return baseVaults.filter((v) => (v.current_nav ?? 0) < tvlThreshold);
 	});
 
 	// Count of hidden vaults
@@ -90,14 +82,17 @@
 	// Vaults that pass TVL filter (used for stats display)
 	let tvlFilteredVaults = $derived.by(() => {
 		if (!filterTvl) return baseVaults;
-		return baseVaults.filter((v) => (v.current_nav ?? 0) >= getVaultTvlThreshold(v));
+		return baseVaults.filter((v) => (v.current_nav ?? 0) >= tvlThreshold);
 	});
 
-	// Calculate total TVL from TVL-filtered vaults
-	let totalTvl = $derived(calculateTotalTvl(tvlFilteredVaults));
+	// Exclude blacklisted vaults from stats calculations
+	let statsVaults = $derived(tvlFilteredVaults.filter((v) => !isBlacklisted(v)));
 
-	// Calculate TVL-weighted average 1M APY from TVL-filtered vaults
-	let avgTvlWeightedApy1M = $derived(calculateTvlWeightedApy(tvlFilteredVaults));
+	// Calculate total TVL from non-blacklisted, TVL-filtered vaults
+	let totalTvl = $derived(calculateTotalTvl(statsVaults));
+
+	// Calculate TVL-weighted average 1M APY from non-blacklisted, TVL-filtered vaults
+	let avgTvlWeightedApy1M = $derived(calculateTvlWeightedApy(statsVaults));
 
 	// filter vaults matching filterValue (search string)
 	let filteredVaults = $derived.by(() => {
@@ -106,7 +101,7 @@
 			const chain = getChain(v.chain_id);
 
 			if (filterTvl) {
-				if ((v.current_nav ?? 0) < getVaultTvlThreshold(v)) {
+				if ((v.current_nav ?? 0) < tvlThreshold) {
 					return false;
 				}
 			}
@@ -249,12 +244,9 @@
 				>
 			</Tooltip>
 			<Tooltip>
-				<svelte:fragment slot="trigger"
-					>Min {formatDollar(tvlThreshold, 0)}{#if !chain}*{/if}</svelte:fragment
-				>
+				<svelte:fragment slot="trigger">Min {formatDollar(tvlThreshold, 0)}</svelte:fragment>
 				<svelte:fragment slot="popup"
-					>{#if chain}The listing is limited to vaults with a minimum of {formatDollar(tvlThreshold, 0)} TVL deposited currently.{:else}Minimum
-						{formatDollar(tvlThreshold, 0)} of current TVL, except for Hyperliquid's native vaults $1M{/if}</svelte:fragment
+					>The listing is limited to vaults with a minimum of {formatDollar(tvlThreshold, 0)} TVL deposited currently.</svelte:fragment
 				>
 			</Tooltip>
 			<Tooltip>
@@ -359,11 +351,12 @@
 			<tbody>
 				{#each visibleVaults as vault (vault.id)}
 					{@const chain = getChain(vault.chain_id)}
+					{@const blacklisted = isBlacklisted(vault)}
 					{@const badStatus = !isGoodVaultStatus(vault)}
 					{@const statusReason = [vault.deposit_closed_reason, vault.redemption_closed_reason]
 						.filter(Boolean)
 						.join('; ')}
-					<tr class="targetable">
+					<tr class={['targetable', blacklisted && 'blacklisted']}>
 						<!-- index cell is populated with row index via `rowNumber` CSS counter -->
 						<td class="index"></td>
 						{#if showChainCol}
@@ -614,6 +607,10 @@
 				&:nth-child(even) {
 					background-color: var(--c-col-b);
 				}
+			}
+
+			tr.blacklisted td {
+				text-decoration: line-through;
 			}
 
 			td:global(:has(.tooltip)) {


### PR DESCRIPTION
## Summary
- Remove HyperCore $1M TVL override from `TopVaultsTable` — the main `/trading-view/vaults` page pre-filters in `+page.svelte`, so chain-specific and other listing pages now treat HyperCore vaults the same as any other vault
- Strikethrough styling for blacklisted vaults in the table (visible on `/trading-view/vaults/all`)
- Exclude blacklisted vaults from total TVL and average return calculations

🤖 Generated with [Claude Code](https://claude.com/claude-code)