### PR TITLE
Add Coinbase benchmarks to strategy charts

### DIFF
--- a/src/lib/top-vaults/CoinbaseBenchmarkSeries.svelte
+++ b/src/lib/top-vaults/CoinbaseBenchmarkSeries.svelte
@@ -1,0 +1,83 @@
+<!--
+@component
+Overlay a Coinbase benchmark line on top of the vault share-price chart.
+
+The benchmark is rebased to the vault's starting share price for the current
+visible range so the lines can be compared on a single axis.
+-->
+<script lang="ts">
+	import type { TimeBucket } from '$lib/schemas/utility';
+	import type { LineSeriesPartialOptions } from 'lightweight-charts';
+	import type { SimpleDataItem } from '$lib/charts/types';
+	import { LineSeries } from 'lightweight-charts';
+	import Series from '$lib/charts/Series.svelte';
+	import { dateToTs, resampleTimeSeries, timeBucketToInterval } from '$lib/charts/helpers';
+	import { fetchCoinbaseBenchmarkCloses } from './coinbase';
+
+	interface Props {
+		productId: 'BTC-USD' | 'ETH-USD';
+		data: SimpleDataItem[];
+		timeBucket: TimeBucket;
+		range: [Date, Date];
+		color: string;
+	}
+
+	let { productId, data, timeBucket, range, color }: Props = $props();
+
+	let benchmarkData = $state<SimpleDataItem[]>([]);
+	let requestVersion = 0;
+
+	let effectiveStartDate = $derived.by(() => {
+		const firstVaultPoint = data[0];
+		if (!firstVaultPoint) return range[0];
+		return new Date(Math.max(range[0].getTime(), firstVaultPoint.time * 1000));
+	});
+
+	let initialVaultValue = $derived.by(() => {
+		const initialTs = dateToTs(effectiveStartDate);
+		return data.find((item) => item.time >= initialTs)?.value ?? data[0]?.value ?? 0;
+	});
+
+	let options: LineSeriesPartialOptions = $derived({
+		color,
+		lineWidth: 2,
+		priceLineVisible: false,
+		lastValueVisible: false,
+		crosshairMarkerVisible: false
+	});
+
+	$effect(() => {
+		void fetchBenchmarkData();
+	});
+
+	async function fetchBenchmarkData() {
+		const currentRequest = ++requestVersion;
+		benchmarkData = [];
+
+		if (!data.length || initialVaultValue <= 0) return;
+
+		try {
+			const closes = await fetchCoinbaseBenchmarkCloses(fetch, productId, timeBucket, effectiveStartDate, range[1]);
+			if (currentRequest !== requestVersion || closes.length === 0) return;
+
+			const resampledCloses = resampleTimeSeries(closes, timeBucketToInterval(timeBucket), range[1]);
+			const initialBenchmarkValue = resampledCloses[0]?.value ?? 0;
+			if (initialBenchmarkValue <= 0) return;
+
+			benchmarkData = resampledCloses.map((item) => {
+				const percentChange = item.value / initialBenchmarkValue - 1;
+				return {
+					time: item.time,
+					value: initialVaultValue * (1 + percentChange),
+					customValues: { percentChange }
+				};
+			});
+		} catch (error) {
+			if (currentRequest === requestVersion) {
+				console.error(`Failed to load Coinbase benchmark ${productId}`, error);
+			}
+		}
+	}
+</script>
+
+<Series type={LineSeries} data={benchmarkData} {options} />

--- a/src/lib/top-vaults/VaultPriceChart.svelte
+++ b/src/lib/top-vaults/VaultPriceChart.svelte
@@ -1,12 +1,22 @@
+<!--
+@component
+Render the vault share-price chart with TVL bars and Coinbase BTC/ETH benchmarks.
+
+The benchmark lines are rebased to the vault share price for the selected range
+so the relative performance is comparable on a single axis.
+-->
 <script lang="ts">
 	import type { VaultInfo } from './schemas';
+	import brandMark from '$lib/assets/brand-mark.svg';
 	import { HistogramSeries } from 'lightweight-charts';
 	import ChartContainer from '$lib/charts/ChartContainer.svelte';
 	import AreaSeries from '$lib/charts/AreaSeries.svelte';
