### PR TITLE
feat: add historical TVL chart controls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Weblog of stuff
 
+- Add historical TVL chart controls for market share and shorter daily history views (2026-05-05)
 - Add MegaETH chain support so MegaETH vaults appear on the by-chain page (2026-05-05)
 - Show Morpho warning flags alert on vault detail pages (2026-05-01)
 - Add Hibachi chain support for perpetual DEX vaults (2026-04-30)

--- a/src/lib/echarts/HistoricalTvlGroupChart.svelte
+++ b/src/lib/echarts/HistoricalTvlGroupChart.svelte
@@ -13,11 +13,12 @@ Reusable client-side ECharts stacked area chart for historical vault TVL groupin
 	/>
 ```
 -->
-<script lang="ts">
+<script lang="ts" generics="TSeries extends HistoricalTvlSeriesBase">
 	import { goto } from '$app/navigation';
 	import { page } from '$app/state';
 	import { removeOnError } from '$lib/actions/image';
 	import logoSvg from '$lib/assets/logo-horizontal.svg?raw';
+	import SegmentedControl from '$lib/components/SegmentedControl.svelte';
 	import Spinner from '$lib/components/Spinner.svelte';
 	import { formatUsd } from '$lib/echarts/cumulative-tvl-apy';
 	import { type HistoricalTvlPayload, type HistoricalTvlSeriesBase } from '$lib/echarts/historical-tvl';
@@ -27,7 +28,7 @@ Reusable client-side ECharts stacked area chart for historical vault TVL groupin
 	import { onMount, tick } from 'svelte';
 
 	interface Props {
-		data: HistoricalTvlPayload | null;
+		data: HistoricalTvlPayload<TSeries> | null;
 		dataLoading?: boolean;
 		error?: string | null;
 		searchParamKey: string;
@@ -36,7 +37,24 @@ Reusable client-side ECharts stacked area chart for historical vault TVL groupin
 		watermarkCorner?: 'top-left' | 'top-right' | null;
 		watermarkInset?: 'default' | 'relaxed';
 		watermarkOpacity?: number;
-		getSeriesLogoUrl?: ((series: HistoricalTvlSeriesBase) => string | undefined) | undefined;
+		getSeriesLogoUrl?: ((series: TSeries) => string | undefined) | undefined;
+	}
+
+	type HistoricalTvlChartMode = 'tvl' | 'market-share';
+	type HistoricalTvlHistoryRange = 'all' | '1y' | '3m';
+
+	interface HistoricalTvlChartDataPoint {
+		value: number;
+		tvl: number;
+		share: number;
+	}
+
+	interface HistoricalTvlTooltipParam {
+		axisValueLabel?: string;
+		seriesName?: string;
+		value?: number;
+		color?: string;
+		data?: HistoricalTvlChartDataPoint;
 	}
 
 	let {
@@ -69,6 +87,19 @@ Reusable client-side ECharts stacked area chart for historical vault TVL groupin
 	const watermarkDesktopWidth = 224;
 	const watermarkMobileWidth = 176;
 	const watermarkAspectRatio = 314 / 60;
+	const chartModeParamKey = 'chart';
+	const chartModeOptions: readonly HistoricalTvlChartMode[] = ['tvl', 'market-share'];
+	const chartModeLabels: Record<HistoricalTvlChartMode, string> = {
+		tvl: 'TVL',
+		'market-share': 'Market share'
+	};
+	const historyRangeParamKey = 'history';
+	const historyRangeOptions: readonly HistoricalTvlHistoryRange[] = ['all', '1y', '3m'];
+	const historyRangeLabels: Record<HistoricalTvlHistoryRange, string> = {
+		all: 'All-time',
+		'1y': '1y',
+		'3m': '3m'
+	};
 	const historicalWatermarkUrl = `data:image/svg+xml;charset=UTF-8,${encodeURIComponent(
 		logoSvg.replace('fill="#0B0B14"', 'fill="#d5deea"')
 	)}`;
@@ -76,7 +107,9 @@ Reusable client-side ECharts stacked area chart for historical vault TVL groupin
 
 	function getSearchParamsSchema() {
 		return {
-			[searchParamKey]: { type: 'string', defaultValue: '' }
+			[searchParamKey]: { type: 'string', defaultValue: '' },
+			[chartModeParamKey]: { type: 'string', defaultValue: 'tvl', options: chartModeOptions },
+			[historyRangeParamKey]: { type: 'string', defaultValue: 'all', options: historyRangeOptions }
 		} as ParamSchema;
 	}
 
@@ -84,20 +117,56 @@ Reusable client-side ECharts stacked area chart for historical vault TVL groupin
 		deserialiseSearchParams(page.url.searchParams, getSearchParamsSchema()) as Record<string, string>
 	);
 	let selectedParamValue = $derived(urlState[searchParamKey] ?? '');
+	let chartMode = $derived((urlState[chartModeParamKey] ?? 'tvl') as HistoricalTvlChartMode);
+	let historyRange = $derived((urlState[historyRangeParamKey] ?? 'all') as HistoricalTvlHistoryRange);
 	let effectiveError = $derived(error ?? chartError);
 	let hasSeries = $derived((data?.series.length ?? 0) > 0);
 	let selectedSeriesKeys = $derived(selectedParamValue ? selectedParamValue.split(',').filter(Boolean) : []);
-	let visibleSeries = $derived(
-		data?.series.filter((item) => selectedSeriesKeys.length === 0 || selectedSeriesKeys.includes(item.key)) ?? []
+	let historySourceWeeks = $derived(historyRange !== 'all' && data?.daily ? data.daily.weeks : (data?.weeks ?? []));
+	let historySourceSeries = $derived(historyRange !== 'all' && data?.daily ? data.daily.series : (data?.series ?? []));
+	let selectedHistorySourceSeries = $derived(
+		historySourceSeries.filter((item) => selectedSeriesKeys.length === 0 || selectedSeriesKeys.includes(item.key))
 	);
-	let latestSelectedTvl = $derived(visibleSeries.reduce((sum, item) => sum + (item.values.at(-1) ?? 0), 0));
+	let visibleHistoryStartIndex = $derived(getHistoryStartIndex(historySourceWeeks, historyRange));
+	let visibleWeeks = $derived(historySourceWeeks.slice(visibleHistoryStartIndex));
+	let visibleHistorySeries = $derived(
+		selectedHistorySourceSeries.map((item) => ({
+			...item,
+			values: item.values.slice(visibleHistoryStartIndex)
+		}))
+	);
+	let latestSelectedTvl = $derived(visibleHistorySeries.reduce((sum, item) => sum + (item.values.at(-1) ?? 0), 0));
 
 	function formatWeekLabel(value: string) {
 		const date = new Date(`${value}T00:00:00Z`);
+		if (historyRange !== 'all') {
+			return new Intl.DateTimeFormat('en-GB', {
+				day: 'numeric',
+				month: 'short'
+			}).format(date);
+		}
+
 		return new Intl.DateTimeFormat('en-GB', {
 			month: 'short',
 			year: 'numeric'
 		}).format(date);
+	}
+
+	function getHistoryStartIndex(weeks: string[], range: HistoricalTvlHistoryRange) {
+		if (range === 'all' || weeks.length === 0) return 0;
+
+		const latestWeek = new Date(`${weeks.at(-1)}T00:00:00Z`);
+		const cutoff = new Date(latestWeek);
+
+		if (range === '1y') {
+			cutoff.setUTCFullYear(cutoff.getUTCFullYear() - 1);
+		} else {
+			cutoff.setUTCMonth(cutoff.getUTCMonth() - 3);
+		}
+
+		const cutoffValue = cutoff.toISOString().slice(0, 10);
+		const index = weeks.findIndex((week) => week >= cutoffValue);
+		return index === -1 ? 0 : index;
 	}
 
 	function withAlpha(colour: string, alpha: number) {
@@ -111,6 +180,22 @@ Reusable client-side ECharts stacked area chart for historical vault TVL groupin
 		}
 
 		return normalized;
+	}
+
+	function formatPercent(value: number) {
+		return `${value.toFixed(1)}%`;
+	}
+
+	function getTooltipTvl(item: HistoricalTvlTooltipParam) {
+		return item.data?.tvl ?? item.value ?? 0;
+	}
+
+	function getTooltipShare(item: HistoricalTvlTooltipParam, total: number) {
+		const share = item.data?.share;
+		if (typeof share === 'number' && Number.isFinite(share)) return share;
+
+		const tvl = getTooltipTvl(item);
+		return total > 0 ? (tvl / total) * 100 : 0;
 	}
 
 	function getSeriesColour(index: number) {
@@ -182,6 +267,16 @@ Reusable client-side ECharts stacked area chart for historical vault TVL groupin
 		goto(href, { replaceState: true, noScroll: true, keepFocus: true });
 	}
 
+	function setChartMode(value: string) {
+		if (!chartModeOptions.includes(value as HistoricalTvlChartMode)) return;
+		updateUrl({ [chartModeParamKey]: value });
+	}
+
+	function setHistoryRange(value: string) {
+		if (!historyRangeOptions.includes(value as HistoricalTvlHistoryRange)) return;
+		updateUrl({ [historyRangeParamKey]: value });
+	}
+
 	function isSeriesSelected(key: string) {
 		return selectedSeriesKeys.length === 0 || selectedSeriesKeys.includes(key);
 	}
@@ -226,23 +321,25 @@ Reusable client-side ECharts stacked area chart for historical vault TVL groupin
 		resizeObserver.observe(chartContainer);
 	}
 
-	function buildTooltip(
-		params: Array<{ axisValueLabel?: string; seriesName?: string; value?: number; color?: string }>
-	) {
-		const sorted = [...params].sort((left, right) => (right.value ?? 0) - (left.value ?? 0));
-		const total = sorted.reduce((sum, item) => sum + (item.value ?? 0), 0);
-		const visible = sorted.filter((item) => (item.value ?? 0) > 0).slice(0, maxTooltipSeries);
-		const hiddenCount = sorted.filter((item) => (item.value ?? 0) > 0).length - visible.length;
+	function buildTooltip(params: HistoricalTvlTooltipParam[]) {
+		const sorted = [...params].sort((left, right) => getTooltipTvl(right) - getTooltipTvl(left));
+		const total = sorted.reduce((sum, item) => sum + getTooltipTvl(item), 0);
+		const visible = sorted.filter((item) => getTooltipTvl(item) > 0).slice(0, maxTooltipSeries);
+		const hiddenCount = sorted.filter((item) => getTooltipTvl(item) > 0).length - visible.length;
 		const hiddenLabel = hiddenCount === 1 ? selectorLabel.toLowerCase() : selectorLabelPlural.toLowerCase();
 
 		return [
 			`<div style="margin-bottom: 0.4rem; color: #ffffff; font-family: ${chartFontFamily}; font-size: 1rem; font-weight: 700;">${params[0]?.axisValueLabel ?? ''}</div>`,
 			`<div style="margin-bottom: 0.5rem; color: #d5deea; font-family: ${chartFontFamily};"><strong>Total TVL:</strong> ${formatUsd(total)}</div>`,
 			...visible.map((item, index) => {
-				const value = item.value ?? 0;
-				const share = total > 0 ? ((value / total) * 100).toFixed(1) : '0.0';
+				const tvl = getTooltipTvl(item);
+				const share = getTooltipShare(item, total);
 				const colour = typeof item.color === 'string' ? item.color : '#94a3b8';
-				return `<div style="color: #d5deea; font-family: ${chartFontFamily}; display: flex; justify-content: space-between; gap: 1rem;"><span style="display: inline-flex; align-items: center; gap: 0.45rem;"><span style="width: 0.72rem; height: 0.72rem; border-radius: 999px; background: ${colour}; box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.18);"></span><span>${index + 1}. ${item.seriesName}</span></span><strong>${formatUsd(value)} (${share}%)</strong></div>`;
+				const valueLabel =
+					chartMode === 'market-share'
+						? `${formatPercent(share)} (${formatUsd(tvl)})`
+						: `${formatUsd(tvl)} (${formatPercent(share)})`;
+				return `<div style="color: #d5deea; font-family: ${chartFontFamily}; display: flex; justify-content: space-between; gap: 1rem;"><span style="display: inline-flex; align-items: center; gap: 0.45rem;"><span style="width: 0.72rem; height: 0.72rem; border-radius: 999px; background: ${colour}; box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.18);"></span><span>${index + 1}. ${item.seriesName}</span></span><strong>${valueLabel}</strong></div>`;
 			}),
 			...(hiddenCount > 0
 				? [
@@ -252,10 +349,35 @@ Reusable client-side ECharts stacked area chart for historical vault TVL groupin
 		].join('');
 	}
 
+	function positionTooltip(
+		point: [number, number],
+		_params: unknown,
+		_dom: HTMLElement,
+		_rect: unknown,
+		size: { contentSize: [number, number] }
+	) {
+		const chartRect = chartContainer?.getBoundingClientRect();
+		const tooltipWidth = size.contentSize[0] ?? 0;
+		const tooltipHeight = size.contentSize[1] ?? 0;
+		const gap = 14;
+
+		if (!chartRect) return [point[0] + gap, point[1] + gap];
+
+		const maxLeft = chartRect.right - tooltipWidth - gap;
+		const minLeft = chartRect.left + gap;
+		const left = Math.min(maxLeft, Math.max(minLeft, point[0] + gap));
+
+		const maxTop = chartRect.bottom - tooltipHeight - gap;
+		const minTop = chartRect.top + gap;
+		const top = Math.min(maxTop, Math.max(minTop, chartRect.top + gap));
+
+		return [left, top];
+	}
+
 	async function renderChart() {
 		if (!chartContainer || !echartsApi) return;
 
-		if (!data || visibleSeries.length === 0) {
+		if (!data || visibleHistorySeries.length === 0 || visibleWeeks.length === 0) {
 			chartError = 'No historical vault TVL data available.';
 			destroyChart();
 			return;
@@ -269,7 +391,10 @@ Reusable client-side ECharts stacked area chart for historical vault TVL groupin
 		const isMobile = viewportMode === 'mobile';
 		const grid = isMobile ? gridMobile : gridDesktop;
 		lastViewportMode = viewportMode;
-		const series = visibleSeries.map((item, index) => {
+		const weekTotals = visibleWeeks.map((_, weekIndex) =>
+			visibleHistorySeries.reduce((sum, item) => sum + (item.values[weekIndex] ?? 0), 0)
+		);
+		const series = visibleHistorySeries.map((item, index) => {
 			const colour = getSeriesColour(index);
 			return {
 				name: item.label,
@@ -294,7 +419,15 @@ Reusable client-side ECharts stacked area chart for historical vault TVL groupin
 				emphasis: {
 					focus: 'series'
 				},
-				data: item.values
+				data: item.values.map((tvl, weekIndex): HistoricalTvlChartDataPoint => {
+					const total = weekTotals[weekIndex] ?? 0;
+					const share = total > 0 ? (tvl / total) * 100 : 0;
+					return {
+						value: chartMode === 'market-share' ? share : tvl,
+						tvl,
+						share
+					};
+				})
 			};
 		});
 
@@ -326,6 +459,7 @@ Reusable client-side ECharts stacked area chart for historical vault TVL groupin
 				backgroundColor: '#111827',
 				borderColor: '#1f2937',
 				borderWidth: 1,
+				confine: true,
 				padding: 12,
 				textStyle: {
 					color: '#f8fafc',
@@ -333,29 +467,32 @@ Reusable client-side ECharts stacked area chart for historical vault TVL groupin
 					fontSize: tooltipFontSize,
 					lineHeight: 20
 				},
-				formatter: (params: Array<{ axisValueLabel?: string; seriesName?: string; value?: number; color?: string }>) =>
-					buildTooltip(params)
+				position: positionTooltip,
+				formatter: (params: HistoricalTvlTooltipParam[]) => buildTooltip(params)
 			},
 			xAxis: {
 				type: 'category',
 				boundaryGap: false,
-				data: data.weeks,
+				data: visibleWeeks,
 				axisLine: { lineStyle: { color: '#64748b' } },
 				axisLabel: {
 					color: '#e2e8f0',
 					fontFamily: axisFontStack,
 					fontSize: axisLabelFontSize,
 					fontWeight: 600,
+					showMinLabel: !isMobile,
 					formatter: (value: string) => formatWeekLabel(value)
 				},
 				splitLine: { show: false }
 			},
 			yAxis: {
 				type: 'value',
-				name: isMobile ? '' : 'TVL',
+				name: isMobile ? '' : chartModeLabels[chartMode],
 				nameLocation: 'end',
 				nameGap: 16,
 				position: 'right',
+				min: 0,
+				max: chartMode === 'market-share' ? 100 : undefined,
 				nameTextStyle: {
 					color: '#ffffff',
 					fontFamily: axisFontStack,
@@ -368,7 +505,7 @@ Reusable client-side ECharts stacked area chart for historical vault TVL groupin
 					fontFamily: axisFontStack,
 					fontSize: axisLabelFontSize,
 					fontWeight: 600,
-					formatter: (value: number) => formatUsd(value)
+					formatter: (value: number) => (chartMode === 'market-share' ? `${Math.round(value)}%` : formatUsd(value))
 				},
 				splitLine: {
 					lineStyle: { color: 'rgba(148, 163, 184, 0.18)' }
@@ -436,6 +573,39 @@ Reusable client-side ECharts stacked area chart for historical vault TVL groupin
 </script>
 
 <div class="historical-tvl-group-chart standalone-historical-tvl-shell" data-testid="vault-scatter-plot">
+	{#if data && !dataLoading && !effectiveError && hasSeries}
+		<div class="chart-controls">
+			<div class="chart-control-group">
+				<span class="chart-control-label">Chart mode</span>
+				<SegmentedControl
+					name={`${searchParamKey}-historical-tvl-chart-mode`}
+					selected={chartMode}
+					options={chartModeOptions}
+					secondary
+					onchange={({ value }) => setChartMode(value)}
+				>
+					{#snippet children(option)}
+						{chartModeLabels[option as HistoricalTvlChartMode]}
+					{/snippet}
+				</SegmentedControl>
+			</div>
+			<div class="chart-control-group">
+				<span class="chart-control-label">History</span>
+				<SegmentedControl
+					name={`${searchParamKey}-historical-tvl-history-range`}
+					selected={historyRange}
+					options={historyRangeOptions}
+					secondary
+					onchange={({ value }) => setHistoryRange(value)}
+				>
+					{#snippet children(option)}
+						{historyRangeLabels[option as HistoricalTvlHistoryRange]}
+					{/snippet}
+				</SegmentedControl>
+			</div>
+		</div>
+	{/if}
+
 	<div class="chart-surface">
 		{#if dataLoading}
 			<div class="chart-state">
@@ -457,7 +627,7 @@ Reusable client-side ECharts stacked area chart for historical vault TVL groupin
 		{/if}
 	</div>
 
-	{#if data && !dataLoading && !effectiveError && visibleSeries.length > 0}
+	{#if data && !dataLoading && !effectiveError && visibleHistorySeries.length > 0}
 		<p class="chart-summary">
 			Today selected {selectorLabelPlural.toLowerCase()} have total {formatUsd(latestSelectedTvl)} TVL
 		</p>
@@ -500,6 +670,33 @@ Reusable client-side ECharts stacked area chart for historical vault TVL groupin
 		flex-wrap: wrap;
 		gap: 0.5rem 0.625rem;
 		align-items: center;
+	}
+
+	.chart-controls {
+		display: flex;
+		flex-wrap: wrap;
+		align-items: center;
+		justify-content: center;
+		gap: 0.625rem 1.25rem;
+	}
+
+	.chart-control-group {
+		display: flex;
+		flex-wrap: wrap;
+		align-items: center;
+		justify-content: center;
+		gap: 0.5rem 0.75rem;
+	}
+
+	.chart-control-label {
+		color: var(--c-text-light);
+		font: var(--f-ui-xs-medium);
+	}
+
+	.chart-controls :global(.segmented-control) {
+		--segmented-control-font: var(--f-ui-xs-medium);
+		--segmented-control-letter-spacing: var(--ls-ui-xs);
+		--segmented-control-padding: 0.48rem 0.72rem;
 	}
 
 	.group-chip {

--- a/src/lib/echarts/historical-tvl-server.ts
+++ b/src/lib/echarts/historical-tvl-server.ts
@@ -23,6 +23,26 @@ export function getMockWeeklyVaultRows(vaults: VaultInfo[]): HistoricalWeeklyVau
 	});
 }
 
+export function getMockDailyVaultRows(vaults: VaultInfo[]): HistoricalWeeklyVaultRow[] {
+	const days = Array.from({ length: 90 }, (_, index) => {
+		const date = new Date('2025-10-08T00:00:00Z');
+		date.setUTCDate(date.getUTCDate() + index);
+		return date.toISOString().slice(0, 10);
+	});
+
+	return vaults.flatMap((vault, index) => {
+		const current = Math.max(vault.current_nav ?? 0, 25_000 + index * 1_000);
+		const peak = Math.max(vault.peak_nav ?? 0, current * 1.18, current);
+
+		return days.map((day, dayIndex) => ({
+			id: vault.id,
+			chainId: vault.chain_id,
+			week: day,
+			tvl: peak * (0.62 + (0.38 * dayIndex) / Math.max(days.length - 1, 1))
+		}));
+	});
+}
+
 export async function getHistoricalWeeklyVaultRows(
 	parquetFile = HISTORICAL_TVL_PARQUET_FILE
 ): Promise<HistoricalWeeklyVaultRow[]> {
@@ -68,6 +88,41 @@ export async function getHistoricalWeeklyVaultRows(
 			id: String(id),
 			chainId: Number(chainId),
 			week: week as string | Date,
+			tvl: Number(tvl)
+		}));
+	} finally {
+		connection.closeSync();
+	}
+}
+
+export async function getHistoricalDailyVaultRows(
+	parquetFile = HISTORICAL_TVL_PARQUET_FILE
+): Promise<HistoricalWeeklyVaultRow[]> {
+	const resolvedParquetFile =
+		parquetFile === HISTORICAL_TVL_PARQUET_FILE ? await ensureVaultPricesParquet() : parquetFile;
+	const connection = await DuckDBConnection.create();
+
+	try {
+		const reader = await connection.runAndReadAll(
+			`
+				SELECT
+					id,
+					chain AS chain_id,
+					CAST(timestamp AS DATE) AS day,
+					arg_max(total_assets, timestamp) AS tvl
+				FROM parquet_scan($parquetFile)
+				WHERE total_assets >= 0
+				GROUP BY 1, 2, 3
+				HAVING day < current_date
+				ORDER BY 3, 2, 1
+			`,
+			{ parquetFile: resolvedParquetFile }
+		);
+
+		return reader.getRows().map(([id, chainId, day, tvl]) => ({
+			id: String(id),
+			chainId: Number(chainId),
+			week: day as string | Date,
 			tvl: Number(tvl)
 		}));
 	} finally {

--- a/src/lib/echarts/historical-tvl.ts
+++ b/src/lib/echarts/historical-tvl.ts
@@ -53,6 +53,10 @@ export interface HistoricalTvlPayload<TSeries extends HistoricalTvlSeriesBase = 
 	cacheTtlSeconds: number;
 	weeks: string[];
 	series: TSeries[];
+	daily?: {
+		weeks: string[];
+		series: TSeries[];
+	};
 	meta: HistoricalTvlPayloadMeta;
 }
 

--- a/src/routes/trading-view/vaults/historical-tvl-chain/+page.svelte
+++ b/src/routes/trading-view/vaults/historical-tvl-chain/+page.svelte
@@ -25,6 +25,7 @@ Benchmark the matching server-side aggregation with
 
 	const title = 'Historical vault TVL by chain';
 	const description = 'Explore how stablecoin vault TVL has evolved on different blockchains over time.';
+	const chartDataVersion = 'daily-short-history-v1';
 	let pageUrl = $derived(new URL(page.url.pathname, page.url.origin).href);
 
 	onMount(() => {
@@ -35,7 +36,9 @@ Benchmark the matching server-side aggregation with
 				chartLoading = true;
 				chartError = null;
 
-				const response = await fetch(resolve('/trading-view/vaults/historical-tvl-chain/chart-data'));
+				const response = await fetch(
+					resolve(`/trading-view/vaults/historical-tvl-chain/chart-data?v=${chartDataVersion}`)
+				);
 				if (!response.ok) throw new Error(`Failed to fetch historical chart data: ${response.status}`);
 
 				const payload = (await response.json()) as HistoricalTvlByChainPayload;

--- a/src/routes/trading-view/vaults/historical-tvl-chain/chart-data/+server.ts
+++ b/src/routes/trading-view/vaults/historical-tvl-chain/chart-data/+server.ts
@@ -5,7 +5,12 @@ import {
 	buildHistoricalTvlByChainPayload,
 	type HistoricalTvlByChainPayload
 } from '$lib/echarts/historical-tvl';
-import { getHistoricalWeeklyVaultRows, getMockWeeklyVaultRows } from '$lib/echarts/historical-tvl-server';
+import {
+	getHistoricalDailyVaultRows,
+	getHistoricalWeeklyVaultRows,
+	getMockDailyVaultRows,
+	getMockWeeklyVaultRows
+} from '$lib/echarts/historical-tvl-server';
 import { getCachedTopVaults } from '$lib/top-vaults/cache';
 
 // Keep this endpoint aligned with `scripts/benchmark-historical-tvl-chain.mjs`
@@ -13,7 +18,7 @@ import { getCachedTopVaults } from '$lib/top-vaults/cache';
 const compress = promisify(brotliCompress);
 
 const CACHE_TTL_MS = HISTORICAL_TVL_CACHE_TTL_SECONDS * 1000;
-const CACHE_VERSION = 'historical-tvl-chain-daily-average-v1';
+const CACHE_VERSION = 'historical-tvl-chain-daily-short-history-v1';
 
 let cache: { json: string; br: Uint8Array; expires: number; version: string } | null = null;
 
@@ -23,14 +28,21 @@ async function getCachedChartData(fetch: Fetch) {
 
 	const startedAt = performance.now();
 	const topVaults = await getCachedTopVaults(fetch);
-	const weeklyRows =
-		import.meta.env.MODE === 'test' ? getMockWeeklyVaultRows(topVaults.vaults) : await getHistoricalWeeklyVaultRows();
+	const [weeklyRows, dailyRows] =
+		import.meta.env.MODE === 'test'
+			? [getMockWeeklyVaultRows(topVaults.vaults), getMockDailyVaultRows(topVaults.vaults)]
+			: await Promise.all([getHistoricalWeeklyVaultRows(), getHistoricalDailyVaultRows()]);
 
 	const payload: HistoricalTvlByChainPayload = buildHistoricalTvlByChainPayload(
 		weeklyRows,
 		topVaults.vaults,
 		performance.now() - startedAt
 	);
+	const dailyPayload = buildHistoricalTvlByChainPayload(dailyRows, topVaults.vaults, 0);
+	payload.daily = {
+		weeks: dailyPayload.weeks,
+		series: dailyPayload.series
+	};
 	const jsonStr = JSON.stringify(payload);
 	const br = new Uint8Array(
 		await compress(new TextEncoder().encode(jsonStr), {

--- a/src/routes/trading-view/vaults/historical-tvl-protocol/+page.svelte
+++ b/src/routes/trading-view/vaults/historical-tvl-protocol/+page.svelte
@@ -22,6 +22,7 @@ Historical vault TVL by vault protocol page with a server-side aggregated weekly
 
 	const title = 'Historical vault TVL by vault protocol';
 	const description = 'Explore how stablecoin vault TVL has evolved across different vault protocols over time.';
+	const chartDataVersion = 'daily-short-history-v1';
 	let pageUrl = $derived(new URL(page.url.pathname, page.url.origin).href);
 
 	onMount(() => {
@@ -32,7 +33,9 @@ Historical vault TVL by vault protocol page with a server-side aggregated weekly
 				chartLoading = true;
 				chartError = null;
 
-				const response = await fetch(resolve('/trading-view/vaults/historical-tvl-protocol/chart-data'));
+				const response = await fetch(
+					resolve(`/trading-view/vaults/historical-tvl-protocol/chart-data?v=${chartDataVersion}`)
+				);
 				if (!response.ok) throw new Error(`Failed to fetch historical chart data: ${response.status}`);
 
 				const payload = (await response.json()) as HistoricalTvlByProtocolPayload;

--- a/src/routes/trading-view/vaults/historical-tvl-protocol/chart-data/+server.ts
+++ b/src/routes/trading-view/vaults/historical-tvl-protocol/chart-data/+server.ts
@@ -5,13 +5,18 @@ import {
 	buildHistoricalTvlByProtocolPayload,
 	type HistoricalTvlByProtocolPayload
 } from '$lib/echarts/historical-tvl';
-import { getHistoricalWeeklyVaultRows, getMockWeeklyVaultRows } from '$lib/echarts/historical-tvl-server';
+import {
+	getHistoricalDailyVaultRows,
+	getHistoricalWeeklyVaultRows,
+	getMockDailyVaultRows,
+	getMockWeeklyVaultRows
+} from '$lib/echarts/historical-tvl-server';
 import { getCachedTopVaults } from '$lib/top-vaults/cache';
 
 const compress = promisify(brotliCompress);
 
 const CACHE_TTL_MS = HISTORICAL_TVL_CACHE_TTL_SECONDS * 1000;
-const CACHE_VERSION = 'historical-tvl-protocol-daily-average-v1';
+const CACHE_VERSION = 'historical-tvl-protocol-daily-short-history-v1';
 
 let cache: { json: string; br: Uint8Array; expires: number; version: string } | null = null;
 
@@ -21,14 +26,21 @@ async function getCachedChartData(fetch: Fetch) {
 
 	const startedAt = performance.now();
 	const topVaults = await getCachedTopVaults(fetch);
-	const weeklyRows =
-		import.meta.env.MODE === 'test' ? getMockWeeklyVaultRows(topVaults.vaults) : await getHistoricalWeeklyVaultRows();
+	const [weeklyRows, dailyRows] =
+		import.meta.env.MODE === 'test'
+			? [getMockWeeklyVaultRows(topVaults.vaults), getMockDailyVaultRows(topVaults.vaults)]
+			: await Promise.all([getHistoricalWeeklyVaultRows(), getHistoricalDailyVaultRows()]);
 
 	const payload: HistoricalTvlByProtocolPayload = buildHistoricalTvlByProtocolPayload(
 		weeklyRows,
 		topVaults.vaults,
 		performance.now() - startedAt
 	);
+	const dailyPayload = buildHistoricalTvlByProtocolPayload(dailyRows, topVaults.vaults, 0);
+	payload.daily = {
+		weeks: dailyPayload.weeks,
+		series: dailyPayload.series
+	};
 	const jsonStr = JSON.stringify(payload);
 	const br = new Uint8Array(
 		await compress(new TextEncoder().encode(jsonStr), {

--- a/src/routes/trading-view/vaults/historical-tvl-stablecoin/+page.svelte
+++ b/src/routes/trading-view/vaults/historical-tvl-stablecoin/+page.svelte
@@ -22,6 +22,7 @@ Historical vault TVL by stablecoin page with a server-side aggregated weekly sta
 
 	const title = 'Historical vault TVL by stablecoin';
 	const description = 'Explore how stablecoin vault TVL has evolved across different stablecoins over time.';
+	const chartDataVersion = 'daily-short-history-v1';
 	let pageUrl = $derived(new URL(page.url.pathname, page.url.origin).href);
 
 	onMount(() => {
@@ -32,7 +33,9 @@ Historical vault TVL by stablecoin page with a server-side aggregated weekly sta
 				chartLoading = true;
 				chartError = null;
 
-				const response = await fetch(resolve('/trading-view/vaults/historical-tvl-stablecoin/chart-data'));
+				const response = await fetch(
+					resolve(`/trading-view/vaults/historical-tvl-stablecoin/chart-data?v=${chartDataVersion}`)
+				);
 				if (!response.ok) throw new Error(`Failed to fetch historical chart data: ${response.status}`);
 
 				const payload = (await response.json()) as HistoricalTvlByStablecoinPayload;

--- a/src/routes/trading-view/vaults/historical-tvl-stablecoin/chart-data/+server.ts
+++ b/src/routes/trading-view/vaults/historical-tvl-stablecoin/chart-data/+server.ts
@@ -5,13 +5,18 @@ import {
 	buildHistoricalTvlByStablecoinPayload,
 	type HistoricalTvlByStablecoinPayload
 } from '$lib/echarts/historical-tvl';
-import { getHistoricalWeeklyVaultRows, getMockWeeklyVaultRows } from '$lib/echarts/historical-tvl-server';
+import {
+	getHistoricalDailyVaultRows,
+	getHistoricalWeeklyVaultRows,
+	getMockDailyVaultRows,
+	getMockWeeklyVaultRows
+} from '$lib/echarts/historical-tvl-server';
 import { getCachedTopVaults } from '$lib/top-vaults/cache';
 
 const compress = promisify(brotliCompress);
 
 const CACHE_TTL_MS = HISTORICAL_TVL_CACHE_TTL_SECONDS * 1000;
-const CACHE_VERSION = 'historical-tvl-stablecoin-daily-average-v1';
+const CACHE_VERSION = 'historical-tvl-stablecoin-daily-short-history-v1';
 
 let cache: { json: string; br: Uint8Array; expires: number; version: string } | null = null;
 
@@ -21,14 +26,21 @@ async function getCachedChartData(fetch: Fetch) {
 
 	const startedAt = performance.now();
 	const topVaults = await getCachedTopVaults(fetch);
-	const weeklyRows =
-		import.meta.env.MODE === 'test' ? getMockWeeklyVaultRows(topVaults.vaults) : await getHistoricalWeeklyVaultRows();
+	const [weeklyRows, dailyRows] =
+		import.meta.env.MODE === 'test'
+			? [getMockWeeklyVaultRows(topVaults.vaults), getMockDailyVaultRows(topVaults.vaults)]
+			: await Promise.all([getHistoricalWeeklyVaultRows(), getHistoricalDailyVaultRows()]);
 
 	const payload: HistoricalTvlByStablecoinPayload = buildHistoricalTvlByStablecoinPayload(
 		weeklyRows,
 		topVaults.vaults,
 		performance.now() - startedAt
 	);
+	const dailyPayload = buildHistoricalTvlByStablecoinPayload(dailyRows, topVaults.vaults, 0);
+	payload.daily = {
+		weeks: dailyPayload.weeks,
+		series: dailyPayload.series
+	};
 	const jsonStr = JSON.stringify(payload);
 	const br = new Uint8Array(
 		await compress(new TextEncoder().encode(jsonStr), {


### PR DESCRIPTION
## Why
Historical TVL charts needed a way to compare absolute TVL against relative market share and inspect shorter windows with daily granularity. The existing weekly all-time view made the 3m and 1y interactions feel too coarse and could be affected by cached chart-data payloads.

## Lessons learnt
ECharts was already receiving daily points after the payload change, but the browser could keep a 24-hour cached weekly-only response because the chart-data URL had not changed. Versioning the client fetch URL avoids that stale-data path while preserving server caching.

## Summary
- Add URL-backed controls for TVL vs Market share and All-time, 1y, and 3m history windows.
- Include daily chart-data payloads and use them for the shorter history windows while keeping all-time weekly.
- Stabilise tooltip positioning, improve mobile x-axis labels, and version chart-data fetches.
- Add a changelog entry for the historical TVL chart controls.