### PR TITLE
feat: revamp pricing page with liquid glass design and updated content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Weblog of stuff
 
+- Revamp pricing page with liquid glass table, Creem checkout, updated copy and dataset links (2026-05-08)
 - Add AI ready feature and data fields section to pricing page (2026-05-07)
 - Add historical TVL chart controls for market share and shorter daily history views (2026-05-05)
 - Add MegaETH chain support so MegaETH vaults appear on the by-chain page (2026-05-05)

--- a/src/lib/assets/icons/check-circle-gradient.svg
+++ b/src/lib/assets/icons/check-circle-gradient.svg
@@ -1,0 +1,4 @@
+<svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<circle cx="12" cy="12" r="11" fill="#22b453"/>
+<path d="M7.5 12.5L10.5 15.5L16.5 9" stroke="white" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -281,3 +281,8 @@ export const vaultApiUrl = config((url: string) => {
  * Checkout URL for Pro subscription
  */
 export const pricingCheckoutUrl = config((url: string) => url, 'PRICING_CHECKOUT_URL');
+
+/**
+ * Creem checkout URL for purchasing a license
+ */
+export const creemCheckoutUrl = config((url: string) => url, 'CREEM_CHECKOUT_URL');

--- a/src/routes/pricing/+page.svelte
+++ b/src/routes/pricing/+page.svelte
@@ -2,10 +2,9 @@
 Pricing page with Basic and Pro tier comparison
 -->
 <script lang="ts">
-	import { Banner, Button, Section, SummaryBox, Tooltip } from '$lib/components';
-	import { pricingCheckoutUrl } from '$lib/config';
-	import IconCheckSquare from '~icons/local/check-square';
-	import IconMail from '~icons/local/mail';
+	import { Button, Section, SummaryBox, Tooltip } from '$lib/components';
+	import { pricingCheckoutUrl, creemCheckoutUrl } from '$lib/config';
+	import IconCheck from '~icons/local/check-circle-gradient';
 
 	let { data } = $props();
 
@@ -151,14 +150,16 @@ Pricing page with Basic and Pro tier comparison
 						{#if pricingCheckoutUrl}
 							<Button label="Subscribe" href={pricingCheckoutUrl} target="_blank" rel="noreferrer" />
 						{/if}
-						<Button
-							label="Purchase license"
-							href="https://www.marketsoftware.co/vaultdata"
-							target="_blank"
-							rel="noreferrer"
-							secondary
-						/>
-						<p class="sold-by">* Sold by Market Software Ltd</p>
+						{#if creemCheckoutUrl}
+							<Button label="Purchase license" href={creemCheckoutUrl} target="_blank" rel="noreferrer" secondary />
+						{/if}
+						<p class="sold-by">
+							* The monthly subscription licence is sold by Market Software Ltd. After subscribing, you will receive an
+							API key in email. <a
+								href="/trading-view/vaults/datasets"
+								style="text-decoration: underline; font-weight: bold;">Download datasets here</a
+							>. For any questions, please use the on-page chat – we are happy to help you.
+						</p>
 					</div>
 				</SummaryBox>
 			</div>
@@ -179,53 +180,48 @@ Pricing page with Basic and Pro tier comparison
 				<tbody>
 					<tr>
 						<td>Vault analytics website</td>
-						<td class="check"><IconCheckSquare /></td>
-						<td class="check"><IconCheckSquare /></td>
+						<td class="check"><IconCheck /></td>
+						<td class="check"><IconCheck /></td>
 					</tr>
 					<tr>
 						<td>1,000+ stablecoin vaults</td>
-						<td class="check"><IconCheckSquare /></td>
-						<td class="check"><IconCheckSquare /></td>
+						<td class="check"><IconCheck /></td>
+						<td class="check"><IconCheck /></td>
 					</tr>
 					<tr>
 						<td>20+ blockchains</td>
-						<td class="check"><IconCheckSquare /></td>
-						<td class="check"><IconCheckSquare /></td>
+						<td class="check"><IconCheck /></td>
+						<td class="check"><IconCheck /></td>
 					</tr>
 					<tr>
 						<td>Lending protocols and perp DEXes</td>
-						<td class="check"><IconCheckSquare /></td>
-						<td class="check"><IconCheckSquare /></td>
+						<td class="check"><IconCheck /></td>
+						<td class="check"><IconCheck /></td>
 					</tr>
 					<tr>
-						<td>$25B+ profit tracked</td>
-						<td class="check"><IconCheckSquare /></td>
-						<td class="check"><IconCheckSquare /></td>
+						<td>$25B+ tracked TVL</td>
+						<td class="check"><IconCheck /></td>
+						<td class="check"><IconCheck /></td>
 					</tr>
 					<tr>
 						<td>Daily updates</td>
-						<td class="check"><IconCheckSquare /></td>
-						<td class="check"><IconCheckSquare /></td>
+						<td class="check"><IconCheck /></td>
+						<td class="check"><IconCheck /></td>
 					</tr>
 					<tr>
 						<td>Equity curves</td>
-						<td class="check"><IconCheckSquare /></td>
-						<td class="check"><IconCheckSquare /></td>
+						<td class="check"><IconCheck /></td>
+						<td class="check"><IconCheck /></td>
 					</tr>
 					<tr>
 						<td>Portfolio metrics</td>
-						<td class="check"><IconCheckSquare /></td>
-						<td class="check"><IconCheckSquare /></td>
+						<td class="check"><IconCheck /></td>
+						<td class="check"><IconCheck /></td>
 					</tr>
 					<tr>
 						<td>Community Discord</td>
-						<td class="check"><IconCheckSquare /></td>
-						<td class="check"><IconCheckSquare /></td>
-					</tr>
-					<tr>
-						<td>Non-stablecoin vaults</td>
-						<td class="dash">—</td>
-						<td class="check"><IconCheckSquare /></td>
+						<td class="check"><IconCheck /></td>
+						<td class="check"><IconCheck /></td>
 					</tr>
 					<tr>
 						<td>
@@ -237,27 +233,44 @@ Pricing page with Basic and Pro tier comparison
 							</Tooltip>
 						</td>
 						<td class="dash">—</td>
-						<td class="check"><IconCheckSquare /></td>
+						<td class="check"><IconCheck /></td>
 					</tr>
 					<tr>
 						<td>Historical data</td>
 						<td class="dash">—</td>
-						<td class="check"><IconCheckSquare /></td>
+						<td class="check"><IconCheck /></td>
 					</tr>
 					<tr>
 						<td>Raw data files</td>
 						<td class="dash">—</td>
-						<td class="check"><IconCheckSquare /></td>
+						<td class="check"><IconCheck /></td>
 					</tr>
 					<tr>
 						<td>Backtesting framework</td>
 						<td class="dash">—</td>
-						<td class="check"><IconCheckSquare /></td>
+						<td class="check"><IconCheck /></td>
 					</tr>
 					<tr>
 						<td>Support</td>
 						<td class="dash">—</td>
-						<td class="check"><IconCheckSquare /></td>
+						<td class="check"><IconCheck /></td>
+					</tr>
+					<tr>
+						<td>
+							<Tooltip>
+								<span slot="trigger" class="underline">BTC/ETH-denominated vaults</span>
+								<svelte:fragment slot="popup">
+									Ask for data for vaults that do not use stablecoins for deposits
+								</svelte:fragment>
+							</Tooltip>
+						</td>
+						<td class="dash">—</td>
+						<td class="check"><IconCheck /></td>
+					</tr>
+					<tr>
+						<td>Startup discounts available</td>
+						<td class="dash">—</td>
+						<td class="check"><IconCheck /></td>
 					</tr>
 				</tbody>
 			</table>
@@ -266,41 +279,33 @@ Pricing page with Basic and Pro tier comparison
 
 	<Section padding="md" gap="md" maxWidth="md">
 		<h2>Data and fields</h2>
-		<p class="data-lead">
-			{#if data.stats}
-				Vault metadata and historical returns for <strong>{data.stats.chains}</strong> blockchains,
-				<strong>{data.stats.protocols}</strong> vault protocols and
-				<strong>{data.stats.stablecoinVaults.toLocaleString()}</strong> stablecoin vaults
-			{:else}
-				Vault metadata and historical returns across blockchains, vault protocols and stablecoin vaults
-			{/if}
-		</p>
+		<div class="data-fields-panel">
+			<p class="data-lead">
+				{#if data.stats}
+					Vault metadata and historical returns for <strong>{data.stats.chains}</strong> blockchains,
+					<strong>{data.stats.protocols}</strong> vault protocols and
+					<strong>{data.stats.stablecoinVaults.toLocaleString()}</strong> stablecoin vaults
+				{:else}
+					Vault metadata and historical returns across blockchains, vault protocols and stablecoin vaults
+				{/if}
+			</p>
 
-		<details class="fields-details">
-			<summary>View details</summary>
-			<div class="fields-body">
-				<div class="fields-group">
-					<h3>Vault metadata</h3>
-					<p class="monospace">{vaultMetadataFields.join(', ')}</p>
+			<details class="fields-details">
+				<summary>View details</summary>
+				<div class="fields-body">
+					<div class="fields-group">
+						<h3>Vault metadata</h3>
+						<p class="monospace">{vaultMetadataFields.join(', ')}</p>
+					</div>
+					<div class="fields-group">
+						<h3>Historical returns</h3>
+						<p class="monospace">{historicalReturnsFields.join(', ')}</p>
+					</div>
+					<a href={docsUrl} target="_blank" rel="noreferrer" class="docs-link">View full field documentation</a>
 				</div>
-				<div class="fields-group">
-					<h3>Historical returns</h3>
-					<p class="monospace">{historicalReturnsFields.join(', ')}</p>
-				</div>
-				<a href={docsUrl} target="_blank" rel="noreferrer" class="docs-link">View full field documentation</a>
-			</div>
-		</details>
+			</details>
+		</div>
 	</Section>
-
-	<Banner title="Ready to get started?" padding="md" gap="md">
-		<p>
-			Request early access to Trading Strategy Pro and unlock advanced vault analytics, API access, and dedicated
-			developer support.
-		</p>
-		<Button slot="cta" label="Request early access" href="mailto:info@tradingstrategy.ai">
-			<IconMail slot="icon" />
-		</Button>
-	</Banner>
 </main>
 
 <style>
@@ -368,11 +373,19 @@ Pricing page with Basic and Pro tier comparison
 		width: 100%;
 		font: var(--f-ui-xs-roman);
 		letter-spacing: var(--f-ui-xs-spacing, normal);
-		color: var(--c-text-ultra-light);
+		color: var(--c-text-light);
 	}
 
 	.table-wrapper {
-		overflow-x: auto;
+		overflow: visible;
+		background: hsl(var(--hsl-box) / 6%);
+		backdrop-filter: blur(16px);
+		-webkit-backdrop-filter: blur(16px);
+		border: 1px solid hsl(var(--hsl-box) / 12%);
+		border-radius: var(--radius-lg, 12px);
+		box-shadow:
+			0 4px 24px hsl(var(--hsl-box) / 6%),
+			inset 0 1px 0 hsl(var(--hsl-box) / 10%);
 	}
 
 	table {
@@ -381,7 +394,7 @@ Pricing page with Basic and Pro tier comparison
 	}
 
 	thead {
-		background: var(--c-box-1);
+		background: hsl(var(--hsl-box) / 8%);
 	}
 
 	th,
@@ -389,7 +402,7 @@ Pricing page with Basic and Pro tier comparison
 		padding: var(--space-md) var(--space-lg);
 		font: var(--f-ui-md-roman);
 		letter-spacing: var(--f-ui-md-spacing, normal);
-		border-bottom: 1px solid var(--c-box-2);
+		border-bottom: 1px solid hsl(var(--hsl-box) / 8%);
 		text-align: left;
 
 		@media (--viewport-sm-down) {
@@ -404,6 +417,18 @@ Pricing page with Basic and Pro tier comparison
 
 		@media (--viewport-sm-down) {
 			font: var(--f-ui-sm-medium);
+		}
+	}
+
+	tbody tr {
+		transition: background var(--time-sm, 0.15s) ease;
+
+		&:hover {
+			background: hsl(var(--hsl-box) / 8%);
+		}
+
+		&:last-child td {
+			border-bottom: none;
 		}
 	}
 
@@ -424,6 +449,16 @@ Pricing page with Basic and Pro tier comparison
 
 	.dash {
 		color: var(--c-text-ultra-light);
+	}
+
+	.data-fields-panel {
+		background: hsl(var(--hsl-box) / 6%);
+		border: 1px solid hsl(var(--hsl-box) / 12%);
+		border-radius: var(--radius-lg, 12px);
+		padding: var(--space-lg);
+		display: flex;
+		flex-direction: column;
+		gap: var(--space-lg);
 	}
 
 	.data-lead {

--- a/src/routes/trading-view/vaults/datasets/+page.server.ts
+++ b/src/routes/trading-view/vaults/datasets/+page.server.ts
@@ -1,7 +1,6 @@
 import { error } from '@sveltejs/kit';
 import { headTopVaults, headVaultPrices } from '$lib/top-vaults/server-config';
 import { isR2Configured } from '$lib/r2/client';
-import { VAULT_PRICES_PARQUET } from '$lib/top-vaults/constants';
 
 const documentationUrl = 'https://tradingstrategy.ai/docs/overview/defi-vault-data.html';
 
@@ -48,7 +47,7 @@ export async function load({ fetch, setHeaders, url }) {
 				'Summary JSON for tracked vaults, including identity, chain, protocol, performance, fees and status fields.',
 			instructions:
 				'Download the summary JSON when you need the latest vault catalogue, rankings, and descriptive fields for offline research or your own pipelines.',
-			filename: 'top_vaults_by_chain.json',
+			filename: 'vault-metadata.json',
 			format: 'JSON',
 			documentation: documentationUrl,
 			downloadUrl: '/trading-view/vaults/datasets/download/vault-metadata'
@@ -60,7 +59,7 @@ export async function load({ fetch, setHeaders, url }) {
 				'Share price, TVL history in Parquet format, suitable for offline analysis, chart generation, and backtesting-style workflows.',
 			instructions:
 				'Download the hourly Parquet file to analyse historical vault performance locally or to feed your own notebooks and research jobs.',
-			filename: VAULT_PRICES_PARQUET,
+			filename: 'vault-historical.parquet',
 			format: 'Parquet',
 			documentation: documentationUrl,
 			downloadUrl: '/trading-view/vaults/datasets/download/vault-prices'

--- a/src/routes/trading-view/vaults/datasets/+page.svelte
+++ b/src/routes/trading-view/vaults/datasets/+page.svelte
@@ -4,7 +4,7 @@ Vault datasets download page
 <script lang="ts">
 	import { resolve } from '$app/paths';
 	import type { PageData } from './$types';
-	import { discordUrl, vaultApiUrl } from '$lib/config';
+	import { vaultApiUrl } from '$lib/config';
 	import { formatByteUnits } from '$lib/helpers/formatters';
 	import { Alert, Button, HeroBanner, Section, Spinner, TextInput, Timestamp } from '$lib/components';
 	import Breadcrumbs from '$lib/breadcrumb/Breadcrumbs.svelte';
@@ -14,8 +14,6 @@ Vault datasets download page
 	let submitting = $state(false);
 	let validApiKey = $state('');
 	let apiKeyError = $state('');
-
-	const documentationUrl = 'https://tradingstrategy.ai/docs/overview/defi-vault-data.html';
 	const apiKeyPlaceholder = 'XXXXX-XXXXX-XXXXX-XXXXX-XXXXX';
 
 	function getDownloadUrl(originalUrl: string) {
@@ -99,16 +97,10 @@ Vault datasets download page
 		<HeroBanner title="Vault datasets">
 			{#snippet subtitle()}
 				<p>
-					<a class="body-link" href={resolve('/pricing')}>Sign up for the professional API key</a> to download the vault
-					data. Read
-					<a class="body-link" href={documentationUrl} rel="external"> data format documention </a>.
-				</p>
-				<p>
-					For any question, contact us via
-					<!-- eslint-disable-next-line svelte/no-navigation-without-resolve -->
-					<a class="body-link" href="mailto:info@tradingstrategy.ai">email</a> or
-					<!-- eslint-disable-next-line svelte/no-navigation-without-resolve -->
-					<a class="body-link" href={discordUrl} target="_blank" rel="noreferrer">Discord</a>.
+					DeFi vault data download. For more information and purchasing a licence, see <a
+						class="body-link"
+						href={resolve('/pricing')}>pricing page</a
+					>.
 				</p>
 			{/snippet}
 		</HeroBanner>

--- a/src/routes/trading-view/vaults/datasets/download/[datasetId]/+server.ts
+++ b/src/routes/trading-view/vaults/datasets/download/[datasetId]/+server.ts
@@ -8,9 +8,13 @@ const TOP_VAULTS_JSON = 'top_vaults_by_chain.json';
 function resolveDataset(datasetId: string): { fileKey: string; filename: string; contentType: string } | null {
 	switch (datasetId) {
 		case 'vault-metadata':
-			return { fileKey: TOP_VAULTS_JSON, filename: TOP_VAULTS_JSON, contentType: 'application/json' };
+			return { fileKey: TOP_VAULTS_JSON, filename: 'vault-metadata.json', contentType: 'application/json' };
 		case 'vault-prices':
-			return { fileKey: VAULT_PRICES_PARQUET, filename: VAULT_PRICES_PARQUET, contentType: 'application/octet-stream' };
+			return {
+				fileKey: VAULT_PRICES_PARQUET,
+				filename: 'vault-historical.parquet',
+				contentType: 'application/octet-stream'
+			};
 		default:
 			return null;
 	}

--- a/tests/integration/pricing.test.ts
+++ b/tests/integration/pricing.test.ts
@@ -9,8 +9,8 @@ test.describe('pricing page', () => {
 		await expect(page).toHaveTitle('Vault data pricing');
 	});
 
-	test('shows Basic and Pro tier cards', async ({ page }) => {
-		await expect(page.getByRole('heading', { name: 'Basic' })).toBeVisible();
+	test('shows Free and Pro tier cards', async ({ page }) => {
+		await expect(page.getByRole('heading', { name: 'Free' })).toBeVisible();
 		await expect(page.getByRole('heading', { name: 'Pro' })).toBeVisible();
 	});
 
@@ -34,12 +34,7 @@ test.describe('pricing page', () => {
 		await expect(page.getByRole('heading', { name: 'Feature comparison' })).toBeVisible();
 	});
 
-	test('API access is listed as Pro-only feature', async ({ page }) => {
-		await expect(page.getByRole('cell', { name: 'API access' })).toBeVisible();
-	});
-
-	test('shows ready to get started call-to-action', async ({ page }) => {
-		await expect(page.getByRole('heading', { name: 'Ready to get started?' })).toBeVisible();
-		await expect(page.getByRole('link', { name: 'Request early access' })).toBeVisible();
+	test('Historical data is listed as Pro-only feature', async ({ page }) => {
+		await expect(page.getByRole('cell', { name: 'Historical data' })).toBeVisible();
 	});
 });

--- a/tests/integration/trading-view/vaults/datasets.test.ts
+++ b/tests/integration/trading-view/vaults/datasets.test.ts
@@ -31,8 +31,8 @@ test.describe('vault datasets page', () => {
 	});
 
 	test('shows expected filenames in dataset table', async ({ page }) => {
-		await expect(page.getByText('top_vaults_by_chain.json', { exact: true })).toBeVisible();
-		await expect(page.getByText('cleaned-vault-prices-1h.parquet', { exact: true })).toBeVisible();
+		await expect(page.getByText('vault-metadata.json', { exact: true })).toBeVisible();
+		await expect(page.getByText('vault-historical.parquet', { exact: true })).toBeVisible();
 	});
 
 	test('shows JSON and Parquet format labels', async ({ page }) => {
@@ -128,7 +128,7 @@ test.describe('vault dataset download endpoint', () => {
 		const res = await request.get(`/trading-view/vaults/datasets/download/vault-metadata?api-key=${VALID_API_KEY}`);
 		expect(res.status()).toBe(200);
 		expect(res.headers()['content-type']).toContain('application/json');
-		expect(res.headers()['content-disposition']).toContain('top_vaults_by_chain.json');
+		expect(res.headers()['content-disposition']).toContain('vault-metadata.json');
 		expect(res.headers()['cache-control']).toBe('private, no-store');
 	});
 
@@ -136,7 +136,7 @@ test.describe('vault dataset download endpoint', () => {
 		const res = await request.get(`/trading-view/vaults/datasets/download/vault-prices?api-key=${VALID_API_KEY}`);
 		expect(res.status()).toBe(200);
 		expect(res.headers()['content-type']).toBe('application/octet-stream');
-		expect(res.headers()['content-disposition']).toContain('cleaned-vault-prices-1h.parquet');
+		expect(res.headers()['content-disposition']).toContain('vault-historical.parquet');
 		expect(res.headers()['cache-control']).toBe('private, no-store');
 	});
 


### PR DESCRIPTION
## Why

The pricing page needed visual polish and content updates: the feature comparison table lacked visual appeal, the purchase button pointed to the old Market Software URL instead of Creem, and several copy updates were needed including new Pro features and clearer dataset download instructions.

## Lessons learnt

- SVG files don't support CSS `hsl()` function syntax — use hex colour values instead
- Vite caches SVG icons via unplugin-icons; changes to icon files may require a dev server restart
- CSS `overflow-y: visible` gets coerced to `auto` when `overflow-x` is `auto` — use `overflow: visible` when tooltip popups need to escape a container

## Summary

- Restyle feature comparison table with liquid glass effect (backdrop blur, translucent borders, rounded corners, row hover)
- Replace square checkbox icons with green filled circle checkmarks
- Wire "Purchase license" button to `TS_PUBLIC_CREEM_CHECKOUT_URL` env var via new `creemCheckoutUrl` config
- Update pricing small print with licence info, bold dataset download link, and support chat note
- Make sold-by text brighter (from `--c-text-ultra-light` to `--c-text-light`)
- Add "BTC/ETH-denominated vaults" (with tooltip) and "Startup discounts available" to Pro features
- Rename "Non-stablecoin vaults" → "BTC/ETH-denominated vaults" and move to end of table
- Change "$25B+ profit tracked" → "$25B+ tracked TVL"
- Wrap "Data and fields" section in a styled panel
- Remove "Ready to get started?" banner section
- Simplify vault datasets page subtitle to link back to pricing
- Rename display filenames to `vault-metadata.json` and `vault-historical.parquet`
- Add changelog entry