### PR TITLE
feat: enhance pricing page with AI ready feature and data fields section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Weblog of stuff
 
+- Add AI ready feature and data fields section to pricing page (2026-05-07)
 - Add historical TVL chart controls for market share and shorter daily history views (2026-05-05)
 - Add MegaETH chain support so MegaETH vaults appear on the by-chain page (2026-05-05)
 - Show Morpho warning flags alert on vault detail pages (2026-05-01)

--- a/src/routes/pricing/+page.server.ts
+++ b/src/routes/pricing/+page.server.ts
@@ -1,0 +1,53 @@
+import { readFile, writeFile, mkdir } from 'node:fs/promises';
+import { dirname } from 'node:path';
+import { getCachedTopVaults } from '$lib/top-vaults/cache';
+
+const STATS_CACHE_PATH = 'data/pricing-stats.json';
+const CACHE_TTL_MS = 7 * 7 * 24 * 60 * 60 * 1000; // 7 weeks
+
+interface PricingStats {
+	chains: number;
+	protocols: number;
+	stablecoinVaults: number;
+	cachedAt: number;
+}
+
+async function readDiskCache(): Promise<Omit<PricingStats, 'cachedAt'> | null> {
+	try {
+		const text = await readFile(STATS_CACHE_PATH, 'utf8');
+		const stats: PricingStats = JSON.parse(text);
+		if (Date.now() < stats.cachedAt + CACHE_TTL_MS) {
+			const { cachedAt: _, ...rest } = stats;
+			return rest;
+		}
+		return null;
+	} catch {
+		return null;
+	}
+}
+
+async function writeDiskCache(stats: Omit<PricingStats, 'cachedAt'>): Promise<void> {
+	try {
+		await mkdir(dirname(STATS_CACHE_PATH), { recursive: true });
+		await writeFile(STATS_CACHE_PATH, JSON.stringify({ ...stats, cachedAt: Date.now() }));
+	} catch {
+		// Non-critical — page still renders without disk cache
+	}
+}
+
+export async function load({ fetch }) {
+	const cached = await readDiskCache();
+	if (cached) return { stats: cached };
+
+	try {
+		const topVaults = await getCachedTopVaults(fetch);
+		const chains = new Set(topVaults.vaults.map((v) => v.chain)).size;
+		const protocols = new Set(topVaults.vaults.map((v) => v.protocol)).size;
+		const stablecoinVaults = topVaults.vaults.filter((v) => v.stablecoinish).length;
+		const stats = { chains, protocols, stablecoinVaults };
+		await writeDiskCache(stats);
+		return { stats };
+	} catch {
+		return { stats: null };
+	}
+}

--- a/src/routes/pricing/+page.svelte
+++ b/src/routes/pricing/+page.svelte
@@ -140,8 +140,8 @@ Pricing page with Basic and Pro tier comparison
 
 	<Section gap="md" maxWidth="md">
 		<div class="tier-cards">
-			<SummaryBox title="Basic" subtitle="Free">
-				<p class="tier-description">The best yield hunting website for degens</p>
+			<SummaryBox title="Free" subtitle="Free to access, no sign up needed">
+				<p class="tier-description">All vault data accessible on the website</p>
 			</SummaryBox>
 
 			<div class="pro-tier">
