### PR TITLE
Update frontpage vaults to Master Vault, HyperAI, Premium Harvest Vault

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -154,7 +154,8 @@ TS_PUBLIC_STRATEGIES=`[
     "id": "vega",
     "name": "Premium Harvest Vault",
     "url": "https://vega.tradingstrategy.ai",
-    "useSharePrice": true
+    "useSharePrice": true,
+    "frontpage": true
   },
   {
     "id": "gmx-ai",
@@ -170,6 +171,7 @@ TS_PUBLIC_STRATEGIES=`[
     "name": "HyperAI",
     "url": "https://hyper-ai.tradingstrategy.ai",
     "useSharePrice": true,
+    "frontpage": true,
     "hiddenElements": {
       "timeframes": true
     }

--- a/src/lib/strategies/sort.test.ts
+++ b/src/lib/strategies/sort.test.ts
@@ -58,13 +58,14 @@ describe('compareStrategiesForFrontend', () => {
 
 	it('keeps frontpage strategies in the requested order', () => {
 		const strategies = [
-			createStrategy({ id: 'opencz', name: 'OpenCZ', sort_priority: 999 }),
+			createStrategy({ id: 'vega', name: 'Premium Harvest Vault', sort_priority: 999 }),
 			createStrategy({ id: 'other-high', name: 'Other high', sort_priority: 100 }),
+			createStrategy({ id: 'hyper-ai', name: 'HyperAI', sort_priority: 1 }),
 			createStrategy({ id: 'master-vault', name: 'Master Vault', sort_priority: 1 })
 		];
 
 		const sortedIds = strategies.sort(compareStrategiesForFrontpage).map((strategy) => strategy.id);
 
-		expect(sortedIds).toEqual(['opencz', 'master-vault', 'other-high']);
+		expect(sortedIds).toEqual(['master-vault', 'hyper-ai', 'vega', 'other-high']);
 	});
 });

--- a/src/lib/strategies/sort.ts
+++ b/src/lib/strategies/sort.ts
@@ -2,7 +2,7 @@ import type { StrategyInfo } from 'trade-executor/models/strategy-info';
 
 const listingPinnedStrategyOrder = ['opencz', 'hyper-ai', 'master-vault', 'ichi-hyperliquid', 'gmx-ai'] as const;
 
-const frontpagePinnedStrategyOrder = ['opencz', 'master-vault'] as const;
+const frontpagePinnedStrategyOrder = ['master-vault', 'hyper-ai', 'vega'] as const;
 
 function createPinnedRankMap(strategyIds: readonly string[]) {
 	return new Map<string, number>(strategyIds.map((strategyId, index) => [strategyId, strategyIds.length - index]));
@@ -41,7 +41,7 @@ export const compareStrategiesForFrontend = createStrategyComparator(listingPinn
 /**
  * Sort strategies for the frontpage featured section.
  *
- * OpenCZ should appear before Master Vault, with all other strategies following
- * the default sort-priority behaviour.
+ * Master Vault appears first, then HyperAI, then Premium Harvest Vault (vega),
+ * with all other strategies following the default sort-priority behaviour.
  */
 export const compareStrategiesForFrontpage = createStrategyComparator(frontpagePinnedStrategyOrder);

--- a/strategies/opencz.yaml
+++ b/strategies/opencz.yaml
@@ -19,7 +19,7 @@ tags:
 # How far up in the listing page we displays this
 sort_priority: 0
 # Show on front page
-frontpage: true
+frontpage: false
 # Mangle HTML file input to iframe-compatible format
 inject_backtest_iframe_resizer: true
 # Use relative direction for the tile chart (matches vault detail page)


### PR DESCRIPTION
## Why

Change the front page featured strategies to show Master Vault, HyperAI, and Premium Harvest Vault (vega) in that order, replacing OpenCZ.

## Lessons learnt

- Frontpage strategy visibility is controlled by `frontpage: true` on each strategy config (API strategies in `TS_PUBLIC_STRATEGIES` env var, YAML strategies in `strategies/*.yaml`)
- Pinned display order is defined in `src/lib/strategies/sort.ts` via `frontpagePinnedStrategyOrder`
- Production `TS_PUBLIC_STRATEGIES` env var also needs `frontpage: true` on `hyper-ai` and `vega` at deploy time

## Summary

- Updated `frontpagePinnedStrategyOrder` to `['master-vault', 'hyper-ai', 'vega']`
- Enabled `frontpage: true` for `hyper-ai` and `vega` in `.env.development`
- Disabled `frontpage` for OpenCZ in `strategies/opencz.yaml`
- Updated sort tests to match new order