### PR TITLE
Remove web-top-node request tracking

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,7 +69,6 @@
     "@reown/appkit": "^1.8.18",
     "@reown/appkit-adapter-wagmi": "^1.8.18",
     "@sentry/sveltekit": "^9.47.1",
-    "@trading-strategy-ai/web-top-node": "0.1.0-beta.10",
     "@wagmi/connectors": "^5.11.2",
     "@wagmi/core": "^2.22.1",
     "@zag-js/dialog": "^1.34.1",

--- a/scripts/server.js
+++ b/scripts/server.js
@@ -1,46 +1,18 @@
 /**
- * Express.js based SvelteKit server-side renderer
- * with web-top HTTP request tracking API installed.
- *
- * You need to set environment variable TOP_WEB_API_KEY
- * to an API key that is used by `web-top` command line application.
- *
- * See https://www.npmjs.com/package/@trading-strategy-ai/web-top-node
- * for details.
- *
+ * Express.js based SvelteKit server-side renderer.
  */
 
 // Check your SvelteKit build/handler.js file
 // location based on your SvelteKit installation
 import { handler } from '../build/handler.js';
 import express from 'express';
-import { Tracker, TrackerServer, createTrackerMiddleware } from '@trading-strategy-ai/web-top-node';
+
+// web-top-node request tracking removed — no longer needed
+// import { Tracker, TrackerServer, createTrackerMiddleware } from '@trading-strategy-ai/web-top-node';
 
 // Create Express server
 // Polka does not work https://github.com/sveltejs/kit/issues/6363
 const app = express();
-
-// Create HTTP request tracker.
-// This will store active and completed HTTP requests
-// in Node.js process memory.
-const tracker = new Tracker();
-
-// Install HTTP request start/end hooks.
-// If no max completed request buffer size is not given,
-// read the max number from TOP_MAX_COMPLETED_TASKS
-// environment variable, or default to 256 requests
-// if not set.
-const trackerMiddleware = createTrackerMiddleware(tracker);
-app.use(trackerMiddleware);
-
-// Install API endpoint.
-// If no API key is given read one from
-// TOP_WEB_API_KEY environment variable.
-const trackerServer = new TrackerServer(tracker);
-
-// Under which path we install the tracker API endpoint
-const trackerPath = '/tracker';
-app.get(trackerPath, trackerServer.serve.bind(trackerServer));
 
 // Install SvelteKit server-side renderer
 app.use(handler);
@@ -48,5 +20,4 @@ app.use(handler);
 // Start web server
 app.listen(3000, () => {
 	console.log('Listening on port 3000');
-	console.log(`HTTP active requests API at ${trackerPath}, API key starts as ${trackerServer.apiKey.slice(0, 4)}…`);
 });


### PR DESCRIPTION
## Why

The `web-top-node` HTTP request tracking middleware is no longer needed and can be removed to simplify the production server setup.

## Lessons learnt

- The Express server in `scripts/server.js` is the production entry point wrapping the SvelteKit handler.

## Summary

- Removed `@trading-strategy-ai/web-top-node` import, tracker instantiation, middleware, and API endpoint from `scripts/server.js`
- Removed `@trading-strategy-ai/web-top-node` dependency from `package.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)