### PR TITLE
Fix Docker pnpm Corepack pin

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,10 +9,10 @@ WORKDIR /app
 ENV PNPM_HOME="/pnpm"
 ENV PNPM_STORE_DIR="/pnpm/store"
 ENV PATH="$PNPM_HOME:$PATH"
-RUN corepack enable && pnpm config set store-dir "$PNPM_STORE_DIR"
 
 # Install package dependencies (cache first)
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
+RUN corepack enable && pnpm config set store-dir "$PNPM_STORE_DIR"
 RUN --mount=type=cache,target=/pnpm/store pnpm install --frozen-lockfile
 
 # copy remaining files


### PR DESCRIPTION
## Why

Release `v671` failed during the Docker image build because Corepack ran before `package.json` was copied into the image. Without the pinned `packageManager` field available, Corepack downloaded `pnpm@11.0.8`, which crashed under Node 20.19 during `pnpm config set store-dir`.

## Lessons learnt

Docker build layers that invoke Corepack need the package manifest present first, otherwise the build can drift to the latest package manager version instead of the repository pin.

## Summary

- Copy `package.json`, `pnpm-lock.yaml`, and `pnpm-workspace.yaml` before enabling Corepack.
- Keep Docker dependency caching behaviour intact while forcing Corepack to resolve the repo-pinned `pnpm@10.17.0`.