### PR TITLE
feat: Cap 3M volatility at >999% and clarify TVL tooltip

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Weblog of stuff
 
+- Cap 3M volatility display at >999% and clarify TVL threshold tooltip for Hyperliquid vaults (2026-02-22)
 - Support GRVT non-EVM vault addresses and hide internal flags from vault headings (2026-02-22)
 - Add GRVT chain support (2026-02-20)
 - Improve vault listing filters: $1M TVL minimum for HyperCore native vaults, cap displayed profit at 9,999%, and use 1 decimal point for return columns (2026-02-20)

--- a/src/lib/top-vaults/TopVaultsPage.svelte
+++ b/src/lib/top-vaults/TopVaultsPage.svelte
@@ -18,6 +18,8 @@
 		title: string;
 		subtitle: string;
 		tvlThreshold?: number;
+		tvlTriggerLabel?: string;
+		tvlTooltip?: string;
 		filterTvl?: boolean;
 		includeBlacklisted?: boolean;
 		protocolMetadata?: VaultProtocolMetadata;
@@ -29,6 +31,8 @@
 		title: pageTitle,
 		subtitle,
 		tvlThreshold,
+		tvlTriggerLabel,
+		tvlTooltip,
 		filterTvl,
 		includeBlacklisted,
 		protocolMetadata
@@ -63,7 +67,15 @@
 			{#if !topVaults.vaults.length}
 				<Alert title="Error">No vault data available.</Alert>
 			{:else}
-				<TopVaultsTable {topVaults} {chain} {tvlThreshold} {filterTvl} {includeBlacklisted} />
+				<TopVaultsTable
+					{topVaults}
+					{chain}
+					{tvlThreshold}
+					{tvlTriggerLabel}
+					{tvlTooltip}
+					{filterTvl}
+					{includeBlacklisted}
+				/>
 			{/if}
 		</div>
 	</Section>

--- a/src/routes/trading-view/vaults/+page.svelte
+++ b/src/routes/trading-view/vaults/+page.svelte
@@ -37,4 +37,6 @@
 	{topVaults}
 	title="Top DeFi stablecoin vaults"
 	subtitle="The best performing DeFi stablecoin vaults across multiple blockchains"
+	tvlTriggerLabel="Min $50K*"
+	tvlTooltip="Minimum $50k TVL for vaults, and $1M for Hyperliquid native vaults."
 />


### PR DESCRIPTION
## Summary
- Cap 3M volatility column display at >999% to prevent abnormally large values from breaking table layout
- Add "Min $50K*" label with tooltip clarifying "$50k TVL for vaults, and $1M for Hyperliquid native vaults" on the main vaults page
- Pass-through `tvlTriggerLabel` and `tvlTooltip` props via TopVaultsPage to TopVaultsTable — other pages keep the default tooltip

🤖 Generated with [Claude Code](https://claude.com/claude-code)