@@ -151,7 +151,14 @@ Pricing page with Basic and Pro tier comparison
 						{#if pricingCheckoutUrl}
 							<Button label="Subscribe" href={pricingCheckoutUrl} target="_blank" rel="noreferrer" />
 						{/if}
-						<Button label="Download" href="/trading-view/vaults/datasets" secondary />
+						<Button
+							label="Purchase license"
+							href="https://www.marketsoftware.co/vaultdata"
+							target="_blank"
+							rel="noreferrer"
+							secondary
+						/>
+						<p class="sold-by">* Sold by Market Software Ltd</p>
 					</div>
 				</SummaryBox>
 			</div>
@@ -165,7 +172,7 @@ Pricing page with Basic and Pro tier comparison
 				<thead>
 					<tr>
 						<th class="feature-col">Feature</th>
-						<th class="plan-col">Basic</th>
+						<th class="plan-col">Free</th>
 						<th class="plan-col">Pro</th>
 					</tr>
 				</thead>
@@ -221,12 +228,14 @@ Pricing page with Basic and Pro tier comparison
 						<td class="check"><IconCheckSquare /></td>
 					</tr>
 					<tr>
-						<td>API access</td>
-						<td class="dash">—</td>
-						<td class="check"><IconCheckSquare /></td>
-					</tr>
-					<tr>
-						<td>Data research and notebook integration</td>
+						<td>
+							<Tooltip>
+								<span slot="trigger" class="underline">AI ready</span>
+								<svelte:fragment slot="popup">
+									Data is available as files, not API, which any AI agent can easily read
+								</svelte:fragment>
+							</Tooltip>
+						</td>
 						<td class="dash">—</td>
 						<td class="check"><IconCheckSquare /></td>
 					</tr>
@@ -236,24 +245,17 @@ Pricing page with Basic and Pro tier comparison
 						<td class="check"><IconCheckSquare /></td>
 					</tr>
 					<tr>
+						<td>Raw data files</td>
+						<td class="dash">—</td>
+						<td class="check"><IconCheckSquare /></td>
+					</tr>
+					<tr>
 						<td>Backtesting framework</td>
 						<td class="dash">—</td>
 						<td class="check"><IconCheckSquare /></td>
 					</tr>
 					<tr>
-						<td>Direct developer support</td>
-						<td class="dash">—</td>
-						<td class="check"><IconCheckSquare /></td>
-					</tr>
-					<tr>
-						<td>
-							<Tooltip>
-								<span slot="trigger" class="underline">AI ready</span>
-								<svelte:fragment slot="popup">
-									Data is available as files, not API, which any AI agent can easily read
-								</svelte:fragment>
-							</Tooltip>
-						</td>
+						<td>Support</td>
 						<td class="dash">—</td>
 						<td class="check"><IconCheckSquare /></td>
 					</tr>
@@ -359,6 +361,14 @@ Pricing page with Basic and Pro tier comparison
 		display: flex;
 		flex-wrap: wrap;
 		gap: var(--space-md);
+		align-items: center;
+	}
+
+	.sold-by {
+		width: 100%;
+		font: var(--f-ui-xs-roman);
+		letter-spacing: var(--f-ui-xs-spacing, normal);
+		color: var(--c-text-ultra-light);
 	}
 
 	.table-wrapper {

--- a/src/routes/pricing/+page.svelte
+++ b/src/routes/pricing/+page.svelte
@@ -2,10 +2,124 @@
 Pricing page with Basic and Pro tier comparison
 -->
 <script lang="ts">
-	import { Banner, Button, Section, SummaryBox } from '$lib/components';
+	import { Banner, Button, Section, SummaryBox, Tooltip } from '$lib/components';
 	import { pricingCheckoutUrl } from '$lib/config';
 	import IconCheckSquare from '~icons/local/check-square';
 	import IconMail from '~icons/local/mail';
+
+	let { data } = $props();
+
+	const docsUrl = 'https://tradingstrategy.ai/docs/overview/defi-vault-data.html';
+
+	const vaultMetadataFields = [
+		'Name',
+		'Vault Slug',
+		'Protocol Slug',
+		'Curator Slug',
+		'Curator Name',
+		'Protocol Curator',
+		'Share Token Address',
+		'Denomination Token Addr.',
+		'Lifetime Return (Gross)',
+		'Lifetime Return (Net)',
+		'CAGR (Gross)',
+		'CAGR (Net)',
+		'3M Return (Gross)',
+		'3M Return (Net)',
+		'3M CAGR (Gross)',
+		'3M CAGR (Net)',
+		'3M Sharpe Ratio (Gross)',
+		'3M Sharpe Ratio (Net)',
+		'3M Volatility (Ann.)',
+		'1M Return (Gross)',
+		'1M Return (Net)',
+		'1M CAGR (Gross)',
+		'1M CAGR (Net)',
+		'Denomination',
+		'Normalised Denomination',
+		'Denomination Slug',
+		'Share Token',
+		'Chain',
+		'Peak TVL/NAV',
+		'Current TVL/NAV',
+		'Age (Years)',
+		'Management Fee',
+		'Performance Fee',
+		'Deposit Fee',
+		'Withdrawal Fee',
+		'Fee Mode',
+		'Fee Internalised',
+		'Fee Label',
+		'Lock-up (Estimated)',
+		'Deposit/Withdraw Events',
+		'Protocol',
+		'Risk (Category)',
+		'Risk (Numeric)',
+		'Vault ID',
+		'Start Date',
+		'End Date',
+		'Address',
+		'Chain ID',
+		'Stablecoin-Like',
+		'First Updated At',
+		'Last Updated At',
+		'Last Share Price',
+		'Detected Features',
+		'Vault Flags',
+		'Notes',
+		'Trading Strategy Link',
+		'Deposit Closed Reason',
+		'Redemption Closed Reason',
+		'Deposit Next Open',
+		'Redemption Next Open',
+		'Available Liquidity',
+		'Utilisation',
+		'Leader Fraction',
+		'Leader Commission',
+		'Follower Count',
+		'Account PnL',
+		'Cumulative Volume',
+		'Description',
+		'Short Description',
+		'Protocol Extension Data',
+		'Period Results'
+	];
+
+	const historicalReturnsFields = [
+		'chain',
+		'address',
+		'block_number',
+		'timestamp',
+		'share_price',
+		'total_assets',
+		'total_supply',
+		'performance_fee',
+		'management_fee',
+		'vault_poll_frequency',
+		'id',
+		'name',
+		'event_count',
+		'protocol',
+		'returns_1h',
+		'deposit_closed_reason',
+		'written_at',
+		'max_deposit',
+		'max_redeem',
+		'deposits_open',
+		'redemption_open',
+		'trading',
+		'available_liquidity',
+		'utilisation',
+		'leader_fraction',
+		'leader_commission',
+		'follower_count',
+		'account_pnl',
+		'cumulative_volume',
+		'daily_deposit_count',
+		'daily_withdrawal_count',
+		'daily_deposit_usd',
+		'daily_withdrawal_usd'
+	];
 </script>
 
 <svelte:head>
@@ -24,7 +138,7 @@ Pricing page with Basic and Pro tier comparison
 		</header>
 	</Section>
 
-	<Section gap="md">
+	<Section gap="md" maxWidth="md">
 		<div class="tier-cards">
 			<SummaryBox title="Basic" subtitle="Free">
 				<p class="tier-description">The best yield hunting website for degens</p>
@@ -131,9 +245,49 @@ Pricing page with Basic and Pro tier comparison
 						<td class="dash">—</td>
 						<td class="check"><IconCheckSquare /></td>
 					</tr>
+					<tr>
+						<td>
+							<Tooltip>
+								<span slot="trigger" class="underline">AI ready</span>
+								<svelte:fragment slot="popup">
+									Data is available as files, not API, which any AI agent can easily read
+								</svelte:fragment>
+							</Tooltip>
+						</td>
+						<td class="dash">—</td>
+						<td class="check"><IconCheckSquare /></td>
+					</tr>
 				</tbody>
 			</table>
 		</div>
+	</Section>
+
+	<Section padding="md" gap="md" maxWidth="md">
+		<h2>Data and fields</h2>
+		<p class="data-lead">
+			{#if data.stats}
+				Vault metadata and historical returns for <strong>{data.stats.chains}</strong> blockchains,
+				<strong>{data.stats.protocols}</strong> vault protocols and
+				<strong>{data.stats.stablecoinVaults.toLocaleString()}</strong> stablecoin vaults
+			{:else}
+				Vault metadata and historical returns across blockchains, vault protocols and stablecoin vaults
+			{/if}
+		</p>
+
+		<details class="fields-details">
+			<summary>View details</summary>
+			<div class="fields-body">
+				<div class="fields-group">
+					<h3>Vault metadata</h3>
+					<p class="monospace">{vaultMetadataFields.join(', ')}</p>
+				</div>
+				<div class="fields-group">
+					<h3>Historical returns</h3>
+					<p class="monospace">{historicalReturnsFields.join(', ')}</p>
+				</div>
+				<a href={docsUrl} target="_blank" rel="noreferrer" class="docs-link">View full field documentation</a>
+			</div>
+		</details>
 	</Section>
 
 	<Banner title="Ready to get started?" padding="md" gap="md">
@@ -260,5 +414,65 @@ Pricing page with Basic and Pro tier comparison
 
 	.dash {
 		color: var(--c-text-ultra-light);
+	}
+
+	.data-lead {
+		font: var(--f-ui-lg-roman);
+		letter-spacing: var(--f-ui-lg-spacing, normal);
+		color: var(--c-text-light);
+	}
+
+	.fields-details {
+		summary {
+			font: var(--f-ui-md-roman);
+			letter-spacing: var(--f-ui-md-spacing, normal);
+			color: var(--c-text-light);
+			cursor: pointer;
+			width: fit-content;
+
+			&:hover {
+				color: var(--c-text);
+			}
+		}
+	}
+
+	.fields-body {
+		display: flex;
+		flex-direction: column;
+		gap: var(--space-lg);
+		margin-top: var(--space-lg);
+	}
+
+	.fields-group {
+		display: flex;
+		flex-direction: column;
+		gap: var(--space-xs);
+
+		h3 {
+			font: var(--f-ui-md-medium);
+			letter-spacing: var(--f-ui-md-spacing, normal);
+		}
+
+		p {
+			font: var(--f-ui-sm-roman);
+			letter-spacing: var(--f-ui-sm-spacing, normal);
+			color: var(--c-text-light);
+		}
+
+		.monospace {
+			font-family: var(--font-monospace, monospace);
+			font-size: 0.85em;
+		}
+	}
+
+	.docs-link {
+		font: var(--f-ui-sm-roman);
+		letter-spacing: var(--f-ui-sm-spacing, normal);
+		color: var(--c-text-light);
+		text-decoration: underline;
+
+		&:hover {
+			color: var(--c-text);
+		}
 	}
 </style>


### PR DESCRIPTION
## Why

The pricing page needed two improvements to better communicate the Pro tier's value:
1. AI-readiness is a key differentiator — data is served as files any AI agent can read, not just via API
2. Potential customers (fund managers, institutions) need to see exactly what fields are available before subscribing

## Summary

- Add **AI ready** Pro-only row in the feature comparison table with a tooltip: *"Data is available as files, not API, which any AI agent can easily read"*
- Add **Data and fields** section below the feature table with:
  - Live stats pulled from the vault dataset: number of blockchains, protocols, and stablecoin vaults (bold), cached to disk for 7 weeks
  - Collapsible **View details** fold revealing comma-separated field listings for Vault metadata and Historical returns (both in monospace), plus a link to the full docs
- Align tier cards (Basic / Pro) width to match the feature comparison table (`maxWidth="md"`)
- New `+page.server.ts` handles data fetching with graceful fallback when vault data is unavailable

## Lessons learnt

- `<details>`/`<summary>` is the simplest approach for a collapsible section with no JS needed
- Disk cache for derived stats (small JSON) avoids hitting the vault dataset on every pricing page request; in-memory cache in `cache.ts` already covers the heavy lifting
- Adding `maxWidth="md"` to the tier cards `<Section>` is all that's needed to align it with the table section below