### PR TITLE
Fix T-bill tooltip values

### DIFF
--- a/src/lib/top-vaults/VaultPriceChart.svelte
+++ b/src/lib/top-vaults/VaultPriceChart.svelte
@@ -24,8 +24,14 @@ so relative performance is comparable on a single axis.
 	import Tooltip from '$lib/components/Tooltip.svelte';
 	import { getLogoUrl } from '$lib/helpers/assets';
 	import { isPerpetualFuturesVault } from './isPerpetualFuturesVault';
-	import type { PriceScaleCalculator } from '$lib/charts/types';
-	import { formatDollar, formatInterestRate, formatPercent, formatTokenAmount } from '$lib/helpers/formatters';
+	import type { PriceScaleCalculator, SimpleDataItem } from '$lib/charts/types';
+	import {
+		formatDollar,
+		formatInterestRate,
+		formatPercent,
+		formatTokenAmount,
+		notFilledMarker
+	} from '$lib/helpers/formatters';
 	import { formatDate, resampleTimeSeries } from '$lib/charts/helpers';
 
 	/** Let lightweight-charts auto-scale to the vault share price only (benchmarks excluded via priceScaleCalculator={() => null}) */
@@ -52,6 +58,12 @@ so relative performance is comparable on a single axis.
 	let priceData = $state<[number, number][]>();
 	let tvlData = $state<[number, number][]>();
 
