### PR TITLE
feat: Show exchange name and Deposit/Withdraw for exchange accounts

### DIFF
--- a/src/lib/trade-executor/models/trade-info.ts
+++ b/src/lib/trade-executor/models/trade-info.ts
@@ -90,6 +90,15 @@ export const createTradeInfo = <T extends TradeExecution>(base: T) => ({
 			}[dir];
 		}
 
+		// Exchange account labels
+		if (this.pair.kind === 'exchange_account') {
+			return {
+				[TradeDirections.Enter]: 'Deposit',
+				[TradeDirections.Exit]: 'Withdraw',
+				[TradeDirections.Unknown]: 'Unknown'
+			}[dir];
+		}
+
 		// All other trade types
 		return {
 			[TradeDirections.Enter]: 'Buy',

--- a/src/lib/trade-executor/models/trading-pair-info.ts
+++ b/src/lib/trade-executor/models/trading-pair-info.ts
@@ -49,6 +49,8 @@ export const createTradingPairInfo = <T extends TradingPairIdentifier>(base: T) 
 				return quote.token_symbol;
 			case 'vault':
 				return this.other_data?.vault_name ?? base.token_symbol;
+			case 'exchange_account':
+				return this.exchange_name ?? this.other_data?.exchange_protocol ?? '<Unknown exchange>';
 			default:
 				return `${base.token_symbol}-${quote.token_symbol}`;
 		}


### PR DESCRIPTION
## Summary

- Display exchange name (from `exchange_name` or `other_data.exchange_protocol`) instead of raw token pair symbol (e.g., "derive" instead of "DERIVE-ACCOUNT-USDC")
- Show "Deposit"/"Withdraw" instead of "Buy"/"Sell" for exchange account trades
- Falls back to `<Unknown exchange>` when neither field is available

🤖 Generated with [Claude Code](https://claude.com/claude-code)