### PR TITLE
feat: Display USD for exchange account position quantities

### DIFF
--- a/src/lib/trade-executor/models/trading-pair-info.ts
+++ b/src/lib/trade-executor/models/trading-pair-info.ts
@@ -58,6 +58,9 @@ export const createTradingPairInfo = <T extends TradingPairIdentifier>(base: T) 
 		if (this.isCreditSupply) {
 			return this.pricingPair.quote.token_symbol;
 		}
+		if (this.kind === 'exchange_account') {
+			return 'USD';
+		}
 		return this.pricingPair.base.token_symbol;
 	},
 


### PR DESCRIPTION
## Summary

- Show "USD" instead of "DERIVE-ACCOUNT" as the quantity unit for `exchange_account` trading pair positions
- Affects position summary, trade listing, and trade detail pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)