### PR TITLE
feat: add US Treasury bill benchmark for non-perp vault charts

### DIFF
--- a/.env
+++ b/.env
@@ -90,7 +90,8 @@ TS_PRIVATE_MAILERLITE_API_KEY=""
 TS_PRIVATE_MAILERLITE_GROUPS=""
 TS_PRIVATE_TURNSTILE_SECRET_KEY=""
 
-# R2 private bucket credentials (vault datasets)
+# R2 private bucket credentials — recommended for both vault datasets
+# (top vaults JSON + vault prices parquet). See docs/vault-data-source.md.
 TS_PRIVATE_R2_ACCOUNT_ID=""
 TS_PRIVATE_R2_ACCESS_KEY_ID=""
 TS_PRIVATE_R2_SECRET_ACCESS_KEY=""
@@ -99,7 +100,7 @@ TS_PRIVATE_R2_BUCKET_NAME=""
 # Fallback: direct private URL for top vaults JSON (used when R2 is not configured)
 TS_PRIVATE_TOP_VAULTS_URL=""
 
-# Direct Cloudflare URL for the vault prices parquet cache source
+# Fallback: direct URL for the vault prices parquet file (used when R2 is not configured)
 TS_PRIVATE_VAULT_PRICES_PARQUET_URL=""
 
 ###############################################################

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Weblog of stuff
 
+- Add US Treasury bill benchmark for non-perpetual-futures vault charts, with R2 parquet download support and vault data source documentation (2026-04-22)
 - Add utilisation chart for lending protocol vaults, with threshold colouring and explanatory tooltip (2026-04-21)
 - Improve vault benchmark chart with protocol icons, USD prices in tooltip, and dynamic legend colours (2026-04-20)
 - Link exchange account positions directly to exchange pages for GMX and Hyperliquid strategies (2026-04-13)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -128,6 +128,7 @@ For detailed information on specific topics, see:
 - `docs/dependencies.md` - Frontend libraries, backend integrations, build tools
 - `docs/security.md` - CSP, geographic blocking, authentication, CAPTCHA
 - `docs/tests.md` - Test suites, frameworks, running tests
+- `docs/vault-data-source.md` - Vault data sources, R2 bucket config, known inconsistencies
 
 ## Pull requests
 

--- a/docs/vault-data-source.md
+++ b/docs/vault-data-source.md
@@ -1,0 +1,106 @@
+# Vault data sources
+
+The frontend consumes two server-side vault datasets. Both are produced by the backend pipeline and stored in a private Cloudflare R2 bucket.
+
+## Datasets
+
+| Dataset              | R2 object key                     | Local cache path                       | Used by                                                  |
+| -------------------- | --------------------------------- | -------------------------------------- | -------------------------------------------------------- |
+| Top vaults JSON      | `top_vaults_by_chain.json`        | In-memory (SWR cache)                  | Vault listings, landing page, vault detail pages         |
+| Vault prices parquet | `cleaned-vault-prices-1h.parquet` | `data/cleaned-vault-prices-1h.parquet` | Share price chart, TVL charts, historical TVL aggregates |
+
+## Configuration
+
+### Recommended: private R2 bucket credentials
+
+Set these four variables in `.env.local`. This is the canonical access method — both datasets are served from the same bucket.
+
+```env
+TS_PRIVATE_R2_ACCOUNT_ID="<cloudflare-account-id>"
+TS_PRIVATE_R2_ACCESS_KEY_ID="<r2-access-key>"
+TS_PRIVATE_R2_SECRET_ACCESS_KEY="<r2-secret-key>"
+TS_PRIVATE_R2_BUCKET_NAME="vaults-pro-data"
+```
+
+The R2 client (`src/lib/r2/client.ts`) uses the S3-compatible API via `@aws-sdk/client-s3`.
+
+### Fallback: direct URLs
+
+If R2 credentials are unavailable, each dataset can be configured with a direct URL independently:
+
+| Variable                              | Dataset              | Notes                          |
+| ------------------------------------- | -------------------- | ------------------------------ |
+| `TS_PRIVATE_TOP_VAULTS_URL`           | Top vaults JSON      | Used when R2 is not configured |
+| `TS_PRIVATE_VAULT_PRICES_PARQUET_URL` | Vault prices parquet | Used when R2 is not configured |
+
+## How each dataset is fetched
+
+### Top vaults JSON
+
+**Code:** `src/lib/top-vaults/server-config.ts` → `fetchTopVaultsRaw()`
+
+1. If R2 is configured → fetch via `getR2Object('top_vaults_by_chain.json')`
+2. If R2 fails or is not configured → fall back to `TS_PRIVATE_TOP_VAULTS_URL`
+3. If neither is available → throws error
+
+The response is parsed, validated against the Zod schema, and cached in memory with SWR (stale-while-revalidate) via `src/lib/top-vaults/cache.ts`.
+
+### Vault prices parquet
+
+**Code:** `src/lib/top-vaults/vault-prices-parquet.ts` → `ensureVaultPricesParquet()`
+
+1. If the local file (`data/cleaned-vault-prices-1h.parquet`) exists and is less than 1 hour old → use it directly
+2. If the file is stale or missing → resolve a remote source and download:
+   - `TS_PRIVATE_VAULT_PRICES_PARQUET_URL` if set (takes precedence — also used by tests to inject a mock)
+   - Otherwise R2 if credentials are configured
+3. If neither URL nor R2 is available → throws error (unless a local file already exists, in which case the stale copy is used)
+4. Change detection uses ETag / Last-Modified / Content-Length from HEAD requests (URL path) or HeadObject (R2 path)
+5. Downloads are atomic (write to temp file, then rename)
+6. Concurrent callers share a single in-flight download
+
+R2 downloads stream the object body via the AWS SDK (`getR2Object`) and pipe it to disk using Node.js `stream.pipeline`. URL downloads use `fetch` with a 5-minute timeout.
+
+### Datasets download endpoint
+
+**Code:** `src/routes/trading-view/vaults/datasets/download/[datasetId]/+server.ts`
+
+This public-facing endpoint proxies downloads through a separate Vault API service (`TS_PUBLIC_VAULT_API_URL`), not through R2 or the local cache. It is used by the datasets listing page for user-facing downloads.
+
+The datasets listing page (`src/routes/trading-view/vaults/datasets/+page.server.ts`) requires R2 to be configured for displaying file metadata (size, last modified), even though the actual download goes through the Vault API.
+
+## Data flow diagram
+
+```
+R2 bucket (vaults-pro-data)
+├── top_vaults_by_chain.json
+│   └─→ server-config.ts (R2 SDK, URL fallback)
+│       ─→ cache.ts (SWR in-memory) ─→ page loaders
+│
+└── cleaned-vault-prices-1h.parquet
+    └─→ vault-prices-parquet.ts (URL if set, else R2 SDK)
+        ─→ local file cache (1h TTL)
+        ├─→ /vaults/[vault]/metrics endpoint (DuckDB query)
+        └─→ historical-tvl-server.ts (DuckDB aggregate)
+```
+
+## Consumers
+
+| Consumer                         | Dataset              | Code path                                                 |
+| -------------------------------- | -------------------- | --------------------------------------------------------- |
+| Vault detail page (server load)  | Top vaults JSON      | `+page.server.ts` → `getCachedTopVaults()`                |
+| Landing page (server load)       | Top vaults JSON      | `+page.server.ts` → `getCachedTopVaults()`                |
+| Vault price chart (client fetch) | Parquet              | `/vaults/[vault]/metrics` → `ensureVaultPricesParquet()`  |
+| Historical TVL charts (server)   | Parquet              | `historical-tvl-server.ts` → `ensureVaultPricesParquet()` |
+| Datasets listing page            | Both (metadata only) | `headTopVaults()` + `headVaultPrices()` via R2            |
+| Datasets download                | Both (proxied)       | `/datasets/download/[datasetId]` via Vault API            |
+
+## Known issues
+
+1. **Datasets page error message is misleading.** The datasets listing page throws "R2 credentials missing" if R2 is not configured, but the actual download endpoint uses the Vault API, not R2. R2 is only needed for the metadata display.
+
+## Local development
+
+For local development, ensure R2 credentials are set in `.env.local`. Both datasets will be fetched automatically:
+
+- Top vaults JSON is fetched on first page load and cached in memory
+- Vault prices parquet (~150 MB) is downloaded on first metrics request and cached locally with a 1-hour refresh interval

