### PR TITLE
Add vault operation disabled warning

### DIFF
--- a/src/routes/trading-view/vaults/[vault=slug]/+page.svelte
+++ b/src/routes/trading-view/vaults/[vault=slug]/+page.svelte
@@ -27,9 +27,20 @@
 		morphoFlags.length > 0 && vault.notes?.startsWith('Morpho has flagged this vault with the following issues:')
 	);
 	let blacklisted = $derived(isBlacklisted(vault));
-	let morphoAlertStatus = $derived(blacklisted ? 'error' : 'warning');
+	let morphoAlertStatus = $derived(blacklisted ? ('error' as const) : ('warning' as const));
 	let showBlacklistedAlert = $derived(blacklisted && !notesDuplicateMorphoFlags);
 	let showNotes = $derived(vault.notes != null && !notesDuplicateMorphoFlags);
+	let depositMayBeDisabled = $derived(vault.deposit_closed_reason != null);
+	let redemptionMayBeDisabled = $derived(vault.redemption_closed_reason != null);
+	let operationWarning = $derived(
+		depositMayBeDisabled && redemptionMayBeDisabled
+			? 'Deposits and withdrawals may be disabled for this vault'
+			: depositMayBeDisabled
+				? 'Deposits may be disabled for this vault'
+				: redemptionMayBeDisabled
+					? 'Withdrawals may be disabled for this vault'
+					: undefined
+	);
 </script>
 
 <SocialMediaTags {vault} {chain} {protocolMetadata} />
@@ -38,6 +49,12 @@
 	<Section tag="header" padding="xs">
 		<VaultListingsSelector />
 	</Section>
+
+	{#if operationWarning}
+		<Section padding="md">
+			<Alert size="md" status="warning">{operationWarning}</Alert>
+		</Section>
+	{/if}
 
 	{#if morphoFlags.length > 0}
 		<Section padding="md">

--- a/tests/integration/trading-view/vaults/index.test.ts
+++ b/tests/integration/trading-view/vaults/index.test.ts
@@ -315,4 +315,28 @@ test.describe('vault index page', () => {
 		await expect(alerts.first()).toContainText('bad_debt_unrealized');
 		await expect(page.locator('.notes')).toHaveCount(0);
 	});
+
+	test('warns when deposits may be disabled on a vault detail page', async ({ page }) => {
+		await page.goto('/trading-view/vaults/deposit-disabled-vault');
+
+		const alert = page.locator('.alert-list.warning').first();
+		await expect(alert).toBeVisible();
+		await expect(alert).toContainText('Deposits may be disabled for this vault');
+	});
+
+	test('warns when withdrawals may be disabled on a vault detail page', async ({ page }) => {
+		await page.goto('/trading-view/vaults/withdrawal-disabled-vault');
+
+		const alert = page.locator('.alert-list.warning').first();
+		await expect(alert).toBeVisible();
+		await expect(alert).toContainText('Withdrawals may be disabled for this vault');
+	});
+
+	test('warns when deposits and withdrawals may be disabled on a vault detail page', async ({ page }) => {
+		await page.goto('/trading-view/vaults/deposit-and-withdrawal-disabled-vault');
+
+		const alert = page.locator('.alert-list.warning').first();
+		await expect(alert).toBeVisible();
+		await expect(alert).toContainText('Deposits and withdrawals may be disabled for this vault');
+	});
 });

--- a/tests/mocks/top-vaults/list.mock.ts
+++ b/tests/mocks/top-vaults/list.mock.ts
@@ -345,6 +345,55 @@ const morphoFlaggedBlacklistedVault = createTestVault('Morpho flagged blackliste
 	]
 });
 
+const closedVaultPeriodResult = {
+	period: '1M',
+	error_reason: null,
+	period_start_at: '2025-12-01T00:00:00',
+	period_end_at: '2026-01-01T00:00:00',
+	share_price_start: 1,
+	share_price_end: 1.01,
+	raw_samples: 720,
+	samples_start_at: '2025-12-01T00:00:00',
+	samples_end_at: '2026-01-01T00:00:00',
+	daily_samples: 30,
+	returns_gross: 0.01,
+	returns_net: 0.01,
+	cagr_gross: 0.12,
+	cagr_net: 0.12,
+	volatility: 0.1,
+	sharpe: 1,
+	max_drawdown: -0.01,
+	tvl_start: 18_000,
+	tvl_end: 20_000,
+	tvl_low: 18_000,
+	tvl_high: 20_000,
+	ranking_overall: 100,
+	ranking_chain: 20,
+	ranking_protocol: 10
+} satisfies VaultInfo['period_results'][number];
+
+const depositDisabledVault = createTestVault('Deposit disabled vault', {
+	chain: 'base',
+	current_nav: 20_000,
+	deposit_closed_reason: 'Deposits paused',
+	period_results: [closedVaultPeriodResult]
+});
+
+const redemptionDisabledVault = createTestVault('Withdrawal disabled vault', {
+	chain: 'base',
+	current_nav: 20_000,
+	redemption_closed_reason: 'Withdrawals paused',
+	period_results: [closedVaultPeriodResult]
+});
+
+const depositAndRedemptionDisabledVault = createTestVault('Deposit and withdrawal disabled vault', {
+	chain: 'base',
+	current_nav: 20_000,
+	deposit_closed_reason: 'Deposits paused',
+	redemption_closed_reason: 'Withdrawals paused',
+	period_results: [closedVaultPeriodResult]
+});
+
 // Real Parquet-backed vault IDs used by the historical TVL by chain endpoint tests.
 // These IDs need to match the local Parquet dataset so blacklist filtering can be
 // exercised against real server-side aggregation.
@@ -395,6 +444,9 @@ export default defineMock({
 		vaults: [
 			yamlStrategyVault,
 			morphoFlaggedBlacklistedVault,
+			depositDisabledVault,
+			redemptionDisabledVault,
+			depositAndRedemptionDisabledVault,
 			limitedCoverageVault,
 			...parquetMatchedVaults,
 			...returnLeaders,


### PR DESCRIPTION
## Why

Vault detail pages should surface when deposits, withdrawals, or both may be unavailable so users see the operational status before reading deeper page details.

## Lessons learnt

Vault availability is represented by `deposit_closed_reason` and `redemption_closed_reason`; mocked detail-page vaults need a 1M period result because the rankings block expects one.

## Summary

- Added a warning alert near the top of vault detail pages for deposit and withdrawal disabled states.
- Added integration fixtures and Playwright coverage for deposit-only, withdrawal-only, and combined warning copy.