### PR TITLE
feat: Add monthly returns filter and negative vaults page

### DIFF
--- a/src/lib/top-vaults/TopVaultsPage.svelte
+++ b/src/lib/top-vaults/TopVaultsPage.svelte
@@ -37,6 +37,12 @@
 		defaultAgeIndex?: number;
 		/** Default value for the "Hide unknown" filter (1 = hide, 0 = show) */
 		defaultHideUnknown?: number;
+		/** Default monthly return filter key */
+		defaultMonthlyReturnKey?: string;
+		/** Default sort column key */
+		defaultSort?: string;
+		/** Default sort direction */
+		defaultDirection?: 'asc' | 'desc';
 		/** Show skeleton loading state while vault data is being fetched */
 		loading?: boolean;
 	}
@@ -57,6 +63,9 @@
 		defaultTvlKey,
 		defaultAgeIndex,
 		defaultHideUnknown,
+		defaultMonthlyReturnKey,
+		defaultSort,
+		defaultDirection,
 		loading = false
 	}: Props = $props();
 </script>
@@ -100,7 +109,15 @@
 			{/if}
 
 			{#if loading}
-				<TopVaultsTable {chain} loading {showFilters} {defaultHideUnknown} />
+				<TopVaultsTable
+					{chain}
+					loading
+					{showFilters}
+					{defaultHideUnknown}
+					{defaultMonthlyReturnKey}
+					{defaultSort}
+					{defaultDirection}
+				/>
 			{:else if !topVaults?.vaults.length}
 				{#if stablecoinMetadata}
 					<Alert status="info">We have not indexed any vaults using this stablecoin as a denomination token yet.</Alert>
@@ -120,6 +137,9 @@
 					{defaultTvlKey}
 					{defaultAgeIndex}
 					{defaultHideUnknown}
+					{defaultMonthlyReturnKey}
+					{defaultSort}
+					{defaultDirection}
 				/>
 			{/if}
 		</div>

--- a/src/lib/top-vaults/TopVaultsTable.svelte
+++ b/src/lib/top-vaults/TopVaultsTable.svelte
@@ -43,9 +43,11 @@
 		getFormattedLockup,
 		getLockupTooltip,
 		getLifetimeMaxDrawdown,
+		getMonthlyReturn,
 		hasSupportedProtocol,
 		isBlacklisted,
 		isGoodVaultStatus,
+		monthlyReturnFilterOptions,
 		rankVaultsBy,
 		resolveVaultDetails,
 		riskFilterOptions,
@@ -95,6 +97,12 @@
 		defaultAgeIndex?: number;
 		/** Default value for the "Hide unknown" filter (1 = hide, 0 = show) */
 		defaultHideUnknown?: number;
+		/** Default monthly return filter key */
+		defaultMonthlyReturnKey?: string;
+		/** Default sort column key */
+		defaultSort?: string;
+		/** Default sort direction */
+		defaultDirection?: 'asc' | 'desc';
 		/** Show skeleton loading state while vault data is being fetched */
 		loading?: boolean;
 	}
@@ -114,6 +122,9 @@
 		defaultTvlKey = DEFAULT_TVL_KEY,
 		defaultAgeIndex = 0,
 		defaultHideUnknown = 1,
+		defaultMonthlyReturnKey = 'any',
+		defaultSort,
+		defaultDirection,
 		loading = false
 	}: Props = $props();
 
@@ -166,14 +177,19 @@
 		risk: { type: 'number', defaultValue: 1 },
 		sort: {
 			type: 'string',
-			defaultValue: DEFAULT_RETURN_COLUMN_IDS[0],
+			defaultValue: defaultSort ?? DEFAULT_RETURN_COLUMN_IDS[0],
 			options: [...Object.keys(sortColumnMap), ...Object.keys(LEGACY_RETURN_SORT_ALIASES)]
 		},
-		direction: { type: 'string', defaultValue: 'desc', options: ['asc', 'desc'] },
+		direction: { type: 'string', defaultValue: defaultDirection ?? 'desc', options: ['asc', 'desc'] },
 		q: { type: 'string', defaultValue: '' },
 		closed: { type: 'number', defaultValue: 0 },
 		unknown: { type: 'number', defaultValue: defaultHideUnknown },
 		dd: { type: 'string', defaultValue: 'any', options: ddFilterOptions.map((o) => o.key) },
+		mr: {
+			type: 'string',
+			defaultValue: defaultMonthlyReturnKey,
+			options: monthlyReturnFilterOptions.map((o) => o.key)
+		},
 		returns: { type: 'string', defaultValue: DEFAULT_RETURN_COLUMN_IDS.join(',') }
 	} as const satisfies ParamSchema;
 
@@ -203,6 +219,13 @@
 	let selectedDdKey = $derived(urlState.dd);
 	let selectedDdOption = $derived(ddFilterOptions.find((o) => o.key === selectedDdKey)!);
 	let ddDropdownOpen = $state(false);
