### PR TITLE
fix: prevent drawdown chart labels clipping

### DIFF
--- a/src/lib/top-vaults/VaultPriceChart.svelte
+++ b/src/lib/top-vaults/VaultPriceChart.svelte
@@ -232,7 +232,7 @@ so relative performance is comparable on a single axis.
 							lineWidth: 1
 						}}
 						paneIndex={1}
-						priceScaleOptions={{ scaleMargins: { top: 0, bottom: 0.1 } }}
+						priceScaleOptions={{ scaleMargins: { top: 0.12, bottom: 0.16 } }}
 						callback={({ series, colors }) => {
 							series.getPane().setHeight(120);
 							series.applyOptions({


### PR DESCRIPTION
## Why

Drawdown axis labels on vault share-price charts could sit directly on pane separators, making the top and bottom labels look clipped.

## Lessons learnt

Multi-pane lightweight-charts panes need their own price scale margins when labels are rendered near pane boundaries.

## Summary

- Added top and bottom scale margin to the drawdown pane.
- Verified the Fire Liquidity Provider vault chart with Playwright.