### PR TITLE
fix: ignore unknown trade flags

### DIFF
--- a/src/lib/trade-executor/models/trade-info.test.ts
+++ b/src/lib/trade-executor/models/trade-info.test.ts
@@ -1,3 +1,4 @@
+import { z } from 'zod';
 import type { TradingPairIdentifier } from 'trade-executor/schemas/identifier';
 import { tradeExecutionSchema } from '../schemas/trade';
 import { type TradeInfo, TradeDirections, createTradeInfo } from './trade-info';
@@ -79,6 +80,25 @@ describe('a spot long position trade', () => {
 		test('should have directionLabel "Sell"', () => {
 			expect(tradeInfo.directionLabel).toBe('Sell');
 		});
+	});
+});
+
+describe('trade flags', () => {
+	test('should drop unknown backend flags', () => {
+		const spotPair: TradingPairIdentifier = {
+			base: WETH,
+			quote: USDC,
+			pool_address: '0x234',
+			kind: 'spot_market_hold'
+		};
+
+		const tradeExecution = tradeExecutionSchema.parse({
+			...partialRawTrade,
+			pair: spotPair,
+			flags: ['close', 'hypercore_duplicate_close', 'future_backend_only_flag']
+		});
+
+		expect(tradeExecution.flags).toEqual(['close']);
 	});
 });
 

--- a/src/lib/trade-executor/schemas/trade.ts
+++ b/src/lib/trade-executor/schemas/trade.ts
@@ -36,7 +36,7 @@ export const tradeType = z.enum([
 ]);
 export type TradeType = z.infer<typeof tradeType>;
 
-export const tradeFlag = z.enum([
+const tradeFlagValues = [
 	'open',
 	'close',
 	'increase',
@@ -47,8 +47,17 @@ export const tradeFlag = z.enum([
 	'missing_position_repair',
 	'partial_take_profit',
 	'ignore_open'
-]);
+] as const;
+export const tradeFlag = z.enum(tradeFlagValues);
 export type TradeFlag = z.infer<typeof tradeFlag>;
+
+const knownTradeFlags = new Set<string>(tradeFlagValues);
+export const tradeFlagsSchema = z
+	.array(z.unknown())
+	.transform((flags) =>
+		flags.filter((flag): flag is TradeFlag => typeof flag === 'string' && knownTradeFlags.has(flag))
+	)
+	.nullish();
 
 // see: https://github.com/tradingstrategy-ai/trade-executor/blob/master/tradeexecutor/strategy/trade_pricing.py
 export const tradePricingSchema = z.object({
@@ -77,7 +86,7 @@ export const tradeExecutionSchema = z.object({
 	planned_price: usDollarPrice,
 	reserve_currency: assetIdentifierSchema,
 	route: z.string().nullish(),
-	flags: tradeFlag.array().nullish(),
+	flags: tradeFlagsSchema,
 	// triggers: see trigger.py; leaving unparsed for now
 	// activated_trigger: see trigger.py; leaving unparsed for now
 	// expired_triggers: see trigger.py; leaving unparsed for now


### PR DESCRIPTION
Why

The strategy state parser rejected backend-only trade flags it did not recognise. A new Hypercore flag caused the whole strategy state parse to fail, which crashed pages like HyperAI open positions even though the frontend did not need that flag.

Lessons learnt

Trade flags can contain backend metadata that is not relevant to frontend display logic. The frontend should keep the UI-handled flags and discard unknown values instead of making every new backend flag a breaking schema change.

Summary

- Filter trade flags during schema parsing so unknown values are dropped.
- Keep known trade flags typed for existing UI logic.
- Add a regression test covering unknown backend flags.