### PR TITLE
feat: show utilisation in vault table and detail page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Weblog of stuff
 
+- Show current utilisation in vault table deposits/delays column with illiquid warning, detail page alert, and filter integration (2026-04-21)
 - Add utilisation chart for lending protocol vaults, with threshold colouring and explanatory tooltip (2026-04-21)
 - Improve vault benchmark chart with protocol icons, USD prices in tooltip, and dynamic legend colours (2026-04-20)
 - Link exchange account positions directly to exchange pages for GMX and Hyperliquid strategies (2026-04-13)

--- a/src/lib/top-vaults/TopVaultsTable.svelte
+++ b/src/lib/top-vaults/TopVaultsTable.svelte
@@ -73,6 +73,15 @@
 	const ROW_BATCH_SIZE = 50;
 	const allVaultsPath = resolve('/trading-view/vaults/all');
 
+	let currentUtilisations = $state<Record<string, number>>({});
+
+	$effect(() => {
+		fetch('/top-vaults/current-utilisations')
+			.then((r) => r.json())
+			.then((data) => (currentUtilisations = data))
+			.catch(() => {});
+	});
+
 	interface SortOptions {
 		key: string;
 		direction: 'asc' | 'desc';
@@ -353,8 +362,9 @@
 				if (dd == null || Math.abs(dd) > selectedDdOption.value) return false;
 			}
 
-			// Hide closed filter (checkbox-driven)
+			// Hide closed/illiquid filter (checkbox-driven)
 			if (hideClosed && v.deposit_closed_reason != null) return false;
+			if (hideClosed && (currentUtilisations[v.id] ?? 0) > 0.95) return false;
 
 			// Hide unknown protocol filter (checkbox-driven)
 			if (hideUnknown && !hasSupportedProtocol(v)) return false;
@@ -643,7 +653,7 @@
 								/>
 							</label>
 							<svelte:fragment slot="popup">
-								Don't show vaults that are not accepting new deposits currently
+								Don't show vaults that are not accepting new deposits currently and illiquid.
 							</svelte:fragment>
 						</Tooltip>
 					</div>
@@ -894,6 +904,13 @@
 					{@const statusReason = [vault.deposit_closed_reason, vault.redemption_closed_reason]
 						.filter(Boolean)
 						.join('; ')}
+					{@const utilisation = currentUtilisations[vault.id]}
+					{@const illiquid = utilisation !== undefined && utilisation > 0.95}
+					{@const lockupLabel = illiquid ? 'Illiquid' : getFormattedLockup(vault)}
+					{@const utilisationTooltip =
+						utilisation !== undefined
+							? ` Utilisation is capital borrowed out from a lending vault. High utilisation affects redemptions.${illiquid ? ' Due to high utilisation this vault is likely illiquid currently.' : ''}`
+							: ''}
 					<tr class={['targetable', blacklisted && 'blacklisted']}>
 						<!-- index cell is populated with row index via `rowNumber` CSS counter -->
 						<td class="index"></td>
@@ -937,28 +954,41 @@
 						<td class="fees right">
 							<FeesCell mgmt_fee={vault.mgmt_fee} perf_fee={vault.perf_fee} />
 						</td>
