### PR TITLE
Skip untracked vault event counts

### DIFF
--- a/src/routes/trading-view/vaults/[vault=slug]/VaultTechnicalDetailsTable.svelte
+++ b/src/routes/trading-view/vaults/[vault=slug]/VaultTechnicalDetailsTable.svelte
@@ -103,7 +103,10 @@
 		{ label: 'Flags', value: vault.flags, type: 'array' as const },
 		{ label: 'Deposit status', value: vault.deposit_closed_reason, type: 'closedReason' as const },
 		{ label: 'Redemption status', value: vault.redemption_closed_reason, type: 'closedReason' as const },
-		{ label: 'Deposit events', value: vault.event_count, type: 'number' as const }
+		// The API uses 0 to mean deposit/redemption event counts are not tracked for this vault.
+		...(vault.event_count !== 0
+			? [{ label: 'Deposit/redemption events', value: vault.event_count, type: 'number' as const }]
+			: [])
 	]);
 
 	function formatValue(value: unknown, type?: string): string {


### PR DESCRIPTION
## Why

Vault event counts use `0` as a sentinel when deposit/redemption tracking is unavailable. Showing that as a real metric makes the vault technical details table misleading.

## Lessons learnt

The top vaults API currently exposes a single `event_count` field for deposit/redemption activity, and `0` means the backend did not track those events for the vault.

## Summary

- Hide the deposit/redemption events row when `event_count` is `0`.
- Add an inline comment documenting the API sentinel value.
- Rename the visible row to `Deposit/redemption events` for clarity.