### PR TITLE
feat: improve vault benchmark chart tooltip and legend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Weblog of stuff
 
+- Improve vault benchmark chart with protocol icons, USD prices in tooltip, and dynamic legend colours (2026-04-20)
 - Link exchange account positions directly to exchange pages for GMX and Hyperliquid strategies (2026-04-13)
 - Show "Hyperliquid vault" as asset management mode for Hyperliquid strategies on listing tiles (2026-04-08)
 - Add HyperEVM wallet support and Hyperliquid vault buttons on position pages (2026-04-08)

--- a/src/lib/top-vaults/CoinbaseBenchmarkSeries.svelte
+++ b/src/lib/top-vaults/CoinbaseBenchmarkSeries.svelte
@@ -69,7 +69,7 @@ visible range so the lines can be compared on a single axis.
 				return {
 					time: item.time,
 					value: initialVaultValue * (1 + percentChange),
-					customValues: { percentChange }
+					customValues: { percentChange, usdPrice: item.value }
 				};
 			});
 		} catch (error) {

--- a/src/lib/top-vaults/VaultPriceChart.svelte
+++ b/src/lib/top-vaults/VaultPriceChart.svelte
@@ -16,22 +16,24 @@ so the relative performance is comparable on a single axis.
 	import SeriesLabel from '$lib/charts/SeriesLabel.svelte';
 	import ChartTooltip from '$lib/charts/ChartTooltip.svelte';
 	import { getLogoUrl } from '$lib/helpers/assets';
-	import { formatPercent, formatTokenAmount } from '$lib/helpers/formatters';
+	import { formatDollar, formatPercent, formatTokenAmount } from '$lib/helpers/formatters';
 	import { formatDate, resampleTimeSeries } from '$lib/charts/helpers';
 
 	interface Props {
 		vault: VaultInfo;
+		/** Optional protocol logo URL to use instead of Trading Strategy brand mark */
+		protocolLogoUrl?: string;
 	}
 
-	let { vault }: Props = $props();
+	let { vault, protocolLogoUrl }: Props = $props();
 
 	let loading = $state(true);
 	let priceData = $state<[number, number][]>();
 	let tvlData = $state<[number, number][]>();
 
-	function getBenchmarkPercentChange(point: unknown) {
+	function getBenchmarkCustomValues(point: unknown) {
 		if (!point || typeof point !== 'object' || !('customValues' in point)) return undefined;
-		return (point as { customValues?: { percentChange?: number } }).customValues?.percentChange;
+		return (point as { customValues?: { percentChange?: number; usdPrice?: number } }).customValues;
 	}
 
 	async function fetchMetrics(vaultId: string) {
@@ -54,11 +56,19 @@ so the relative performance is comparable on a single axis.
 
 	const formatValue = (v: number) => formatTokenAmount(v, 2);
 
-	const benchmarkLegend = [
-		{ label: 'Vault', color: 'var(--c-bullish)', logoUrl: brandMark },
+	let vaultDirection = $state(0);
+
+	function getVaultColor(direction: number) {
+		if (direction < 0) return 'var(--c-bearish)';
+		if (direction > 0) return 'var(--c-bullish)';
+		return 'var(--c-text-ultra-light)';
+	}
+
+	const benchmarkLegend = $derived([
+		{ label: 'Vault', color: getVaultColor(vaultDirection), logoUrl: protocolLogoUrl ?? brandMark },
 		{ label: 'BTC', color: '#f7931a80', logoUrl: getLogoUrl('token', 'btc') },
 		{ label: 'ETH', color: '#627eea80', logoUrl: getLogoUrl('token', 'eth') }
-	] as const;
+	] as const);
 </script>
 
 <div class="vault-price-chart">
@@ -75,6 +85,7 @@ so the relative performance is comparable on a single axis.
 				{data}
 				options={{ priceLineVisible: false, crosshairMarkerVisible: false }}
 				priceScaleOptions={{ scaleMargins: { top: 0.1, bottom: 0.1 } }}
+				onVisibleDataChange={(_, profitInfo) => (vaultDirection = profitInfo.direction)}
 			/>
 
 			{#if data.length > 1 && range}
@@ -92,34 +103,42 @@ so the relative performance is comparable on a single axis.
 					{range}
 					color="#627eea80"
 				/>
-			{/if}
 
-			<Series
-				type={HistogramSeries}
-				data={resampleTimeSeries(tvlData ?? [], timeSpan.interval)}
-				options={{ priceLineVisible: false, color: 'transparent' }}
-				paneIndex={1}
-				priceScaleOptions={{ scaleMargins: { top: 0.25, bottom: 0 } }}
-				callback={({ series, colors }) => {
-					series.getPane().setHeight(150);
-					series.applyOptions({ color: colors.box3 });
-				}}
-			>
-				<SeriesLabel heading>TVL</SeriesLabel>
-			</Series>
+				<Series
+					type={HistogramSeries}
+					data={resampleTimeSeries(tvlData ?? [], timeSpan.interval)}
+					options={{ priceLineVisible: false, color: 'transparent' }}
+					paneIndex={1}
+					priceScaleOptions={{ scaleMargins: { top: 0.25, bottom: 0 } }}
+					callback={({ series, colors }) => {
+						series.getPane().setHeight(150);
+						series.applyOptions({ color: colors.box3 });
+					}}
+				>
+					<SeriesLabel heading>TVL</SeriesLabel>
+				</Series>
+			{/if}
 		{/snippet}
 
 		{#snippet tooltip({ point, time }, [price, btcBenchmark, ethBenchmark, tvl])}
 			{#if price || btcBenchmark || ethBenchmark || tvl}
+				{@const btc = getBenchmarkCustomValues(btcBenchmark)}
+				{@const eth = getBenchmarkCustomValues(ethBenchmark)}
 				<ChartTooltip {point}>
 					<div class="tooltip-date">{formatDate(time as number, '1d')}</div>
 					<dl class="tooltip-items">
 						<dt>Price:</dt>
 						<dd>{formatValue(price?.value)} {vault.denomination}</dd>
 						<dt>BTC:</dt>
-						<dd>{formatPercent(getBenchmarkPercentChange(btcBenchmark), 1, 1, { signDisplay: 'exceptZero' })}</dd>
+						<dd>
+							{formatPercent(btc?.percentChange, 1, 1, { signDisplay: 'exceptZero' })}
+							{#if btc?.usdPrice}<span class="benchmark-usd">{formatDollar(btc.usdPrice, 1)}</span>{/if}
+						</dd>
 						<dt>ETH:</dt>
-						<dd>{formatPercent(getBenchmarkPercentChange(ethBenchmark), 1, 1, { signDisplay: 'exceptZero' })}</dd>
+						<dd>
+							{formatPercent(eth?.percentChange, 1, 1, { signDisplay: 'exceptZero' })}
+							{#if eth?.usdPrice}<span class="benchmark-usd">{formatDollar(eth.usdPrice, 1)}</span>{/if}
+						</dd>
 						<dt>TVL:</dt>
 						<dd>{formatValue(tvl?.value)}</dd>
 					</dl>
@@ -176,6 +195,13 @@ so the relative performance is comparable on a single axis.
 				font: var(--f-ui-md-medium);
 				letter-spacing: var(--ls-ui-md, normal);
 				color: var(--c-text);
+			}
+
+			.benchmark-usd {
+				margin-left: 0.25rem;
+				font: var(--f-ui-sm-roman);
+				letter-spacing: var(--ls-ui-sm, normal);
+				color: var(--c-text-extra-light);
 			}
 		}
 

--- a/src/routes/trading-view/vaults/[vault=slug]/+page.svelte
+++ b/src/routes/trading-view/vaults/[vault=slug]/+page.svelte
@@ -17,6 +17,7 @@
 	import VaultRankings from './VaultRankings.svelte';
 	import IconDiscord from '~icons/local/discord';
 	import { hasSupportedProtocol, isBlacklisted } from '$lib/top-vaults/helpers';
+	import { getVaultProtocolLogoUrl } from '$lib/vault-protocol/helpers.js';
 
 	let { data } = $props();
 	let { vault, chain, protocolMetadata, stablecoinMetadata, generated_at } = $derived(data);
@@ -51,7 +52,10 @@
 
 		<VaultRankings {vault} {chain} {protocolMetadata} />
 
-		<ChartWithFeaturedMetrics {vault} />
+		<ChartWithFeaturedMetrics
+			{vault}
+			protocolLogoUrl={protocolMetadata ? getVaultProtocolLogoUrl(protocolMetadata.slug) : undefined}
+		/>
 
 		<VaultMetrics {vault} />
 

--- a/src/routes/trading-view/vaults/[vault=slug]/ChartWithFeaturedMetrics.svelte
+++ b/src/routes/trading-view/vaults/[vault=slug]/ChartWithFeaturedMetrics.svelte
@@ -9,14 +9,15 @@
 
 	interface Props {
 		vault: VaultInfo;
+		protocolLogoUrl?: string;
 	}
 
-	let { vault }: Props = $props();
+	let { vault, protocolLogoUrl }: Props = $props();
 </script>
 
 <MetricsBox>
 	<div class="chart-area">
-		<VaultPriceChart {vault} />
+		<VaultPriceChart {vault} {protocolLogoUrl} />
 
 		<div class="divider"></div>
 


### PR DESCRIPTION
## Why

Vault listing pages (e.g. `/trading-view/vaults/goon-edging`) had several issues with the benchmark chart:

1. **Wrong icon**: Used Trading Strategy brand mark instead of the protocol icon (e.g. Hyperliquid logo)
2. **Broken tooltip values**: BTC always showed `---` and ETH showed BTC's percentage — caused by a series registration order mismatch where the TVL histogram mounted before the conditional benchmark series, breaking positional tooltip destructuring
3. **Missing USD prices**: Tooltip only showed relative percent change for BTC/ETH, not the actual dollar price
4. **Static legend colour**: Vault legend swatch was always green even when the chart line turned red on negative windows (e.g. 1M)

## Lessons learnt

- lightweight-charts registers series in mount order via `chart.addSeries()`. When mixing unconditional and conditional series in Svelte templates, the positional tooltip array can silently break if unconditional series mount before conditional ones. All series that participate in the same tooltip destructuring should share the same conditional block.

## Summary

- **Protocol icon on vault pages**: Pass protocol logo URL through to `VaultPriceChart`; Trading Strategy brand mark still used on `/strategies` pages
- **Fix tooltip series order**: Move TVL histogram inside the same `{#if}` block as the benchmark series so they all mount together in the expected order: [price, BTC, ETH, TVL]
- **Add USD prices**: Store original Coinbase close price in `customValues.usdPrice` and display it in the tooltip (e.g. `BTC: -29.5% $68.3K`)
- **Dynamic legend colour**: Track vault `AreaSeries` direction via `onVisibleDataChange` callback and update the legend swatch colour to match (green/red/neutral)

🤖 Generated with [Claude Code](https://claude.com/claude-code)