+
+	let selectedMrKey = $derived(urlState.mr);
+	let selectedMrOption = $derived(monthlyReturnFilterOptions.find((o) => o.key === selectedMrKey)!);
+	let mrDropdownOpen = $state(false);
+
+	/** Treasury note annual rate (percentage, e.g. 4.25) from layout server data */
+	let treasuryRate = $derived((page.data as { treasuryRate?: number | null }).treasuryRate ?? null);
 
 	let hideClosed = $derived(urlState.closed === 1);
 	let hideUnknown = $derived(urlState.unknown === 1);
@@ -351,6 +374,18 @@
 			if (showFilters && selectedDdOption.value < Infinity) {
 				const dd = getLifetimeMaxDrawdown(v);
 				if (dd == null || Math.abs(dd) > selectedDdOption.value) return false;
+			}
+
+			// Monthly returns filter (dropdown-driven)
+			if (showFilters && selectedMrOption.mode !== 'any') {
+				const mr = getMonthlyReturn(v);
+				if (mr == null) return false;
+				if (selectedMrOption.mode === 'lt' && !(mr < selectedMrOption.value)) return false;
+				if (selectedMrOption.mode === 'gt' && !(mr > selectedMrOption.value)) return false;
+				if (selectedMrOption.mode === 'gt-treasury') {
+					if (treasuryRate == null) return false;
+					if (!(mr > treasuryRate / 100)) return false;
+				}
 			}
 
 			// Hide closed filter (checkbox-driven)
@@ -745,6 +780,41 @@
 													}}
 												>
 													{option.optionLabel}
