### PR TITLE
fix: Only run Docker build on tagged releases

### DIFF
--- a/.github/workflows/javascript.yml
+++ b/.github/workflows/javascript.yml
@@ -75,8 +75,8 @@ jobs:
     runs-on: ubuntu-latest
     # 2023-02 disable because tests are too flaky and do not pass on CI at all
     # needs: test
-    # Skip build on master push
-    if: github.event_name != 'push' || github.ref != 'refs/heads/master'
+    # Only build Docker image for tagged releases
+    if: startsWith(github.ref, 'refs/tags/v')
     steps:
       - name: Set up SSH deploy key for fonts
         uses: webfactory/ssh-agent@v0.9.0


### PR DESCRIPTION
## Summary
- Change Docker build CI condition from `github.event_name != 'push' || github.ref != 'refs/heads/master'` to `startsWith(github.ref, 'refs/tags/v')`
- Docker build now only runs when a version tag (v*) is pushed, skipping PR and master push builds
- Speeds up CI feedback on PRs and regular pushes

🤖 Generated with [Claude Code](https://claude.com/claude-code)