### PR TITLE
Update frontend strategy ordering

### DIFF
--- a/src/lib/strategies/sort.test.ts
+++ b/src/lib/strategies/sort.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from 'vitest';
+import type { StrategyInfo } from 'trade-executor/models/strategy-info';
+import { compareStrategiesForFrontend, compareStrategiesForFrontpage } from './sort';
+
+function createStrategy({
+	id,
+	name,
+	sort_priority
+}: {
+	id: string;
+	name: string;
+	sort_priority: number;
+}): StrategyInfo {
+	return {
+		id,
+		name,
+		sort_priority,
+		url: '',
+		hiddenPositions: [],
+		hiddenElements: { timeframes: false },
+		frontpage: false,
+		microsite: false,
+		depositExternal: false,
+		useSharePrice: false,
+		tileChartDirection: 'absolute',
+		connected: false,
+		icon_url: '',
+		error: 'test error'
+	};
+}
+
+describe('compareStrategiesForFrontend', () => {
+	it('keeps pinned strategies in the requested order', () => {
+		const strategies = [
+			createStrategy({ id: 'gmx-ai', name: 'GMX AI', sort_priority: 999 }),
+			createStrategy({ id: 'master-vault', name: 'Master Vault', sort_priority: 999 }),
+			createStrategy({ id: 'opencz', name: 'OpenCZ', sort_priority: 0 }),
+			createStrategy({ id: 'hyper-ai', name: 'HyperAI', sort_priority: 1 }),
+			createStrategy({ id: 'ichi-hyperliquid', name: 'Ichi', sort_priority: 500 })
+		];
+
+		const sortedIds = strategies.sort(compareStrategiesForFrontend).map((strategy) => strategy.id);
+
+		expect(sortedIds).toEqual(['opencz', 'hyper-ai', 'master-vault', 'ichi-hyperliquid', 'gmx-ai']);
+	});
+
+	it('places all other strategies afterwards by sort priority', () => {
+		const strategies = [
+			createStrategy({ id: 'other-low', name: 'Other low', sort_priority: 1 }),
+			createStrategy({ id: 'other-high', name: 'Other high', sort_priority: 5 }),
+			createStrategy({ id: 'opencz', name: 'OpenCZ', sort_priority: 0 })
+		];
+
+		const sortedIds = strategies.sort(compareStrategiesForFrontend).map((strategy) => strategy.id);
+
+		expect(sortedIds).toEqual(['opencz', 'other-high', 'other-low']);
+	});
+
+	it('keeps frontpage strategies in the requested order', () => {
+		const strategies = [
+			createStrategy({ id: 'opencz', name: 'OpenCZ', sort_priority: 999 }),
+			createStrategy({ id: 'other-high', name: 'Other high', sort_priority: 100 }),
+			createStrategy({ id: 'master-vault', name: 'Master Vault', sort_priority: 1 })
+		];
+
+		const sortedIds = strategies.sort(compareStrategiesForFrontpage).map((strategy) => strategy.id);
+
+		expect(sortedIds).toEqual(['opencz', 'master-vault', 'other-high']);
+	});
+});

--- a/src/lib/strategies/sort.ts
+++ b/src/lib/strategies/sort.ts
@@ -1,0 +1,47 @@
+import type { StrategyInfo } from 'trade-executor/models/strategy-info';
+
+const listingPinnedStrategyOrder = ['opencz', 'hyper-ai', 'master-vault', 'ichi-hyperliquid', 'gmx-ai'] as const;
+
+const frontpagePinnedStrategyOrder = ['opencz', 'master-vault'] as const;
+
+function createPinnedRankMap(strategyIds: readonly string[]) {
+	return new Map<string, number>(strategyIds.map((strategyId, index) => [strategyId, strategyIds.length - index]));
+}
+
+function createStrategyComparator(pinnedStrategyOrder: readonly string[]) {
+	const pinnedStrategyRanks = createPinnedRankMap(pinnedStrategyOrder);
+
+	return function compareStrategies(a: StrategyInfo, b: StrategyInfo) {
+		const pinnedRankA = pinnedStrategyRanks.get(a.id) ?? 0;
+		const pinnedRankB = pinnedStrategyRanks.get(b.id) ?? 0;
+
+		if (pinnedRankA !== pinnedRankB) {
+			return pinnedRankB - pinnedRankA;
+		}
+
+		const sortPriorityA = a.sort_priority ?? 0;
+		const sortPriorityB = b.sort_priority ?? 0;
+
+		if (sortPriorityA !== sortPriorityB) {
+			return sortPriorityB - sortPriorityA;
+		}
+
+		return a.name.localeCompare(b.name);
+	};
+}
+
+/**
+ * Sort strategies for frontend listings.
+ *
+ * Pinned strategies always appear first in a fixed order.
+ * Remaining strategies fall back to existing sort priority rules.
+ */
+export const compareStrategiesForFrontend = createStrategyComparator(listingPinnedStrategyOrder);
+
+/**
+ * Sort strategies for the frontpage featured section.
+ *
+ * OpenCZ should appear before Master Vault, with all other strategies following
+ * the default sort-priority behaviour.
+ */
+export const compareStrategiesForFrontpage = createStrategyComparator(frontpagePinnedStrategyOrder);

