### PR TITLE
feat: Add MegaETH chain support for vault listings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Weblog of stuff
 
+- Add MegaETH chain support so MegaETH vaults appear on the by-chain page (2026-05-05)
 - Show Morpho warning flags alert on vault detail pages (2026-05-01)
 - Add Hibachi chain support for perpetual DEX vaults (2026-04-30)
 - Add underwater drawdown chart pane for perpetual DEX vault share price charts (2026-04-28)

--- a/src/lib/assets/logos/blockchains/megaeth.svg
+++ b/src/lib/assets/logos/blockchains/megaeth.svg
@@ -1,0 +1,5 @@
+<svg viewBox="0 0 200 200" fill="none" xmlns="http://www.w3.org/2000/svg">
+<rect width="200" height="200" rx="40" fill="#0A0A0A"/>
+<path d="M40 140L70 60L100 110L130 60L160 140" stroke="#39FF87" stroke-width="14" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M55 140H145" stroke="#39FF87" stroke-width="14" stroke-linecap="round"/>
+</svg>

--- a/src/lib/helpers/chain.ts
+++ b/src/lib/helpers/chain.ts
@@ -281,6 +281,15 @@ export const chains = (() => {
 			explorer: 'https://katanascan.com',
 			nativeCurrency: 'ETH',
 			hasBackendData: false
+		},
+		{
+			id: 4326,
+			slug: 'megaeth',
+			name: 'MegaETH',
+			homepage: 'https://megaeth.com',
+			explorer: 'https://mega.etherscan.io',
+			nativeCurrency: 'ETH',
+			hasBackendData: false
 		}
 	] as const satisfies ChainData[];
 


### PR DESCRIPTION
## Why

MegaETH vaults (chain ID 4326) were not appearing on the by-chain page because the chain was missing from the frontend chain registry. The page server silently skips any vault whose `chain_id` has no matching entry in `getChain()`, so all MegaETH vaults were filtered out.

## Lessons learnt

When adding a new chain to vault listings, two things are always required: a chain registry entry in `src/lib/helpers/chain.ts` and a logo SVG in `src/lib/assets/logos/blockchains/{slug}.svg`. Missing either causes vaults to silently disappear.

## Summary

- Added MegaETH (chain ID 4326) to the chain registry in `src/lib/helpers/chain.ts` with `hasBackendData: false`
- Added `megaeth.svg` logo to blockchain logo assets