### PR TITLE
feat: Link exchange account positions directly to exchange pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Weblog of stuff
 
+- Link exchange account positions directly to exchange pages for GMX and Hyperliquid strategies (2026-04-13)
 - Show "Hyperliquid vault" as asset management mode for Hyperliquid strategies on listing tiles (2026-04-08)
 - Add HyperEVM wallet support and Hyperliquid vault buttons on position pages (2026-04-08)
 - Add position entry and exit charts to API strategy open and closed position pages (2026-04-06)

--- a/src/lib/components/MenuItem.svelte
+++ b/src/lib/components/MenuItem.svelte
@@ -5,11 +5,12 @@
 	export let external = false;
 
 	$: href = active ? undefined : targetUrl;
-	$: rel = external ? 'external' : undefined;
+	$: rel = external ? 'external noreferrer' : undefined;
+	$: target = external ? '_blank' : undefined;
 </script>
 
 <li class="menu-item">
-	<a {href} {rel} on:click>
+	<a {href} {rel} {target} on:click>
 		<slot>{label}</slot>
 	</a>
 </li>

--- a/src/lib/components/datatable/TableRowTarget.svelte
+++ b/src/lib/components/datatable/TableRowTarget.svelte
@@ -4,13 +4,15 @@
 	interface Props {
 		label?: string;
 		href: string;
+		target?: string;
+		rel?: string;
 	}
 
-	let { label = 'Details', href }: Props = $props();
+	let { label = 'Details', href, target, rel }: Props = $props();
 </script>
 