+												</button>
+											</li>
+										{/each}
+									</ul>
+								{/if}
+							</div>
+						</div>
+
+						<div class="filter-group">
+							<Tooltip>
+								<span class="filter-label filter-label-hint" slot="trigger">Monthly returns</span>
+								<svelte:fragment slot="popup">
+									Filter vaults by annualised one-month return (net of fees when available).
+								</svelte:fragment>
+							</Tooltip>
+							<div class="tvl-dropdown" use:clickOutside={() => (mrDropdownOpen = false)}>
+								<button class="tvl-trigger" onclick={() => (mrDropdownOpen = !mrDropdownOpen)}>
+									{selectedMrOption.label}
+									<IconChevronDown />
+								</button>
+								{#if mrDropdownOpen}
+									<ul class="tvl-options">
+										{#each monthlyReturnFilterOptions as option (option.key)}
+											<li>
+												<button
+													class:active={selectedMrKey === option.key}
+													disabled={option.mode === 'gt-treasury' && treasuryRate == null}
+													onclick={() => {
+														updateSearchParams({ mr: option.key });
+														mrDropdownOpen = false;
+													}}
+												>
+													{option.optionLabel}{option.mode === 'gt-treasury' && treasuryRate != null
+														? ` (${formatPercent(treasuryRate / 100, 2)})`
+														: ''}
 												</button>
 											</li>
 										{/each}

--- a/src/lib/top-vaults/VaultListingsSelector.svelte
+++ b/src/lib/top-vaults/VaultListingsSelector.svelte
@@ -10,6 +10,7 @@
 		{ href: '/trading-view/vaults/stablecoins', label: 'By stablecoin' },
 		{ href: '/trading-view/vaults/chains', label: 'By chain' },
 		{ href: '/trading-view/vaults/protocols', label: 'By protocol' },
+		{ href: '/trading-view/vaults/negative', label: 'Negative' },
 		{ href: '/trading-view/vaults/all', label: 'All' }
 	] as const;
 

--- a/src/lib/top-vaults/helpers.ts
+++ b/src/lib/top-vaults/helpers.ts
@@ -88,6 +88,37 @@ export interface DdFilterOption {
 	value: number;
 }
 
+export interface MonthlyReturnFilterOption {
+	key: string;
+	label: string;
+	optionLabel: string;
+	/**
+	 * Filter mode:
+	 * - 'any': no filter
+	 * - 'lt': vault annualised 1M return < threshold
+	 * - 'gt': vault annualised 1M return > threshold
+	 * - 'gt-treasury': vault annualised 1M return > treasury note rate
+	 */
+	mode: 'any' | 'lt' | 'gt' | 'gt-treasury';
+	/** Threshold as a decimal (e.g. 0.05 = 5%). Ignored for 'any' and 'gt-treasury' modes */
+	value: number;
+}
+
+export const monthlyReturnFilterOptions: MonthlyReturnFilterOption[] = [
+	{ key: 'any', label: 'Any', optionLabel: 'Any', mode: 'any', value: 0 },
+	{ key: 'neg', label: '< 0%', optionLabel: '< 0%', mode: 'lt', value: 0 },
+	{ key: 'treasury', label: '> US Treasury', optionLabel: '> US Treasury note', mode: 'gt-treasury', value: 0 },
+	{ key: '5', label: '> 5%', optionLabel: '> 5%', mode: 'gt', value: 0.05 },
+	{ key: '10', label: '> 10%', optionLabel: '> 10%', mode: 'gt', value: 0.1 }
+];
+
+/**
+ * Get the annualised 1-month return for a vault (net if available, otherwise gross).
+ */
+export function getMonthlyReturn(vault: Pick<VaultInfo, 'one_month_cagr_net' | 'one_month_cagr'>): number | null {
+	return vault.one_month_cagr_net ?? vault.one_month_cagr ?? null;
+}
+
 export const ddFilterOptions: DdFilterOption[] = [
 	{ key: '0.1', label: '0.1%', optionLabel: '0.1% or less', value: 0.001 },
 	{ key: '1', label: '1%', optionLabel: '1% or less', value: 0.01 },

--- a/src/routes/trading-view/vaults/+layout.server.ts
+++ b/src/routes/trading-view/vaults/+layout.server.ts
@@ -1,6 +1,10 @@
 import { getCachedTopVaults } from '$lib/top-vaults/cache';
+import { fetchLatestTreasuryRate } from '$lib/reference-rates';
 
 export async function load({ fetch }) {
-	const { generated_at } = await getCachedTopVaults(fetch);
-	return { generatedAt: generated_at };
+	const [{ generated_at }, treasuryRate] = await Promise.all([
+		getCachedTopVaults(fetch),
+		fetchLatestTreasuryRate().catch(() => null)
+	]);
+	return { generatedAt: generated_at, treasuryRate };
 }

--- a/src/routes/trading-view/vaults/negative/+page.svelte
+++ b/src/routes/trading-view/vaults/negative/+page.svelte
@@ -1,0 +1,56 @@
+<script lang="ts">
+	import type { TopVaults } from '$lib/top-vaults/schemas';
+	import { fetchAllVaultData, hasVaultCache } from '$lib/top-vaults/client-cache';
+	import { page } from '$app/state';
+	import TopVaultsPage from '$lib/top-vaults/TopVaultsPage.svelte';
+	import { MetaTags, JsonLd } from 'svelte-meta-tags';
+
+	let topVaults = $state<TopVaults>();
+	let loading = $state(!hasVaultCache());
+
+	$effect(() => {
+		fetchAllVaultData()
+			.then((data) => (topVaults = data))
+			.catch((e) => console.error('Failed to load vault data:', e))
+			.finally(() => (loading = false));
+	});
+
+	const title = 'DeFi stablecoin vaults making loss';
+	const description = 'Vaults with negative returns.';
+	let pageUrl = $derived(new URL(page.url.pathname, page.url.origin).href);
+</script>
+
+<MetaTags
+	{title}
+	{description}
+	canonical={pageUrl}
+	openGraph={{ siteName: 'Trading Strategy', url: pageUrl, title, description, type: 'website' }}
+	twitter={{ site: '@TradingProtocol', cardType: 'summary', title, description }}
+/>
+
+<JsonLd
+	schema={{
+		'@context': 'http://schema.org',
+		'@type': 'CollectionPage',
+		name: title,
+		description,
+		url: pageUrl,
+		provider: { '@type': 'Organization', name: 'Trading Strategy' },
+		mainEntity: {
+			'@type': 'ItemList',
+			numberOfItems: topVaults?.vaults.length ?? 0
+		}
+	}}
+/>
+
+<TopVaultsPage
+	{topVaults}
+	{loading}
+	title="DeFi stablecoin vaults making loss"
+	subtitle="Vaults with negative returns"
+	showFilters
+	defaultTvlKey="10k"
+	defaultMonthlyReturnKey="neg"
+	defaultSort="1m-ann"
+	defaultDirection="asc"
+/>


### PR DESCRIPTION
## Why

Users need to filter vaults by monthly return performance and quickly find vaults that are losing money. The monthly returns filter enables filtering by return thresholds (including comparison against US Treasury note rate), while the dedicated "Negative" page provides a direct navigation path to underperforming vaults.

## Lessons learnt

- The vault layout server (`+layout.server.ts`) is the right place to add shared data (like the treasury rate) that all vault listing pages need, since it flows through `page.data`.
- Filter options using dynamic external data (treasury rate) need graceful degradation — the option disables itself when the rate is unavailable.

## Summary

- Added "Monthly returns" dropdown to advanced filters with options: Any, < 0%, > US Treasury note, > 5%, > 10%
- Treasury note rate fetched in vault layout server and displayed dynamically in the filter option
- Added `getMonthlyReturn()` helper using annualised 1-month return (net, falling back to gross)
- Added "Negative" navigation category in vault listings selector
- Created `/trading-view/vaults/negative` page showing loss-making vaults, sorted most negative first
- Plumbed `defaultSort`, `defaultDirection`, and `defaultMonthlyReturnKey` props through TopVaultsPage → TopVaultsTable

🤖 Generated with [Claude Code](https://claude.com/claude-code)