### PR TITLE
feat: Support exchange_account pair kind for CeFi strategies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Weblog of stuff
 
+- Support exchange account trading pair kind and non-0x-prefixed transaction hashes for CeFi strategies (2026-02-24)
 - Add human-readable fee mode labels with tooltip descriptions to vault technical details (2026-02-24)
 - Move HyperCore native vault limited history warning from alert banner to Age tooltip (2026-02-22)
 - Cap 3M volatility display at >999% and clarify TVL threshold tooltip for Hyperliquid vaults (2026-02-22)

--- a/src/lib/trade-executor/models/trading-pair-info.ts
+++ b/src/lib/trade-executor/models/trading-pair-info.ts
@@ -14,7 +14,8 @@ const kindShortLabels = {
 	lending_protocol_short: 'short',
 	lending_protocol_long: 'long',
 	vault: 'vault',
-	cash: 'cash'
+	cash: 'cash',
+	exchange_account: 'exchange'
 } as const;
 
 export const createTradingPairInfo = <T extends TradingPairIdentifier>(base: T) => ({

--- a/src/lib/trade-executor/schemas/balance-update.ts
+++ b/src/lib/trade-executor/schemas/balance-update.ts
@@ -34,7 +34,10 @@ export const balanceUpdateSchema = z.object({
 	created_at: unixTimestamp.nullish(),
 	previous_update_at: unixTimestamp.nullish(),
 	owner_address: hexString.nullish(),
-	tx_hash: hexString.nullish(),
+	tx_hash: z
+		.string()
+		.regex(/^(0x)?[0-9a-fA-F]+$/)
+		.nullish(),
 	log_index: hexString.nullish(),
 	position_id: primaryKey.nullish(),
 	notes: z.string().nullish(),

--- a/src/lib/trade-executor/schemas/identifier.ts
+++ b/src/lib/trade-executor/schemas/identifier.ts
@@ -33,7 +33,8 @@ export const tradingPairKind = z.enum([
 	'lending_protocol_long',
 	'lending_protocol_short',
 	'vault',
-	'cash'
+	'cash',
+	'exchange_account'
 ]);
 
 // Using Zod 4's recursive types with getter syntax


### PR DESCRIPTION
## Summary

- Add `exchange_account` to the `tradingPairKind` Zod enum and `kindShortLabels` map to support Derive CeFi exchange positions
- Relax `tx_hash` validation in balance updates to accept hex strings with or without `0x` prefix (CeFi transaction hashes lack the prefix)
- Support exchange account trading pair kind and non-0x-prefixed transaction hashes for CeFi strategies (2026-02-24)

🤖 Generated with [Claude Code](https://claude.com/claude-code)