### PR TITLE
Use cached Cloudflare vault prices parquet

### DIFF
--- a/.env
+++ b/.env
@@ -77,6 +77,12 @@ TS_PUBLIC_TOS_CONTRACTS=`{
   }
 }`
 
+###############################################################
+#
+# Put private data to .env.local which is .gitignored
+#
+###############################################################
+
 # PRIVATE configuration variables (prefix: TS_PRIVATE_) - declare only
 TS_PRIVATE_ADMIN_PW=""
 TS_PRIVATE_MAILERLITE_URL=""
@@ -92,3 +98,12 @@ TS_PRIVATE_R2_BUCKET_NAME=""
 
 # Fallback: direct private URL for top vaults JSON (used when R2 is not configured)
 TS_PRIVATE_TOP_VAULTS_URL=""
+
+# Direct Cloudflare URL for the vault prices parquet cache source
+TS_PRIVATE_VAULT_PRICES_PARQUET_URL=""
+
+###############################################################
+#
+# Put private data to .env.local
+#
+###############################################################

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ node_modules
 /.svelte-kit-test
 /package
 /data
+*.local
 vite.config.js.timestamp-*
 vite.config.ts.timestamp-*
 .idea

--- a/README.md
+++ b/README.md
@@ -49,8 +49,14 @@ bash scripts/build-deps.sh
 
 ## Running in local dev
 
