### PR TITLE
feat: Move HyperCore vault history warning to Age tooltip

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Weblog of stuff
 
+- Move HyperCore native vault limited history warning from alert banner to Age tooltip (2026-02-22)
 - Cap 3M volatility display at >999% and clarify TVL threshold tooltip for Hyperliquid vaults (2026-02-22)
 - Support GRVT non-EVM vault addresses and hide internal flags from vault headings (2026-02-22)
 - Add GRVT chain support (2026-02-20)

--- a/src/routes/trading-view/vaults/[vault=slug]/+page.svelte
+++ b/src/routes/trading-view/vaults/[vault=slug]/+page.svelte
@@ -53,13 +53,6 @@
 
 		<ChartWithFeaturedMetrics {vault} />
 
-		{#if vault.chain_id === 9999}
-			<Alert size="md">
-				Due to Hyperliquid architecture, we currently have limited history of data on this vault and it might not reach
-				all the way back to the launch of the vault.
-			</Alert>
-		{/if}
-
 		<VaultMetrics {vault} />
 
 		{#if vault.description}

--- a/src/routes/trading-view/vaults/[vault=slug]/VaultMetrics.svelte
+++ b/src/routes/trading-view/vaults/[vault=slug]/VaultMetrics.svelte
@@ -12,8 +12,11 @@
 		vault: VaultInfo;
 	}
 
+	const HYPERCORE_CHAIN_ID = 9999;
+
 	let { vault }: Props = $props();
 
+	let isHyperCore = $derived(vault.chain_id === HYPERCORE_CHAIN_ID);
 	let showTransactionStatus = $derived(!isGoodVaultStatus(vault));
 
 	function getDaysUntil(dateString: string | null): number | null {
@@ -72,7 +75,20 @@
 				</Metric>
 			</div>
 
-			<Metric label="Age">
+			{#snippet ageLabel()}
+				<Tooltip>
+					<span slot="trigger">
+						<span class="underline">Age*</span>
+						<IconQuestionCircle />
+					</span>
+					<svelte:fragment slot="popup">
+						Due to Hyperliquid architecture, we currently have limited history of data on this vault and it might not
+						reach all the way back to the launch of the vault.
+					</svelte:fragment>
+				</Tooltip>
+			{/snippet}
+
+			<Metric label={isHyperCore ? ageLabel : 'Age'}>
 				{formatNumber(vault.years, 1)} years
 			</Metric>
 


### PR DESCRIPTION
## Summary
- Replace the red Alert banner on HyperCore native vault pages with a tooltip on the Age metric field
- HyperCore vaults now show "Age*" with a question-circle icon; hovering reveals the limited history explanation
- Non-HyperCore vaults are unaffected (plain "Age" label)

🤖 Generated with [Claude Code](https://claude.com/claude-code)