+	type ChartSeriesKind = 'vault-price' | 'tvl';
+
+	function withChartSeriesKind(data: SimpleDataItem[], series: ChartSeriesKind) {
+		return data.map((item) => ({ ...item, customValues: { ...item.customValues, series } }));
+	}
+
 	function getBenchmarkCustomValues(point: unknown) {
 		if (!point || typeof point !== 'object' || !('customValues' in point)) return undefined;
 		return (point as { customValues?: { percentChange?: number; usdPrice?: number } }).customValues;
@@ -59,7 +71,18 @@ so relative performance is comparable on a single axis.
 
 	function getTreasuryCustomValues(point: unknown) {
 		if (!point || typeof point !== 'object' || !('customValues' in point)) return undefined;
-		return (point as { customValues?: { percentChange?: number; annualRate?: number } }).customValues;
+		const customValues = (
+			point as { customValues?: { percentChange?: number; annualRate?: number; rateDate?: number } }
+		).customValues;
+		return customValues?.annualRate != null || customValues?.rateDate != null ? customValues : undefined;
+	}
+
+	function getSeriesValuePoint(points: unknown[], series: ChartSeriesKind) {
+		return points.find((point) => {
+			if (!point || typeof point !== 'object' || !('value' in point)) return false;
+			const item = point as { value?: unknown; customValues?: { series?: unknown } };
+			return typeof item.value === 'number' && item.customValues?.series === series;
+		}) as { value: number } | undefined;
 	}
 
 	async function fetchMetrics(vaultId: string) {
@@ -128,12 +151,15 @@ so relative performance is comparable on a single axis.
 		options={{ handleScroll: false, handleScale: false }}
 	>
 		{#snippet series({ data, timeSpan, range })}
+			{@const vaultSeriesData = withChartSeriesKind(data, 'vault-price')}
+			{@const tvlSeriesData = withChartSeriesKind(resampleTimeSeries(tvlData ?? [], timeSpan.interval), 'tvl')}
+
 			{#if data.length > 1 && range && !showCryptoBenchmarks}
 				<TreasuryBenchmarkSeries {data} timeBucket={timeSpan.timeBucket} {range} color="#4a90d9a0" />
 			{/if}
 
 			<AreaSeries
-				{data}
+				data={vaultSeriesData}
 				options={{ priceLineVisible: false, crosshairMarkerVisible: false }}
 				priceScaleOptions={{ scaleMargins: { top: 0.1, bottom: 0.1 } }}
 				priceScaleCalculator={vaultPriceScaleCalculator}
@@ -160,7 +186,7 @@ so relative performance is comparable on a single axis.
 
 				<Series
 					type={HistogramSeries}
-					data={resampleTimeSeries(tvlData ?? [], timeSpan.interval)}
+					data={tvlSeriesData}
 					options={{ priceLineVisible: false, color: 'transparent' }}
 					paneIndex={1}
 					priceScaleOptions={{ scaleMargins: { top: 0.25, bottom: 0 } }}
@@ -176,16 +202,16 @@ so relative performance is comparable on a single axis.
 
 		{#snippet tooltip({ point, time }, seriesData)}
 			{#if showCryptoBenchmarks}
-				{@const price = seriesData[0]}
+				{@const price = getSeriesValuePoint(seriesData, 'vault-price')}
 				{@const btc = getBenchmarkCustomValues(seriesData[1])}
 				{@const eth = getBenchmarkCustomValues(seriesData[2])}
-				{@const tvl = seriesData[3]}
+				{@const tvl = getSeriesValuePoint(seriesData, 'tvl')}
 				{#if price || btc || eth || tvl}
 					<ChartTooltip {point}>
 						<div class="tooltip-date">{formatDate(time as number, '1d')}</div>
 						<dl class="tooltip-items">
 							<dt>Price:</dt>
-							<dd>{formatValue(price?.value)} {vault.denomination}</dd>
+							<dd>{price ? formatValue(price.value) : notFilledMarker} {vault.denomination}</dd>
 							<dt>BTC:</dt>
 							<dd>
 								{formatPercent(btc?.percentChange, 1, 1, { signDisplay: 'exceptZero' })}
@@ -197,30 +223,38 @@ so relative performance is comparable on a single axis.
 								{#if eth?.usdPrice}<span class="benchmark-usd">{formatDollar(eth.usdPrice, 1)}</span>{/if}
 							</dd>
 							<dt>TVL:</dt>
-							<dd>{formatValue(tvl?.value)}</dd>
+							<dd>{tvl ? formatValue(tvl.value) : notFilledMarker}</dd>
 						</dl>
 					</ChartTooltip>
 				{/if}
 			{:else}
-				{@const treasury = getTreasuryCustomValues(seriesData[0])}
-				{@const price = seriesData[1]}
-				{@const tvl = seriesData[2]}
+				{@const treasury = seriesData.map(getTreasuryCustomValues).find(Boolean)}
+				{@const price = getSeriesValuePoint(seriesData, 'vault-price')}
+				{@const tvl = getSeriesValuePoint(seriesData, 'tvl')}
 				{#if price || treasury || tvl}
 					<ChartTooltip {point}>
 						<div class="tooltip-date">{formatDate(time as number, '1d')}</div>
 						<dl class="tooltip-items">
 							<dt>Price:</dt>
-							<dd>{formatValue(price?.value)} {vault.denomination}</dd>
-							<dt>T-bill:</dt>
-							<dd>
-								{formatPercent(treasury?.percentChange, 1, 1, { signDisplay: 'exceptZero' })}
-								{#if treasury?.annualRate != null}
-									<span class="benchmark-usd">{formatInterestRate(treasury.annualRate)} p.a.</span>
-								{/if}
-							</dd>
+							<dd>{price ? formatValue(price.value) : notFilledMarker} {vault.denomination}</dd>
 							<dt>TVL:</dt>
-							<dd>{formatValue(tvl?.value)}</dd>
+							<dd>{tvl ? formatValue(tvl.value) : notFilledMarker}</dd>
 						</dl>
+						{#if treasury}
+							<dl class="tooltip-items tooltip-items-secondary">
+								<dt>T-bill:</dt>
+								<dd>
+									{formatPercent(treasury.percentChange, 1, 1, { signDisplay: 'exceptZero' })}
+									{#if treasury.annualRate != null}
+										<span class="benchmark-usd">{formatInterestRate(treasury.annualRate)} p.a.</span>
+									{/if}
+								</dd>
+								{#if treasury.rateDate != null}
+									<dt>Rate date:</dt>
+									<dd>{formatDate(treasury.rateDate, '1d')}</dd>
+								{/if}
+							</dl>
+						{/if}
 					</ChartTooltip>
 				{/if}
 			{/if}
@@ -305,6 +339,18 @@ so relative performance is comparable on a single axis.
 				font: var(--f-ui-sm-roman);
 				letter-spacing: var(--ls-ui-sm, normal);
 				color: var(--c-text-extra-light);
+			}
+
+			&.tooltip-items-secondary {
+				margin-top: 0.75rem;
+				padding-top: 0.75rem;
+				border-top: 1px solid var(--c-box-3);
+
+				dt,
+				dd,
+				.benchmark-usd {
+					font-size: 80%;
+				}
 			}
 		}
 

--- a/src/lib/top-vaults/treasury-benchmark.test.ts
+++ b/src/lib/top-vaults/treasury-benchmark.test.ts
@@ -88,8 +88,27 @@ describe('ratesToCumulativeReturn', () => {
 
 		for (const point of result) {
 			expect(point.customValues.annualRate).toBe(3.5);
+			expect(typeof point.customValues.rateDate).toBe('number');
 			expect(typeof point.customValues.percentChange).toBe('number');
 		}
+	});
+
+	test('customValues.rateDate tracks the source rate observation date', () => {
+		const start = new Date('2025-01-03T00:00:00Z'); // Friday
+		const end = new Date('2025-01-06T00:00:00Z'); // Monday
+		const rates: [number, number][] = [
+			[start.getTime() / 1000, 4.0],
+			[end.getTime() / 1000, 4.1]
+		];
+		const result = ratesToCumulativeReturn(rates, 1.0, day, start, end);
+
+		expect(result.map((point) => point.customValues.rateDate)).toEqual([
+			new Date('2025-01-03T00:00:00Z').getTime() / 1000,
+			new Date('2025-01-03T00:00:00Z').getTime() / 1000,
+			new Date('2025-01-03T00:00:00Z').getTime() / 1000,
+			new Date('2025-01-06T00:00:00Z').getTime() / 1000
+		]);
+		expect(result.at(-1)?.customValues.annualRate).toBe(4.1);
 	});
 
 	test('seed days before startDate are excluded from output', () => {

--- a/src/lib/top-vaults/treasury-benchmark.ts
+++ b/src/lib/top-vaults/treasury-benchmark.ts
@@ -13,7 +13,7 @@ function formatDateYMD(d: Date): string {
 type RateEntry = [timestamp: number, rate: number];
 
 export type TreasuryDataItem = SimpleDataItem & {
-	customValues: { percentChange: number; annualRate: number };
+	customValues: { percentChange: number; annualRate: number; rateDate: number };
 };
 
 const SEED_DAYS = 7;
@@ -79,13 +79,16 @@ export function ratesToCumulativeReturn(
 	const results: TreasuryDataItem[] = [];
 	let currentRateIndex = 0;
 	let currentRate = sortedRates[0].rate;
+	let currentRateDateMs = sortedRates[0].dateMs;
 	let cumulativeValue = startingValue;
 	let prevDateMs = startDate.getTime();
 	const startMs = startDate.getTime();
 
 	// Advance rate index to the last observation at or before startDate
 	while (currentRateIndex < sortedRates.length - 1 && sortedRates[currentRateIndex + 1].dateMs <= startMs) {
-		currentRate = sortedRates[++currentRateIndex].rate;
+		const nextRate = sortedRates[++currentRateIndex];
+		currentRate = nextRate.rate;
+		currentRateDateMs = nextRate.dateMs;
 	}
 
 	// Generate points at each interval step
@@ -103,7 +106,9 @@ export function ratesToCumulativeReturn(
 
 		// Forward-fill: advance to the last rate observation at or before this point
 		while (currentRateIndex < sortedRates.length - 1 && sortedRates[currentRateIndex + 1].dateMs <= currentMs) {
-			currentRate = sortedRates[++currentRateIndex].rate;
+			const nextRate = sortedRates[++currentRateIndex];
+			currentRate = nextRate.rate;
+			currentRateDateMs = nextRate.dateMs;
 		}
 
 		// Compound based on actual elapsed time
@@ -118,7 +123,7 @@ export function ratesToCumulativeReturn(
 		results.push({
 			time: (currentMs / 1000) as UTCTimestamp,
 			value: cumulativeValue,
-			customValues: { percentChange, annualRate: currentRate }
+			customValues: { percentChange, annualRate: currentRate, rateDate: currentRateDateMs / 1000 }
 		});
 
 		prevDateMs = currentMs;


### PR DESCRIPTION
## Why

The vault chart tooltip could show an empty T-bill value because tooltip data was read by series index. Users also needed to see which Treasury observation date the displayed rate came from.

## Lessons learnt

Lightweight Charts tooltip data should be identified from explicit metadata because series order can change when benchmark overlays and pane series mount.

Forward-filled benchmark points should carry their source observation date so weekend and holiday rates are auditable in the UI.

## Summary

- Track the source T-bill rate date when building the cumulative Treasury benchmark.
- Tag vault price and TVL series so tooltip values are read deterministically.
- Move T-bill and rate date into a compact separated tooltip footer.