-<a class="row-link" {href}>{label}</a>
-<TargetableLink {href} {label} />
+<a class="row-link" {href} {target} {rel}>{label}</a>
+<TargetableLink {href} {label} {target} {rel} />
 
 <style>
 	.row-link {

--- a/src/lib/trade-executor/helpers/exchange-account.ts
+++ b/src/lib/trade-executor/helpers/exchange-account.ts
@@ -1,19 +1,41 @@
 /**
- * Helpers for exchange account strategies (e.g., GMX, Derive).
+ * Helpers for exchange account strategies (e.g., GMX, Derive, Hyperliquid).
  *
  * Provides URL builders and display names for linking to external exchange
  * account views from strategy and position pages.
  */
+import type { Portfolio } from '../schemas/portfolio';
+import type { OnChainData } from '../schemas/summary';
 
 const exchangeUrls: Record<string, (address: string) => string> = {
 	gmx: (address) => `https://app.gmx.io/#/accounts/${address}`,
-	derive: (address) => `https://explorer.derive.xyz/address/${address}`
+	derive: (address) => `https://explorer.derive.xyz/address/${address}`,
+	hyperliquid: (address) => `https://app.hyperliquid.xyz/vaults/${address}`
 };
 
 const exchangeNames: Record<string, string> = {
 	gmx: 'GMX',
-	derive: 'Derive'
+	derive: 'Derive',
+	hyperliquid: 'Hyperliquid'
 };
+
+/** Position statuses viewable on each exchange's external page. */
+const exchangeVisiblePositions: Record<string, Set<string>> = {
+	gmx: new Set(['open']),
+	derive: new Set(['open', 'closed']),
+	hyperliquid: new Set(['open', 'closed'])
+};
+
+export type ExchangeAccountInfo = { url: string; name: string; protocol: string };
+
+/**
+ * Check whether an exchange supports viewing a given position status.
+ *
+ * GMX, for example, only shows open positions on its external page.
+ */
+export function exchangeSupportsPositionStatus(protocol: string, status: string): boolean {
+	return exchangeVisiblePositions[protocol]?.has(status) ?? true;
+}
 
 /**
  * Build the external URL for viewing an exchange account.
@@ -45,4 +67,74 @@ const TAG_PREFIX = 'exchange_account_strategy_';
 export function getExchangeProtocolFromTags(tags: string[]): string | undefined {
 	const tag = tags.find((t) => t.startsWith(TAG_PREFIX));
 	return tag?.slice(TAG_PREFIX.length);
+}
+
+/**
+ * Extract the exchange protocol from portfolio positions.
+ *
+ * Checks open positions (falling back to closed) for an `exchange_account`
+ * pair kind and returns the `exchange_protocol` from `other_data`.
+ */
+export function getExchangeProtocolFromPortfolio(portfolio: Portfolio): string | undefined {
+	const allPositions = { ...portfolio.open_positions, ...portfolio.closed_positions };
+	for (const position of Object.values(allPositions)) {
+		if (position.pair.kind === 'exchange_account') {
+			return position.pair.other_data?.exchange_protocol as string | undefined;
+		}
+	}
+}
+
+/**
+ * Resolve the on-chain address used for exchange account URLs.
+ */
+function getExchangeAddress(onChainData: OnChainData): string | undefined {
+	if (onChainData.asset_management_mode === 'lagoon') {
+		return onChainData.smart_contracts.safe;
+	}
+}
+
+/**
+ * Build exchange account info from a known protocol and on-chain data.
+ */
+function buildExchangeAccountInfo(protocol: string, onChainData: OnChainData): ExchangeAccountInfo | undefined {
+	const address = getExchangeAddress(onChainData);
+	if (!address) return undefined;
+
+	const url = getExchangeAccountUrl(protocol, address);
+	if (!url) return undefined;
+
+	return { url, name: getExchangeDisplayName(protocol), protocol };
+}
+
+/**
+ * Resolve exchange account info from strategy tags and on-chain data.
+ *
+ * Detects the exchange protocol from strategy tags. Returns undefined if
+ * the strategy is not an exchange account strategy or required data is missing.
+ *
+ * @param strategy - object with tags and on_chain_data
+ */
+export function getExchangeAccountInfo(strategy: {
+	tags: string[];
+	on_chain_data: OnChainData;
+}): ExchangeAccountInfo | undefined {
+	const protocol = getExchangeProtocolFromTags(strategy.tags);
+	if (!protocol) return undefined;
+	return buildExchangeAccountInfo(protocol, strategy.on_chain_data);
+}
+
+/**
+ * Resolve exchange account info, using portfolio positions as fallback
+ * when strategy tags don't include the exchange protocol.
+ *
+ * @param strategy - object with tags and on_chain_data
+ * @param portfolio - portfolio with position data
+ */
+export function getExchangeAccountInfoFromPortfolio(
+	strategy: { tags: string[]; on_chain_data: OnChainData },
+	portfolio: Portfolio
+): ExchangeAccountInfo | undefined {
+	const protocol = getExchangeProtocolFromTags(strategy.tags) ?? getExchangeProtocolFromPortfolio(portfolio);
+	if (!protocol) return undefined;
+	return buildExchangeAccountInfo(protocol, strategy.on_chain_data);
 }

--- a/src/routes/strategies/[strategy=apiStrategy]/+layout.svelte
+++ b/src/routes/strategies/[strategy=apiStrategy]/+layout.svelte
@@ -9,6 +9,7 @@
 		shouldDisplayError,
 		adminOnlyError
 	} from 'trade-executor/components/StrategyError.svelte';
+	import { getExchangeAccountInfo } from 'trade-executor/helpers/exchange-account';
 	import { menuOptions, default as StrategyNav } from './StrategyNav.svelte';
 	import WalletWidget from '$lib/wallet/WalletWidget.svelte';
 
@@ -16,6 +17,7 @@
 	const isBetaTag = (tag: string) => tag.toLowerCase() === 'beta';
 
 	$: ({ admin, strategy, vault, deferred } = data);
+	$: exchangeAccount = getExchangeAccountInfo(strategy);
 
 	$: tags = strategy.tags.filter((tag) => tag !== 'live');
 	$: isPrivate = !strategy.tags.includes('live');
@@ -104,6 +106,8 @@
 					hasVault={vault.depositEnabled()}
 					backtestAvailable={strategy.backtest_available}
 					portfolioPromise={deferred.state.then((s) => s?.portfolio)}
+					{exchangeAccount}
+					onChainData={strategy.on_chain_data}
 				/>
 				<slot />
 			</div>

--- a/src/routes/strategies/[strategy=apiStrategy]/+page.svelte
+++ b/src/routes/strategies/[strategy=apiStrategy]/+page.svelte
@@ -4,29 +4,14 @@
 	import SummaryMetrics from './SummaryMetrics.svelte';
 	import StrategyPerformanceChart from './StrategyPerformanceChart.svelte';
 	import { getMetricsWithAltCAGR } from 'trade-executor/helpers/metrics';