--- a/src/lib/assets/logos/tokens/us-treasury.svg
+++ b/src/lib/assets/logos/tokens/us-treasury.svg
@@ -1,0 +1,14 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <clipPath id="c"><circle cx="16" cy="16" r="16"/></clipPath>
+  <g clip-path="url(#c)">
+    <rect width="32" height="32" fill="#fff"/>
+    <rect y="0" width="32" height="2.46" fill="#B22234"/>
+    <rect y="4.92" width="32" height="2.46" fill="#B22234"/>
+    <rect y="9.85" width="32" height="2.46" fill="#B22234"/>
+    <rect y="14.77" width="32" height="2.46" fill="#B22234"/>
+    <rect y="19.69" width="32" height="2.46" fill="#B22234"/>
+    <rect y="24.62" width="32" height="2.46" fill="#B22234"/>
+    <rect y="29.54" width="32" height="2.46" fill="#B22234"/>
+    <rect width="12.8" height="17.23" fill="#3C3B6E"/>
+  </g>
+</svg>

--- a/src/lib/fred-helpers.ts
+++ b/src/lib/fred-helpers.ts
@@ -1,0 +1,82 @@
+/**
+ * Shared helpers for fetching FRED (Federal Reserve Economic Data) series.
+ *
+ * Provides User-Agent rotation (FRED blocks bare Node.js fetches),
+ * file-based caching with stale-fallback, and strict date validation.
+ */
+import { readFile, writeFile, mkdir, stat } from 'node:fs/promises';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+
+export const FRED_CSV_BASE = 'https://fred.stlouisfed.org/graph/fredgraph.csv';
+export const FRED_TIMEOUT = 20_000;
+export const ONE_DAY_S = 24 * 60 * 60;
+export const ONE_DAY_MS = ONE_DAY_S * 1000;
+
+const DEFAULT_CACHE_DIR = join(homedir(), '.cache', 'ts-frontend');
+
+// FRED drops connections without a User-Agent header (Node.js fetch sends none by default).
+// Chrome-style UAs are blocked (TLS fingerprint mismatch), so use Firefox/simple UAs.
+const USER_AGENTS = [
+	'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:133.0) Gecko/20100101 Firefox/133.0',
+	'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:133.0) Gecko/20100101 Firefox/133.0',
+	'Mozilla/5.0 (X11; Linux x86_64; rv:133.0) Gecko/20100101 Firefox/133.0',
+	'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:128.0) Gecko/20100101 Firefox/128.0',
+	'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:128.0) Gecko/20100101 Firefox/128.0'
+];
+
+export function randomUserAgent(): string {
+	return USER_AGENTS[Math.floor(Math.random() * USER_AGENTS.length)];
+}
+
+// --- Date validation ---
+
+const DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
+
+/**
+ * Validate a YYYY-MM-DD string strictly: regex + round-trip check.
+ * Rejects impossible dates like 2026-02-31.
+ */
+export function isValidDateString(value: string): boolean {
+	if (!DATE_RE.test(value)) return false;
+	const d = new Date(value + 'T00:00:00Z');
+	if (isNaN(d.getTime())) return false;
+	// Round-trip: format back and compare
+	const [y, m, day] = value.split('-').map(Number);
+	return d.getUTCFullYear() === y && d.getUTCMonth() + 1 === m && d.getUTCDate() === day;
+}
+
+/** Format a Date as YYYY-MM-DD in UTC. */
+export function formatDateYMD(d: Date): string {
+	return d.toISOString().slice(0, 10);
+}
+
+// --- File cache helpers ---
+
+export async function readJsonFileCache<T>(key: string, cacheDir = DEFAULT_CACHE_DIR): Promise<T | null> {
+	try {
+		const data = await readFile(join(cacheDir, `${key}.json`), 'utf-8');
+		return JSON.parse(data) as T;
+	} catch {
+		return null;
+	}
+}
+
+export async function writeJsonFileCache<T>(key: string, value: T, cacheDir = DEFAULT_CACHE_DIR): Promise<void> {
+	try {
+		await mkdir(cacheDir, { recursive: true });
+		await writeFile(join(cacheDir, `${key}.json`), JSON.stringify(value));
+	} catch {
+		// ignore write errors
+	}
+}
+
+/** Check if a cache file exists and was written within the given TTL (in seconds). */
+export async function isCacheFresh(key: string, ttlSeconds: number, cacheDir = DEFAULT_CACHE_DIR): Promise<boolean> {
+	try {
+		const s = await stat(join(cacheDir, `${key}.json`));
+		return Date.now() - s.mtimeMs < ttlSeconds * 1000;
+	} catch {
+		return false;
+	}
+}

--- a/src/lib/reference-rates.ts
+++ b/src/lib/reference-rates.ts
@@ -9,55 +9,19 @@
  * 2. File cache (~/.cache/ts-frontend/) so a valid rate survives server
  *    restarts and transient API failures (e.g. FRED rate-limiting)
  */
-import { readFile, writeFile, mkdir } from 'node:fs/promises';
-import { homedir } from 'node:os';
-import { join } from 'node:path';
 import swrCache from '$lib/swrCache';
+import {
+	FRED_CSV_BASE,
+	FRED_TIMEOUT,
+	ONE_DAY_S,
+	randomUserAgent,
+	readJsonFileCache,
+	writeJsonFileCache
+} from '$lib/fred-helpers';
 
-const TIMEOUT = 20_000;
-const ONE_DAY = 24 * 60 * 60;
-const TWO_DAYS = 2 * ONE_DAY;
-
-// FRED drops connections without a User-Agent header (Node.js fetch sends none by default).
-// Chrome-style UAs are blocked (TLS fingerprint mismatch), so use Firefox/simple UAs.
-const USER_AGENTS = [
-	'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:133.0) Gecko/20100101 Firefox/133.0',
-	'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:133.0) Gecko/20100101 Firefox/133.0',
-	'Mozilla/5.0 (X11; Linux x86_64; rv:133.0) Gecko/20100101 Firefox/133.0',
-	'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:128.0) Gecko/20100101 Firefox/128.0',
-	'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:128.0) Gecko/20100101 Firefox/128.0'
-];
-
-function randomUserAgent(): string {
-	return USER_AGENTS[Math.floor(Math.random() * USER_AGENTS.length)];
-}
-
-// --- File cache helpers ---
-
-const CACHE_DIR = join(homedir(), '.cache', 'ts-frontend');
-
-async function readFileCache(key: string): Promise<number | null> {
-	try {
-		const data = await readFile(join(CACHE_DIR, `${key}.json`), 'utf-8');
-		const value = JSON.parse(data);
-		return typeof value === 'number' && Number.isFinite(value) ? value : null;
-	} catch {
-		return null;
-	}
-}
-
-async function writeFileCache(key: string, value: number): Promise<void> {
-	try {
-		await mkdir(CACHE_DIR, { recursive: true });
-		await writeFile(join(CACHE_DIR, `${key}.json`), JSON.stringify(value));
-	} catch {
-		// ignore write errors
-	}
-}
+const TWO_DAYS = 2 * ONE_DAY_S;
 
 // --- FRED CSV export ---
