### PR TITLE
feat: Add human-readable fee mode labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Weblog of stuff
 
+- Add human-readable fee mode labels with tooltip descriptions to vault technical details (2026-02-24)
 - Move HyperCore native vault limited history warning from alert banner to Age tooltip (2026-02-22)
 - Cap 3M volatility display at >999% and clarify TVL threshold tooltip for Hyperliquid vaults (2026-02-22)
 - Support GRVT non-EVM vault addresses and hide internal flags from vault headings (2026-02-22)

--- a/src/lib/top-vaults/helpers.test.ts
+++ b/src/lib/top-vaults/helpers.test.ts
@@ -1,5 +1,13 @@
 import { describe, test, expect } from 'vitest';
-import { isBlacklisted, hasSupportedProtocol, meetsMinTvl, getFormattedLockup, getFormattedFeeMode } from './helpers';
+import {
+	isBlacklisted,
+	hasSupportedProtocol,
+	meetsMinTvl,
+	getFormattedLockup,
+	getFormattedFeeMode,
+	getFeeModeLabel,
+	getFeeModeDescription
+} from './helpers';
 import { createTestVault } from './test-utils';
 
 describe('isBlacklisted', () => {
@@ -114,5 +122,57 @@ describe('getFormattedFeeMode', () => {
 	test('handles feeless mode', () => {
 		const vault = createTestVault('Test vault', { fee_mode: 'feeless' });
 		expect(getFormattedFeeMode(vault)).toBe('Feeless');
+	});
+});
+
+describe('getFeeModeLabel', () => {
+	test('returns "Unknown" for null', () => {
+		expect(getFeeModeLabel(null)).toBe('Unknown');
+	});
+
+	test('returns "Unknown" for undefined', () => {
+		expect(getFeeModeLabel(undefined)).toBe('Unknown');
+	});
+
+	test('returns label for internalised_skimming', () => {
+		expect(getFeeModeLabel('internalised_skimming')).toBe('Internalised skimming');
+	});
+
+	test('returns label for internalised_minting', () => {
+		expect(getFeeModeLabel('internalised_minting')).toBe('Internalised minting');
+	});
+
+	test('returns label for externalised', () => {
+		expect(getFeeModeLabel('externalised')).toBe('Externalised');
+	});
+
+	test('returns label for feeless', () => {
+		expect(getFeeModeLabel('feeless')).toBe('Feeless');
+	});
+});
+
+describe('getFeeModeDescription', () => {
+	test('returns empty string for null', () => {
+		expect(getFeeModeDescription(null)).toBe('');
+	});
+
+	test('returns empty string for undefined', () => {
+		expect(getFeeModeDescription(undefined)).toBe('');
+	});
+
+	test('returns description for internalised_skimming', () => {
+		expect(getFeeModeDescription('internalised_skimming')).toContain('deducted from closed trades');
+	});
+
+	test('returns description for internalised_minting', () => {
+		expect(getFeeModeDescription('internalised_minting')).toContain('minting additional vault shares');
+	});
+
+	test('returns description for externalised', () => {
+		expect(getFeeModeDescription('externalised')).toContain('charged separately');
+	});
+
+	test('returns description for feeless', () => {
+		expect(getFeeModeDescription('feeless')).toContain('No fees');
 	});
 });

--- a/src/lib/top-vaults/helpers.ts
+++ b/src/lib/top-vaults/helpers.ts
@@ -1,6 +1,10 @@
 import type { VaultInfo } from './schemas';
+import { feeMode } from './schemas';
 import { resolve } from '$app/paths';
 import { capitalize, isNumber } from '$lib/helpers/formatters';
+import type { z } from 'zod';
+
+type FeeMode = z.infer<typeof feeMode>;
 
 /** Minimum TVL threshold for vault group breakdown pages */
 export const MIN_TVL_THRESHOLD = 10_000;
@@ -68,6 +72,46 @@ export function getFormattedLockup({ lockup: seconds }: VaultInfo): string {
 export function getFormattedFeeMode({ fee_mode }: VaultInfo): string {
 	if (fee_mode == null) return 'Unknown';
 	return capitalize(fee_mode.replaceAll('_', ' '));
+}
+
+/** Human-readable labels and descriptions for each fee mode */
+const feeModeDetails: Record<FeeMode, { label: string; description: string }> = {
+	internalised_skimming: {
+		label: 'Internalised skimming',
+		description: 'Fees are deducted from closed trades; net fees are reflected in the vault PnL and share price'
+	},
+	internalised_minting: {
+		label: 'Internalised minting',
+		description: 'Fees are collected by minting additional vault shares to the fee recipient'
+	},
+	externalised: {
+		label: 'Externalised',
+		description: 'Fees are charged separately at deposit or redemption'
+	},
+	feeless: {
+		label: 'Feeless',
+		description: 'No fees are charged'
+	}
+};
+
+/**
+ * Return a human-readable label for a fee mode value.
+ *
+ * @param mode - raw fee_mode string (e.g. `internalised_skimming`)
+ */
+export function getFeeModeLabel(mode: string | null | undefined): string {
+	if (mode == null) return 'Unknown';
+	return feeModeDetails[mode as FeeMode]?.label ?? capitalize(mode.replaceAll('_', ' '));
+}
+
+/**
+ * Return a human-readable description for a fee mode value.
+ *
+ * @param mode - raw fee_mode string (e.g. `internalised_skimming`)
+ */
+export function getFeeModeDescription(mode: string | null | undefined): string {
+	if (mode == null) return '';
+	return feeModeDetails[mode as FeeMode]?.description ?? '';
 }
 
 /** Maximum APY to include in weighted average calculation (1000% = 10.0)

--- a/src/routes/trading-view/vaults/[vault=slug]/VaultTechnicalDetailsTable.svelte
+++ b/src/routes/trading-view/vaults/[vault=slug]/VaultTechnicalDetailsTable.svelte
@@ -6,6 +6,7 @@
 	import { CopyWidget, HashAddress, Timestamp, Tooltip } from '$lib/components';
 	import { formatAmount, notFilledMarker } from '$lib/helpers/formatters';
 	import { parseDate } from '$lib/helpers/date';
+	import { getFeeModeLabel, getFeeModeDescription } from '$lib/top-vaults/helpers';
 
 	const THREE_DAYS_MS = 3 * 24 * 60 * 60 * 1000;
 
@@ -67,7 +68,11 @@
 		{ label: 'Last updated block', value: vault.last_updated_block, type: 'number' as const },
 
 		{ label: 'Data starts', value: vault.start_date, type: 'date' as const },
-		{ label: 'Fee mode', value: vault.fee_mode },
+		{
+			label: 'Fee mode',
+			value: getFeeModeLabel(vault.fee_mode),
+			tooltip: getFeeModeDescription(vault.fee_mode)
+		},
 		{ label: 'Fees internalised', value: vault.fee_internalised, type: 'boolean' as const },
 		{ label: 'Features', value: vault.features, type: 'array' as const },
 		{ label: 'Flags', value: vault.flags, type: 'array' as const },
@@ -170,6 +175,11 @@
 								{:else}
 									{notFilledMarker}
 								{/if}
+							{:else if row.tooltip}
+								<Tooltip>
+									<span slot="trigger" class="tooltip-hint">{formatValue(row.value, row.type)}</span>
+									<svelte:fragment slot="popup">{row.tooltip}</svelte:fragment>
+								</Tooltip>
 							{:else}
 								{formatValue(row.value, row.type)}
 							{/if}
@@ -246,6 +256,12 @@
 			background: none;
 			cursor: pointer;
 		}
+	}
+
+	.tooltip-hint {
+		text-decoration: underline;
+		text-decoration-style: dashed;
+		cursor: help;
 	}
 
 	.stale-date {


### PR DESCRIPTION
## Summary

- Add `getFeeModeLabel()` and `getFeeModeDescription()` helper functions for mapping raw fee mode values to human-readable labels and descriptions
- Display formatted fee mode with tooltip description in vault technical details table
- Add human-readable fee mode labels with tooltip descriptions to vault technical details (2026-02-24)

🤖 Generated with [Claude Code](https://claude.com/claude-code)