### PR TITLE
fix: Capitalise exchange protocol name in position display

### DIFF
--- a/src/lib/trade-executor/models/trading-pair-info.ts
+++ b/src/lib/trade-executor/models/trading-pair-info.ts
@@ -49,8 +49,10 @@ export const createTradingPairInfo = <T extends TradingPairIdentifier>(base: T) 
 				return quote.token_symbol;
 			case 'vault':
 				return this.other_data?.vault_name ?? base.token_symbol;
-			case 'exchange_account':
-				return this.exchange_name ?? this.other_data?.exchange_protocol ?? '<Unknown exchange>';
+			case 'exchange_account': {
+				const name = this.exchange_name ?? this.other_data?.exchange_protocol;
+				return name ? name.charAt(0).toUpperCase() + name.slice(1) : '<Unknown exchange>';
+			}
 			default:
 				return `${base.token_symbol}-${quote.token_symbol}`;
 		}


### PR DESCRIPTION
## Summary

- Capitalise the first letter of the exchange protocol name (e.g., "Derive" instead of "derive")

🤖 Generated with [Claude Code](https://claude.com/claude-code)