+	import CoinbaseBenchmarkSeries from './CoinbaseBenchmarkSeries.svelte';
 	import Series from '$lib/charts/Series.svelte';
 	import SeriesLabel from '$lib/charts/SeriesLabel.svelte';
 	import ChartTooltip from '$lib/charts/ChartTooltip.svelte';
-	import { formatTokenAmount } from '$lib/helpers/formatters';
+	import { getLogoUrl } from '$lib/helpers/assets';
+	import { formatPercent, formatTokenAmount } from '$lib/helpers/formatters';
 	import { formatDate, resampleTimeSeries } from '$lib/charts/helpers';
 
 	interface Props {
@@ -18,6 +28,11 @@
 	let loading = $state(true);
 	let priceData = $state<[number, number][]>();
 	let tvlData = $state<[number, number][]>();
+
+	function getBenchmarkPercentChange(point: unknown) {
+		if (!point || typeof point !== 'object' || !('customValues' in point)) return undefined;
+		return (point as { customValues?: { percentChange?: number } }).customValues?.percentChange;
+	}
 
 	async function fetchMetrics(vaultId: string) {
 		loading = true;
@@ -38,6 +53,12 @@
 	});
 
 	const formatValue = (v: number) => formatTokenAmount(v, 2);
+
+	const benchmarkLegend = [
+		{ label: 'Vault', color: 'var(--c-bullish)', logoUrl: brandMark },
+		{ label: 'BTC', color: '#f7931a80', logoUrl: getLogoUrl('token', 'btc') },
+		{ label: 'ETH', color: '#627eea80', logoUrl: getLogoUrl('token', 'eth') }
+	] as const;
 </script>
 
 <div class="vault-price-chart">
@@ -49,12 +70,29 @@
 		{formatValue}
 		options={{ handleScroll: false, handleScale: false }}
 	>