--- a/src/routes/+page.server.ts
+++ b/src/routes/+page.server.ts
@@ -1,5 +1,6 @@
 import { getCachedStrategies } from 'trade-executor/client/strategy-info';
 import { yamlStrategies } from '$lib/strategies/yaml/loader';
+import { compareStrategiesForFrontpage } from '$lib/strategies/sort';
 import { toListingStrategy } from '$lib/strategies/yaml/adapter';
 import { fetchTopVaults } from '$lib/top-vaults/client';
 import { type SlimVaultInfo, type VaultAggregates } from '$lib/top-vaults/schemas';
@@ -35,7 +36,7 @@ export async function load({ fetch }) {
 		Promise.all([fetchLatestFredValue('SNDR'), fetchLatestTreasuryRate()])
 	]);
 
-	const frontpageStrategies = strategies.filter((s) => s.frontpage && s.connected);
+	const frontpageStrategies = strategies.filter((s) => s.frontpage);
 	const yamlTileFreshness: {
 		strategyId: string;
 		vaultId: string | null;
@@ -73,6 +74,8 @@ export async function load({ fetch }) {
 			frontpageStrategies.push(toListingStrategy(config));
 		}
 	}
+
+	frontpageStrategies.sort(compareStrategiesForFrontpage);
 
 	const [savingsRate, treasuryRate] = ratesResult;
 

--- a/src/routes/strategies/+page.server.ts
+++ b/src/routes/strategies/+page.server.ts
@@ -9,6 +9,7 @@ import type { PerformanceData } from 'trade-executor/schemas/utility-types.js';
 import { getCachedStrategies } from 'trade-executor/client/strategy-info';
 import { fetchPublicApi } from '$lib/helpers/public-api';
 import { yamlStrategies } from '$lib/strategies/yaml/loader';
+import { compareStrategiesForFrontend } from '$lib/strategies/sort';
 import { toListingStrategy } from '$lib/strategies/yaml/adapter';
 import { fetchTopVaults } from '$lib/top-vaults/client';
 import { getCachedSharePriceReturns } from '$lib/strategies/yaml/share-price';
@@ -59,7 +60,7 @@ export async function load({ fetch, locals }) {
 	const tvlData = admin ? fetchTvlData() : undefined;
 
 	const allStrategies = [...(await apiStrategies), ...(await yamlStrategyList)];
-	allStrategies.sort((a, b) => (b.sort_priority ?? 0) - (a.sort_priority ?? 0));
+	allStrategies.sort(compareStrategiesForFrontend);
 
 	return {
 		strategies: allStrategies,

--- a/strategies/ichi-hyperliquid.yaml
+++ b/strategies/ichi-hyperliquid.yaml
@@ -19,7 +19,7 @@ tags:
 # How far up in the listing page we displays this
 sort_priority: 0
 # Show on front page
-frontpage: true
+frontpage: false
 # Mangle HTML file input to iframe-compatible format
 inject_backtest_iframe_resizer: true
 # Use relative direction for the tile chart (matches vault detail page)


### PR DESCRIPTION
## Why

The frontend needs a stable strategy ordering for both the main strategy listing and the homepage featured strategy section. The frontpage should feature OpenCZ followed by Master Vault, while Ichi should no longer be featured there.

## Lessons learnt

The homepage previously filtered featured API strategies to connected-only entries, which meant temporarily unavailable metadata could hide a deliberately featured strategy. Keeping the frontpage flag as the source of truth makes the featured set more predictable.

## Summary

- Add shared strategy sort helpers for the main listing and frontpage featured section.
- Sort the main strategy list with the requested pinned order and sort the frontpage as OpenCZ, then Master Vault.
- Include frontpage API strategies even when metadata fetches temporarily fail, so featured strategies do not disappear during transient backend issues.
- Disable Ichi on the frontpage.