### PR TITLE
feat: add utilisation chart for lending protocol vaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Weblog of stuff
 
+- Add utilisation chart for lending protocol vaults, with threshold colouring and explanatory tooltip (2026-04-21)
 - Improve vault benchmark chart with protocol icons, USD prices in tooltip, and dynamic legend colours (2026-04-20)
 - Link exchange account positions directly to exchange pages for GMX and Hyperliquid strategies (2026-04-13)
 - Show "Hyperliquid vault" as asset management mode for Hyperliquid strategies on listing tiles (2026-04-08)

--- a/src/lib/top-vaults/VaultUtilisationChart.svelte
+++ b/src/lib/top-vaults/VaultUtilisationChart.svelte
@@ -1,0 +1,160 @@
+<!--
+@component
+Render the vault utilisation chart for lending protocol vaults (Morpho, Euler, Silo Finance, etc.).
+
+Only renders if the vault has utilisation data available in the metrics endpoint.
+Utilisation values above 100% are possible for some lending protocols.
+
+The chart is coloured green below 80% utilisation and red above, with a dashed
+separator line at the 80% threshold.
+
+@example
+
+```svelte
+  <VaultUtilisationChart {vault} />
+```
+-->
+<script lang="ts">
+	import type { VaultInfo } from './schemas';
+	import { BaselineSeries } from 'lightweight-charts';
+	import MetricsBox from '$lib/components/MetricsBox.svelte';
+	import ChartContainer from '$lib/charts/ChartContainer.svelte';
+	import Series from '$lib/charts/Series.svelte';
+	import ChartTooltip from '$lib/charts/ChartTooltip.svelte';
+	import { formatDate } from '$lib/charts/helpers';
+	import { formatPercent } from '$lib/helpers/formatters';
+
+	interface Props {
+		vault: VaultInfo;
+	}
+
+	let { vault }: Props = $props();
+
+	let loading = $state(true);
+	let utilisationData = $state<[number, number][] | undefined>();
+
+	async function fetchMetrics(vaultId: string) {
+		loading = true;
+		utilisationData = undefined;
+		try {
+			const resp = await fetch(`/trading-view/vaults/${vaultId}/metrics`);
+			const data = await resp.json();
+			utilisationData = data.utilisation;
+		} finally {
+			loading = false;
+		}
+	}
+
+	$effect(() => {
+		fetchMetrics(vault.id);
+	});
+
+	const formatValue = (v: number) => formatPercent(v, 1);
+</script>
+
+{#if utilisationData === undefined || utilisationData.length > 0}
+	<MetricsBox>
+		<div class="vault-utilisation-chart">
+			<ChartContainer
+				title="Utilisation"
+				timeSpanOptions={['1M', '3M', 'Max']}
+				{loading}
+				data={utilisationData}
+				{formatValue}
+				options={{ handleScroll: false, handleScale: false }}
+			>
+				{#snippet series({ data })}
+					<Series
+						type={BaselineSeries}
+						{data}
+						options={{
+							baseValue: { type: 'price', price: 0.8 },
+							priceLineVisible: false,
+							crosshairMarkerVisible: false,
+							lineWidth: 2
+						}}
+						priceScaleOptions={{ scaleMargins: { top: 0.1, bottom: 0.1 } }}
+						callback={({ series, colors }) => {
+							series.applyOptions({
+								topLineColor: colors.bearish,
+								topFillColor1: colors.bearish30,
+								topFillColor2: colors.bearish0,
+								bottomLineColor: colors.bullish,
+								bottomFillColor1: colors.bullish0,
+								bottomFillColor2: colors.bullish30
+							});
+							series.createPriceLine({
+								price: 0.8,
+								color: colors.neutral30,
+								lineWidth: 1,
+								lineStyle: 2,
+								axisLabelVisible: false
+							});
+						}}
+					/>
+				{/snippet}
+
+				{#snippet tooltip({ point, time }, [utilisation])}
+					{#if utilisation}
+						<ChartTooltip {point}>
+							<div class="tooltip-date">{formatDate(time as number, '1d')}</div>
+							<dl class="tooltip-items">
+								<dt>Utilisation:</dt>
+								<dd>{formatValue(utilisation.value)}</dd>
+							</dl>
+							<p class="tooltip-explanation">
+								For lending based vaults, utilisation tells how much capital is borrowed out. It will affect the
+								interest rate and availability of redemptions.
+							</p>
+						</ChartTooltip>
+					{/if}
+				{/snippet}
+			</ChartContainer>
+		</div>
+	</MetricsBox>
+{/if}
+
+<style>
+	.vault-utilisation-chart {
+		:global([data-css-props]) {
+			--chart-aspect-ratio: auto;
+			--chart-height: 12rem;
+		}
+
+		.tooltip-date {
+			margin-bottom: 0.75rem;
+			font: var(--f-ui-sm-bold);
+			letter-spacing: var(--ls-ui-sm, normal);
+			color: var(--c-text-extra-light);
+		}
+
+		.tooltip-items {
+			display: grid;
+			grid-template-columns: auto auto;
+			align-items: end;
+			gap: 0.25rem 0.75rem;
+
+			dt {
+				font: var(--f-ui-sm-medium);
+				letter-spacing: var(--ls-ui-sm, normal);
+				color: var(--c-text-extra-light);
+				text-transform: uppercase;
+			}
+
+			dd {
+				font: var(--f-ui-md-medium);
+				letter-spacing: var(--ls-ui-md, normal);
+				color: var(--c-text);
+			}
+		}
+
+		.tooltip-explanation {
+			margin-top: 0.75rem;
+			max-width: 16rem;
+			white-space: normal;
+			font: var(--f-ui-sm-roman);
+			letter-spacing: var(--ls-ui-sm, normal);
+			color: var(--c-text-extra-light);
+		}
+	}
+</style>

--- a/src/routes/trading-view/vaults/[vault=slug]/+page.svelte
+++ b/src/routes/trading-view/vaults/[vault=slug]/+page.svelte
@@ -10,6 +10,7 @@
 	import SocialMediaTags from './SocialMetaTags.svelte';
 	import VaultPageHeader from './VaultPageHeader.svelte';
 	import ChartWithFeaturedMetrics from './ChartWithFeaturedMetrics.svelte';
+	import VaultUtilisationChart from '$lib/top-vaults/VaultUtilisationChart.svelte';
 	import VaultMetrics from './VaultMetrics.svelte';
 	import VaultTechnicalDetailsTable from './VaultTechnicalDetailsTable.svelte';
 	import VaultPeriodicMetrics from './VaultPeriodicMetrics.svelte';
@@ -56,6 +57,8 @@
 			{vault}
 			protocolLogoUrl={protocolMetadata ? getVaultProtocolLogoUrl(protocolMetadata.slug) : undefined}
 		/>
+
+		<VaultUtilisationChart {vault} />
 
 		<VaultMetrics {vault} />
 

--- a/src/routes/trading-view/vaults/[vault=vaultId]/metrics/+server.ts
+++ b/src/routes/trading-view/vaults/[vault=vaultId]/metrics/+server.ts
@@ -9,13 +9,14 @@ async function getPriceAndTvlData(vaultId: string) {
 
 	try {
 		const reader = await connection.runAndReadAll(
-			`SELECT EXTRACT(EPOCH FROM timestamp) as ts, share_price, total_assets
+			`SELECT EXTRACT(EPOCH FROM timestamp) as ts, share_price, total_assets,
+              CASE WHEN utilisation >= 0 AND utilisation <= 2 THEN utilisation ELSE NULL END as utilisation
        FROM parquet_scan($parquetFile)
        WHERE id = $vaultId
        ORDER BY timestamp`,
 			{ parquetFile, vaultId }
 		);
-		return reader.getRows() as [UTCTimestamp, number, number][];
+		return reader.getRows() as [UTCTimestamp, number, number, number | null][];
 	} catch (e) {
 		console.error(`Error loading data from ${parquetFile} for vault <${vaultId}>`);
 		const { stack } = e as Error;
@@ -33,11 +34,15 @@ export async function GET({ params }) {
 
 	const price: [UTCTimestamp, number][] = [];
 	const tvl: [UTCTimestamp, number][] = [];
+	const utilisation: [UTCTimestamp, number][] = [];
 
-	for (const [ts, p, t] of rows) {
+	for (const [ts, p, t, u] of rows) {
 		price.push([ts, p]);
 		tvl.push([ts, t]);
+		if (u !== null) {
+			utilisation.push([ts, u]);
+		}
 	}
 
-	return json({ price, tvl });
+	return json({ price, tvl, utilisation });
 }


### PR DESCRIPTION
## Why

Lending protocol vaults (Morpho, Euler, Silo Finance, Fluid, etc.) expose a utilisation metric in the parquet data — how much of the deposited capital is currently borrowed out. This is a key metric for lenders as it directly affects the yield rate and whether redemptions are available. ~1,500 out of ~8,100 vaults have this data. There was no way to see it historically.

## Summary

- Extended the `/metrics` endpoint to include a `utilisation` time-series alongside the existing `price` and `tvl` arrays. Bad outlier values (outside 0–200%) are filtered at the query level.
- Added `VaultUtilisationChart.svelte` using lightweight-charts `BaselineSeries` with the 80% threshold as the baseline: green fill below, red fill above, dashed semi-transparent separator line at 80%.
- The chart self-hides for vaults with no utilisation data — no conditional logic needed in the page.
- Tooltip includes the current utilisation percentage and a plain-English explanation of what utilisation means for lending vaults.

## Lessons learnt

- `BaselineSeries` from lightweight-charts is the right primitive for threshold-coloured area charts — it natively handles two-colour fills above/below a configurable base value, removing the need for dual overlapping series.
- The `callback` prop on `Series.svelte` provides resolved `colors` from the chart context, making it straightforward to apply theme-aware colours without needing a dedicated wrapper component.
- The parquet file has a `utilisation` column (FLOAT, 0–1 scale) but contains extreme outlier values (e.g. −72,394) for two Euler TermMax vaults due to on-chain data errors. A `CASE WHEN` filter in the SQL handles this cleanly.