-		{#snippet series({ data, timeSpan })}
+		{#snippet series({ data, timeSpan, range })}
 			<AreaSeries
 				{data}
 				options={{ priceLineVisible: false, crosshairMarkerVisible: false }}
 				priceScaleOptions={{ scaleMargins: { top: 0.1, bottom: 0.1 } }}
 			/>
+
+			{#if data.length > 1 && range}
+				<CoinbaseBenchmarkSeries
+					productId="BTC-USD"
+					{data}
+					timeBucket={timeSpan.timeBucket}
+					{range}
+					color="#f7931a80"
+				/>
+				<CoinbaseBenchmarkSeries
+					productId="ETH-USD"
+					{data}
+					timeBucket={timeSpan.timeBucket}
+					{range}
+					color="#627eea80"
+				/>
+			{/if}
 
 			<Series
 				type={HistogramSeries}
@@ -71,18 +109,36 @@
 			</Series>
 		{/snippet}
 
-		{#snippet tooltip({ point, time }, [price, tvl])}
-			{#if price || tvl}
+		{#snippet tooltip({ point, time }, [price, btcBenchmark, ethBenchmark, tvl])}
+			{#if price || btcBenchmark || ethBenchmark || tvl}
 				<ChartTooltip {point}>
 					<div class="tooltip-date">{formatDate(time as number, '1d')}</div>
 					<dl class="tooltip-items">
 						<dt>Price:</dt>
 						<dd>{formatValue(price?.value)} {vault.denomination}</dd>
+						<dt>BTC:</dt>
+						<dd>{formatPercent(getBenchmarkPercentChange(btcBenchmark), 1, 1, { signDisplay: 'exceptZero' })}</dd>
+						<dt>ETH:</dt>
+						<dd>{formatPercent(getBenchmarkPercentChange(ethBenchmark), 1, 1, { signDisplay: 'exceptZero' })}</dd>
 						<dt>TVL:</dt>
 						<dd>{formatValue(tvl?.value)}</dd>
 					</dl>
 				</ChartTooltip>
 			{/if}
+		{/snippet}
+
+		{#snippet footer()}
+			<footer class="benchmark-legend" aria-label="Chart legend">
+				{#each benchmarkLegend as benchmark}
+					<div class="legend-item" style:--legend-color={benchmark.color}>
+						<span class="legend-swatch" aria-hidden="true"></span>
+						{#if benchmark.logoUrl}
+							<img class="legend-logo" src={benchmark.logoUrl} alt="" aria-hidden="true" />
+						{/if}
+						<span>{benchmark.label}</span>
+					</div>
+				{/each}
+			</footer>
 		{/snippet}
 	</ChartContainer>
 </div>
@@ -121,6 +177,37 @@
 				letter-spacing: var(--ls-ui-md, normal);
 				color: var(--c-text);
 			}
+		}
+
+		.benchmark-legend {
+			margin-top: 0.75rem;
+			margin-bottom: -0.25rem;
+			display: flex;
+			flex-wrap: wrap;
+			gap: 0.75rem 1rem;
+			justify-content: center;
+		}
+
+		.legend-item {
+			display: inline-flex;
+			align-items: center;
+			gap: 0.5rem;
+			font: var(--f-ui-sm-medium);
+			letter-spacing: var(--ls-ui-sm, normal);
+			color: var(--c-text-extra-light);
+		}
+
+		.legend-logo {
+			width: 1rem;
+			height: 1rem;
+			flex: 0 0 auto;
+		}
+
+		.legend-swatch {
+			width: 1.5rem;
+			height: 0;
+			border-top: 2px solid var(--legend-color);
+			border-radius: 999px;
 		}
 	}
 </style>

--- a/src/lib/top-vaults/coinbase.ts
+++ b/src/lib/top-vaults/coinbase.ts
@@ -1,0 +1,77 @@
+import type { TimeBucket } from '$lib/schemas/utility';
+
+type CoinbaseProductId = 'BTC-USD' | 'ETH-USD';
+type CoinbaseCandle = [time: number, low: number, high: number, open: number, close: number, volume: number];
+
+const COINBASE_API_URL = 'https://api.exchange.coinbase.com';
+const MAX_CANDLES_PER_REQUEST = 300;
+const benchmarkRequestCache = new Map<string, Promise<[number, number][]>>();
+
+function getGranularitySeconds(timeBucket: TimeBucket) {
+	return timeBucket === '1d' ? 86_400 : 3_600;
+}
+
+/**
+ * Fetch Coinbase close prices for a benchmark product across the requested chart range.
+ *
+ * Coinbase limits candle responses to 300 rows per request, so we fetch the range
+ * in chunks and merge the close-price samples into a single ascending series.
+ */
+export function fetchCoinbaseBenchmarkCloses(
+	fetch: Fetch,
+	productId: CoinbaseProductId,
+	timeBucket: TimeBucket,
+	start: Date,
+	end: Date
+): Promise<[number, number][]> {
+	const granularitySeconds = getGranularitySeconds(timeBucket);
+	const cacheKey = `${productId}:${granularitySeconds}:${start.toISOString()}:${end.toISOString()}`;
+
+	const cachedResponse = benchmarkRequestCache.get(cacheKey);
+	if (cachedResponse) return cachedResponse;
+
+	const responsePromise = fetchCoinbaseBenchmarkClosesUncached(fetch, productId, granularitySeconds, start, end).catch(
+		(error) => {
+			benchmarkRequestCache.delete(cacheKey);
+			throw error;
+		}
+	);
+
+	benchmarkRequestCache.set(cacheKey, responsePromise);
+	return responsePromise;
+}
+
+async function fetchCoinbaseBenchmarkClosesUncached(
+	fetch: Fetch,
+	productId: CoinbaseProductId,
+	granularitySeconds: number,
+	start: Date,
+	end: Date
+): Promise<[number, number][]> {
+	const endExclusive = new Date(end.getTime() + granularitySeconds * 1000);
+	const chunkSpanMs = granularitySeconds * MAX_CANDLES_PER_REQUEST * 1000;
+	const candlesByTimestamp = new Map<number, number>();
+
+	for (let chunkStartMs = start.getTime(); chunkStartMs < endExclusive.getTime(); chunkStartMs += chunkSpanMs) {
+		const chunkEndMs = Math.min(chunkStartMs + chunkSpanMs, endExclusive.getTime());
+		const searchParams = new URLSearchParams({
+			granularity: String(granularitySeconds),
+			start: new Date(chunkStartMs).toISOString(),
+			end: new Date(chunkEndMs).toISOString()
+		});
+
+		const response = await fetch(`${COINBASE_API_URL}/products/${productId}/candles?${searchParams}`);
+		if (!response.ok) {
+			throw new Error(`Failed to load Coinbase benchmark data for ${productId}: ${response.status}`);
+		}
+
+		const candles = (await response.json()) as CoinbaseCandle[];
+		for (const [timestamp, , , , close] of candles) {
+			if (timestamp >= start.getTime() / 1000 && timestamp <= end.getTime() / 1000) {
+				candlesByTimestamp.set(timestamp, close);
+			}
+		}
+	}
+
+	return Array.from(candlesByTimestamp.entries()).sort(([leftTs], [rightTs]) => leftTs - rightTs);
+}

--- a/src/lib/trade-executor/helpers/benchmark.svelte.ts
+++ b/src/lib/trade-executor/helpers/benchmark.svelte.ts
@@ -61,10 +61,17 @@ const benchmarkTokens: BenchmarkTokenInfo[] = [
 	}
 ];
 
+const strategyBenchmarkOverrides: Record<string, string[]> = {
+	'gmx-ai': ['BTC', 'ETH']
+};
+
 // FIXME: using strategy id hack to infer list of tokens based on strategy ID.
 // In the future this should be provided by strategy configuration.
 export function getBenchmarkTokens({ id }: { id: string }): BenchmarkToken[] {
 	const parts = id.split('-');
-	const tokens = benchmarkTokens.filter((token) => parts.includes(token.symbol.toLowerCase()));
+	const explicitSymbols = strategyBenchmarkOverrides[id];
+	const tokens = benchmarkTokens.filter((token) =>
+		explicitSymbols ? explicitSymbols.includes(token.symbol) : parts.includes(token.symbol.toLowerCase())
+	);
 	return tokens.map((t) => new BenchmarkToken(t));
 }

--- a/src/routes/strategies/[strategy=apiStrategy]/StrategyPerformanceChart.svelte
+++ b/src/routes/strategies/[strategy=apiStrategy]/StrategyPerformanceChart.svelte
@@ -5,6 +5,7 @@
 	import Profitability, { type ProfitInfo } from '$lib/components/Profitability.svelte';
 	import AreaSeries from '$lib/charts/AreaSeries.svelte';
 	import BenchmarkSeries from '$lib/charts/BenchmarkSeries.svelte';
+	import { getLogoUrl } from '$lib/helpers/assets';
 	import { getChartClient } from 'trade-executor/client/chart';
 	import { getBenchmarkTokens } from 'trade-executor/helpers/benchmark.svelte';
 	import { formatPercent } from '$lib/helpers/formatters';
@@ -78,6 +79,7 @@
 				{#each benchmarkTokens as benchmark (benchmark.pairId)}
 					<label style:--color={benchmark.color}>
 						<input type="checkbox" name="benchmarks" bind:checked={benchmark.checked} />
+						<img class="benchmark-logo" src={getLogoUrl('token', benchmark.symbol)} alt="" aria-hidden="true" />
 						{benchmark.symbol}
 						<span class="performance" class:skeleton={benchmark.loading}>
 							{formatPercent(benchmark.periodPerformance, 1, 1, { signDisplay: 'exceptZero' })}
@@ -138,6 +140,12 @@
 				/* NOTE: There's no way to remove alpha-channel with color-mix, so have to use */
 				/* relative color syntax here (not supported by Mobile Safari < 16.4 ) */
 				color: hsl(from var(--color) h s l / 100%);
+			}
+
+			.benchmark-logo {
+				width: 1rem;
+				height: 1rem;
+				flex: 0 0 auto;
 			}
 
 			input[type='checkbox'] {


### PR DESCRIPTION
Why

Add BTC and ETH benchmark overlays where strategy users compare vault share-price performance, and make sure GMX-AI can show benchmark lines as well. This gives strategy pages a clearer market context without requiring a backend change.

Lessons learnt

- Vault share-price overlays need benchmark series rebased to the vault start value for the selected range, otherwise raw BTC or ETH prices do not compare meaningfully on the same axis.
- Coinbase candle history is limited to 300 rows per request, so benchmark history needs to be fetched in chunks for longer ranges.
- GMX-AI cannot rely on benchmark inference from the strategy id alone, so it needs an explicit BTC/ETH benchmark override.

Summary

- add Coinbase-backed BTC and ETH benchmark overlays to the vault share-price chart, including tooltip values and a legend with brand/token logos
- clamp benchmark start times to the vault's first available datapoint when a vault does not have the full selected history
- add benchmark logos to the API strategy performance legend and explicitly enable BTC and ETH benchmarks for GMX-AI