-Environment variables required by the app are maintained in a `.env` file. Read about about
-[magic VITE envs](https://stackoverflow.com/questions/68479217/how-to-load-environment-variables-in-svelte).
+Environment variables required by the app are maintained in a checked-in `.env` file for defaults.
+Put local-only secrets and overrides in `.env.local`, which is gitignored and loaded automatically
+by Vite/SvelteKit. Variables in `.env.local` override `.env`.
+
+Use the existing prefixes when adding variables:
+
+- `TS_PUBLIC_` for values that may be exposed client-side
+- `TS_PRIVATE_` for server-only secrets and private configuration
 
 Start the SvelteKit development server:
 
@@ -67,9 +73,12 @@ pnpm run test:unit --run
 # Integration tests (requires test build)
 pnpm run build --mode=test
 pnpm run test:integration
+
+# Secret-backed private R2 integration check
+pnpm exec playwright test --config tests/integration/private.playwright.config.ts
 ```
 
-Test builds use separate output directories (`.svelte-kit-test/`, `node_modules/.vite-test/`) so they don't interfere with the dev server. See [docs/tests.md](./docs/tests.md) for details.
+Test builds use separate output directories (`.svelte-kit-test/`, `node_modules/.vite-test/`) so they don't interfere with the dev server. The regular integration suite uses deterministic `.env.test` values and mock APIs. Secret-backed checks that depend on your local `.env.local` use the dedicated private Playwright config above. See [docs/tests.md](./docs/tests.md) for details.
 
 ## Documentation
 

--- a/docs/new-vault-chain.md
+++ b/docs/new-vault-chain.md
@@ -60,7 +60,7 @@ If the new chain's vaults need a different default TVL threshold, add an entry t
 
 ## 6. Parquet data
 
-Vault share price chart data is served from `data/cleaned-vault-prices-1h.parquet`. The metrics endpoint (`src/routes/trading-view/vaults/[vault=vaultId]/metrics/+server.ts`) queries this file by vault ID.
+Vault share price chart data is served from a locally cached `data/cleaned-vault-prices-1h.parquet` file. The server refreshes this cache from the configured Cloudflare source when the file has not been checked for over one hour. The metrics endpoint (`src/routes/trading-view/vaults/[vault=vaultId]/metrics/+server.ts`) queries this file by vault ID.
 
 Ensure the parquet file is updated to include rows for the new chain's vaults. Without this, the chart will render empty (no error shown to the user).
 

--- a/docs/tests.md
+++ b/docs/tests.md
@@ -63,6 +63,25 @@ pnpm run test:integration
 - runs tests in `tests/integration` folder (headlessly) and reports results
 - automatically runs `pnpm preview --mode=test` to start a node preview server
 - uses mock API data found in `tests/mocks`
+- loads `.env.test` for deterministic test configuration
+
+#### Local secrets and `.env.local`
+
+For normal development, keep checked-in defaults in `.env` and place local-only secrets in
+`.env.local`. Vite/SvelteKit loads `.env.local` automatically and it overrides `.env`.
+
+The regular integration suite intentionally stays deterministic and uses `.env.test` plus mock
+APIs. This means secret-backed features should not be added to the default `pnpm run test:integration`
+flow unless they can be mocked reliably.
+
+For checks that should use your local private secrets, use the dedicated private Playwright config:
+
+```shell
+pnpm exec playwright test --config tests/integration/private.playwright.config.ts
+```
+
+This private harness overlays the relevant private values from `.env.local` on top of the normal
+test-mode configuration. Tests in this harness should skip when the required secrets are absent.
 
 See [Integration and e2e test frameworks](#integration-and-e2e-test-frameworks) below for additional info.
 

--- a/src/lib/echarts/historical-tvl-server.ts
+++ b/src/lib/echarts/historical-tvl-server.ts
@@ -2,6 +2,7 @@ import { DuckDBConnection } from '@duckdb/node-api';
 import type { VaultInfo } from '$lib/top-vaults/schemas';
 import type { HistoricalWeeklyVaultRow } from './historical-tvl';
 import { VAULT_PRICES_PARQUET_PATH } from '$lib/top-vaults/constants';
+import { ensureVaultPricesParquet } from '$lib/top-vaults/vault-prices-parquet';
 
 export const HISTORICAL_TVL_PARQUET_FILE = VAULT_PRICES_PARQUET_PATH;
 
@@ -25,6 +26,8 @@ export function getMockWeeklyVaultRows(vaults: VaultInfo[]): HistoricalWeeklyVau
 export async function getHistoricalWeeklyVaultRows(
 	parquetFile = HISTORICAL_TVL_PARQUET_FILE
 ): Promise<HistoricalWeeklyVaultRow[]> {
+	const resolvedParquetFile =
+		parquetFile === HISTORICAL_TVL_PARQUET_FILE ? await ensureVaultPricesParquet() : parquetFile;
 	const connection = await DuckDBConnection.create();
 
 	try {
@@ -58,7 +61,7 @@ export async function getHistoricalWeeklyVaultRows(
 				WHERE week < date_trunc('week', current_date)
 				ORDER BY 3, 2, 1
 			`,
-			{ parquetFile }
+			{ parquetFile: resolvedParquetFile }
 		);
 
 		return reader.getRows().map(([id, chainId, week, tvl]) => ({

--- a/src/lib/top-vaults/vault-prices-parquet.test.ts
+++ b/src/lib/top-vaults/vault-prices-parquet.test.ts
@@ -1,0 +1,171 @@
+import { mkdtemp, readFile, rm, stat, utimes, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { ensureVaultPricesParquet } from './vault-prices-parquet';
+
+const ONE_HOUR_MS = 60 * 60 * 1000;
+const REMOTE_URL = 'https://vault-prices.example/cleaned-vault-prices-1h.parquet';
+
+const tempDirs: string[] = [];
+
+async function makeTempDir(): Promise<string> {
+	const dir = await mkdtemp(join(tmpdir(), 'vault-prices-cache-'));
+	tempDirs.push(dir);
+	return dir;
+}
+
+afterEach(async () => {
+	await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
+});
+
+describe('ensureVaultPricesParquet', () => {
+	it('returns the existing local file without checking upstream while the timer is still fresh', async () => {
+		const dir = await makeTempDir();
+		const localPath = join(dir, 'cleaned-vault-prices-1h.parquet');
+		const now = new Date('2026-04-10T12:00:00.000Z');
+		const freshTime = new Date(now.getTime() - 5 * 60 * 1000);
+
+		await writeFile(localPath, 'local-data');
+		await utimes(localPath, freshTime, freshTime);
+
+		const fetchFn = vi.fn<typeof fetch>();
+
+		const result = await ensureVaultPricesParquet({
+			localPath,
+			upstreamUrl: REMOTE_URL,
+			fetchFn,
+			now: () => now
+		});
+
+		expect(result).toBe(localPath);
+		expect(fetchFn).not.toHaveBeenCalled();
+	});
+
+	it('touches the local file when the remote file is unchanged', async () => {
+		const dir = await makeTempDir();
+		const localPath = join(dir, 'cleaned-vault-prices-1h.parquet');
+		const metadataPath = `${localPath}.cache.json`;
+		const oldTime = new Date('2026-04-10T09:00:00.000Z');
+		const now = new Date(oldTime.getTime() + ONE_HOUR_MS + 5_000);
+
+		await writeFile(localPath, 'local-data');
+		await writeFile(
+			metadataPath,
+			JSON.stringify({
+				etag: '"same-etag"',
+				lastModified: 'Thu, 10 Apr 2026 08:00:00 GMT',
+				contentLength: 10
+			})
+		);
+		await utimes(localPath, oldTime, oldTime);
+
+		const fetchFn = vi.fn<typeof fetch>().mockResolvedValue(
+			new Response(null, {
+				status: 200,
+				headers: {
+					etag: '"same-etag"',
+					'last-modified': 'Thu, 10 Apr 2026 08:00:00 GMT',
+					'content-length': '10'
+				}
+			})
+		);
+
+		await ensureVaultPricesParquet({
+			localPath,
+			upstreamUrl: REMOTE_URL,
+			fetchFn,
+			now: () => now
+		});
+
+		const fileStat = await stat(localPath);
+		expect(fetchFn).toHaveBeenCalledTimes(1);
+		expect(fetchFn).toHaveBeenCalledWith(REMOTE_URL, expect.objectContaining({ method: 'HEAD' }));
+		expect(fileStat.mtimeMs).toBe(now.getTime());
+		expect(await readFile(localPath, 'utf8')).toBe('local-data');
+	});
+
+	it('downloads a fresh copy when the remote file has changed', async () => {
+		const dir = await makeTempDir();
+		const localPath = join(dir, 'cleaned-vault-prices-1h.parquet');
+		const metadataPath = `${localPath}.cache.json`;
+		const oldTime = new Date('2026-04-10T09:00:00.000Z');
+		const now = new Date(oldTime.getTime() + ONE_HOUR_MS + 5_000);
+
+		await writeFile(localPath, 'old-data');
+		await writeFile(
+			metadataPath,
+			JSON.stringify({
+				etag: '"old-etag"',
+				lastModified: 'Thu, 10 Apr 2026 08:00:00 GMT',
+				contentLength: 8
+			})
+		);
+		await utimes(localPath, oldTime, oldTime);
+
+		const fetchFn = vi
+			.fn<typeof fetch>()
+			.mockResolvedValueOnce(
+				new Response(null, {
+					status: 200,
+					headers: {
+						etag: '"new-etag"',
+						'last-modified': 'Thu, 10 Apr 2026 10:00:00 GMT',
+						'content-length': '8'
+					}
+				})
+			)
+			.mockResolvedValueOnce(
+				new Response('new-data', {
+					status: 200,
+					headers: {
+						etag: '"new-etag"',
+						'last-modified': 'Thu, 10 Apr 2026 10:00:00 GMT',
+						'content-length': '8'
+					}
+				})
+			);
+
+		await ensureVaultPricesParquet({
+			localPath,
+			upstreamUrl: REMOTE_URL,
+			fetchFn,
+			now: () => now
+		});
+
+		expect(fetchFn).toHaveBeenCalledTimes(2);
+		expect(await readFile(localPath, 'utf8')).toBe('new-data');
+		expect(JSON.parse(await readFile(metadataPath, 'utf8'))).toMatchObject({ etag: '"new-etag"' });
+		expect((await stat(localPath)).mtimeMs).toBe(now.getTime());
+	});
+
+	it('downloads the file when the local cache is missing', async () => {
+		const dir = await makeTempDir();
+		const localPath = join(dir, 'cleaned-vault-prices-1h.parquet');
+		const now = new Date('2026-04-10T12:00:00.000Z');
+
+		const fetchFn = vi.fn<typeof fetch>().mockResolvedValue(
+			new Response('fresh-data', {
+				status: 200,
+				headers: {
+					etag: '"fresh-etag"',
+					'last-modified': 'Thu, 10 Apr 2026 12:00:00 GMT',
+					'content-length': '10'
+				}
+			})
+		);
+
+		await ensureVaultPricesParquet({
+			localPath,
+			upstreamUrl: REMOTE_URL,
+			fetchFn,
+			now: () => now
+		});
+
+		expect(fetchFn).toHaveBeenCalledTimes(1);
+		expect(await readFile(localPath, 'utf8')).toBe('fresh-data');
+		expect(JSON.parse(await readFile(`${localPath}.cache.json`, 'utf8'))).toMatchObject({
+			etag: '"fresh-etag"'
+		});
+	});
+});

--- a/src/lib/top-vaults/vault-prices-parquet.ts
+++ b/src/lib/top-vaults/vault-prices-parquet.ts
@@ -1,0 +1,209 @@
+import { env } from '$env/dynamic/private';
+import { createWriteStream } from 'node:fs';
+import { mkdir, readFile, rename, rm, stat, utimes, writeFile } from 'node:fs/promises';
+import { once } from 'node:events';
+import { dirname } from 'node:path';
+import { VAULT_PRICES_PARQUET, VAULT_PRICES_PARQUET_PATH } from './constants';
+
+const ONE_HOUR_MS = 60 * 60 * 1000;
+const HEAD_TIMEOUT_MS = 20_000;
+const DOWNLOAD_TIMEOUT_MS = 5 * 60 * 1000;
+
+type RemoteFileMetadata = {
+	etag: string | null;
+	lastModified: string | null;
+	contentLength: number | null;
+};
+
+type EnsureVaultPricesParquetOptions = {
+	localPath?: string;
+	upstreamUrl?: string | null;
+	checkIntervalMs?: number;
+	fetchFn?: typeof fetch;
+	now?: () => Date;
+};
+
+const refreshInFlight = new Map<string, Promise<string>>();
+
+function getMetadataPath(localPath: string): string {
+	return `${localPath}.cache.json`;
+}
+
+function parseContentLength(value: string | null): number | null {
+	if (!value) return null;
+
+	const parsed = Number.parseInt(value, 10);
+	return Number.isFinite(parsed) ? parsed : null;
+}
+
+function getRemoteMetadataFromHeaders(headers: Headers): RemoteFileMetadata {
+	return {
+		etag: headers.get('etag'),
+		lastModified: headers.get('last-modified'),
+		contentLength: parseContentLength(headers.get('content-length'))
+	};
+}
+
+async function readCachedMetadata(localPath: string): Promise<RemoteFileMetadata | null> {
+	try {
+		const raw = await readFile(getMetadataPath(localPath), 'utf8');
+		const parsed = JSON.parse(raw) as Partial<RemoteFileMetadata>;
+
+		return {
+			etag: typeof parsed.etag === 'string' ? parsed.etag : null,
+			lastModified: typeof parsed.lastModified === 'string' ? parsed.lastModified : null,
+			contentLength: typeof parsed.contentLength === 'number' ? parsed.contentLength : null
+		};
+	} catch {
+		return null;
+	}
+}
+
+async function writeCachedMetadata(localPath: string, metadata: RemoteFileMetadata): Promise<void> {
+	await writeFile(getMetadataPath(localPath), JSON.stringify(metadata));
+}
+
+function hasRemoteFileChanged(remote: RemoteFileMetadata, cached: RemoteFileMetadata | null): boolean {
+	if (!cached) return true;
+
+	if (remote.etag && cached.etag) return remote.etag !== cached.etag;
+
+	if (remote.lastModified && cached.lastModified && remote.contentLength !== null && cached.contentLength !== null) {
+		return remote.lastModified !== cached.lastModified || remote.contentLength !== cached.contentLength;
+	}
+
+	if (remote.lastModified && cached.lastModified) return remote.lastModified !== cached.lastModified;
+	if (remote.contentLength !== null && cached.contentLength !== null)
+		return remote.contentLength !== cached.contentLength;
+
+	return true;
+}
+
+async function touchFile(path: string, now: Date): Promise<void> {
+	await utimes(path, now, now);
+}
+
+async function headRemoteFile(fetchFn: typeof fetch, upstreamUrl: string): Promise<RemoteFileMetadata> {
+	const response = await fetchFn(upstreamUrl, {
+		method: 'HEAD',
+		signal: AbortSignal.timeout(HEAD_TIMEOUT_MS)
+	});
+
+	if (!response.ok) {
+		throw new Error(`Vault prices HEAD failed with status ${response.status}`);
+	}
+
+	return getRemoteMetadataFromHeaders(response.headers);
+}
+
+async function downloadRemoteFile(
+	fetchFn: typeof fetch,
+	upstreamUrl: string,
+	localPath: string,
+	now: Date
+): Promise<RemoteFileMetadata> {
+	const response = await fetchFn(upstreamUrl, {
+		signal: AbortSignal.timeout(DOWNLOAD_TIMEOUT_MS)
+	});
+
+	if (!response.ok || !response.body) {
+		throw new Error(`Vault prices download failed with status ${response.status}`);
+	}
+
+	await mkdir(dirname(localPath), { recursive: true });
+
+	const tempPath = `${localPath}.${process.pid}.${Date.now()}.tmp`;
+	const writer = createWriteStream(tempPath);
+
+	try {
+		const reader = response.body.getReader();
+
+		while (true) {
+			const { done, value } = await reader.read();
+
+			if (done) break;
+			if (!value || value.byteLength === 0) continue;
+
+			if (!writer.write(value)) {
+				await once(writer, 'drain');
+			}
+		}
+
+		writer.end();
+		await once(writer, 'finish');
+
+		await rename(tempPath, localPath);
+		await touchFile(localPath, now);
+		return getRemoteMetadataFromHeaders(response.headers);
+	} catch (error) {
+		writer.destroy();
+		await rm(tempPath, { force: true });
+		throw error;
+	}
+}
+
+function getConfiguredUpstreamUrl(): string | null {
+	const url = env.TS_PRIVATE_VAULT_PRICES_PARQUET_URL?.trim();
+	return url ? url : null;
+}
+
+async function ensureVaultPricesParquetInner({
+	localPath = VAULT_PRICES_PARQUET_PATH,
+	upstreamUrl = getConfiguredUpstreamUrl(),
+	checkIntervalMs = ONE_HOUR_MS,
+	fetchFn = fetch,
+	now = () => new Date()
+}: EnsureVaultPricesParquetOptions = {}): Promise<string> {
+	const localStat = await stat(localPath).catch(() => null);
+	const currentTime = now();
+
+	if (!localStat) {
+		if (!upstreamUrl) {
+			throw new Error(
+				`Vault prices parquet is missing at ${localPath} and TS_PRIVATE_VAULT_PRICES_PARQUET_URL is not configured`
+			);
+		}
+
+		const metadata = await downloadRemoteFile(fetchFn, upstreamUrl, localPath, currentTime);
+		await writeCachedMetadata(localPath, metadata);
+		return localPath;
+	}
+
+	if (currentTime.getTime() - localStat.mtimeMs < checkIntervalMs || !upstreamUrl) {
+		return localPath;
+	}
+
+	try {
+		const remoteMetadata = await headRemoteFile(fetchFn, upstreamUrl);
+		const cachedMetadata = await readCachedMetadata(localPath);
+
+		if (hasRemoteFileChanged(remoteMetadata, cachedMetadata)) {
+			const downloadedMetadata = await downloadRemoteFile(fetchFn, upstreamUrl, localPath, currentTime);
+			await writeCachedMetadata(localPath, downloadedMetadata);
+		} else {
+			await touchFile(localPath, currentTime);
+		}
+	} catch (error) {
+		console.warn(`Failed to refresh ${VAULT_PRICES_PARQUET} cache`, error);
+	}
+
+	return localPath;
+}
+
+/**
+ * Resolve the local vault prices Parquet file, refreshing it from Cloudflare
+ * when the cache check interval has expired.
+ */
+export async function ensureVaultPricesParquet(options: EnsureVaultPricesParquetOptions = {}): Promise<string> {
+	const localPath = options.localPath ?? VAULT_PRICES_PARQUET_PATH;
+	const existingRefresh = refreshInFlight.get(localPath);
+
+	if (existingRefresh) return existingRefresh;
+
+	const refresh = ensureVaultPricesParquetInner(options).finally(() => {
+		refreshInFlight.delete(localPath);
+	});
+
+	refreshInFlight.set(localPath, refresh);
+	return refresh;
+}

--- a/src/routes/trading-view/vaults/[vault=vaultId]/metrics/+server.ts
+++ b/src/routes/trading-view/vaults/[vault=vaultId]/metrics/+server.ts
@@ -1,12 +1,11 @@
 import type { UTCTimestamp } from 'lightweight-charts';
 import { error, json } from '@sveltejs/kit';
 import { DuckDBConnection } from '@duckdb/node-api';
-import { VAULT_PRICES_PARQUET_PATH } from '$lib/top-vaults/constants';
-
-const parquetFile = VAULT_PRICES_PARQUET_PATH;
+import { ensureVaultPricesParquet } from '$lib/top-vaults/vault-prices-parquet';
 
 async function getPriceAndTvlData(vaultId: string) {
 	const connection = await DuckDBConnection.create();
+	const parquetFile = await ensureVaultPricesParquet();
 
 	try {
 		const reader = await connection.runAndReadAll(

--- a/tests/helpers.ts
+++ b/tests/helpers.ts
@@ -1,8 +1,97 @@
+import { loadEnv } from 'vite';
+import { existsSync, readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
 export function webServerConfig(mode: string) {
 	return {
 		command: `pnpm run preview --mode=${mode} --host=127.0.0.1 --port=4173`,
 		port: 4173,
+		env: {
+			...process.env,
+			...loadModeEnv(mode)
+		},
 		stdout: 'ignore' as const,
 		stderr: 'ignore' as const
+	};
+}
+
+function loadModeEnv(mode: string): Record<string, string | undefined> {
+	return {
+		...loadEnv(mode, process.cwd(), ''),
+		...process.env
+	};
+}
+
+function stripQuotes(value: string): string {
+	if (
+		(value.startsWith('"') && value.endsWith('"')) ||
+		(value.startsWith("'") && value.endsWith("'")) ||
+		(value.startsWith('`') && value.endsWith('`'))
+	) {
+		return value.slice(1, -1);
+	}
+
+	return value;
+}
+
+function loadLocalEnvFile(fileName = '.env.local'): Record<string, string> {
+	const filePath = resolve(process.cwd(), fileName);
+	if (!existsSync(filePath)) return {};
+
+	const env: Record<string, string> = {};
+
+	for (const line of readFileSync(filePath, 'utf8').split('\n')) {
+		const trimmed = line.trim();
+		if (!trimmed || trimmed.startsWith('#')) continue;
+
+		const separatorIndex = trimmed.indexOf('=');
+		if (separatorIndex === -1) continue;
+
+		const key = trimmed.slice(0, separatorIndex).trim();
+		const value = trimmed.slice(separatorIndex + 1).trim();
+		env[key] = stripQuotes(value);
+	}
+
+	return env;
+}
+
+function loadRealPrivateR2Env(): Record<string, string> {
+	const localEnv = loadLocalEnvFile();
+	const processEnv = process.env as Record<string, string | undefined>;
+
+	const keys = [
+		'TS_PRIVATE_R2_ACCOUNT_ID',
+		'TS_PRIVATE_R2_ACCESS_KEY_ID',
+		'TS_PRIVATE_R2_SECRET_ACCESS_KEY',
+		'TS_PRIVATE_R2_BUCKET_NAME',
+		'TS_PRIVATE_VAULT_PRICES_PARQUET_URL'
+	] as const;
+
+	return Object.fromEntries(
+		keys
+			.map((key) => [key, processEnv[key] || localEnv[key]])
+			.filter((entry): entry is [string, string] => Boolean(entry[1]))
+	);
+}
+
+export function hasPrivateR2Secrets(mode: string, source: 'mode' | 'local' = 'mode'): boolean {
+	const env = source === 'local' ? loadRealPrivateR2Env() : loadModeEnv(mode);
+
+	return Boolean(
+		env.TS_PRIVATE_R2_ACCOUNT_ID &&
+		env.TS_PRIVATE_R2_ACCESS_KEY_ID &&
+		env.TS_PRIVATE_R2_SECRET_ACCESS_KEY &&
+		env.TS_PRIVATE_R2_BUCKET_NAME
+	);
+}
+
+export function privateR2WebServerConfig(mode: string) {
+	return {
+		...webServerConfig(mode),
+		env: {
+			...loadModeEnv(mode),
+			...loadRealPrivateR2Env(),
+			TS_PRIVATE_R2_INTEGRATION: '1'
+		}
 	};
 }

--- a/tests/integration/private.playwright.config.ts
+++ b/tests/integration/private.playwright.config.ts
@@ -1,8 +1,8 @@
 import { defineConfig } from '@playwright/test';
-import { webServerConfig } from '../helpers';
+import { privateR2WebServerConfig } from '../helpers';
 
 export default defineConfig({
-	testIgnore: /private-r2\.test\.ts/,
-	webServer: webServerConfig('test'),
+	testMatch: /private-r2\.test\.ts/,
+	webServer: privateR2WebServerConfig('test'),
 	reporter: process.env.GITHUB_ACTIONS ? [['dot'], ['github']] : 'list'
 });

--- a/tests/integration/trading-view/vaults/private-r2.test.ts
+++ b/tests/integration/trading-view/vaults/private-r2.test.ts
@@ -1,0 +1,17 @@
+import { expect, test } from '@playwright/test';
+import { hasPrivateR2Secrets } from '../../../helpers';
+
+const hasSecrets = hasPrivateR2Secrets('test', 'local');
+
+test.describe('private R2 vault dataset metadata', () => {
+	test.skip(!hasSecrets, 'Private R2 secrets are not configured for integration tests');
+
+	test('shows vault prices metadata from the private bucket', async ({ page }) => {
+		await page.goto('/trading-view/vaults/datasets');
+
+		const vaultPricesRow = page.locator('tbody tr').filter({ hasText: 'Vault prices' });
+		await expect(vaultPricesRow).toHaveCount(1);
+		await expect(vaultPricesRow.locator('td').nth(3)).not.toHaveText('Unavailable');
+		await expect(vaultPricesRow.locator('td').nth(4)).not.toHaveText('Unavailable');
+	});
+});


### PR DESCRIPTION
Why

We were still relying on a manually copied local vault-prices parquet bundle. This change switches the server-side readers to a cached Cloudflare-backed flow so the file can refresh automatically without redownloading on every request.

Lessons learnt

Vite test mode loads `.env.test` before local overrides, which meant our checked-in fake R2 credentials masked real `.env.local` secrets in preview-based integration tests. Secret-backed checks are now isolated behind a dedicated private Playwright config so the normal integration suite stays deterministic.

Summary

- add a server-side parquet cache helper that keeps a local copy, checks `mtime` on each read, issues `HEAD` after one hour, redownloads when the remote file changes, and touches the local file when it does not
- route vault metrics and historical TVL parquet readers through the cache helper
- document `.env.local` usage for local secrets and add a dedicated private R2 integration harness that can verify secret-backed metadata without changing the default integration suite