### PR TITLE
feat: Show Morpho warning flags alert on vault detail pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Weblog of stuff
 
+- Show Morpho warning flags alert on vault detail pages (2026-05-01)
 - Add Hibachi chain support for perpetual DEX vaults (2026-04-30)
 - Add underwater drawdown chart pane for perpetual DEX vault share price charts (2026-04-28)
 - Add US Treasury bill benchmark for non-perpetual-futures vault charts, with R2 parquet download support and vault data source documentation (2026-04-22)

--- a/src/lib/top-vaults/helpers.ts
+++ b/src/lib/top-vaults/helpers.ts
@@ -173,6 +173,15 @@ export function getProtocolDisplayName(protocol: string | null | undefined): str
 }
 
 /**
+ * Get combined Morpho warning flags from vault other_data
+ */
+export function getMorphoFlags(vault: Pick<VaultInfo, 'other_data'>): string[] {
+	const data = vault.other_data;
+	if (!data) return [];
+	return [...new Set([...data.morpho_vault_flags, ...data.morpho_market_flags])];
+}
+
+/**
  * Check if vault has good operational status (deposits and redemptions are both open)
  */
 export function isGoodVaultStatus(vault: VaultInfo): boolean {

--- a/src/lib/top-vaults/schemas.ts
+++ b/src/lib/top-vaults/schemas.ts
@@ -260,7 +260,18 @@ export const vaultInfoSchema = z.object({
 	lifetime_samples: z.int().nullable(),
 
 	/** Detailed per-period performance metrics (e.g. 1d, 7d, 30d, 90d, 1y, all-time) */
-	period_results: periodMetricsSchema.array()
+	period_results: periodMetricsSchema.array(),
+
+	/** Protocol-specific metadata (e.g. Morpho flags) */
+	other_data: z
+		.object({
+			/** Morpho vault-level warning flags (e.g. "not_whitelisted", "short_timelock") */
+			morpho_vault_flags: z.string().array(),
+			/** Morpho market-level warning flags */
+			morpho_market_flags: z.string().array()
+		})
+		.nullable()
+		.optional()
 });
 export type VaultInfo = z.infer<typeof vaultInfoSchema>;
 

--- a/src/routes/trading-view/vaults/[vault=slug]/+page.svelte
+++ b/src/routes/trading-view/vaults/[vault=slug]/+page.svelte
@@ -17,11 +17,12 @@
 	import VaultProtocolInfo from './VaultProtocolInfo.svelte';
 	import VaultRankings from './VaultRankings.svelte';
 	import IconDiscord from '~icons/local/discord';
-	import { hasSupportedProtocol, isBlacklisted } from '$lib/top-vaults/helpers';
+	import { getMorphoFlags, hasSupportedProtocol, isBlacklisted } from '$lib/top-vaults/helpers';
 	import { getVaultProtocolLogoUrl } from '$lib/vault-protocol/helpers.js';
 
 	let { data } = $props();
 	let { vault, chain, protocolMetadata, stablecoinMetadata, generated_at } = $derived(data);
+	let morphoFlags = $derived(getMorphoFlags(vault));
 </script>
 
 <SocialMediaTags {vault} {chain} {protocolMetadata} />
@@ -30,6 +31,14 @@
 	<Section tag="header" padding="xs">
 		<VaultListingsSelector />
 	</Section>
+
+	{#if morphoFlags.length > 0}
+		<Section padding="md">
+			<Alert size="md" status="warning" title="Morpho has flagged this vault">
+				{morphoFlags.join(', ')}
+			</Alert>
+		</Section>
+	{/if}
 
 	<VaultPageHeader {vault} />
 


### PR DESCRIPTION
## Why

Morpho-flagged vaults (e.g. `not_whitelisted`, `short_timelock`) should surface warnings to users before they interact with the vault. The backend already provides these flags in `other_data` but the frontend wasn't consuming them.

## Lessons learnt

- All 3919 vaults have `other_data` with shape `{ morpho_vault_flags: string[], morpho_market_flags: string[] }` — 258 currently have non-empty flags.
- The `other_data` field is nullable/optional to handle future vaults that may not have it.

## Summary

- Added `other_data` field to `vaultInfoSchema` with `morpho_vault_flags` and `morpho_market_flags` string arrays
- Added `getMorphoFlags()` helper that combines and deduplicates both flag arrays
- Added warning alert above the vault page title when Morpho flags are present
- Added changelog entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)