-
-const FRED_CSV_BASE = 'https://fred.stlouisfed.org/graph/fredgraph.csv';
 
 /**
  * Fetch the latest value of a FRED series from the CSV export.
@@ -70,21 +34,21 @@ async function fetchFredCsvLatest(seriesId: string): Promise<number | null> {
 	const cacheKey = `fred-${seriesId}`;
 	try {
 		const resp = await fetch(`${FRED_CSV_BASE}?id=${encodeURIComponent(seriesId)}`, {
-			signal: AbortSignal.timeout(TIMEOUT),
+			signal: AbortSignal.timeout(FRED_TIMEOUT),
 			headers: { 'User-Agent': randomUserAgent() }
 		});
-		if (!resp.ok) return readFileCache(cacheKey);
+		if (!resp.ok) return readJsonFileCache<number>(cacheKey);
 		const text = await resp.text();
 		const lines = text.trim().split('\n');
 		const lastLine = lines[lines.length - 1];
 		const value = parseFloat(lastLine.split(',')[1]);
 		if (Number.isFinite(value)) {
-			await writeFileCache(cacheKey, value);
+			await writeJsonFileCache(cacheKey, value);
 			return value;
 		}
-		return readFileCache(cacheKey);
+		return readJsonFileCache<number>(cacheKey);
 	} catch {
-		return readFileCache(cacheKey);
+		return readJsonFileCache<number>(cacheKey);
 	}
 }
 
@@ -105,19 +69,19 @@ async function fetchTreasuryNoteRate(): Promise<number | null> {
 	const cacheKey = 'treasury-note-rate';
 	try {
 		const resp = await fetch(TREASURY_RATES_URL, {
-			signal: AbortSignal.timeout(TIMEOUT),
+			signal: AbortSignal.timeout(FRED_TIMEOUT),
 			headers: { 'User-Agent': randomUserAgent() }
 		});
-		if (!resp.ok) return readFileCache(cacheKey);
+		if (!resp.ok) return readJsonFileCache<number>(cacheKey);
 		const json = await resp.json();
 		const rate = parseFloat(json.data?.[0]?.avg_interest_rate_amt);
 		if (Number.isFinite(rate)) {
-			await writeFileCache(cacheKey, rate);
+			await writeJsonFileCache(cacheKey, rate);
 			return rate;
 		}
-		return readFileCache(cacheKey);
+		return readJsonFileCache<number>(cacheKey);
 	} catch {
-		return readFileCache(cacheKey);
+		return readJsonFileCache<number>(cacheKey);
 	}
 }
 

--- a/src/lib/top-vaults/TreasuryBenchmarkSeries.svelte
+++ b/src/lib/top-vaults/TreasuryBenchmarkSeries.svelte
@@ -1,30 +1,31 @@
 <!--
 @component
-Overlay a Coinbase benchmark line on top of the vault share-price chart.
+Overlay a US 3-month Treasury bill benchmark line on the vault share-price chart.
 
-The benchmark is rebased to the vault's starting share price for the current
-visible range so the lines can be compared on a single axis.
+The benchmark compounds daily FRED DTB3 rates into a cumulative return line
+rebased to the vault's starting share price, so relative performance is
+comparable on a single axis. Does not affect Y-axis scaling.
 -->
 <script lang="ts">
 	import type { TimeBucket } from '$lib/schemas/utility';
 	import type { LineSeriesPartialOptions } from 'lightweight-charts';
 	import type { SimpleDataItem } from '$lib/charts/types';
+	import type { TreasuryDataItem } from './treasury-benchmark';
 	import { LineSeries } from 'lightweight-charts';
 	import Series from '$lib/charts/Series.svelte';
-	import { dateToTs, resampleTimeSeries, timeBucketToInterval } from '$lib/charts/helpers';
-	import { fetchCoinbaseBenchmarkCloses } from './coinbase';
+	import { dateToTs, timeBucketToInterval } from '$lib/charts/helpers';
+	import { fetchTreasuryBenchmarkSeries, ratesToCumulativeReturn } from './treasury-benchmark';
 
 	interface Props {
-		productId: 'BTC-USD' | 'ETH-USD';
 		data: SimpleDataItem[];
 		timeBucket: TimeBucket;
 		range: [Date, Date];
 		color: string;
 	}
 
-	let { productId, data, timeBucket, range, color }: Props = $props();
+	let { data, timeBucket, range, color }: Props = $props();
 
-	let benchmarkData = $state<SimpleDataItem[]>([]);
+	let benchmarkData = $state<TreasuryDataItem[]>([]);
 	let requestVersion = 0;
 
 	let effectiveStartDate = $derived.by(() => {
@@ -57,24 +58,14 @@ visible range so the lines can be compared on a single axis.
 		if (!data.length || initialVaultValue <= 0) return;
 
 		try {
-			const closes = await fetchCoinbaseBenchmarkCloses(fetch, productId, timeBucket, effectiveStartDate, range[1]);
-			if (currentRequest !== requestVersion || closes.length === 0) return;
+			const rates = await fetchTreasuryBenchmarkSeries(fetch, effectiveStartDate, range[1]);
+			if (currentRequest !== requestVersion || rates.length === 0) return;
 
-			const resampledCloses = resampleTimeSeries(closes, timeBucketToInterval(timeBucket), range[1]);
-			const initialBenchmarkValue = resampledCloses[0]?.value ?? 0;
-			if (initialBenchmarkValue <= 0) return;
-
-			benchmarkData = resampledCloses.map((item) => {
-				const percentChange = item.value / initialBenchmarkValue - 1;
-				return {
-					time: item.time,
-					value: initialVaultValue * (1 + percentChange),
-					customValues: { percentChange, usdPrice: item.value }
-				};
-			});
+			const interval = timeBucketToInterval(timeBucket);
+			benchmarkData = ratesToCumulativeReturn(rates, initialVaultValue, interval, effectiveStartDate, range[1]);
 		} catch (error) {
 			if (currentRequest === requestVersion) {
-				console.error(`Failed to load Coinbase benchmark ${productId}`, error);
+				console.error('Failed to load Treasury benchmark', error);
 			}
 		}
 	}

--- a/src/lib/top-vaults/VaultPriceChart.svelte
+++ b/src/lib/top-vaults/VaultPriceChart.svelte
@@ -1,23 +1,43 @@
 <!--
 @component
-Render the vault share-price chart with TVL bars and Coinbase BTC/ETH benchmarks.
+Render the vault share-price chart with TVL bars and benchmark overlays.
 
-The benchmark lines are rebased to the vault share price for the selected range
-so the relative performance is comparable on a single axis.
+Perpetual futures vaults (Hyperliquid, GRVT, Lighter) show BTC/ETH benchmarks.
+All other vaults show a US 3M T-bill (risk-free rate) benchmark instead.
+
+Benchmark lines are rebased to the vault share price for the selected range
+so relative performance is comparable on a single axis.
 -->
 <script lang="ts">
 	import type { VaultInfo } from './schemas';
 	import brandMark from '$lib/assets/brand-mark.svg';
+	import usTreasuryLogo from '$lib/assets/logos/tokens/us-treasury.svg';
 	import { HistogramSeries } from 'lightweight-charts';
 	import ChartContainer from '$lib/charts/ChartContainer.svelte';
 	import AreaSeries from '$lib/charts/AreaSeries.svelte';
 	import CoinbaseBenchmarkSeries from './CoinbaseBenchmarkSeries.svelte';
+	import TreasuryBenchmarkSeries from './TreasuryBenchmarkSeries.svelte';
 	import Series from '$lib/charts/Series.svelte';
 	import SeriesLabel from '$lib/charts/SeriesLabel.svelte';
 	import ChartTooltip from '$lib/charts/ChartTooltip.svelte';
+	import Tooltip from '$lib/components/Tooltip.svelte';
 	import { getLogoUrl } from '$lib/helpers/assets';
-	import { formatDollar, formatPercent, formatTokenAmount } from '$lib/helpers/formatters';
+	import { isPerpetualFuturesVault } from './isPerpetualFuturesVault';
+	import type { PriceScaleCalculator } from '$lib/charts/types';
+	import { formatDollar, formatInterestRate, formatPercent, formatTokenAmount } from '$lib/helpers/formatters';
 	import { formatDate, resampleTimeSeries } from '$lib/charts/helpers';
+
+	/** Scale the Y-axis to the vault share price with ±20% margin */
+	const vaultPriceScaleCalculator: PriceScaleCalculator = (data) => {
+		if (!data.length) return null;
+		const values = data.map((d) => (d as { value: number }).value).filter((v) => v != null);
+		if (!values.length) return null;
+		const min = Math.min(...values);
+		const max = Math.max(...values);
+		const mid = (min + max) / 2;
+		const margin = mid * 0.2;
+		return { priceRange: { minValue: min - margin, maxValue: max + margin } };
+	};
 
 	interface Props {
 		vault: VaultInfo;
@@ -27,6 +47,8 @@ so the relative performance is comparable on a single axis.
 
 	let { vault, protocolLogoUrl }: Props = $props();
 
+	let showCryptoBenchmarks = $derived(isPerpetualFuturesVault(vault));
+
 	let loading = $state(true);
 	let priceData = $state<[number, number][]>();
 	let tvlData = $state<[number, number][]>();
@@ -34,6 +56,11 @@ so the relative performance is comparable on a single axis.
 	function getBenchmarkCustomValues(point: unknown) {
 		if (!point || typeof point !== 'object' || !('customValues' in point)) return undefined;
 		return (point as { customValues?: { percentChange?: number; usdPrice?: number } }).customValues;
+	}
+
+	function getTreasuryCustomValues(point: unknown) {
+		if (!point || typeof point !== 'object' || !('customValues' in point)) return undefined;
+		return (point as { customValues?: { percentChange?: number; annualRate?: number } }).customValues;
 	}
 
 	async function fetchMetrics(vaultId: string) {
@@ -64,11 +91,26 @@ so the relative performance is comparable on a single axis.
 		return 'var(--c-text-ultra-light)';
 	}
 
-	const benchmarkLegend = $derived([
-		{ label: 'Vault', color: getVaultColor(vaultDirection), logoUrl: protocolLogoUrl ?? brandMark },
-		{ label: 'BTC', color: '#f7931a80', logoUrl: getLogoUrl('token', 'btc') },
-		{ label: 'ETH', color: '#627eea80', logoUrl: getLogoUrl('token', 'eth') }
-	] as const);
+	type LegendItem = { label: string; color: string; logoUrl?: string; href?: string; tooltip?: string };
+
+	const benchmarkLegend: LegendItem[] = $derived(
+		showCryptoBenchmarks
+			? [
+					{ label: 'Vault', color: getVaultColor(vaultDirection), logoUrl: protocolLogoUrl ?? brandMark },
+					{ label: 'BTC', color: '#f7931a80', logoUrl: getLogoUrl('token', 'btc') },
+					{ label: 'ETH', color: '#627eea80', logoUrl: getLogoUrl('token', 'eth') }
+				]
+			: [
+					{ label: 'Vault', color: getVaultColor(vaultDirection), logoUrl: protocolLogoUrl ?? brandMark },
+					{
+						label: 'US 3M T-bill',
+						color: '#4a90d9a0',
+						logoUrl: usTreasuryLogo,
+						href: '/glossary/risk-free-rate',
+						tooltip: 'Risk-free rate: Equivalent investment to U.S. Treasury notes.'
+					}
+				]
+	);
 </script>
 
 <div class="vault-price-chart">
@@ -81,28 +123,35 @@ so the relative performance is comparable on a single axis.
 		options={{ handleScroll: false, handleScale: false }}
 	>
 		{#snippet series({ data, timeSpan, range })}
+			{#if data.length > 1 && range && !showCryptoBenchmarks}
+				<TreasuryBenchmarkSeries {data} timeBucket={timeSpan.timeBucket} {range} color="#4a90d9a0" />
+			{/if}
+
 			<AreaSeries
 				{data}
 				options={{ priceLineVisible: false, crosshairMarkerVisible: false }}
 				priceScaleOptions={{ scaleMargins: { top: 0.1, bottom: 0.1 } }}
+				priceScaleCalculator={vaultPriceScaleCalculator}
 				onVisibleDataChange={(_, profitInfo) => (vaultDirection = profitInfo.direction)}
 			/>
 
 			{#if data.length > 1 && range}
-				<CoinbaseBenchmarkSeries
-					productId="BTC-USD"
-					{data}
-					timeBucket={timeSpan.timeBucket}
-					{range}
-					color="#f7931a80"
-				/>
-				<CoinbaseBenchmarkSeries
-					productId="ETH-USD"
-					{data}
-					timeBucket={timeSpan.timeBucket}
-					{range}
-					color="#627eea80"
-				/>
+				{#if showCryptoBenchmarks}
+					<CoinbaseBenchmarkSeries
+						productId="BTC-USD"
+						{data}
+						timeBucket={timeSpan.timeBucket}
+						{range}
+						color="#f7931a80"
+					/>
+					<CoinbaseBenchmarkSeries
+						productId="ETH-USD"
+						{data}
+						timeBucket={timeSpan.timeBucket}
+						{range}
+						color="#627eea80"
+					/>
+				{/if}
 
 				<Series
 					type={HistogramSeries}
@@ -120,42 +169,84 @@ so the relative performance is comparable on a single axis.
 			{/if}
 		{/snippet}
 
-		{#snippet tooltip({ point, time }, [price, btcBenchmark, ethBenchmark, tvl])}
-			{#if price || btcBenchmark || ethBenchmark || tvl}
-				{@const btc = getBenchmarkCustomValues(btcBenchmark)}
-				{@const eth = getBenchmarkCustomValues(ethBenchmark)}
-				<ChartTooltip {point}>
-					<div class="tooltip-date">{formatDate(time as number, '1d')}</div>
-					<dl class="tooltip-items">
-						<dt>Price:</dt>
-						<dd>{formatValue(price?.value)} {vault.denomination}</dd>
-						<dt>BTC:</dt>
-						<dd>
-							{formatPercent(btc?.percentChange, 1, 1, { signDisplay: 'exceptZero' })}
-							{#if btc?.usdPrice}<span class="benchmark-usd">{formatDollar(btc.usdPrice, 1)}</span>{/if}
-						</dd>
-						<dt>ETH:</dt>
-						<dd>
-							{formatPercent(eth?.percentChange, 1, 1, { signDisplay: 'exceptZero' })}
-							{#if eth?.usdPrice}<span class="benchmark-usd">{formatDollar(eth.usdPrice, 1)}</span>{/if}
-						</dd>
-						<dt>TVL:</dt>
-						<dd>{formatValue(tvl?.value)}</dd>
-					</dl>
-				</ChartTooltip>
+		{#snippet tooltip({ point, time }, seriesData)}
+			{#if showCryptoBenchmarks}
+				{@const price = seriesData[0]}
+				{@const btc = getBenchmarkCustomValues(seriesData[1])}
+				{@const eth = getBenchmarkCustomValues(seriesData[2])}
+				{@const tvl = seriesData[3]}
+				{#if price || btc || eth || tvl}
+					<ChartTooltip {point}>
+						<div class="tooltip-date">{formatDate(time as number, '1d')}</div>
+						<dl class="tooltip-items">
+							<dt>Price:</dt>
+							<dd>{formatValue(price?.value)} {vault.denomination}</dd>
+							<dt>BTC:</dt>
+							<dd>
+								{formatPercent(btc?.percentChange, 1, 1, { signDisplay: 'exceptZero' })}
+								{#if btc?.usdPrice}<span class="benchmark-usd">{formatDollar(btc.usdPrice, 1)}</span>{/if}
+							</dd>
+							<dt>ETH:</dt>
+							<dd>
+								{formatPercent(eth?.percentChange, 1, 1, { signDisplay: 'exceptZero' })}
+								{#if eth?.usdPrice}<span class="benchmark-usd">{formatDollar(eth.usdPrice, 1)}</span>{/if}
+							</dd>
+							<dt>TVL:</dt>
+							<dd>{formatValue(tvl?.value)}</dd>
+						</dl>
+					</ChartTooltip>
+				{/if}
+			{:else}
+				{@const treasury = getTreasuryCustomValues(seriesData[0])}
+				{@const price = seriesData[1]}
+				{@const tvl = seriesData[2]}
+				{#if price || treasury || tvl}
+					<ChartTooltip {point}>
+						<div class="tooltip-date">{formatDate(time as number, '1d')}</div>
+						<dl class="tooltip-items">
+							<dt>Price:</dt>
+							<dd>{formatValue(price?.value)} {vault.denomination}</dd>
+							<dt>T-bill:</dt>
+							<dd>
+								{formatPercent(treasury?.percentChange, 1, 1, { signDisplay: 'exceptZero' })}
+								{#if treasury?.annualRate != null}
+									<span class="benchmark-usd">{formatInterestRate(treasury.annualRate)} p.a.</span>
+								{/if}
+							</dd>
+							<dt>TVL:</dt>
+							<dd>{formatValue(tvl?.value)}</dd>
+						</dl>
+					</ChartTooltip>
+				{/if}
 			{/if}
 		{/snippet}
 
 		{#snippet footer()}
 			<footer class="benchmark-legend" aria-label="Chart legend">
 				{#each benchmarkLegend as benchmark}
-					<div class="legend-item" style:--legend-color={benchmark.color}>
-						<span class="legend-swatch" aria-hidden="true"></span>
-						{#if benchmark.logoUrl}
-							<img class="legend-logo" src={benchmark.logoUrl} alt="" aria-hidden="true" />
-						{/if}
-						<span>{benchmark.label}</span>
-					</div>
+					{#if benchmark.tooltip}
+						<Tooltip>
+							<a slot="trigger" class="legend-item" style:--legend-color={benchmark.color} href={benchmark.href}>
+								<span class="legend-swatch" aria-hidden="true"></span>
+								{#if benchmark.logoUrl}
+									<img class="legend-logo" src={benchmark.logoUrl} alt="" aria-hidden="true" />
+								{/if}
+								<span>{benchmark.label}</span>
+							</a>
+							<svelte:fragment slot="popup">
+								<p>{benchmark.tooltip}</p>
+								<p><a href={benchmark.href}>Click here for more information</a></p>
+							</svelte:fragment>
+						</Tooltip>
+					{:else}
+						<div class="legend-item" style:--legend-color={benchmark.color}>
+							<span class="legend-swatch" aria-hidden="true"></span>
+							{#if benchmark.logoUrl}
+								<img class="legend-logo" src={benchmark.logoUrl} alt="" aria-hidden="true" />
+							{/if}
+							<span>{benchmark.label}</span>
+						</div>
+					{/if}
 				{/each}
 			</footer>
 		{/snippet}
@@ -210,8 +301,19 @@ so the relative performance is comparable on a single axis.
 			margin-bottom: -0.25rem;
 			display: flex;
 			flex-wrap: wrap;
+			align-items: center;
 			gap: 0.75rem 1rem;
 			justify-content: center;
+
+			:global(.tooltip) {
+				display: inline-flex;
+				align-items: center;
+			}
+
+			:global(.tooltip .trigger) {
+				display: inline-flex;
+				align-items: center;
+			}
 		}
 
 		.legend-item {
@@ -221,12 +323,14 @@ so the relative performance is comparable on a single axis.
 			font: var(--f-ui-sm-medium);
 			letter-spacing: var(--ls-ui-sm, normal);
 			color: var(--c-text-extra-light);
+			text-decoration: none;
 		}
 
 		.legend-logo {
-			width: 1rem;
-			height: 1rem;
+			width: 1.25rem;
+			height: 1.25rem;
 			flex: 0 0 auto;
+			object-fit: contain;
 		}
 
 		.legend-swatch {

--- a/src/lib/top-vaults/isPerpetualFuturesVault.ts
+++ b/src/lib/top-vaults/isPerpetualFuturesVault.ts
@@ -1,0 +1,21 @@
+import type { VaultInfo } from './schemas';
+
+/** Chain IDs for dedicated perpetual futures trading platforms. */
+const PERP_CHAIN_IDS = new Set([
+	9999, // HyperCore (Hyperliquid native)
+	325, // GRVT
+	9998 // Lighter
+]);
+
+/**
+ * Whether a vault is a perpetual futures trading vault.
+ *
+ * Checks the `perp_dex_trading_vault` flag first, then falls back to
+ * chain_id for synthetic perp-only chains that may lack the flag.
+ *
+ * HyperEVM (chain_id 999) is intentionally excluded — it is a regular
+ * EVM chain that can host DeFi / lending vaults.
+ */
+export function isPerpetualFuturesVault(vault: Pick<VaultInfo, 'flags' | 'chain_id'>): boolean {
+	return vault.flags.includes('perp_dex_trading_vault') || PERP_CHAIN_IDS.has(vault.chain_id);
+}

--- a/src/lib/top-vaults/treasury-benchmark.test.ts
+++ b/src/lib/top-vaults/treasury-benchmark.test.ts
@@ -1,0 +1,183 @@
+import { describe, test, expect } from 'vitest';
+import { utcDay, utcHour } from 'd3-time';
+import { ratesToCumulativeReturn } from './treasury-benchmark';
+import { isPerpetualFuturesVault } from './isPerpetualFuturesVault';
+import { isValidDateString } from '$lib/fred-helpers';
+
+// --- ratesToCumulativeReturn ---
+
+describe('ratesToCumulativeReturn', () => {
+	const day = utcDay;
+	const hour4 = utcHour.every(4)!;
+
+	function makeRates(startDate: Date, count: number, rate: number): [number, number][] {
+		const rates: [number, number][] = [];
+		for (let i = 0; i < count; i++) {
+			const d = new Date(startDate.getTime() + i * 86_400_000);
+			// Skip weekends (like FRED)
+			if (d.getUTCDay() === 0 || d.getUTCDay() === 6) continue;
+			rates.push([d.getTime() / 1000, rate]);
+		}
+		return rates;
+	}
+
+	test('constant 5% rate over 365 days yields ~5% total return', () => {
+		const start = new Date('2025-01-01T00:00:00Z');
+		const end = new Date('2025-12-31T00:00:00Z');
+		const rates = makeRates(start, 365, 5.0);
+		const result = ratesToCumulativeReturn(rates, 1.0, day, start, end);
+
+		expect(result.length).toBeGreaterThan(0);
+		const lastValue = result.at(-1)!.value;
+		// Should be ~1.05 (5% annual return)
+		expect(lastValue).toBeCloseTo(1.05, 1);
+
+		const lastPctChange = result.at(-1)!.customValues.percentChange;
+		expect(lastPctChange).toBeCloseTo(0.05, 1);
+	});
+
+	test('first output point has value === startingValue', () => {
+		const start = new Date('2025-01-01T00:00:00Z');
+		const end = new Date('2025-01-31T00:00:00Z');
+		const rates = makeRates(start, 31, 4.0);
+		const result = ratesToCumulativeReturn(rates, 1.23, day, start, end);
+
+		expect(result[0].value).toBe(1.23);
+		expect(result[0].customValues.percentChange).toBe(0);
+	});
+
+	test('first output time >= startDate', () => {
+		const start = new Date('2025-01-01T00:00:00Z');
+		const end = new Date('2025-01-31T00:00:00Z');
+		const rates = makeRates(start, 31, 4.0);
+		const result = ratesToCumulativeReturn(rates, 1.0, day, start, end);
+
+		const startTs = start.getTime() / 1000;
+		expect(result[0].time).toBeGreaterThanOrEqual(startTs);
+	});
+
+	test('4h interval produces ~6x more points than 1d for same range', () => {
+		const start = new Date('2025-01-01T00:00:00Z');
+		const end = new Date('2025-01-31T00:00:00Z');
+		const rates = makeRates(start, 31, 4.0);
+
+		const daily = ratesToCumulativeReturn(rates, 1.0, day, start, end);
+		const fourHourly = ratesToCumulativeReturn(rates, 1.0, hour4, start, end);
+
+		// 4h should have roughly 6x the points of daily
+		expect(fourHourly.length).toBeGreaterThan(daily.length * 4);
+		expect(fourHourly.length).toBeLessThanOrEqual(daily.length * 7);
+	});
+
+	test('4h and 1d intervals yield the same final return', () => {
+		const start = new Date('2025-01-01T00:00:00Z');
+		const end = new Date('2025-01-31T00:00:00Z');
+		const rates = makeRates(start, 31, 4.0);
+
+		const daily = ratesToCumulativeReturn(rates, 1.0, day, start, end);
+		const fourHourly = ratesToCumulativeReturn(rates, 1.0, hour4, start, end);
+
+		expect(fourHourly.at(-1)!.value).toBeCloseTo(daily.at(-1)!.value, 6);
+	});
+
+	test('customValues.annualRate is preserved on every point', () => {
+		const start = new Date('2025-01-01T00:00:00Z');
+		const end = new Date('2025-01-10T00:00:00Z');
+		const rates = makeRates(start, 10, 3.5);
+		const result = ratesToCumulativeReturn(rates, 1.0, day, start, end);
+
+		for (const point of result) {
+			expect(point.customValues.annualRate).toBe(3.5);
+			expect(typeof point.customValues.percentChange).toBe('number');
+		}
+	});
+
+	test('seed days before startDate are excluded from output', () => {
+		// Simulate seed: rates start 7 days before the visible range
+		const seedStart = new Date('2024-12-25T00:00:00Z');
+		const visibleStart = new Date('2025-01-01T00:00:00Z');
+		const end = new Date('2025-01-10T00:00:00Z');
+		const rates = makeRates(seedStart, 20, 4.0);
+
+		const result = ratesToCumulativeReturn(rates, 1.0, day, visibleStart, end);
+
+		const seedTs = seedStart.getTime() / 1000;
+		const visibleTs = visibleStart.getTime() / 1000;
+		for (const point of result) {
+			expect(point.time).toBeGreaterThanOrEqual(visibleTs);
+			expect(point.time).not.toBeLessThan(seedTs);
+		}
+
+		// First point should be at visibleStart, not seedStart
+		expect(result[0].value).toBe(1.0);
+	});
+
+	test('returns empty array for empty rates', () => {
+		const start = new Date('2025-01-01T00:00:00Z');
+		const end = new Date('2025-01-31T00:00:00Z');
+		expect(ratesToCumulativeReturn([], 1.0, day, start, end)).toEqual([]);
+	});
+
+	test('returns empty array for zero starting value', () => {
+		const start = new Date('2025-01-01T00:00:00Z');
+		const end = new Date('2025-01-31T00:00:00Z');
+		const rates = makeRates(start, 31, 4.0);
+		expect(ratesToCumulativeReturn(rates, 0, day, start, end)).toEqual([]);
+	});
+});
+
+// --- isPerpetualFuturesVault ---
+
+describe('isPerpetualFuturesVault', () => {
+	test('detects perp via flag', () => {
+		expect(isPerpetualFuturesVault({ flags: ['perp_dex_trading_vault'], chain_id: 1 })).toBe(true);
+	});
+
+	test('detects HyperCore (9999) as perp', () => {
+		expect(isPerpetualFuturesVault({ flags: [], chain_id: 9999 })).toBe(true);
+	});
+
+	test('detects GRVT (325) as perp', () => {
+		expect(isPerpetualFuturesVault({ flags: [], chain_id: 325 })).toBe(true);
+	});
+
+	test('detects Lighter (9998) as perp', () => {
+		expect(isPerpetualFuturesVault({ flags: [], chain_id: 9998 })).toBe(true);
+	});
+
+	test('HyperEVM (999) is NOT perp', () => {
+		expect(isPerpetualFuturesVault({ flags: [], chain_id: 999 })).toBe(false);
+	});
+
+	test('regular Ethereum vault is NOT perp', () => {
+		expect(isPerpetualFuturesVault({ flags: [], chain_id: 1 })).toBe(false);
+	});
+
+	test('flag takes priority over non-perp chain_id', () => {
+		expect(isPerpetualFuturesVault({ flags: ['perp_dex_trading_vault', 'beta'], chain_id: 1 })).toBe(true);
+	});
+});
+
+// --- isValidDateString ---
+
+describe('isValidDateString', () => {
+	test('accepts valid dates', () => {
+		expect(isValidDateString('2025-01-01')).toBe(true);
+		expect(isValidDateString('2024-02-29')).toBe(true); // leap year
+		expect(isValidDateString('1954-01-04')).toBe(true);
+	});
+
+	test('rejects impossible dates', () => {
+		expect(isValidDateString('2025-02-29')).toBe(false); // not a leap year
+		expect(isValidDateString('2026-02-31')).toBe(false);
+		expect(isValidDateString('2025-13-01')).toBe(false);
+		expect(isValidDateString('2025-00-01')).toBe(false);
+	});
+
+	test('rejects non-YYYY-MM-DD formats', () => {
+		expect(isValidDateString('01-01-2025')).toBe(false);
+		expect(isValidDateString('2025/01/01')).toBe(false);
+		expect(isValidDateString('not-a-date')).toBe(false);
+		expect(isValidDateString('')).toBe(false);
+	});
+});

--- a/src/lib/top-vaults/treasury-benchmark.ts
+++ b/src/lib/top-vaults/treasury-benchmark.ts
@@ -1,0 +1,129 @@
+/**
+ * Client-side fetcher for FRED DTB3 (3-month Treasury bill) time series,
+ * and cumulative return conversion for chart overlay.
+ */
+import type { TimeInterval } from 'd3-time';
+import type { UTCTimestamp } from 'lightweight-charts';
+import type { SimpleDataItem } from '$lib/charts/types';
+/** Format a Date as YYYY-MM-DD in UTC. */
+function formatDateYMD(d: Date): string {
+	return d.toISOString().slice(0, 10);
+}
+
+type RateEntry = [timestamp: number, rate: number];
+
+export type TreasuryDataItem = SimpleDataItem & {
+	customValues: { percentChange: number; annualRate: number };
+};
+
+const SEED_DAYS = 7;
+const YEAR_MS = 365.25 * 86_400 * 1000;
+
+const benchmarkRequestCache = new Map<string, Promise<RateEntry[]>>();
+
+/**
+ * Fetch DTB3 time series from the server-side proxy endpoint.
+ *
+ * Expands the start date backwards by 7 days to seed forward-fill,
+ * so we have a rate observation even if the visible start falls on a weekend.
+ */
+export function fetchTreasuryBenchmarkSeries(fetch: Fetch, start: Date, end: Date): Promise<RateEntry[]> {
+	const seedStart = new Date(start.getTime() - SEED_DAYS * 86_400 * 1000);
+	const cosd = formatDateYMD(seedStart);
+	const coed = formatDateYMD(end);
+	const cacheKey = `${cosd}:${coed}`;
+
+	const cached = benchmarkRequestCache.get(cacheKey);
+	if (cached) return cached;
+
+	const params = new URLSearchParams({ cosd, coed });
+	const promise = fetch(`/trading-view/vaults/treasury-benchmark?${params}`)
+		.then((resp) => {
+			if (!resp.ok) throw new Error(`Treasury benchmark fetch failed: ${resp.status}`);
+			return resp.json() as Promise<RateEntry[]>;
+		})
+		.catch((error) => {
+			benchmarkRequestCache.delete(cacheKey);
+			throw error;
+		});
+
+	benchmarkRequestCache.set(cacheKey, promise);
+	return promise;
+}
+
+/**
+ * Convert FRED daily annual yield rates into a cumulative return price line.
+ *
+ * Does NOT use resampleTimeSeries — that would discard customValues metadata.
+ * Instead generates interval-aligned points directly, compounding based on
+ * actual elapsed time to handle any interval (4h, 1d, etc.) correctly.
+ *
+ * @param rates - Raw FRED data: [unixTimestamp, annualRatePercent][]
+ * @param startingValue - Vault share price at the start (the baseline)
+ * @param interval - d3 time interval for output points (e.g. utcHour.every(4) for 1M)
+ * @param startDate - Visible range start (cumulative compounding starts here)
+ * @param endDate - Visible range end
+ */
+export function ratesToCumulativeReturn(
+	rates: RateEntry[],
+	startingValue: number,
+	interval: TimeInterval,
+	startDate: Date,
+	endDate: Date
+): TreasuryDataItem[] {
+	if (rates.length === 0 || startingValue <= 0) return [];
+
+	// Build sorted rate lookup: [{dateMs, rate}]
+	const sortedRates = rates.map(([ts, rate]) => ({ dateMs: ts * 1000, rate })).sort((a, b) => a.dateMs - b.dateMs);
+
+	const results: TreasuryDataItem[] = [];
+	let currentRateIndex = 0;
+	let currentRate = sortedRates[0].rate;
+	let cumulativeValue = startingValue;
+	let prevDateMs = startDate.getTime();
+	const startMs = startDate.getTime();
+
+	// Advance rate index to the last observation at or before startDate
+	while (currentRateIndex < sortedRates.length - 1 && sortedRates[currentRateIndex + 1].dateMs <= startMs) {
+		currentRate = sortedRates[++currentRateIndex].rate;
+	}
+
+	// Generate points at each interval step
+	let current = interval.floor(startDate);
+	const lastDate = interval.floor(endDate);
+
+	while (current <= lastDate) {
+		const currentMs = current.getTime();
+
+		// Skip floored points before the actual start
+		if (currentMs < startMs) {
+			current = interval.offset(current);
+			continue;
+		}
+
+		// Forward-fill: advance to the last rate observation at or before this point
+		while (currentRateIndex < sortedRates.length - 1 && sortedRates[currentRateIndex + 1].dateMs <= currentMs) {
+			currentRate = sortedRates[++currentRateIndex].rate;
+		}
+
+		// Compound based on actual elapsed time
+		const elapsedMs = currentMs - prevDateMs;
+		if (elapsedMs > 0) {
+			const growthFactor = (1 + currentRate / 100) ** (elapsedMs / YEAR_MS);
+			cumulativeValue *= growthFactor;
+		}
+
+		const percentChange = cumulativeValue / startingValue - 1;
+
+		results.push({
+			time: (currentMs / 1000) as UTCTimestamp,
+			value: cumulativeValue,
+			customValues: { percentChange, annualRate: currentRate }
+		});
+
+		prevDateMs = currentMs;
+		current = interval.offset(current);
+	}
+
+	return results;
+}

--- a/src/lib/top-vaults/vault-prices-parquet.ts
+++ b/src/lib/top-vaults/vault-prices-parquet.ts
@@ -1,9 +1,12 @@
 import { env } from '$env/dynamic/private';
 import { createWriteStream } from 'node:fs';
 import { mkdir, readFile, rename, rm, stat, utimes, writeFile } from 'node:fs/promises';
+import { Readable } from 'node:stream';
+import { pipeline } from 'node:stream/promises';
 import { once } from 'node:events';
 import { dirname } from 'node:path';
 import { VAULT_PRICES_PARQUET, VAULT_PRICES_PARQUET_PATH } from './constants';
+import { getR2Object, headR2Object, isR2Configured } from '$lib/r2/client';
 
 const ONE_HOUR_MS = 60 * 60 * 1000;
 const HEAD_TIMEOUT_MS = 20_000;
@@ -83,6 +86,8 @@ async function touchFile(path: string, now: Date): Promise<void> {
 	await utimes(path, now, now);
 }
 
+// --- URL-based remote access ---
+
 async function headRemoteFile(fetchFn: typeof fetch, upstreamUrl: string): Promise<RemoteFileMetadata> {
 	const response = await fetchFn(upstreamUrl, {
 		method: 'HEAD',
@@ -142,10 +147,80 @@ async function downloadRemoteFile(
 	}
 }
 
+// --- R2-based remote access ---
+
+function r2MetadataToRemoteFileMetadata(meta: {
+	contentLength: number | null;
+	lastModified: Date | null;
+}): RemoteFileMetadata {
+	return {
+		etag: null,
+		lastModified: meta.lastModified?.toUTCString() ?? null,
+		contentLength: meta.contentLength
+	};
+}
+
+async function headR2File(): Promise<RemoteFileMetadata> {
+	const meta = await headR2Object(VAULT_PRICES_PARQUET);
+	if (!meta) throw new Error('R2 HEAD returned null');
+	return r2MetadataToRemoteFileMetadata(meta);
+}
+
+async function downloadR2File(localPath: string, now: Date): Promise<RemoteFileMetadata> {
+	const result = await getR2Object(VAULT_PRICES_PARQUET);
+	if (!result?.body) throw new Error('R2 GET returned null or empty body');
+
+	await mkdir(dirname(localPath), { recursive: true });
+
+	const tempPath = `${localPath}.${process.pid}.${Date.now()}.tmp`;
+
+	try {
+		// AWS SDK body is a SdkStream that extends Readable
+		const readable = result.body as unknown as Readable;
+		const writer = createWriteStream(tempPath);
+		await pipeline(readable, writer);
+
+		await rename(tempPath, localPath);
+		await touchFile(localPath, now);
+		return r2MetadataToRemoteFileMetadata(result);
+	} catch (error) {
+		await rm(tempPath, { force: true });
+		throw error;
+	}
+}
+
+// --- Source resolution ---
+
+/** Determine which remote source to use: R2 (preferred) or direct URL (fallback). */
+type RemoteSource = { kind: 'r2' } | { kind: 'url'; url: string; fetchFn: typeof fetch } | null;
+
 function getConfiguredUpstreamUrl(): string | null {
 	const url = env.TS_PRIVATE_VAULT_PRICES_PARQUET_URL?.trim();
 	return url ? url : null;
 }
+
+function resolveRemoteSource(upstreamUrl: string | null, fetchFn: typeof fetch): RemoteSource {
+	// Explicit URL takes precedence (also used by tests to inject a mock URL)
+	if (upstreamUrl) return { kind: 'url', url: upstreamUrl, fetchFn };
+	if (isR2Configured()) return { kind: 'r2' };
+	return null;
+}
+
+async function headRemote(source: RemoteSource & object): Promise<RemoteFileMetadata> {
+	if (source.kind === 'r2') return headR2File();
+	return headRemoteFile(source.fetchFn, source.url);
+}
+
+async function downloadRemote(
+	source: RemoteSource & object,
+	localPath: string,
+	now: Date
+): Promise<RemoteFileMetadata> {
+	if (source.kind === 'r2') return downloadR2File(localPath, now);
+	return downloadRemoteFile(source.fetchFn, source.url, localPath, now);
+}
+
+// --- Main logic ---
 
 async function ensureVaultPricesParquetInner({
 	localPath = VAULT_PRICES_PARQUET_PATH,
@@ -156,29 +231,30 @@ async function ensureVaultPricesParquetInner({
 }: EnsureVaultPricesParquetOptions = {}): Promise<string> {
 	const localStat = await stat(localPath).catch(() => null);
 	const currentTime = now();
+	const source = resolveRemoteSource(upstreamUrl, fetchFn);
 
 	if (!localStat) {
-		if (!upstreamUrl) {
+		if (!source) {
 			throw new Error(
-				`Vault prices parquet is missing at ${localPath} and TS_PRIVATE_VAULT_PRICES_PARQUET_URL is not configured`
+				`Vault prices parquet is missing at ${localPath} and neither R2 nor TS_PRIVATE_VAULT_PRICES_PARQUET_URL is configured`
 			);
 		}
 
-		const metadata = await downloadRemoteFile(fetchFn, upstreamUrl, localPath, currentTime);
+		const metadata = await downloadRemote(source, localPath, currentTime);
 		await writeCachedMetadata(localPath, metadata);
 		return localPath;
 	}
 
-	if (currentTime.getTime() - localStat.mtimeMs < checkIntervalMs || !upstreamUrl) {
+	if (currentTime.getTime() - localStat.mtimeMs < checkIntervalMs || !source) {
 		return localPath;
 	}
 
 	try {
-		const remoteMetadata = await headRemoteFile(fetchFn, upstreamUrl);
+		const remoteMetadata = await headRemote(source);
 		const cachedMetadata = await readCachedMetadata(localPath);
 
 		if (hasRemoteFileChanged(remoteMetadata, cachedMetadata)) {
-			const downloadedMetadata = await downloadRemoteFile(fetchFn, upstreamUrl, localPath, currentTime);
+			const downloadedMetadata = await downloadRemote(source, localPath, currentTime);
 			await writeCachedMetadata(localPath, downloadedMetadata);
 		} else {
 			await touchFile(localPath, currentTime);
@@ -191,8 +267,8 @@ async function ensureVaultPricesParquetInner({
 }
 
 /**
- * Resolve the local vault prices Parquet file, refreshing it from Cloudflare
- * when the cache check interval has expired.
+ * Resolve the local vault prices Parquet file, refreshing it from R2 (preferred)
+ * or a direct URL when the cache check interval has expired.
  */
 export async function ensureVaultPricesParquet(options: EnsureVaultPricesParquetOptions = {}): Promise<string> {
 	const localPath = options.localPath ?? VAULT_PRICES_PARQUET_PATH;

--- a/src/routes/trading-view/vaults/treasury-benchmark/+server.ts
+++ b/src/routes/trading-view/vaults/treasury-benchmark/+server.ts
@@ -1,0 +1,141 @@
+/**
+ * Server-side proxy for FRED DTB3 (3-month Treasury bill) time series.
+ *
+ * Proxies through the server to avoid CORS issues and FRED rate-limiting.
+ * Uses file-based caching with stale-fallback on fetch failure.
+ */
+import { error, json } from '@sveltejs/kit';
+import {
+	FRED_CSV_BASE,
+	FRED_TIMEOUT,
+	ONE_DAY_S,
+	formatDateYMD,
+	isValidDateString,
+	randomUserAgent,
+	readJsonFileCache,
+	writeJsonFileCache,
+	isCacheFresh
+} from '$lib/fred-helpers';
+
+const SERIES_ID = 'DTB3';
+/** Earliest DTB3 observation on FRED */
+const SERIES_START = '1954-01-04';
+
+type RateEntry = [timestamp: number, rate: number];
+
+function todayYMD(): string {
+	return formatDateYMD(new Date());
+}
+
+/**
+ * Validate and clamp date range parameters.
+ * Returns clamped [cosd, coed] or throws a 400 error.
+ */
+function validateAndClampDates(rawCosd: string | null, rawCoed: string | null): [string, string] {
+	if (!rawCosd || !rawCoed) {
+		error(400, 'Missing required query params: cosd, coed');
+	}
+
+	if (!isValidDateString(rawCosd) || !isValidDateString(rawCoed)) {
+		error(400, 'Invalid date format — expected YYYY-MM-DD with valid calendar dates');
+	}
+
+	const today = todayYMD();
+
+	// Reject future start date
+	if (rawCosd > today) {
+		error(400, 'cosd must not be in the future');
+	}
+
+	// Clamp to DTB3 series bounds
+	const cosd = rawCosd < SERIES_START ? SERIES_START : rawCosd;
+	const coed = rawCoed > today ? today : rawCoed;
+
+	// Re-validate ordering after clamping
+	if (coed < cosd) {
+		error(400, 'coed must be >= cosd (after clamping to valid range)');
+	}
+
+	return [cosd, coed];
+}
+
+function parseFredCsv(text: string): RateEntry[] {
+	const lines = text.trim().split('\n');
+	const entries: RateEntry[] = [];
+
+	// Skip header row
+	for (let i = 1; i < lines.length; i++) {
+		const [dateStr, valueStr] = lines[i].split(',');
+		// FRED uses "." for missing values (holidays, weekends)
+		if (!valueStr || valueStr.trim() === '.') continue;
+		const rate = parseFloat(valueStr);
+		if (!Number.isFinite(rate)) continue;
+		const timestamp = Date.parse(dateStr + 'T00:00:00Z') / 1000;
+		if (!Number.isFinite(timestamp)) continue;
+		entries.push([timestamp, rate]);
+	}
+
+	return entries;
+}
+
+export async function GET({ url }) {
+	const [cosd, coed] = validateAndClampDates(url.searchParams.get('cosd'), url.searchParams.get('coed'));
+
+	const cacheKey = `fred-${SERIES_ID}-${cosd}-${coed}`;
+
+	// Check file cache
+	if (await isCacheFresh(cacheKey, ONE_DAY_S)) {
+		const cached = await readJsonFileCache<RateEntry[]>(cacheKey);
+		if (cached) {
+			return json(cached, {
+				headers: { 'Cache-Control': 'public, max-age=86400' }
+			});
+		}
+	}
+
+	// Fetch from FRED
+	const params = new URLSearchParams({ id: SERIES_ID, cosd, coed });
+	try {
+		const resp = await fetch(`${FRED_CSV_BASE}?${params}`, {
+			signal: AbortSignal.timeout(FRED_TIMEOUT),
+			headers: { 'User-Agent': randomUserAgent() }
+		});
+
+		if (!resp.ok) {
+			console.warn(`FRED fetch failed (${resp.status}), attempting stale cache for ${cacheKey}`);
+			return returnStaleOrError(cacheKey, `FRED returned ${resp.status}`);
+		}
+
+		const text = await resp.text();
+		const entries = parseFredCsv(text);
+
+		if (entries.length === 0) {
+			console.warn(`FRED returned no valid data for ${cacheKey}, attempting stale cache`);
+			return returnStaleOrError(cacheKey, 'No valid FRED data');
+		}
+
+		// Write cache
+		await writeJsonFileCache(cacheKey, entries);
+
+		return json(entries, {
+			headers: { 'Cache-Control': 'public, max-age=86400' }
+		});
+	} catch (e) {
+		console.warn(`FRED fetch error for ${cacheKey}:`, e);
+		return returnStaleOrError(cacheKey, 'FRED fetch failed');
+	}
+}
+
+/**
+ * Return stale cache data if available, otherwise throw 502.
+ */
+async function returnStaleOrError(cacheKey: string, reason: string) {
+	const stale = await readJsonFileCache<RateEntry[]>(cacheKey);
+	if (stale) {
+		console.warn(`Serving stale cache for ${cacheKey} (reason: ${reason})`);
+		return json(stale, {
+			headers: { 'Cache-Control': 'public, max-age=3600' }
+		});
+	}
+	error(502, `Treasury benchmark unavailable: ${reason}`);
+}


### PR DESCRIPTION
## Why

Non-perpetual-futures vaults (lending, DeFi, prediction markets) were showing BTC/ETH benchmarks on their share price charts, which is a poor comparison. A US Treasury bill rate (risk-free benchmark) is far more relevant for these vaults. Additionally, the vault prices parquet file couldn't auto-download because it only supported a direct URL, not the R2 credentials that are actually configured.

## Lessons learnt

- `fred-helpers.ts` must not be imported by client-side modules — Node.js `fs` imports poison the entire module for browser use. Pure utility functions (like date formatting) that need to work on both sides should be inlined or placed in a separate browser-safe module.
- The Tooltip component's `<dfn>` wrapper defaults to `display: block`, which breaks vertical alignment when used inline alongside flex items. Override with `display: inline-flex` in the parent context.
- lightweight-charts series render order is determined by mount order (first = bottom layer). When a benchmark line should appear behind the vault area fill, it must be rendered before the AreaSeries in the template.
- The parquet downloader and top vaults JSON fetcher had inconsistent data source strategies — one used R2 with URL fallback, the other only supported direct URLs. Both now follow the same pattern.

## Summary

**Treasury benchmark for non-perp vaults:**
- Replace BTC/ETH benchmarks with US 3M T-bill (FRED DTB3) for non-perpetual-futures vaults
- Perp vaults (Hyperliquid/GRVT/Lighter) keep BTC/ETH benchmarks unchanged
- Vault classification via `perp_dex_trading_vault` flag with chain_id fallback
- Server-side FRED proxy endpoint with file cache, stale fallback, and strict date validation
- Client-side cumulative return conversion with time-correct compounding (handles 4h/1d intervals)
- Y-axis scales to vault share price ±20% margin; benchmarks clip off-chart gracefully
- US flag icon, glossary tooltip, and clickable legend link to `/glossary/risk-free-rate`
- 19 unit tests covering compounding math, vault classification, and date validation

**Parquet R2 download fix:**
- Add R2 SDK as download source for vault prices parquet (was URL-only, now matches top vaults JSON pattern)
- Explicit URL takes precedence over R2 (preserves test injection)

**Documentation:**
- Add `docs/vault-data-source.md` documenting both vault datasets, R2 config, data flow, and known issues
- Fix `.env` comments to accurately describe data source options
- Add reference in `CLAUDE.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)