### PR TITLE
feat: Support GRVT non-EVM vault addresses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Weblog of stuff
 
+- Support GRVT non-EVM vault addresses and hide internal flags from vault headings (2026-02-22)
 - Add GRVT chain support (2026-02-20)
 - Improve vault listing filters: $1M TVL minimum for HyperCore native vaults, cap displayed profit at 9,999%, and use 1 decimal point for return columns (2026-02-20)
 - Add HyperCore chain support and group HyperEVM and HyperCore under Hyperliquid in listings and statistics (2026-02-20)

--- a/src/lib/components/HashAddress.svelte
+++ b/src/lib/components/HashAddress.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	export let address: Address;
+	export let address: string;
 	export let endChars = 6;
 
 	$: sliceAt = address.length - endChars;

--- a/src/lib/eth-defi/schemas/core.ts
+++ b/src/lib/eth-defi/schemas/core.ts
@@ -13,3 +13,11 @@ export const hexString = z.custom<`0x${string}`>((arg) => {
 	return typeof arg === 'string' && /^0x[0-9a-fA-F]+$/.test(arg);
 });
 export type HexString = z.infer<typeof hexString>;
+
+/**
+ * Vault address schema supporting multiple address formats:
+ * - EVM hex addresses: 0x-prefixed hex strings (e.g., 0x1234...abcd)
+ * - GRVT vault identifiers: vlt:-prefixed strings (e.g., vlt:2zqosukicgltfcjdet4kpmecvfg)
+ */
+export const vaultAddress = z.string().min(1);
+export type VaultAddress = z.infer<typeof vaultAddress>;

--- a/src/lib/helpers/chain.ts
+++ b/src/lib/helpers/chain.ts
@@ -283,13 +283,13 @@ export function getChainsBySlug(slug: string): ChainData[] {
 /**
  * Extract explorer URL from Chain object and append address or transaction path
  */
-export function getExplorerUrl(chain: Maybe<Chain>, hash: Address) {
+export function getExplorerUrl(chain: Maybe<Chain>, hash: string) {
 	const baseUrl = chain?.explorer ?? 'https://blockscan.com';
 
 	let path = '';
-	if (hash.length === 42) {
+	if (hash.startsWith('0x') && hash.length === 42) {
 		path = `/address/${hash}`;
-	} else if (hash.length === 66) {
+	} else if (hash.startsWith('0x') && hash.length === 66) {
 		path = `/tx/${hash}`;
 	}
 	return `${baseUrl}${path}`;

--- a/src/lib/top-vaults/schemas.ts
+++ b/src/lib/top-vaults/schemas.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import { blockNumber, chainId, hexString } from '$lib/eth-defi/schemas/core';
+import { blockNumber, chainId, vaultAddress } from '$lib/eth-defi/schemas/core';
 import { isoDateTime } from '$lib/schemas/utility';
 
 const nullableNumber = z.number().nullable();
@@ -106,9 +106,12 @@ export const vaultInfoSchema = z.object({
 	id: z.string(),
 	start_date: isoDateTime,
 	end_date: isoDateTime,
-	address: hexString,
-	share_token_address: hexString.nullable(),
-	denomination_token_address: hexString.nullable(),
+	/** Vault address: EVM hex (0x...) or GRVT vault identifier (vlt:...) */
+	address: vaultAddress,
+	/** Share token address: EVM hex (0x...) or GRVT vault identifier (vlt:...) */
+	share_token_address: vaultAddress.nullable(),
+	/** Denomination token address: EVM hex (0x...) or GRVT vault identifier (vlt:...) */
+	denomination_token_address: vaultAddress.nullable(),
 	chain_id: chainId,
 	stablecoinish: z.boolean(),
 	first_updated_at: isoDateTime.nullable(),

--- a/src/routes/trading-view/vaults/[vault=slug]/+page.svelte
+++ b/src/routes/trading-view/vaults/[vault=slug]/+page.svelte
@@ -55,8 +55,8 @@
 
 		{#if vault.chain_id === 9999}
 			<Alert size="md">
-				Due to Hyperliquid architecture, we currently have limited history of data on this vault and it
-				might not reach all the way back to the launch of the vault.
+				Due to Hyperliquid architecture, we currently have limited history of data on this vault and it might not reach
+				all the way back to the launch of the vault.
 			</Alert>
 		{/if}
 

--- a/src/routes/trading-view/vaults/[vault=slug]/VaultPageHeader.svelte
+++ b/src/routes/trading-view/vaults/[vault=slug]/VaultPageHeader.svelte
@@ -12,6 +12,10 @@
 
 	let { vault }: Props = $props();
 
+	const hiddenFlags = ['perp_dex_trading_vault'];
+
+	let visibleFlags = $derived(vault.flags.filter((f) => !hiddenFlags.includes(f)));
+
 	let externalSiteName = $derived.by(() => {
 		if (hasSupportedProtocol(vault)) return vault.protocol;
 		if (vault.link) return new URL(vault.link).host;
@@ -22,7 +26,7 @@
 	{#snippet title()}
 		<span class="page-title">
 			<span>{vault.name}</span>
-			{#each vault.flags as flag (flag)}
+			{#each visibleFlags as flag (flag)}
 				<DataBadge class="badge" status="warning">{flag}</DataBadge>
 			{/each}
 		</span>


### PR DESCRIPTION
## Summary
- Add `vaultAddress` Zod schema accepting both EVM hex (`0x...`) and GRVT vault identifiers (`vlt:...`), fixing a 500 error on the vaults listing page
- Update `getExplorerUrl` and `HashAddress` component to handle non-EVM address formats gracefully
- Hide `perp_dex_trading_vault` internal flag from vault page headings

🤖 Generated with [Claude Code](https://claude.com/claude-code)