### PR TITLE
Fix duplicate vault risk alerts

### DIFF
--- a/src/routes/trading-view/vaults/[vault=slug]/+page.svelte
+++ b/src/routes/trading-view/vaults/[vault=slug]/+page.svelte
@@ -23,6 +23,13 @@
 	let { data } = $props();
 	let { vault, chain, protocolMetadata, stablecoinMetadata, generated_at } = $derived(data);
 	let morphoFlags = $derived(getMorphoFlags(vault));
+	let notesDuplicateMorphoFlags = $derived(
+		morphoFlags.length > 0 && vault.notes?.startsWith('Morpho has flagged this vault with the following issues:')
+	);
+	let blacklisted = $derived(isBlacklisted(vault));
+	let morphoAlertStatus = $derived(blacklisted ? 'error' : 'warning');
+	let showBlacklistedAlert = $derived(blacklisted && !notesDuplicateMorphoFlags);
+	let showNotes = $derived(vault.notes != null && !notesDuplicateMorphoFlags);
 </script>
 
 <SocialMediaTags {vault} {chain} {protocolMetadata} />
@@ -34,7 +41,7 @@
 
 	{#if morphoFlags.length > 0}
 		<Section padding="md">
-			<Alert size="md" status="warning" title="Morpho has flagged this vault">
+			<Alert size="md" status={morphoAlertStatus} title="Morpho has flagged this vault">
 				{morphoFlags.join(', ')}
 			</Alert>
 		</Section>
@@ -43,7 +50,7 @@
 	<VaultPageHeader {vault} />
 
 	<Section padding="md" --section-gap="var(--gap)">
-		{#if isBlacklisted(vault)}
+		{#if showBlacklistedAlert}
 			<Alert size="md" title="Blacklisted">
 				{vault.notes ?? 'Unknown reason'}
 			</Alert>
@@ -77,7 +84,7 @@
 			</MetricsBox>
 		{/if}
 
-		{#if vault.notes}
+		{#if showNotes && vault.notes}
 			<MetricsBox class="notes" title="Notes">
 				<Markdown content={vault.notes} />
 			</MetricsBox>

--- a/tests/integration/trading-view/vaults/index.test.ts
+++ b/tests/integration/trading-view/vaults/index.test.ts
@@ -304,4 +304,15 @@ test.describe('vault index page', () => {
 		// Verify URL search params are preserved
 		await page.waitForURL(urlParamsMatch(searchParams), { timeout: 5000 });
 	});
+
+	test('does not duplicate generated Morpho risk notes on vault detail pages', async ({ page }) => {
+		await page.goto('/trading-view/vaults/morpho-flagged-blacklisted-vault');
+
+		const alerts = page.locator('.alert-list');
+		await expect(alerts).toHaveCount(1);
+		await expect(alerts.first()).toHaveClass(/error/);
+		await expect(alerts.first()).toContainText('Morpho has flagged this vault');
+		await expect(alerts.first()).toContainText('bad_debt_unrealized');
+		await expect(page.locator('.notes')).toHaveCount(0);
+	});
 });

--- a/tests/mocks/top-vaults/list.mock.ts
+++ b/tests/mocks/top-vaults/list.mock.ts
@@ -302,6 +302,49 @@ const yamlStrategyVault = createTestVault('Trading Strategy ICHIv3 LS 2', {
 	]
 });
 
+const morphoFlaggedBlacklistedVault = createTestVault('Morpho flagged blacklisted vault', {
+	address: '0xc3415c9231dad88f8146107372143f6dae042967',
+	chain: 'arbitrum',
+	protocol: 'Morpho',
+	current_nav: 20_000,
+	peak_nav: 30_000,
+	risk: 'Blacklisted',
+	flags: ['morpho_issues'],
+	notes: 'Morpho has flagged this vault with the following issues: bad_debt_unrealized, short_timelock',
+	other_data: {
+		morpho_vault_flags: ['not_whitelisted', 'short_timelock'],
+		morpho_market_flags: ['bad_debt_unrealized', 'not_whitelisted']
+	},
+	period_results: [
+		{
+			period: '1M',
+			error_reason: null,
+			period_start_at: '2025-12-01T00:00:00',
+			period_end_at: '2026-01-01T00:00:00',
+			share_price_start: 1,
+			share_price_end: 1.01,
+			raw_samples: 720,
+			samples_start_at: '2025-12-01T00:00:00',
+			samples_end_at: '2026-01-01T00:00:00',
+			daily_samples: 30,
+			returns_gross: 0.01,
+			returns_net: 0.01,
+			cagr_gross: 0.12,
+			cagr_net: 0.12,
+			volatility: 0.1,
+			sharpe: 1,
+			max_drawdown: -0.01,
+			tvl_start: 18_000,
+			tvl_end: 20_000,
+			tvl_low: 18_000,
+			tvl_high: 20_000,
+			ranking_overall: null,
+			ranking_chain: null,
+			ranking_protocol: null
+		}
+	]
+});
+
 // Real Parquet-backed vault IDs used by the historical TVL by chain endpoint tests.
 // These IDs need to match the local Parquet dataset so blacklist filtering can be
 // exercised against real server-side aggregation.
@@ -351,6 +394,7 @@ export default defineMock({
 		generated_at: new Date().toISOString(),
 		vaults: [
 			yamlStrategyVault,
+			morphoFlaggedBlacklistedVault,
 			limitedCoverageVault,
 			...parquetMatchedVaults,
 			...returnLeaders,


### PR DESCRIPTION
## Why

Morpho-flagged blacklisted vaults rendered the same generated risk message in multiple places, making pages such as `/trading-view/vaults/frobusdc` show duplicate message boxes. Blacklisted vaults should also use the red error alert treatment.

## Lessons learnt

Generated Morpho risk notes can duplicate the structured Morpho flags already available on the vault payload. When those notes are generated from the same flags, the detail page should treat the flags as the canonical alert source.

## Summary

- Deduplicate generated Morpho risk notes on vault detail pages.
- Show the Morpho alert in red when the vault is blacklisted and keep non-blacklisted Morpho alerts as warnings.
- Add an integration fixture and regression assertion for a blacklisted Morpho vault.