### PR TITLE
feat: Show lifetime maximum drawdown in vault other metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Weblog of stuff
 
+- Show lifetime maximum drawdown in vault other metrics instead of deposit events (2026-02-25)
 - Support exchange account trading pair kind and non-0x-prefixed transaction hashes for CeFi strategies (2026-02-24)
 - Add human-readable fee mode labels with tooltip descriptions to vault technical details (2026-02-24)
 - Move HyperCore native vault limited history warning from alert banner to Age tooltip (2026-02-22)

--- a/src/routes/trading-view/vaults/[vault=slug]/VaultMetrics.svelte
+++ b/src/routes/trading-view/vaults/[vault=slug]/VaultMetrics.svelte
@@ -6,7 +6,7 @@
 	import Metric from './Metric.svelte';
 	import IconQuestionCircle from '~icons/local/question-circle';
 	import { getFormattedLockup, isGoodVaultStatus } from '$lib/top-vaults/helpers';
-	import { formatAmount, formatNumber, formatPercent, formatPercentProfit } from '$lib/helpers/formatters';
+	import { formatNumber, formatPercent, formatPercentProfit } from '$lib/helpers/formatters';
 
 	interface Props {
 		vault: VaultInfo;
@@ -30,6 +30,10 @@
 
 	let depositDaysLeft = $derived(getDaysUntil(vault.deposit_next_open));
 	let redemptionDaysLeft = $derived(getDaysUntil(vault.redemption_next_open));
+
+	let lifetimeMaxDrawdown = $derived(
+		vault.period_results?.find((p) => p.period.toLowerCase() === 'lifetime')?.max_drawdown ?? null
+	);
 </script>
 
 <div class="additional-metrics">
@@ -79,7 +83,6 @@
 				<Tooltip>
 					<span slot="trigger">
 						<span class="underline">Age*</span>
-						<IconQuestionCircle />
 					</span>
 					<svelte:fragment slot="popup">
 						Due to Hyperliquid architecture, we currently have limited history of data on this vault and it might not
@@ -92,8 +95,17 @@
 				{formatNumber(vault.years, 1)} years
 			</Metric>
 
-			<Metric label="Deposit events">
-				{formatAmount(vault.event_count)}
+			{#snippet maxDrawdownLabel()}
+				<Tooltip>
+					<span slot="trigger">
+						<a class="glossary-link" href="/glossary/maximum-drawdown">Maximum drawdown</a>
+					</span>
+					<svelte:fragment slot="popup">Maximum drawdown over the vault lifetime.</svelte:fragment>
+				</Tooltip>
+			{/snippet}
+
+			<Metric label={maxDrawdownLabel}>
+				{formatPercent(lifetimeMaxDrawdown)}
 			</Metric>
 
 			<Metric label="Protocol Technical Risk">
@@ -320,7 +332,8 @@
 		}
 
 		.risk-link,
-		.denomination-link {
+		.denomination-link,
+		.glossary-link {
 			text-decoration: underline;
 			text-decoration-style: dashed;
 		}


### PR DESCRIPTION
## Summary
- Show lifetime maximum drawdown in vault other metrics instead of deposit events

🤖 Generated with [Claude Code](https://claude.com/claude-code)