### PR TITLE
fix: proxy Coinbase benchmark requests through SvelteKit server

### DIFF
--- a/src/lib/top-vaults/coinbase.test.ts
+++ b/src/lib/top-vaults/coinbase.test.ts
@@ -1,29 +1,10 @@
 import { describe, expect, test, vi } from 'vitest';
 import { fetchCoinbaseBenchmarkCloses, getCoinbaseGranularitySeconds } from './coinbase';
 
-function makeCoinbaseFetch(requests: URL[]) {
+function makeProxyFetch(responseData: [number, number][]) {
 	return vi.fn(async (input: RequestInfo | URL) => {
-		const url = new URL(String(input));
-		requests.push(url);
-
-		const granularitySeconds = Number(url.searchParams.get('granularity'));
-		const start = new Date(url.searchParams.get('start') ?? '');
-		const end = new Date(url.searchParams.get('end') ?? '');
-		const candles: [number, number, number, number, number, number][] = [];
-
-		for (let ts = start.getTime() / 1000; ts <= end.getTime() / 1000; ts += granularitySeconds) {
-			candles.push([ts, 1, 1, 1, ts, 0]);
-		}
-
-		return new Response(JSON.stringify([...candles].reverse()), { status: 200 });
+		return new Response(JSON.stringify(responseData), { status: 200 });
 	}) as unknown as Fetch;
-}
-
-function requestedPointCount(url: URL) {
-	const granularitySeconds = Number(url.searchParams.get('granularity'));
-	const start = new Date(url.searchParams.get('start') ?? '');
-	const end = new Date(url.searchParams.get('end') ?? '');
-	return Math.floor((end.getTime() - start.getTime()) / (granularitySeconds * 1000)) + 1;
 }
 
 describe('getCoinbaseGranularitySeconds', () => {
@@ -44,31 +25,34 @@ describe('getCoinbaseGranularitySeconds', () => {
 });
 
 describe('fetchCoinbaseBenchmarkCloses', () => {
-	test('chunks long daily ranges below the Coinbase per-request candle limit', async () => {
-		const requests: URL[] = [];
-		const fetch = makeCoinbaseFetch(requests);
+	test('calls the server-side proxy endpoint with correct params', async () => {
 		const start = new Date('2025-01-01T00:00:00Z');
 		const end = new Date('2026-01-01T00:00:00Z');
+		const expectedData: [number, number][] = [
+			[1735689600, 42000],
+			[1735776000, 42500]
+		];
+		const fetch = makeProxyFetch(expectedData);
 
 		const closes = await fetchCoinbaseBenchmarkCloses(fetch, 'BTC-USD', start, end);
 
-		expect(requests).toHaveLength(2);
-		expect(requests.every((url) => url.searchParams.get('granularity') === '86400')).toBe(true);
-		expect(requests.every((url) => requestedPointCount(url) <= 300)).toBe(true);
-		expect(closes).toHaveLength(366);
-		expect(closes[0][0]).toBe(start.getTime() / 1000);
-		expect(closes.at(-1)?.[0]).toBe(end.getTime() / 1000);
+		expect(fetch).toHaveBeenCalledOnce();
+		const calledUrl = new URL(String(fetch.mock.calls[0][0]), 'http://localhost');
+		expect(calledUrl.pathname).toBe('/trading-view/vaults/coinbase-candles');
+		expect(calledUrl.searchParams.get('productId')).toBe('BTC-USD');
+		expect(calledUrl.searchParams.get('granularity')).toBe('86400');
+		expect(calledUrl.searchParams.get('start')).toBe(start.toISOString());
+		expect(calledUrl.searchParams.get('end')).toBe(end.toISOString());
+		expect(closes).toEqual(expectedData);
 	});
 
-	test('uses six-hour candles for a ninety-day range to keep over 100 chart points', async () => {
-		const requests: URL[] = [];
-		const fetch = makeCoinbaseFetch(requests);
-		const start = new Date('2025-01-01T00:00:00Z');
-		const end = new Date('2025-04-01T00:00:00Z');
+	test('throws on proxy error response', async () => {
+		const fetch = vi.fn(async () => new Response('error', { status: 502 })) as unknown as Fetch;
+		const start = new Date('2025-06-01T00:00:00Z');
+		const end = new Date('2025-09-01T00:00:00Z');
 
-		const closes = await fetchCoinbaseBenchmarkCloses(fetch, 'ETH-USD', start, end);
-
-		expect(requests.every((url) => url.searchParams.get('granularity') === '21600')).toBe(true);
-		expect(closes.length).toBeGreaterThanOrEqual(100);
+		await expect(fetchCoinbaseBenchmarkCloses(fetch, 'ETH-USD', start, end)).rejects.toThrow(
+			'Coinbase benchmark proxy failed: 502'
+		);
 	});
 });

--- a/src/lib/top-vaults/coinbase.ts
+++ b/src/lib/top-vaults/coinbase.ts
@@ -1,8 +1,5 @@
 type CoinbaseProductId = 'BTC-USD' | 'ETH-USD';
-type CoinbaseCandle = [time: number, low: number, high: number, open: number, close: number, volume: number];
 
-const COINBASE_API_URL = 'https://api.exchange.coinbase.com';
-const MAX_CANDLES_PER_REQUEST = 300;
 const MIN_BENCHMARK_POINTS = 100;
 const COINBASE_GRANULARITIES_SECONDS = [60, 300, 900, 3_600, 21_600, 86_400] as const;
 const benchmarkRequestCache = new Map<string, Promise<[number, number][]>>();
@@ -21,12 +18,10 @@ export function getCoinbaseGranularitySeconds(start: Date, end: Date) {
 }
 
 /**
- * Fetch Coinbase close prices for a benchmark product across the requested chart range.
+ * Fetch Coinbase close prices for a benchmark product via the server-side proxy.
  *
- * Coinbase limits candle responses to 300 rows per request. We choose the coarsest
- * Coinbase-supported granularity that still gives about 100 samples across the
- * full chart width, then fetch the range in chunks and merge the close prices into
- * a single ascending series.
+ * The proxy handles chunking, retries, and caching to avoid CORS issues
+ * and Coinbase rate-limiting.
  */
 export function fetchCoinbaseBenchmarkCloses(
 	fetch: Fetch,
@@ -40,52 +35,23 @@ export function fetchCoinbaseBenchmarkCloses(
 	const cachedResponse = benchmarkRequestCache.get(cacheKey);
 	if (cachedResponse) return cachedResponse;
 
-	const responsePromise = fetchCoinbaseBenchmarkClosesUncached(fetch, productId, granularitySeconds, start, end).catch(
-		(error) => {
+	const params = new URLSearchParams({
+		productId,
+		granularity: String(granularitySeconds),
+		start: start.toISOString(),
+		end: end.toISOString()
+	});
+
+	const responsePromise = fetch(`/trading-view/vaults/coinbase-candles?${params}`)
+		.then((resp) => {
+			if (!resp.ok) throw new Error(`Coinbase benchmark proxy failed: ${resp.status}`);
+			return resp.json() as Promise<[number, number][]>;
+		})
+		.catch((error) => {
 			benchmarkRequestCache.delete(cacheKey);
 			throw error;
-		}
-	);
+		});
 
 	benchmarkRequestCache.set(cacheKey, responsePromise);
 	return responsePromise;
-}
-
-async function fetchCoinbaseBenchmarkClosesUncached(
-	fetch: Fetch,
-	productId: CoinbaseProductId,
-	granularitySeconds: number,
-	start: Date,
-	end: Date
-): Promise<[number, number][]> {
-	const granularityMs = granularitySeconds * 1000;
-	const maxChunkSpanMs = granularityMs * (MAX_CANDLES_PER_REQUEST - 1);
-	const candlesByTimestamp = new Map<number, number>();
-
-	for (
-		let chunkStartMs = start.getTime();
-		chunkStartMs <= end.getTime();
-		chunkStartMs += maxChunkSpanMs + granularityMs
-	) {
-		const chunkEndMs = Math.min(chunkStartMs + maxChunkSpanMs, end.getTime());
-		const searchParams = new URLSearchParams({
-			granularity: String(granularitySeconds),
-			start: new Date(chunkStartMs).toISOString(),
-			end: new Date(chunkEndMs).toISOString()
-		});
-
-		const response = await fetch(`${COINBASE_API_URL}/products/${productId}/candles?${searchParams}`);
-		if (!response.ok) {
-			throw new Error(`Failed to load Coinbase benchmark data for ${productId}: ${response.status}`);
-		}
-
-		const candles = (await response.json()) as CoinbaseCandle[];
-		for (const [timestamp, , , , close] of candles) {
-			if (timestamp >= start.getTime() / 1000 && timestamp <= end.getTime() / 1000) {
-				candlesByTimestamp.set(timestamp, close);
-			}
-		}
-	}
-
-	return Array.from(candlesByTimestamp.entries()).sort(([leftTs], [rightTs]) => leftTs - rightTs);
 }

--- a/src/routes/trading-view/vaults/coinbase-candles/+server.ts
+++ b/src/routes/trading-view/vaults/coinbase-candles/+server.ts
@@ -1,0 +1,145 @@
+/**
+ * Server-side proxy for Coinbase candle data (BTC-USD, ETH-USD).
+ *
+ * Proxies through the server to avoid CORS issues and Coinbase rate-limiting.
+ * Uses file-based caching with stale-fallback on fetch failure.
+ */
+import { error, json } from '@sveltejs/kit';
+import { readJsonFileCache, writeJsonFileCache, isCacheFresh } from '$lib/fred-helpers';
+
+const COINBASE_API_URL = 'https://api.exchange.coinbase.com';
+const MAX_CANDLES_PER_REQUEST = 300;
+const VALID_PRODUCT_IDS = ['BTC-USD', 'ETH-USD'] as const;
+const VALID_GRANULARITIES = [60, 300, 900, 3_600, 21_600, 86_400] as const;
+const CACHE_TTL_S = 3_600; // 1 hour
+const FETCH_TIMEOUT = 15_000;
+
+type CoinbaseCandle = [time: number, low: number, high: number, open: number, close: number, volume: number];
+
+function isValidISODate(value: string): boolean {
+	const d = new Date(value);
+	return !isNaN(d.getTime());
+}
+
+async function fetchCoinbaseChunk(
+	productId: string,
+	granularitySeconds: number,
+	start: Date,
+	end: Date
+): Promise<CoinbaseCandle[]> {
+	const searchParams = new URLSearchParams({
+		granularity: String(granularitySeconds),
+		start: start.toISOString(),
+		end: end.toISOString()
+	});
+
+	const response = await fetch(`${COINBASE_API_URL}/products/${productId}/candles?${searchParams}`, {
+		signal: AbortSignal.timeout(FETCH_TIMEOUT)
+	});
+
+	if (!response.ok) {
+		throw new Error(`Coinbase returned ${response.status}`);
+	}
+
+	return (await response.json()) as CoinbaseCandle[];
+}
+
+async function fetchAllChunks(
+	productId: string,
+	granularitySeconds: number,
+	start: Date,
+	end: Date
+): Promise<[number, number][]> {
+	const granularityMs = granularitySeconds * 1000;
+	const maxChunkSpanMs = granularityMs * (MAX_CANDLES_PER_REQUEST - 1);
+	const candlesByTimestamp = new Map<number, number>();
+
+	for (
+		let chunkStartMs = start.getTime();
+		chunkStartMs <= end.getTime();
+		chunkStartMs += maxChunkSpanMs + granularityMs
+	) {
+		const chunkEndMs = Math.min(chunkStartMs + maxChunkSpanMs, end.getTime());
+		const candles = await fetchCoinbaseChunk(
+			productId,
+			granularitySeconds,
+			new Date(chunkStartMs),
+			new Date(chunkEndMs)
+		);
+
+		for (const [timestamp, , , , close] of candles) {
+			if (timestamp >= start.getTime() / 1000 && timestamp <= end.getTime() / 1000) {
+				candlesByTimestamp.set(timestamp, close);
+			}
+		}
+	}
+
+	return Array.from(candlesByTimestamp.entries()).sort(([a], [b]) => a - b);
+}
+
+export async function GET({ url }) {
+	const productId = url.searchParams.get('productId');
+	const granularity = url.searchParams.get('granularity');
+	const start = url.searchParams.get('start');
+	const end = url.searchParams.get('end');
+
+	if (!productId || !VALID_PRODUCT_IDS.includes(productId as (typeof VALID_PRODUCT_IDS)[number])) {
+		error(400, 'Invalid productId — must be BTC-USD or ETH-USD');
+	}
+
+	const granularitySeconds = Number(granularity);
+	if (!VALID_GRANULARITIES.includes(granularitySeconds as (typeof VALID_GRANULARITIES)[number])) {
+		error(400, 'Invalid granularity');
+	}
+
+	if (!start || !end || !isValidISODate(start) || !isValidISODate(end)) {
+		error(400, 'Invalid start/end — expected ISO 8601 date strings');
+	}
+
+	const startDate = new Date(start);
+	const endDate = new Date(end);
+
+	if (endDate < startDate) {
+		error(400, 'end must be >= start');
+	}
+
+	const cacheKey = `coinbase-${productId}-${granularitySeconds}-${startDate.toISOString()}-${endDate.toISOString()}`;
+
+	// Check file cache
+	if (await isCacheFresh(cacheKey, CACHE_TTL_S)) {
+		const cached = await readJsonFileCache<[number, number][]>(cacheKey);
+		if (cached) {
+			return json(cached, {
+				headers: { 'Cache-Control': 'public, max-age=3600' }
+			});
+		}
+	}
+
+	// Fetch from Coinbase with one retry
+	for (let attempt = 0; attempt < 2; attempt++) {
+		try {
+			const closes = await fetchAllChunks(productId, granularitySeconds, startDate, endDate);
+			await writeJsonFileCache(cacheKey, closes);
+			return json(closes, {
+				headers: { 'Cache-Control': 'public, max-age=3600' }
+			});
+		} catch (e) {
+			if (attempt === 0) {
+				console.warn(`Coinbase fetch attempt 1 failed for ${productId}, retrying:`, e);
+				continue;
+			}
+			console.warn(`Coinbase fetch failed for ${cacheKey}:`, e);
+		}
+	}
+
+	// Fall back to stale cache
+	const stale = await readJsonFileCache<[number, number][]>(cacheKey);
+	if (stale) {
+		console.warn(`Serving stale Coinbase cache for ${cacheKey}`);
+		return json(stale, {
+			headers: { 'Cache-Control': 'public, max-age=600' }
+		});
+	}
+
+	error(502, `Coinbase benchmark unavailable for ${productId}`);
+}


### PR DESCRIPTION
## Why

BTC/ETH benchmark price charts on perpetual futures vault pages (e.g. `/trading-view/vaults/robonet-ai-long-short-strategy`) are broken. The browser fetches candle data directly from `api.exchange.coinbase.com`, which returns 503 without CORS headers, surfacing as `TypeError: Failed to fetch`. The benchmark lines silently disappear.

## Summary

- **New server endpoint** (`/trading-view/vaults/coinbase-candles`) that proxies Coinbase candle requests server-side, eliminating CORS issues
- Server handles chunked fetching (Coinbase 300-candle limit), automatic retry on failure, and file-based caching (1h TTL with stale fallback)
- Client-side `coinbase.ts` now calls the proxy instead of Coinbase directly; all chunking/retry logic moved server-side
- Tests updated to mock the proxy endpoint

## Lessons learnt

- Coinbase's public Exchange API increasingly rate-limits/blocks browser origins and omits CORS headers on error responses, making client-side fetching unreliable
- The treasury benchmark already followed the proxy pattern via `fred-helpers` caching utilities — reusing the same infrastructure kept the fix consistent