### PR TITLE
fix: Remove Trading Strategy logo fallback for unknown vaults

### DIFF
--- a/src/lib/top-vaults/VaultPriceChart.svelte
+++ b/src/lib/top-vaults/VaultPriceChart.svelte
@@ -12,7 +12,6 @@ so relative performance is comparable on a single axis.
 <script lang="ts">
 	import { resolve } from '$app/paths';
 	import type { VaultInfo } from './schemas';
-	import brandMark from '$lib/assets/brand-mark.svg';
 	import usTreasuryLogo from '$lib/assets/logos/tokens/us-treasury.svg';
 	import { BaselineSeries as BaselineSeriesType, HistogramSeries } from 'lightweight-charts';
 	import ChartContainer from '$lib/charts/ChartContainer.svelte';
@@ -151,12 +150,12 @@ so relative performance is comparable on a single axis.
 	const benchmarkLegend: LegendItem[] = $derived(
 		showCryptoBenchmarks
 			? [
-					{ label: vault.name, color: getVaultColor(vaultDirection), logoUrl: protocolLogoUrl ?? brandMark },
+					{ label: vault.name, color: getVaultColor(vaultDirection), logoUrl: protocolLogoUrl },
 					{ label: 'BTC', color: '#f7931a80', logoUrl: getLogoUrl('token', 'btc') },
 					{ label: 'ETH', color: '#627eea80', logoUrl: getLogoUrl('token', 'eth') }
 				]
 			: [
-					{ label: vault.name, color: getVaultColor(vaultDirection), logoUrl: protocolLogoUrl ?? brandMark },
+					{ label: vault.name, color: getVaultColor(vaultDirection), logoUrl: protocolLogoUrl },
 					{
 						label: 'US 3M T-bill',
 						color: '#4a90d9a0',


### PR DESCRIPTION
## Why

Unknown vault protocols (e.g. yieldcore-3rd-deal) were incorrectly showing the Trading Strategy brand mark as a fallback logo in the chart legend. This is misleading since these vaults are not associated with Trading Strategy.

## Lessons learnt

- The `brandMark` SVG was used as a fallback via `protocolLogoUrl ?? brandMark` — the template already had `{#if benchmark.logoUrl}` guards, so simply passing `undefined` is sufficient.

## Summary

- Removed `brandMark` fallback from vault chart legend in `VaultPriceChart.svelte`
- When a vault has no identified protocol, no logo is displayed instead of the Trading Strategy logo
- Removed unused `brandMark` import

🤖 Generated with [Claude Code](https://claude.com/claude-code)