-	import {
-		getExchangeAccountUrl,
-		getExchangeDisplayName,
-		getExchangeProtocolFromTags
-	} from 'trade-executor/helpers/exchange-account';
+	import { getExchangeAccountInfo } from 'trade-executor/helpers/exchange-account';
 
 	let { data } = $props();
 	let { chain, strategy, vault, admin, ipCountry } = $derived(data);
 
 	let backtestLink = $derived(`/strategies/${strategy.id}/backtest`);
 
-	let exchangeAccount = $derived.by(() => {
-		const protocol = getExchangeProtocolFromTags(strategy.tags ?? []);
-		if (!protocol) return undefined;
-		const safeAddress =
-			strategy.on_chain_data.asset_management_mode === 'lagoon'
-				? strategy.on_chain_data.smart_contracts.safe
-				: undefined;
-		if (!safeAddress) return undefined;
-		const url = getExchangeAccountUrl(protocol, safeAddress);
-		if (!url) return undefined;
-		return { url, name: getExchangeDisplayName(protocol), protocol };
-	});
+	let exchangeAccount = $derived(getExchangeAccountInfo(strategy));
 
 	// Temporary hack to address inaccurate CAGR metric (remove once this is fixed)
 	let keyMetrics = $derived(getMetricsWithAltCAGR(strategy));

--- a/src/routes/strategies/[strategy=apiStrategy]/StrategyNav.svelte
+++ b/src/routes/strategies/[strategy=apiStrategy]/StrategyNav.svelte
@@ -69,7 +69,13 @@
 
 <script lang="ts">
 	import type { Portfolio } from 'trade-executor/schemas/portfolio';
+	import type { OnChainData } from 'trade-executor/schemas/summary';
 	import type { PositionStatus } from 'trade-executor/schemas/position';
+	import type { ExchangeAccountInfo } from 'trade-executor/helpers/exchange-account';
+	import {
+		getExchangeAccountInfoFromPortfolio,
+		exchangeSupportsPositionStatus
+	} from 'trade-executor/helpers/exchange-account';
 	import fsm from 'svelte-fsm';
 	import { Button, Menu, MenuItem } from '$lib/components';
 	import IconChevronDown from '~icons/local/chevron-down';
@@ -79,11 +85,26 @@
 	export let hasVault: boolean;
 	export let backtestAvailable: boolean;
 	export let portfolioPromise: Promise<Portfolio | undefined>;
+	export let exchangeAccount: ExchangeAccountInfo | undefined = undefined;
+	export let onChainData: OnChainData;
 
 	let menuWrapper: HTMLElement;
 	let menuHeight = 'auto';
 
 	let hasFrozenPositions = false;
