### PR TITLE
fix: defer Sentry.init until after SvelteKit runtime is ready

### DIFF
--- a/src/hooks.client.ts
+++ b/src/hooks.client.ts
@@ -1,13 +1,14 @@
 import type { ClientInit } from '@sveltejs/kit';
 import * as Sentry from '@sentry/sveltekit';
-import { env } from '$env/dynamic/public';
 
 export const handleError = Sentry.handleErrorWithSentry();
 
-// Sentry.init must run inside `init` so that $env/dynamic/public is available.
-// Accessing it at module evaluation time fails because globalThis.__sveltekit_*
-// is not yet set when hooks.client.ts is first evaluated.
+// Sentry.init must run inside `init` with a dynamic import of $env/dynamic/public.
+// A static top-level import causes the env module to be evaluated at hook module
+// load time, before SvelteKit sets up globalThis.__sveltekit_*, which throws:
+// "TypeError: can't access property 'env', globalThis.__sveltekit_* is undefined".
 export const init: ClientInit = async () => {
+	const { env } = await import('$env/dynamic/public');
 	Sentry.init({
 		dsn: env['TS_PUBLIC_SENTRY_DSN'],
 		sendDefaultPii: true,

--- a/src/hooks.client.ts
+++ b/src/hooks.client.ts
@@ -1,16 +1,18 @@
 import type { ClientInit } from '@sveltejs/kit';
 import * as Sentry from '@sentry/sveltekit';
-import { sentryDsn, siteMode, version } from '$lib/config';
-
-Sentry.init({
-	dsn: sentryDsn,
-	sendDefaultPii: true,
-	environment: siteMode,
-	release: `frontend@${version}`,
-	tracesSampleRate: 0.1
-});
+import { env } from '$env/dynamic/public';
 
 export const handleError = Sentry.handleErrorWithSentry();
 
-// adding empty init to silence build warning
-export const init: ClientInit = async () => {};
+// Sentry.init must run inside `init` so that $env/dynamic/public is available.
+// Accessing it at module evaluation time fails because globalThis.__sveltekit_*
+// is not yet set when hooks.client.ts is first evaluated.
+export const init: ClientInit = async () => {
+	Sentry.init({
+		dsn: env['TS_PUBLIC_SENTRY_DSN'],
+		sendDefaultPii: true,
+		environment: env['TS_PUBLIC_SITE_MODE'] || 'local',
+		release: `frontend@${env['TS_PUBLIC_FRONTEND_VERSION_TAG']}`,
+		tracesSampleRate: 0.1
+	});
+};


### PR DESCRIPTION
## Why

Production was throwing `TypeError: can't access property 'env', globalThis.__sveltekit_* is undefined`. The cause: `hooks.client.ts` imported `sentryDsn/siteMode/version` from `$lib/config`, which uses `$env/dynamic/public`. That module reads `globalThis.__sveltekit_*.env` at module evaluation time, but SvelteKit only sets up that global during its `start()` call — after all modules have already been evaluated.

## Lessons learnt

- `$env/dynamic/public` must not be statically imported in `hooks.client.ts` — a static top-level import causes the env module itself to be evaluated at hook module load time, before SvelteKit sets up `globalThis.__sveltekit_*`, even if the imported value is only used later.
- The safe pattern is a dynamic import (`await import('$env/dynamic/public')`) inside the exported `init: ClientInit` function, so the env module is only evaluated after the runtime global is available.
- `$lib/config` eagerly evaluates all exports at import time, so importing it in hooks or other early-lifecycle files will trigger the same issue.

## Summary

- Moved `Sentry.init()` from module top-level into the exported `init: ClientInit` function in `hooks.client.ts`
- Replaced static `$lib/config` import with a dynamic `await import('$env/dynamic/public')` inside `init()`, ensuring the env module is not evaluated until SvelteKit's runtime global is ready
- `handleError = Sentry.handleErrorWithSentry()` remains at module level (safe — it only creates a wrapper, reads no env vars)