### PR TITLE
Fix stablecoin heatmap row order

### DIFF
--- a/src/routes/trading-view/vaults/stablecoin-chain-heatmap/StablecoinChainHeatmapChart.svelte
+++ b/src/routes/trading-view/vaults/stablecoin-chain-heatmap/StablecoinChainHeatmapChart.svelte
@@ -214,6 +214,7 @@ Client-side ECharts heatmap for current vault TVL by stablecoin and chain.
 			yAxis: {
 				type: 'category',
 				data: data.stablecoins.map((stablecoin) => stablecoin.label),
+				inverse: true,
 				show: false
 			},
 			visualMap: {
@@ -549,11 +550,6 @@ Client-side ECharts heatmap for current vault TVL by stablecoin and chain.
 		font: var(--f-ui-sm-bold);
 		font-size: 0.98rem;
 		letter-spacing: var(--f-ui-sm-spacing, normal);
-	}
-
-	.axis-tooltip-copy {
-		display: block;
-		color: #d5deea;
 	}
 
 	.axis-tooltip-metric-line {

--- a/tests/integration/trading-view/vaults/stablecoin-chain-heatmap.test.ts
+++ b/tests/integration/trading-view/vaults/stablecoin-chain-heatmap.test.ts
@@ -1,5 +1,22 @@
 import { expect, test, type Page } from '@playwright/test';
 
+type EChartsOption = {
+	graphic?: { elements?: { id?: string }[] }[];
+	yAxis?: { inverse?: boolean } | { inverse?: boolean }[];
+};
+
+declare global {
+	interface Window {
+		echarts?: {
+			getInstanceByDom: (container: Element) =>
+				| {
+						getOption?: () => EChartsOption;
+				  }
+				| undefined;
+		};
+	}
+}
+
 async function expectNativeChartWatermark(page: Page, containerSelector: string) {
 	await expect
 		.poll(async () =>
@@ -69,6 +86,16 @@ test.describe('stablecoin / chain heatmap page', () => {
 		await expect(firstStablecoin).toBeVisible();
 		await expect(firstChain).toBeVisible();
 		await expect(plotWrapper.getByText('Min TVL:')).toHaveCount(0);
+		await expect
+			.poll(async () =>
+				page.evaluate(() => {
+					const container = document.querySelector('.chart-canvas');
+					const yAxis = container ? window.echarts?.getInstanceByDom(container)?.getOption?.().yAxis : undefined;
+					const firstYAxis = Array.isArray(yAxis) ? yAxis[0] : yAxis;
+					return firstYAxis?.inverse;
+				})
+			)
+			.toBe(true);
 	});
 
 	test('axis labels link to stablecoin and chain vault pages', async ({ page }) => {


### PR DESCRIPTION
## Why

Stablecoin labels in the vault stablecoin / chain heatmap rendered top-to-bottom, but ECharts category y-axis values were plotted bottom-to-top. This made cell labels and tooltips refer to a different stablecoin than the visible row label.

## Lessons learnt

When custom axis labels are rendered outside ECharts, the hidden chart axis still needs to mirror the visual label direction. ECharts category y-axes place the first category at the bottom unless inverted.

## Summary

- Invert the stablecoin heatmap y-axis so plotted cells align with the visible stablecoin rows.
- Add an integration assertion that the rendered ECharts y-axis remains inverted.
- Remove an unused tooltip CSS selector from the heatmap component.