+	let resolvedExchangeAccount: ExchangeAccountInfo | undefined = exchangeAccount;
+
+	// Resolve exchange account from portfolio positions when tags don't provide it
+	if (!exchangeAccount) {
+		portfolioPromise.then((portfolio) => {
+			if (portfolio) {
+				resolvedExchangeAccount = getExchangeAccountInfoFromPortfolio(
+					{ tags: [], on_chain_data: onChainData },
+					portfolio
+				);
+			}
+		});
+	}
 
 	getPositionCount('frozen').then((count) => {
 		hasFrozenPositions = Boolean(count);
@@ -92,7 +113,10 @@
 	$: currentSlug = currentPath.split('/')[3] ?? '';
 	$: currentOption = menuOptions.find(({ slug }) => slug === currentSlug);
 
-	$: visibleOptions = menuOptions.filter(({ slug }) => {
+	$: visibleOptions = menuOptions.filter(({ slug, positionStatus }) => {
+		if (resolvedExchangeAccount && positionStatus) {
+			return exchangeSupportsPositionStatus(resolvedExchangeAccount.protocol, positionStatus);
+		}
 		// prettier-ignore
 		switch (slug) {
 			case currentOption?.slug : return true;
@@ -141,9 +165,20 @@
 		<Menu on:click={mobileMenu.close}>
 			{#each visibleOptions as { slug, label, positionStatus }}
 				{@const active = slug === currentOption?.slug}
-				<MenuItem targetUrl={getTargetUrl(slug)} {active}>
-					<span class="label">{label}</span>
-					{#if positionStatus}
+				{@const isExchangePosition = !!(resolvedExchangeAccount && positionStatus)}
+				<MenuItem
+					targetUrl={isExchangePosition ? (resolvedExchangeAccount?.url ?? '') : getTargetUrl(slug)}
+					external={isExchangePosition}
+					{active}
+				>
+					<span class="label">
+						{#if isExchangePosition}
+							{label} ↗
+						{:else}
+							{label}
+						{/if}
+					</span>
+					{#if positionStatus && !resolvedExchangeAccount}
 						{#await getPositionCount(positionStatus)}
 							<span class="count skeleton"></span>
 						{:then count}

--- a/src/routes/strategies/[strategy=apiStrategy]/[status=positionStatus]-positions/+page.svelte
+++ b/src/routes/strategies/[strategy=apiStrategy]/[status=positionStatus]-positions/+page.svelte
@@ -3,11 +3,37 @@
 	import { page } from '$app/state';
 	import { goto } from '$app/navigation';
 	import { Alert } from '$lib/components';
+	import {
+		getExchangeAccountInfo,
+		getExchangeAccountUrl,
+		getExchangeDisplayName
+	} from 'trade-executor/helpers/exchange-account';
 	import PositionTable from './PositionTable.svelte';
 	import { capitalize } from '$lib/helpers/formatters';
 
 	let { data } = $props();
 	let { admin, positions, status, strategy, reserves } = $derived(data);
+
+	let exchangeAccount = $derived.by(() => {
+		// Try tag-based detection first
+		const fromTags = getExchangeAccountInfo(strategy);
+		if (fromTags) return fromTags;
+
+		// Fall back to detecting from position data
+		const exchangePosition = positions.find((p) => p.pair.kind === 'exchange_account');
+		const protocol = exchangePosition?.pair.other_data?.exchange_protocol as string | undefined;
+		if (!protocol) return undefined;
+
+		const address =
+			strategy.on_chain_data.asset_management_mode === 'lagoon'
+				? strategy.on_chain_data.smart_contracts.safe
+				: undefined;
+		if (!address) return undefined;
+
+		const url = getExchangeAccountUrl(protocol, address);
+		if (!url) return undefined;
+		return { url, name: getExchangeDisplayName(protocol), protocol };
+	});
 
 	type Options = Pick<ComponentProps<typeof PositionTable>, 'page' | 'sort' | 'direction'>;
 
@@ -54,6 +80,7 @@
 			hasPagination={positions.length > 5}
 			hasSearch={positions.length > 5}
 			hiddenPositions={strategy.hiddenPositions}
+			{exchangeAccount}
 			{reserves}
 			{onChange}
 		/>

--- a/src/routes/strategies/[strategy=apiStrategy]/[status=positionStatus]-positions/PositionTable.svelte
+++ b/src/routes/strategies/[strategy=apiStrategy]/[status=positionStatus]-positions/PositionTable.svelte
@@ -27,6 +27,7 @@
 		direction: 'asc' | 'desc';
 		hiddenPositions?: number[];
 		reserves: ReservePosition;
+		exchangeAccount?: { url: string; name: string };
 	}
 
 	let {
@@ -38,6 +39,7 @@
 		direction,
 		hiddenPositions = [],
 		reserves,
+		exchangeAccount,
 		...restProps
 	}: Props = $props();
 
@@ -147,8 +149,12 @@
 		table.column({
 			header: '',
 			id: 'cta',
-			accessor: ({ position_id }) => `./${status}-positions/${position_id}`,
-			cell: ({ value }) => createRender(TableRowTarget, { href: value, size: 'xs' }),
+			accessor: ({ position_id }) => (exchangeAccount ? exchangeAccount.url : `./${status}-positions/${position_id}`),
+			cell: ({ value }) =>
+				createRender(TableRowTarget, {
+					href: value,
+					...(exchangeAccount ? { label: `View on ${exchangeAccount.name}`, target: '_blank', rel: 'noreferrer' } : {})
+				}),
 			plugins: { sort: { disable: true } }
 		})
 	]);

--- a/src/routes/strategies/[strategy=apiStrategy]/[status=positionStatus]-positions/[position=integer]/+page.svelte
+++ b/src/routes/strategies/[strategy=apiStrategy]/[status=positionStatus]-positions/[position=integer]/+page.svelte
@@ -1,7 +1,11 @@
 <script lang="ts">
 	import { getExplorerUrl } from '$lib/helpers/chain';
 	import { Alert, Button, HashAddress, PageHeading, Section } from '$lib/components';
-	import { getExchangeAccountUrl, getExchangeDisplayName } from 'trade-executor/helpers/exchange-account';
+	import {
+		getExchangeAccountInfo,
+		getExchangeAccountUrl,
+		getExchangeDisplayName
+	} from 'trade-executor/helpers/exchange-account';
 	import TradeTable from './TradeTable.svelte';
 	import PositionProfitability from './PositionProfitability.svelte';
 	import PositionSummary from './PositionSummary.svelte';
@@ -21,13 +25,17 @@
 			: undefined;
 	const isExchangeAccountPosition = position.pair.kind === 'exchange_account';
 	const exchangeProtocol = position.pair.other_data?.exchange_protocol;
-	const safeAddress =
-		strategy.on_chain_data.asset_management_mode === 'lagoon' ? strategy.on_chain_data.smart_contracts.safe : undefined;
-	const exchangeUrl =
-		isExchangeAccountPosition && exchangeProtocol && safeAddress
-			? getExchangeAccountUrl(exchangeProtocol, safeAddress)
-			: undefined;
-	const exchangeName = exchangeProtocol ? getExchangeDisplayName(exchangeProtocol) : undefined;
+	const exchangeAccount = getExchangeAccountInfo(strategy);
+	// Fall back to position-level protocol detection when tags are missing
+	const exchangeUrl = isExchangeAccountPosition
+		? (exchangeAccount?.url ??
+			(exchangeProtocol && strategy.on_chain_data.asset_management_mode === 'lagoon'
+				? getExchangeAccountUrl(exchangeProtocol, strategy.on_chain_data.smart_contracts.safe)
+				: undefined))
+		: undefined;
+	const exchangeName = isExchangeAccountPosition
+		? (exchangeAccount?.name ?? (exchangeProtocol ? getExchangeDisplayName(exchangeProtocol) : undefined))
+		: undefined;
 	const tradePathBase = `./${position.position_id}`;
 </script>
 

--- a/src/routes/strategies/[strategy=yamlStrategy]/+layout.svelte
+++ b/src/routes/strategies/[strategy=yamlStrategy]/+layout.svelte
@@ -50,7 +50,12 @@ Layout for YAML-configured strategies — heading with sidebar navigation.
 	{/if}
 
 	<div class="subpage">
-		<YamlStrategyNav basePath="/strategies/{strategy.slug}" currentPath={page.url.pathname} {backtestAvailable} />
+		<YamlStrategyNav
+			basePath="/strategies/{strategy.slug}"
+			currentPath={page.url.pathname}
+			{backtestAvailable}
+			vaultAddress={strategy.vault_address}
+		/>
 		<slot />
 	</div>
 </main>

--- a/src/routes/strategies/[strategy=yamlStrategy]/YamlStrategyNav.svelte
+++ b/src/routes/strategies/[strategy=yamlStrategy]/YamlStrategyNav.svelte
@@ -6,17 +6,30 @@ Sidebar on desktop, collapsible dropdown on mobile — same pattern as StrategyN
 but with a static set of menu items (no conditional visibility or badges).
 -->
 <script context="module" lang="ts">
-	const baseMenuOptions = [
+	type MenuOption = {
+		slug: string;
+		label: string;
+		externalUrl?: string;
+	};
+
+	const baseMenuOptions: MenuOption[] = [
 		{ slug: '', label: 'Overview' },
-		{ slug: 'performance', label: 'Performance' },
 		{ slug: 'description', label: 'Description' },
+		{ slug: 'performance', label: 'Performance' },
 		{ slug: 'vault', label: 'Vault info' },
 		{ slug: 'fees', label: 'Fees' }
 	];
 
-	export function getMenuOptions(backtestAvailable: boolean) {
-		if (!backtestAvailable) return baseMenuOptions;
-		return [...baseMenuOptions, { slug: 'backtest', label: 'Backtest results' }];
+	export function getMenuOptions(backtestAvailable: boolean, positionsUrl?: string): MenuOption[] {
+		let options = [...baseMenuOptions];
+		if (positionsUrl) {
+			// Insert after Description (index 1)
+			options.splice(2, 0, { slug: 'open-positions', label: 'Open positions ↗', externalUrl: positionsUrl });
+		}
+		if (backtestAvailable) {
+			options.push({ slug: 'backtest', label: 'Backtest results' });
+		}
+		return options;
 	}
 
 	export { baseMenuOptions as menuOptions };
@@ -25,16 +38,20 @@ but with a static set of menu items (no conditional visibility or badges).
 <script lang="ts">
 	import fsm from 'svelte-fsm';
 	import { Button, Menu, MenuItem } from '$lib/components';
+	import { getExchangeAccountUrl } from 'trade-executor/helpers/exchange-account';
 	import IconChevronDown from '~icons/local/chevron-down';
 
 	export let basePath: string;
 	export let currentPath: string;
 	export let backtestAvailable: boolean = false;
+	export let vaultAddress: string | undefined = undefined;
+
+	$: positionsUrl = vaultAddress ? getExchangeAccountUrl('hyperliquid', vaultAddress) : undefined;
 
 	let menuWrapper: HTMLElement;
 	let menuHeight = 'auto';
 
-	$: visibleOptions = getMenuOptions(backtestAvailable);
+	$: visibleOptions = getMenuOptions(backtestAvailable, positionsUrl);
 	$: currentSlug = currentPath.split('/')[3] ?? '';
 	$: currentOption = visibleOptions.find(({ slug }) => slug === currentSlug);
 
@@ -67,9 +84,9 @@ but with a static set of menu items (no conditional visibility or badges).
 
 	<div class="menu-wrapper" bind:this={menuWrapper}>
 		<Menu on:click={mobileMenu.close}>
-			{#each visibleOptions as { slug, label }}
+			{#each visibleOptions as { slug, label, externalUrl }}
 				{@const active = slug === currentOption?.slug}
-				<MenuItem targetUrl={getTargetUrl(slug)} {active}>
+				<MenuItem targetUrl={externalUrl ?? getTargetUrl(slug)} external={!!externalUrl} {active}>
 					<span class="label">{label}</span>
 				</MenuItem>
 			{/each}


### PR DESCRIPTION
## Why

Exchange account strategies (GMX, Hyperliquid freqtrade) have position detail pages that show limited info — trades and metrics are hidden since the real data lives on the exchange. Users should go directly to the exchange to see their positions rather than viewing sparse internal pages.

## Lessons learnt

- The `gmx-ai` trade executor backend doesn't emit `exchange_account_strategy_gmx` tags, so tag-based exchange detection alone is insufficient. Falling back to position pair data (`pair.kind === 'exchange_account'` + `pair.other_data.exchange_protocol`) is needed.
- GMX doesn't expose closed positions on their external account page, so the "Closed positions" nav link should be hidden for GMX strategies specifically. A per-exchange visibility config (`exchangeVisiblePositions`) handles this cleanly.

## Summary

- **GMX (API strategies)**: Position table rows link directly to `app.gmx.io` account page with "View on GMX" label in new tab. Nav links for "Open positions" go to GMX externally without position counts. "Closed positions" hidden since GMX doesn't show them.
- **Hyperliquid (YAML strategies)**: "Open positions ↗" nav link added after "Description", linking to `app.hyperliquid.xyz/vaults/{address}` in new tab.
- **Shared infrastructure**: Added Hyperliquid URL builder, `getExchangeAccountInfo` convenience helper consolidating duplicated resolution logic, `exchangeSupportsPositionStatus` per-exchange visibility config, and external link support in `MenuItem` and `TableRowTarget` components.
- **Fallback detection**: Exchange protocol is detected from portfolio position data when strategy tags don't include `exchange_account_strategy_*` tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)