-						<td class={['lockup', vault.lockup === null && 'unknown']}>
+						<td class={['lockup', vault.lockup === null && 'unknown', illiquid && 'illiquid']}>
 							{#if badStatus}
 								<Tooltip>
 									<svelte:fragment slot="trigger">
 										<span class="status-wrapper">
-											{#if vault.deposit_closed_reason != null}<IconLock />{/if}{getFormattedLockup(vault)}
+											<span class="lockup-line">
+												{#if vault.deposit_closed_reason != null}<IconLock />{/if}{lockupLabel}
+											</span>
+											{#if utilisation !== undefined}
+												<span class={['utilisation-badge', !illiquid && utilisation > 0.8 && 'high']}
+													>U: {Math.round(utilisation * 100)}%</span
+												>
+											{/if}
 										</span>
 									</svelte:fragment>
 									<svelte:fragment slot="popup"
-										>The vault deposit or redemption may be currently closed: {statusReason}. {getLockupTooltip(
-											vault
-										)}</svelte:fragment
+										>The vault deposit or redemption may be currently closed: {statusReason}.{utilisationTooltip}</svelte:fragment
 									>
 								</Tooltip>
 							{:else}
 								<Tooltip>
 									<svelte:fragment slot="trigger">
 										<span class="status-wrapper">
-											{#if vault.deposit_closed_reason != null}<IconLock />{/if}{getFormattedLockup(vault)}
+											<span class="lockup-line">
+												{#if vault.deposit_closed_reason != null}<IconLock />{/if}{lockupLabel}
+											</span>
+											{#if utilisation !== undefined}
+												<span class={['utilisation-badge', !illiquid && utilisation > 0.8 && 'high']}
+													>U: {Math.round(utilisation * 100)}%</span
+												>
+											{/if}
 										</span>
 									</svelte:fragment>
-									<svelte:fragment slot="popup">{getLockupTooltip(vault)}</svelte:fragment>
+									<svelte:fragment slot="popup">{getLockupTooltip(vault, illiquid)}{utilisationTooltip}</svelte:fragment
+									>
 								</Tooltip>
 							{/if}
 						</td>
@@ -1461,16 +1491,35 @@
 					color: var(--c-text-light);
 				}
 
-				&:has(:global(.icon)) {
+				&:has(:global(.icon)):not(.illiquid) {
 					color: var(--c-warning);
+				}
+
+				&.illiquid {
+					color: var(--c-error);
 				}
 
 				.status-wrapper {
 					display: inline-flex;
-					align-items: center;
-					gap: 0.25rem;
-					white-space: nowrap;
+					flex-direction: column;
+					align-items: flex-start;
+					gap: 0.15rem;
 					--icon-size: 0.875rem;
+
+					.lockup-line {
+						display: inline-flex;
+						align-items: center;
+						gap: 0.25rem;
+						white-space: nowrap;
+					}
+
+					.utilisation-badge {
+						white-space: nowrap;
+
+						&.high {
+							color: var(--c-error);
+						}
+					}
 				}
 			}
 

--- a/src/lib/top-vaults/helpers.ts
+++ b/src/lib/top-vaults/helpers.ts
@@ -187,10 +187,12 @@ export function getFormattedLockup({ lockup: seconds }: VaultInfo): string {
 /**
  * Return a tooltip string describing the vault's deposit acceptance and lockup period.
  */
-export function getLockupTooltip({ lockup }: Pick<VaultInfo, 'lockup'>): string {
+export function getLockupTooltip({ lockup }: Pick<VaultInfo, 'lockup'>, illiquid = false): string {
 	if (lockup == null) return 'This vault is unlikely to have any standard lockup mechanism.';
 	if (lockup <= 0)
-		return 'This vault currently accepts deposits. This vault should allow instant redemptions under normal conditions.';
+		return illiquid
+			? 'This vault currently accepts deposits.'
+			: 'This vault currently accepts deposits. This vault should allow instant redemptions under normal conditions.';
 
 	const hours = lockup / 3600;
 	const days = Math.floor(hours / 24);

--- a/src/routes/top-vaults/current-utilisations/+server.ts
+++ b/src/routes/top-vaults/current-utilisations/+server.ts
@@ -1,0 +1,32 @@
+import { json } from '@sveltejs/kit';
+import { DuckDBConnection } from '@duckdb/node-api';
+import { ensureVaultPricesParquet } from '$lib/top-vaults/vault-prices-parquet';
+
+/**
+ * Returns the most recent utilisation value for each vault that has utilisation data.
+ * Response: Record<vaultId, utilisation> where utilisation is a decimal in [0, 2].
+ */
+export async function GET() {
+	const connection = await DuckDBConnection.create();
+	const parquetFile = await ensureVaultPricesParquet();
+
+	try {
+		const reader = await connection.runAndReadAll(
+			`SELECT DISTINCT ON (id) id,
+              CASE WHEN utilisation >= 0 AND utilisation <= 2 THEN utilisation ELSE NULL END AS utilisation
+       FROM parquet_scan($parquetFile)
+       WHERE utilisation IS NOT NULL AND utilisation >= 0 AND utilisation <= 2
+       ORDER BY id, timestamp DESC`,
+			{ parquetFile }
+		);
+
+		const result: Record<string, number> = {};
+		for (const [id, utilisation] of reader.getRows() as [string, number | null][]) {
+			if (utilisation !== null) result[id] = utilisation;
+		}
+
+		return json(result, { headers: { 'cache-control': 'public, max-age=3600' } });
+	} finally {
+		connection.closeSync();
+	}
+}

--- a/src/routes/trading-view/vaults/[vault=slug]/+page.svelte
+++ b/src/routes/trading-view/vaults/[vault=slug]/+page.svelte
@@ -22,6 +22,17 @@
 
 	let { data } = $props();
 	let { vault, chain, protocolMetadata, stablecoinMetadata, generated_at } = $derived(data);
+
+	let currentUtilisation = $state<number | undefined>();
+
+	$effect(() => {
+		fetch(`/trading-view/vaults/${vault.id}/metrics`)
+			.then((r) => r.json())
+			.then(({ utilisation }: { utilisation: [number, number][] }) => {
+				if (utilisation.length > 0) currentUtilisation = utilisation.at(-1)![1];
+			})
+			.catch(() => {});
+	});
 </script>
 
 <SocialMediaTags {vault} {chain} {protocolMetadata} />
@@ -52,6 +63,12 @@
 		{/if}
 
 		<VaultRankings {vault} {chain} {protocolMetadata} />
+
+		{#if currentUtilisation !== undefined && currentUtilisation > 0.95}
+			<Alert size="md" status="warning">
+				This vault is currently at maximum lending utilisation and redemptions may not be possible at the moment.
+			</Alert>
+		{/if}
 
 		<ChartWithFeaturedMetrics
 			{vault}


### PR DESCRIPTION
## Why

Lending protocol vaults (Morpho, Euler, Silo, etc.) have a utilisation metric that directly affects whether users can redeem. High utilisation (>80%) slows redemptions; at >95% the vault is effectively illiquid. This information was only visible in the utilisation chart on the detail page — not surfaced anywhere users browse the vault listing.

## Summary

- **New endpoint** `/top-vaults/current-utilisations` — DuckDB query returning latest utilisation per vault from the parquet file
- **Deposit and delays column** — shows `U: xx%` badge on a second row; red when >80%, entire cell red + "Illiquid" label (replacing "Instant") when >95%
- **Tooltips** — lockup tooltip gains utilisation explanation sentence; adds illiquid warning sentence at >95%; removes contradictory "instant redemptions" sentence for illiquid vaults; bad-status tooltip no longer shows the contradictory "This vault currently accepts deposits" sentence
- **Hide undepositable filter** — now also hides illiquid (>95% utilisation) vaults
- **Vault detail page** — warning Alert rendered above the price chart when current utilisation >95%

## Lessons learnt

- Svelte strips leading whitespace inside `{#if}` blocks when it's the first character — use a `{@const}` string or template literal to build tooltip text with spaces, rather than relying on ` text` inside blocks
- `{@const}` tags must be immediate children of block-level Svelte constructs (`{#each}`, `{#if}`, etc.), not of plain HTML elements like `<td>`
- When a tooltip contains both a "vault is closed" status reason and the `getLockupTooltip` text, the two can contradict each other — the lockup tooltip should be omitted in the bad-status branch

## ⚠️ Known issue — do not merge

Our utilisation data is likely incorrect as all IPOR/Morpho vaults report maximum utilisation. We cannot merge this until we figure out the cause.

🤖 Generated with [Claude Code](https://claude.com/claude-code)