### PR TITLE
feat: vault curators category and per-curator listing pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Weblog of stuff
 
 - Add Core3 protocol risk ratings — a rating box on vault detail and protocol pages, plus a Core3 column on the protocols listing (2026-06-10)
+- Add "By curator" vault category page and per-curator vault listing pages (2026-06-09)
 - Revamp pricing page with liquid glass table, Creem checkout, updated copy and dataset links (2026-05-08)
 - Add AI ready feature and data fields section to pricing page (2026-05-07)
 - Add historical TVL chart controls for market share and shorter daily history views (2026-05-05)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,6 +20,7 @@ See `docs/theme.md`.
 ```shell
 pnpm run dev              # Start development server
 pnpm run build            # Build for production
+pnpm run preview          # Serve a production build — for verifying the build only, NOT for development
 pnpm run check            # Run Svelte type checking
 pnpm run format           # Format code with Prettier
 pnpm run lint             # Run ESLint and Prettier checks
@@ -108,7 +109,7 @@ Use it for:
 - checking rendered content
 - reproducing layout and interaction issues
 
-Typical local target:
+Always develop and verify against the Vite dev server started with `pnpm run dev` (typical local target `http://127.0.0.1:5173/`). Do **not** use `pnpm run preview` (Vite preview) for development or verification: its preview server runs its own prerender/manifest step that can resolve routes differently from both dev and the production adapter-node server (e.g. newly added routes may 404 under preview while working everywhere else). `pnpm run preview` is only for sanity-checking a production build. Integration tests (`pnpm run test:integration`) intentionally run against a build via the test harness; that is separate from manual development.
 
 ```text
 http://127.0.0.1:5173/

--- a/src/lib/curator/CuratorDescription.svelte
+++ b/src/lib/curator/CuratorDescription.svelte
@@ -2,10 +2,10 @@
 @component
 About-the-curator widget for vault curator detail pages.
 
-Shows the curator's external links (homepage, social, RSS) behind a "View more"
-control, matching the vault protocol description widget. Links are sourced from
-the top-vaults dataset `curators` map; recent posts are rendered separately by
-`CuratorRecentPosts`.
+Shows the curator's short description, with the long description (markdown) and
+external links (homepage, social, RSS) behind a "View more" control, matching
+the vault protocol description widget. Sourced from the top-vaults dataset
+`curators` map; recent posts are rendered separately by `CuratorRecentPosts`.
 
 @example
 
@@ -16,6 +16,7 @@ the top-vaults dataset `curators` map; recent posts are rendered separately by
 <script lang="ts">
 	import type { CuratorInfo } from '$lib/top-vaults/schemas';
 	import { slide } from 'svelte/transition';
+	import { micromark } from 'micromark';
 	import MetricsBox from '$lib/components/MetricsBox.svelte';
 	import Button from '$lib/components/Button.svelte';
 	import IconTwitter from '~icons/local/twitter';
@@ -39,26 +40,44 @@ the top-vaults dataset `curators` map; recent posts are rendered separately by
 			{ href: curator.rss, label: 'RSS', Icon: IconRss }
 		].filter((link) => link.href)
 	);
+
+	let hasExpandableContent = $derived(Boolean(curator.long_description) || links.length > 0);
 </script>
 
 <div class="curator-description">
 	<MetricsBox title="About {curator.name}">
-		{#if links.length > 0}
-			<Button ghost class="toggle-btn" on:click={() => (expanded = !expanded)}>
-				{expanded ? 'View less' : 'View more'}
-			</Button>
+		{#if curator.short_description || hasExpandableContent}
+			<div class="description-text">
+				{#if curator.short_description}
+					<p>{curator.short_description}</p>
+				{/if}
+				{#if hasExpandableContent}
+					<Button ghost class="toggle-btn" on:click={() => (expanded = !expanded)}>
+						{expanded ? 'View less' : 'View more'}
+					</Button>
+				{/if}
+			</div>
 
 			{#if expanded}
 				<div transition:slide>
-					<div class="links">
-						{#each links as { href, label, Icon } (label)}
-							<!-- eslint-disable-next-line svelte/no-navigation-without-resolve -->
-							<a href={href!} target="_blank" rel="noreferrer">
-								<Icon --icon-size="1rem" />
-								<span>{label}</span>
-							</a>
-						{/each}
-					</div>
+					{#if curator.long_description}
+						<div class="long-description">
+							<!-- eslint-disable-next-line svelte/no-at-html-tags -->
+							{@html micromark(curator.long_description)}
+						</div>
+					{/if}
+
+					{#if links.length > 0}
+						<div class="links">
+							{#each links as { href, label, Icon } (label)}
+								<!-- eslint-disable-next-line svelte/no-navigation-without-resolve -->
+								<a href={href!} target="_blank" rel="noreferrer">
+									<Icon --icon-size="1rem" />
+									<span>{label}</span>
+								</a>
+							{/each}
+						</div>
+					{/if}
 				</div>
 			{/if}
 		{:else}
@@ -73,11 +92,58 @@ the top-vaults dataset `curators` map; recent posts are rendered separately by
 		font: var(--f-ui-md-roman);
 		color: var(--c-text-light);
 
+		.description-text {
+			display: flex;
+			flex-wrap: wrap;
+			align-items: baseline;
+			align-content: flex-start;
+			gap: 1rem;
+
+			p {
+				margin: 0;
+			}
+		}
+
 		:global(.toggle-btn) {
 			color: var(--c-text-extra-light);
 
 			&:hover {
 				color: var(--c-text);
+			}
+		}
+
+		.long-description {
+			margin-block: 1rem 1.5rem;
+
+			:global(p) {
+				margin-block: 1em;
+
+				&:first-child {
+					margin-top: 0;
+				}
+
+				&:last-child {
+					margin-bottom: 0;
+				}
+			}
+
+			:global(a) {
+				color: var(--c-text);
+				text-decoration: underline;
+			}
+
+			:global(ul),
+			:global(ol) {
+				margin: 0 0 1em;
+				padding-left: 1.5em;
+			}
+
+			:global(li) {
+				margin-bottom: 0.25em;
+			}
+
+			:global(strong) {
+				font-weight: 600;
 			}
 		}
 

--- a/src/lib/curator/CuratorDescription.svelte
+++ b/src/lib/curator/CuratorDescription.svelte
@@ -1,0 +1,111 @@
+<!--
+@component
+About-the-curator widget for vault curator detail pages.
+
+Shows the curator's external links (homepage, social, RSS) behind a "View more"
+control, matching the vault protocol description widget. Links are sourced from
+the top-vaults dataset `curators` map; recent posts are rendered separately by
+`CuratorRecentPosts`.
+
+@example
+
+```svelte
+	<CuratorDescription curator={curatorInfo} />
+```
+-->
+<script lang="ts">
+	import type { CuratorInfo } from '$lib/top-vaults/schemas';
+	import { slide } from 'svelte/transition';
+	import MetricsBox from '$lib/components/MetricsBox.svelte';
+	import Button from '$lib/components/Button.svelte';
+	import IconTwitter from '~icons/local/twitter';
+	import IconLinkedin from '~icons/local/linkedin';
+	import IconRss from '~icons/local/rss';
+	import IconHome from '~icons/local/home';
+
+	interface Props {
+		curator: CuratorInfo;
+	}
+
+	let { curator }: Props = $props();
+
+	let expanded = $state(false);
+
+	let links = $derived(
+		[
+			{ href: curator.website, label: 'Homepage', Icon: IconHome },
+			{ href: curator.twitter, label: 'Twitter', Icon: IconTwitter },
+			{ href: curator.linkedin, label: 'LinkedIn', Icon: IconLinkedin },
+			{ href: curator.rss, label: 'RSS', Icon: IconRss }
+		].filter((link) => link.href)
+	);
+</script>
+
+<div class="curator-description">
+	<MetricsBox title="About {curator.name}">
+		{#if links.length > 0}
+			<Button ghost class="toggle-btn" on:click={() => (expanded = !expanded)}>
+				{expanded ? 'View less' : 'View more'}
+			</Button>
+
+			{#if expanded}
+				<div transition:slide>
+					<div class="links">
+						{#each links as { href, label, Icon } (label)}
+							<!-- eslint-disable-next-line svelte/no-navigation-without-resolve -->
+							<a href={href!} target="_blank" rel="noreferrer">
+								<Icon --icon-size="1rem" />
+								<span>{label}</span>
+							</a>
+						{/each}
+					</div>
+				</div>
+			{/if}
+		{:else}
+			<p class="empty">No additional information available for this curator.</p>
+		{/if}
+	</MetricsBox>
+</div>
+
+<style>
+	.curator-description {
+		display: contents;
+		font: var(--f-ui-md-roman);
+		color: var(--c-text-light);
+
+		:global(.toggle-btn) {
+			color: var(--c-text-extra-light);
+
+			&:hover {
+				color: var(--c-text);
+			}
+		}
+
+		.links {
+			display: flex;
+			flex-wrap: wrap;
+			gap: 1rem;
+			margin-top: 1rem;
+
+			a {
+				display: inline-flex;
+				align-items: center;
+				gap: 0.5em;
+				font: var(--f-ui-sm-medium);
+				color: var(--c-text-extra-light);
+				text-decoration: none;
+				transition: color var(--time-sm);
+
+				&:hover {
+					color: var(--c-text);
+				}
+			}
+		}
+
+		.empty {
+			margin: 0;
+			color: var(--c-text-extra-light);
+			font: var(--f-ui-sm-roman);
+		}
+	}
+</style>

--- a/src/lib/curator/CuratorRecentPosts.svelte
+++ b/src/lib/curator/CuratorRecentPosts.svelte
@@ -36,7 +36,7 @@ its latest entry).
 
 	// Normalise the (sometimes timezone-less) published_at into a UTC timestamp.
 	function normaliseDate(value: string): string {
-		return value.includes('Z') || value.includes('+') ? value : `${value}Z`;
+		return /([zZ]|[+-]\d\d:?\d\d)$/.test(value) ? value : `${value}Z`;
 	}
 
 	function toTime(value: string): number {

--- a/src/lib/curator/CuratorRecentPosts.svelte
+++ b/src/lib/curator/CuratorRecentPosts.svelte
@@ -47,6 +47,9 @@ its latest entry).
 	// Upstream feed caps each snippet at 200 characters, cutting mid-word with no ellipsis.
 	const SNIPPET_CAP = 200;
 
+	// Our own display cap when the untruncated post content is available.
+	const FULL_TEXT_CAP = 400;
+
 	// Strip t.co short URLs and collapse whitespace from feed text.
 	function cleanContent(text: string | null): string {
 		return (text ?? '')
@@ -55,13 +58,26 @@ its latest entry).
 			.trim();
 	}
 
-	// Render a snippet, appending an ellipsis when it was truncated by the upstream cap.
+	// Drop the dangling partial word and any trailing punctuation, then add an ellipsis.
+	function ellipsise(text: string): string {
+		return `${text.replace(/\s*\S*$/, '').replace(/[\s.,;:!?-]+$/, '')}…`;
+	}
+
+	// Render the post body: tweets show their full content (short-form by nature),
+	// other sources (RSS articles can run to tens of thousands of characters) are
+	// capped at FULL_TEXT_CAP. Falls back to the upstream snippet, appending an
+	// ellipsis when the upstream cap cut it.
 	function displaySnippet(item: CuratorRecentPost): string {
+		const fullText = cleanContent(item.full_text ?? null);
+		if (fullText) {
+			const isTweet = ['twitter', 'x'].includes(item.source_type.toLowerCase());
+			if (isTweet || fullText.length <= FULL_TEXT_CAP) return fullText;
+			return ellipsise(fullText.slice(0, FULL_TEXT_CAP));
+		}
+
 		const text = cleanContent(item.snippet);
 		const truncated = (item.snippet ?? '').length >= SNIPPET_CAP && !/[.!?…"']$/.test(text);
-		if (!truncated) return text;
-		// Drop the dangling partial word and any trailing punctuation, then add an ellipsis.
-		return `${text.replace(/\s*\S*$/, '').replace(/[\s.,;:!?-]+$/, '')}…`;
+		return truncated ? ellipsise(text) : text;
 	}
 
 	function sourceIcon(sourceType: string): Component {
@@ -89,6 +105,8 @@ its latest entry).
 		const seen = new Set<string>();
 		return sorted.filter((item) => {
 			const key = contentKey(item);
+			// Skip posts with no displayable text (e.g. a tweet that is only a t.co link)
+			if (!key) return false;
 			if (seen.has(key)) return false;
 			seen.add(key);
 			return true;
@@ -148,8 +166,6 @@ its latest entry).
 		.feed {
 			display: flex;
 			flex-direction: column;
-			max-width: 600px;
-			margin-inline: auto;
 			padding-block: 0.5rem;
 		}
 
@@ -199,7 +215,7 @@ its latest entry).
 		}
 
 		:global(.toggle-btn) {
-			align-self: center;
+			align-self: flex-start;
 			margin-top: 0.75rem;
 			color: var(--c-text-extra-light);
 

--- a/src/lib/curator/CuratorRecentPosts.svelte
+++ b/src/lib/curator/CuratorRecentPosts.svelte
@@ -1,0 +1,215 @@
+<!--
+@component
+Full-width "Latest posts" panel for vault curator detail pages.
+
+Shows the curator's most recent post by default; any older posts are tucked
+into a foldable section toggled by a "Show more" button. Posts are sourced
+from the top-vaults dataset `curators` map, sorted most-recent first, and
+de-duplicated by content (the same post syndicated across feeds collapses to
+its latest entry).
+
+@example
+
+```svelte
+	<CuratorRecentPosts curator={curatorInfo} />
+```
+-->
+<script lang="ts">
+	import type { Component } from 'svelte';
+	import type { CuratorInfo, CuratorRecentPost } from '$lib/top-vaults/schemas';
+	import { slide } from 'svelte/transition';
+	import MetricsBox from '$lib/components/MetricsBox.svelte';
+	import Button from '$lib/components/Button.svelte';
+	import Timestamp from '$lib/components/Timestamp.svelte';
+	import IconTwitter from '~icons/local/twitter';
+	import IconLinkedin from '~icons/local/linkedin';
+	import IconRss from '~icons/local/rss';
+	import IconNewspaper from '~icons/local/newspaper';
+
+	interface Props {
+		curator: CuratorInfo;
+	}
+
+	let { curator }: Props = $props();
+
+	let expanded = $state(false);
+
+	// Normalise the (sometimes timezone-less) published_at into a UTC timestamp.
+	function normaliseDate(value: string): string {
+		return value.includes('Z') || value.includes('+') ? value : `${value}Z`;
+	}
+
+	function toTime(value: string): number {
+		const date = new Date(normaliseDate(value));
+		return Number.isNaN(date.getTime()) ? 0 : date.getTime();
+	}
+
+	// Upstream feed caps each snippet at 200 characters, cutting mid-word with no ellipsis.
+	const SNIPPET_CAP = 200;
+
+	// Strip t.co short URLs and collapse whitespace from feed text.
+	function cleanContent(text: string | null): string {
+		return (text ?? '')
+			.replace(/https?:\/\/t\.co\/\S+/gi, '')
+			.replace(/\s+/g, ' ')
+			.trim();
+	}
+
+	// Render a snippet, appending an ellipsis when it was truncated by the upstream cap.
+	function displaySnippet(item: CuratorRecentPost): string {
+		const text = cleanContent(item.snippet);
+		const truncated = (item.snippet ?? '').length >= SNIPPET_CAP && !/[.!?…"']$/.test(text);
+		if (!truncated) return text;
+		// Drop the dangling partial word and any trailing punctuation, then add an ellipsis.
+		return `${text.replace(/\s*\S*$/, '').replace(/[\s.,;:!?-]+$/, '')}…`;
+	}
+
+	function sourceIcon(sourceType: string): Component {
+		switch (sourceType.toLowerCase()) {
+			case 'twitter':
+			case 'x':
+				return IconTwitter;
+			case 'linkedin':
+				return IconLinkedin;
+			case 'rss':
+				return IconRss;
+			default:
+				return IconNewspaper;
+		}
+	}
+
+	// Content key collapses syndicated duplicates (same text via several feeds).
+	function contentKey(item: CuratorRecentPost): string {
+		return `${cleanContent(item.title)} ${cleanContent(item.snippet)}`.trim().toLowerCase();
+	}
+
+	let posts = $derived.by(() => {
+		const sorted = [...curator.recent_posts].sort((a, b) => toTime(b.published_at) - toTime(a.published_at));
+		// Sorted most-recent first, so the first occurrence of each content is the latest entry.
+		const seen = new Set<string>();
+		return sorted.filter((item) => {
+			const key = contentKey(item);
+			if (seen.has(key)) return false;
+			seen.add(key);
+			return true;
+		});
+	});
+	let latest = $derived(posts[0]);
+	let rest = $derived(posts.slice(1));
+</script>
+
+{#if latest}
+	<div class="curator-latest-posts">
+		<MetricsBox title="Latest posts from {curator.name}">
+			<div class="feed">
+				{@render post(latest)}
+
+				{#if rest.length > 0}
+					<Button ghost class="toggle-btn" on:click={() => (expanded = !expanded)}>
+						{expanded ? 'Show less' : `Show ${rest.length} more`}
+					</Button>
+
+					{#if expanded}
+						<div class="more" transition:slide>
+							{#each rest as item (item.link)}
+								{@render post(item)}
+							{/each}
+						</div>
+					{/if}
+				{/if}
+			</div>
+		</MetricsBox>
+	</div>
+{/if}
+
+{#snippet post(item: CuratorRecentPost)}
+	{@const Icon = sourceIcon(item.source_type)}
+	{@const title = cleanContent(item.title)}
+	<!-- eslint-disable-next-line svelte/no-navigation-without-resolve -->
+	<a class="post" href={item.link} target="_blank" rel="noreferrer">
+		<span class="post-source" title={item.source_type}>
+			<Icon --icon-size="1.1rem" />
+		</span>
+		<div class="post-body">
+			{#if title}
+				<span class="post-title">{title}</span>
+			{/if}
+			<span class="post-snippet">{displaySnippet(item)}</span>
+			<Timestamp class="post-date" date={normaliseDate(item.published_at)} relative={{ strict: true }} wrap="none" />
+		</div>
+	</a>
+{/snippet}
+
+<style>
+	.curator-latest-posts {
+		font: var(--f-ui-md-roman);
+		color: var(--c-text-light);
+
+		.feed {
+			display: flex;
+			flex-direction: column;
+			max-width: 600px;
+			margin-inline: auto;
+			padding-block: 0.5rem;
+		}
+
+		.post {
+			display: flex;
+			align-items: flex-start;
+			gap: 0.75rem 1rem;
+			padding: 0.75rem 0;
+			text-decoration: none;
+			color: var(--c-text-light);
+			border-bottom: 1px solid color-mix(in srgb, var(--c-box-4), transparent 35%);
+
+			&:hover .post-title,
+			&:hover .post-snippet {
+				color: var(--c-text);
+			}
+		}
+
+		.post-source {
+			flex: none;
+			display: inline-flex;
+			align-items: center;
+			color: var(--c-text-extra-light);
+		}
+
+		.post-body {
+			display: grid;
+			gap: 0.25rem;
+			flex: 1;
+			min-width: 0;
+		}
+
+		.post-title {
+			font: var(--f-ui-md-medium);
+			color: var(--c-text);
+		}
+
+		.post-snippet {
+			color: var(--c-text-light);
+			transition: color var(--time-sm);
+		}
+
+		:global(.post-date) {
+			margin-top: 0.15rem;
+			color: var(--c-text-extra-light);
+			font: var(--f-ui-xs-roman);
+		}
+
+		:global(.toggle-btn) {
+			align-self: center;
+			margin-top: 0.75rem;
+			color: var(--c-text-extra-light);
+
+			&:hover {
+				color: var(--c-text);
+			}
+		}
+
+		.more {
+			display: grid;
+		}
+	}
+</style>

--- a/src/lib/top-vaults/TopVaultsPage.svelte
+++ b/src/lib/top-vaults/TopVaultsPage.svelte
@@ -54,6 +54,8 @@
 		detailAside?: Snippet;
 		/** Optional content rendered above the vaults table (and its status line) */
 		beforeTable?: Snippet;
+		/** Whole-database vault count for the "out of {total}" listing meta on pre-filtered listings */
+		totalVaultCount?: number;
 	}
 
 	let {
@@ -78,7 +80,8 @@
 		defaultDirection,
 		loading = false,
 		detailAside,
-		beforeTable
+		beforeTable,
+		totalVaultCount
 	}: Props = $props();
 
 	let renderDetailAsideInHero = $derived(chain && detailAside && !protocolMetadata && !stablecoinMetadata);
@@ -144,15 +147,20 @@
 				<ProtocolDescription metadata={protocolMetadata} />
 			{/if}
 
-			{#if curatorMetadata && detailAside}
-				<div class="detail-overview">
-					<CuratorDescription curator={curatorMetadata} />
-					<aside class="detail-aside">
-						{@render detailAside()}
-					</aside>
+			{#if curatorMetadata}
+				<div class={['curator-overview', { 'detail-overview': detailAside }]}>
+					<div class="curator-main">
+						<CuratorDescription curator={curatorMetadata} />
+						{#if curatorMetadata.recent_posts.length > 0}
+							<CuratorRecentPosts curator={curatorMetadata} />
+						{/if}
+					</div>
+					{#if detailAside}
+						<aside class="detail-aside">
+							{@render detailAside()}
+						</aside>
+					{/if}
 				</div>
-			{:else if curatorMetadata}
-				<CuratorDescription curator={curatorMetadata} />
 			{/if}
 
 			{#if stablecoinMetadata}
@@ -165,10 +173,6 @@
 						{@render detailAside()}
 					</aside>
 				</div>
-			{/if}
-
-			{#if curatorMetadata && curatorMetadata.recent_posts.length > 0}
-				<CuratorRecentPosts curator={curatorMetadata} />
 			{/if}
 
 			{@render beforeTable?.()}
@@ -192,6 +196,7 @@
 			{:else}
 				<TopVaultsTable
 					{topVaults}
+					{totalVaultCount}
 					{chain}
 					{tvlThreshold}
 					{tvlTriggerLabel}
@@ -284,6 +289,34 @@
 		.detail-aside {
 			display: grid;
 			align-self: stretch;
+		}
+
+		/* About box and Latest posts stacked in the left column; the aside chart
+		   keeps a stable height (matching the typical collapsed column) so expanding
+		   the posts or about widgets doesn't stretch and distort it */
+		.curator-main {
+			display: grid;
+			gap: 1rem;
+			min-width: 0;
+			align-content: start;
+		}
+
+		@media (--viewport-lg-up) {
+			.curator-overview {
+				align-items: start;
+
+				.detail-aside {
+					height: 28rem;
+				}
+			}
+		}
+
+		/* on tablet widths the two-column layout makes the box content unreadable —
+		   stack the about, posts and chart boxes vertically as on mobile */
+		@media (--viewport-md-down) {
+			.curator-overview {
+				grid-template-columns: 1fr;
+			}
 		}
 
 		.detail-overview-single {

--- a/src/lib/top-vaults/TopVaultsPage.svelte
+++ b/src/lib/top-vaults/TopVaultsPage.svelte
@@ -4,13 +4,17 @@
 	import type { TopVaults } from './schemas';
 	import type { VaultProtocolMetadata } from '$lib/vault-protocol/schemas';
 	import type { StablecoinMetadata } from '$lib/stablecoin-metadata/schemas';
+	import type { CuratorInfo } from './schemas';
 	import Alert from '$lib/components/Alert.svelte';
 	import HeroBanner from '$lib/components/HeroBanner.svelte';
 	import Section from '$lib/components/Section.svelte';
 	import TopVaultsOptIn from './TopVaultsOptIn.svelte';
 	import TopVaultsTable from './TopVaultsTable.svelte';
 	import VaultListingsSelector from './VaultListingsSelector.svelte';
+	import UpdateInfoButton from './UpdateInfoButton.svelte';
 	import ProtocolDescription from '$lib/vault-protocol/ProtocolDescription.svelte';
+	import CuratorDescription from '$lib/curator/CuratorDescription.svelte';
+	import CuratorRecentPosts from '$lib/curator/CuratorRecentPosts.svelte';
 	import StablecoinDetailHeader from '$lib/stablecoin-metadata/StablecoinDetailHeader.svelte';
 	import { getLogoUrl } from '$lib/helpers/assets';
 	import { getStablecoinLogoUrl } from '$lib/stablecoin-metadata/helpers.js';
@@ -29,6 +33,7 @@
 		includeBlacklisted?: boolean;
 		protocolMetadata?: VaultProtocolMetadata;
 		stablecoinMetadata?: StablecoinMetadata;
+		curatorMetadata?: CuratorInfo;
 		/** Show interactive filter dropdowns (Min TVL, Min age, Max risk) */
 		showFilters?: boolean;
 		/** Default TVL filter key (used to initialise the dropdown when showFilters is true) */
@@ -63,6 +68,7 @@
 		includeBlacklisted,
 		protocolMetadata,
 		stablecoinMetadata,
+		curatorMetadata,
 		showFilters,
 		defaultTvlKey,
 		defaultAgeIndex,
@@ -81,7 +87,14 @@
 <main class="top-vaults-page ds-3">
 	<Section tag="header">
 		<div class="top-vaults-header">
-			<VaultListingsSelector />
+			<div class="header-top">
+				<VaultListingsSelector />
+				{#if protocolMetadata || curatorMetadata}
+					<div class="update-info">
+						<UpdateInfoButton />
+					</div>
+				{/if}
+			</div>
 			<div class:hero-layout={renderDetailAsideInHero}>
 				<HeroBanner {subtitle}>
 					{#snippet title()}
@@ -100,6 +113,9 @@
 								{#if stablecoinLogoUrl}
 									<img src={stablecoinLogoUrl} alt={stablecoinMetadata.name} />
 								{/if}
+							{/if}
+							{#if curatorMetadata?.logos.generic}
+								<img src={curatorMetadata.logos.generic} alt={curatorMetadata.name} />
 							{/if}
 							<span>{pageTitle}</span>
 						</span>
@@ -128,16 +144,31 @@
 				<ProtocolDescription metadata={protocolMetadata} />
 			{/if}
 
+			{#if curatorMetadata && detailAside}
+				<div class="detail-overview">
+					<CuratorDescription curator={curatorMetadata} />
+					<aside class="detail-aside">
+						{@render detailAside()}
+					</aside>
+				</div>
+			{:else if curatorMetadata}
+				<CuratorDescription curator={curatorMetadata} />
+			{/if}
+
 			{#if stablecoinMetadata}
 				<StablecoinDetailHeader metadata={stablecoinMetadata} vaults={topVaults?.vaults ?? []} {detailAside} />
 			{/if}
 
-			{#if !renderDetailAsideInHero && !protocolMetadata && !stablecoinMetadata && detailAside}
+			{#if !renderDetailAsideInHero && !protocolMetadata && !stablecoinMetadata && !curatorMetadata && detailAside}
 				<div class="detail-overview detail-overview-single">
 					<aside class="detail-aside">
 						{@render detailAside()}
 					</aside>
 				</div>
+			{/if}
+
+			{#if curatorMetadata && curatorMetadata.recent_posts.length > 0}
+				<CuratorRecentPosts curator={curatorMetadata} />
 			{/if}
 
 			{@render beforeTable?.()}
@@ -189,6 +220,21 @@
 		.top-vaults-header {
 			display: grid;
 			gap: 1rem;
+		}
+
+		.header-top {
+			display: flex;
+			align-items: flex-start;
+			justify-content: space-between;
+			gap: 1rem;
+
+			:global(.vault-listings-selector) {
+				flex: 1;
+			}
+
+			.update-info {
+				flex: none;
+			}
 		}
 
 		.hero-layout {

--- a/src/lib/top-vaults/TopVaultsTable.svelte
+++ b/src/lib/top-vaults/TopVaultsTable.svelte
@@ -105,9 +105,16 @@
 		defaultDirection?: 'asc' | 'desc';
 		/** Show skeleton loading state while vault data is being fetched */
 		loading?: boolean;
+		/** Override for the "out of {total}" listing meta; defaults to the vaults passed in (use to show the whole-database count on pre-filtered listings) */
+		totalVaultCount?: number;
 	}
 
-	const emptyTopVaults: TopVaults = { generated_at: new Date().toISOString(), vaults: [], core3_protocols: {}, curators: {} };
+	const emptyTopVaults: TopVaults = {
+		generated_at: new Date().toISOString(),
+		vaults: [],
+		core3_protocols: {},
+		curators: {}
+	};
 	const SKELETON_ROW_COUNT = 10;
 
 	let {
@@ -125,7 +132,8 @@
 		defaultMonthlyReturnKey = 'any',
 		defaultSort,
 		defaultDirection,
-		loading = false
+		loading = false,
+		totalVaultCount: totalVaultCountProp
 	}: Props = $props();
 
 	// --- Sort column registry (key → compareFn + default direction) ---
@@ -340,8 +348,9 @@
 	// Count of hidden vaults
 	let hiddenByTvl = $derived(hiddenVaults.length);
 
-	// Total number of vaults available to this listing, before any filtering
-	let totalVaultCount = $derived(topVaults.vaults.length);
+	// Total vault count for the listing meta — the whole-database count when
+	// provided by the page, otherwise the vaults available to this listing
+	let totalVaultCount = $derived(totalVaultCountProp ?? topVaults.vaults.length);
 
 	// Filter vaults matching all active filters (TVL, age, risk, search)
 	let filteredVaults = $derived.by(() => {

--- a/src/lib/top-vaults/TopVaultsTable.svelte
+++ b/src/lib/top-vaults/TopVaultsTable.svelte
@@ -340,6 +340,9 @@
 	// Count of hidden vaults
 	let hiddenByTvl = $derived(hiddenVaults.length);
 
+	// Total number of vaults available to this listing, before any filtering
+	let totalVaultCount = $derived(topVaults.vaults.length);
+
 	// Filter vaults matching all active filters (TVL, age, risk, search)
 	let filteredVaults = $derived.by(() => {
 		const filterCompareStr = filterValue.trim().toLowerCase();
@@ -576,7 +579,9 @@
 	<div class="table-extras">
 		<div class="table-stats" class:hidden={loading} data-testid="top-vaults-meta">
 			<Tooltip>
-				<svelte:fragment slot="trigger">{filteredVaults.length} vaults</svelte:fragment>
+				<svelte:fragment slot="trigger"
+					>{filteredVaults.length} vaults{#if totalVaultCount > filteredVaults.length}{' '}out of {totalVaultCount}{/if}</svelte:fragment
+				>
 				<svelte:fragment slot="popup"
 					>{#if hiddenByTvl > 0}
 						{hiddenByTvl} vault{hiddenByTvl === 1 ? ' is' : 's are'} hidden because {hiddenByTvl === 1

--- a/src/lib/top-vaults/TopVaultsTable.svelte
+++ b/src/lib/top-vaults/TopVaultsTable.svelte
@@ -107,7 +107,7 @@
 		loading?: boolean;
 	}
 
-	const emptyTopVaults: TopVaults = { generated_at: new Date().toISOString(), vaults: [], core3_protocols: {} };
+	const emptyTopVaults: TopVaults = { generated_at: new Date().toISOString(), vaults: [], core3_protocols: {}, curators: {} };
 	const SKELETON_ROW_COUNT = 10;
 
 	let {

--- a/src/lib/top-vaults/UpdateInfoButton.svelte
+++ b/src/lib/top-vaults/UpdateInfoButton.svelte
@@ -1,0 +1,32 @@
+<!--
+@component
+"Update info" button shown on vault protocol, curator and vault detail pages.
+
+Links to the Community page; the tooltip explains that details are updated by
+contacting the Trading Strategy Discord server.
+
+@example
+
+```svelte
+	<UpdateInfoButton />
+	<UpdateInfoButton size="md" />
+```
+-->
+<script lang="ts">
+	import { resolve } from '$app/paths';
+	import Tooltip from '$lib/components/Tooltip.svelte';
+	import Button from '$lib/components/Button.svelte';
+
+	interface Props {
+		size?: 'xs' | 'sm' | 'md' | 'lg' | 'xl' | 'xxl';
+	}
+
+	let { size = 'sm' }: Props = $props();
+</script>
+
+<Tooltip>
+	<Button slot="trigger" {size} secondary href={resolve('/community')}>Update info</Button>
+	<svelte:fragment slot="popup">
+		Contact us at Trading Strategy Discord server to update any details. Click here for Discord info.
+	</svelte:fragment>
+</Tooltip>

--- a/src/lib/top-vaults/VaultGroupTable.svelte
+++ b/src/lib/top-vaults/VaultGroupTable.svelte
@@ -30,6 +30,8 @@
 		includeRisk?: boolean;
 		includeCore3Risk?: boolean;
 		includeFullName?: boolean;
+		/** Widen the name column for groups with long display names (e.g. curators) */
+		wideName?: boolean;
 		getLogoHref?: (slug: string) => string | undefined;
 		page?: number;
 		sort?: SortOptions['keys'][number];
@@ -43,6 +45,7 @@
 		includeRisk = false,
 		includeCore3Risk = false,
 		includeFullName = false,
+		wideName = false,
 		getLogoHref,
 		page: pageIndex = 0,
 		sort = sortOptions.keys[0],
@@ -151,7 +154,7 @@
 	const tableViewModel = table.createViewModel(columns);
 </script>
 
-<div class="vault-protocol-table">
+<div class="vault-protocol-table" class:wide-name={wideName}>
 	<DataTable isResponsive hasPagination targetableRows {loading} {tableViewModel} {...restProps} />
 </div>
 
@@ -204,6 +207,16 @@
 
 				:global(.cta) {
 					width: 12rem;
+				}
+			}
+
+			&.wide-name {
+				:global(:is(th, td):not(.name, .cta)) {
+					width: 16%;
+				}
+
+				:global(.name) {
+					width: 36%;
 				}
 			}
 		}

--- a/src/lib/top-vaults/VaultListingsSelector.svelte
+++ b/src/lib/top-vaults/VaultListingsSelector.svelte
@@ -10,6 +10,7 @@
 		{ href: '/trading-view/vaults/stablecoins', label: 'By stablecoin' },
 		{ href: '/trading-view/vaults/chains', label: 'By chain' },
 		{ href: '/trading-view/vaults/protocols', label: 'By protocol' },
+		{ href: '/trading-view/vaults/curators', label: 'By curator' },
 		{ href: '/trading-view/vaults/negative', label: 'Negative' },
 		{ href: '/trading-view/vaults/all', label: 'All' }
 	] as const;

--- a/src/lib/top-vaults/VaultListingsSelector.svelte
+++ b/src/lib/top-vaults/VaultListingsSelector.svelte
@@ -5,12 +5,15 @@
 
 	const links = [
 		{ href: '/trading-view/vaults', label: 'Top' },
-		{ href: '/trading-view/vaults/high-tvl', label: 'Top with $2M TVL' },
-		{ href: '/trading-view/vaults/new-vaults', label: 'New' },
 		{ href: '/trading-view/vaults/stablecoins', label: 'By stablecoin' },
 		{ href: '/trading-view/vaults/chains', label: 'By chain' },
 		{ href: '/trading-view/vaults/protocols', label: 'By protocol' },
-		{ href: '/trading-view/vaults/curators', label: 'By curator' },
+		{ href: '/trading-view/vaults/curators', label: 'By curator' }
+	] as const;
+
+	const otherListLinks = [
+		{ href: '/trading-view/vaults/high-tvl', label: 'Top with $2M TVL' },
+		{ href: '/trading-view/vaults/new-vaults', label: 'New' },
 		{ href: '/trading-view/vaults/negative', label: 'Negative' },
 		{ href: '/trading-view/vaults/all', label: 'All' }
 	] as const;
@@ -31,7 +34,7 @@
 		return page.url.pathname === href;
 	}
 
-	function resolveChartHref(href: string): string {
+	function resolveDropdownHref(href: string): string {
 		return (resolve as (path: string) => string)(href);
 	}
 </script>
@@ -43,7 +46,14 @@
 			{label}
 		</a>
 	{/each}
-	<DropdownMenu label="Charts" items={chartLinks} {isActive} resolveHref={resolveChartHref} class="charts-dropdown" />
+	<DropdownMenu
+		label="More rankings"
+		items={otherListLinks}
+		{isActive}
+		resolveHref={resolveDropdownHref}
+		class="nav-dropdown"
+	/>
+	<DropdownMenu label="Charts" items={chartLinks} {isActive} resolveHref={resolveDropdownHref} class="nav-dropdown" />
 </nav>
 
 <style>
@@ -84,13 +94,13 @@
 		}
 	}
 
-	:global(.charts-dropdown)::before {
+	:global(.nav-dropdown)::before {
 		content: '|';
 		color: var(--c-text-ultra-light);
 		padding-right: 0.5rem;
 	}
 
-	:global(.charts-dropdown) {
+	:global(.nav-dropdown) {
 		--dropdown-menu-open-z-index: 200;
 		--dropdown-menu-panel-z-index: 2400;
 	}

--- a/src/lib/top-vaults/schemas.test.ts
+++ b/src/lib/top-vaults/schemas.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest';
+import { curatorInfoSchema, topVaultsSchema } from './schemas';
+
+const validCurator = {
+	slug: 'steakhouse-financial',
+	name: 'Steakhouse Financial',
+	website: 'https://example.com/steakhouse',
+	twitter: null,
+	linkedin: null,
+	rss: null,
+	protocol_curator: false,
+	canonical_feeder_id: null,
+	logos: { generic: null, dark: null, light: null },
+	recent_posts: [
+		{
+			title: 'Latest market update',
+			snippet: 'A summary of recent curation activity.',
+			link: 'https://example.com/steakhouse/post-1',
+			source_type: 'rss',
+			published_at: '2026-01-05T00:00:00'
+		}
+	]
+};
+
+const basePayload = {
+	generated_at: '2026-06-10T00:00:00Z',
+	vaults: []
+};
+
+describe('topVaultsSchema resilience', () => {
+	it('parses curator metadata', () => {
+		const result = topVaultsSchema.parse({ ...basePayload, curators: { [validCurator.slug]: validCurator } });
+		expect(result.curators['steakhouse-financial'].name).toBe('Steakhouse Financial');
+		expect(result.curators['steakhouse-financial'].recent_posts).toHaveLength(1);
+	});
+
+	it('defaults curators to an empty record when absent', () => {
+		expect(topVaultsSchema.parse(basePayload).curators).toEqual({});
+	});
+
+	it('falls back to an empty curators record on a malformed payload instead of failing the parse', () => {
+		const malformed = { ...basePayload, curators: { broken: { slug: 'broken' } } };
+		const result = topVaultsSchema.parse(malformed);
+		expect(result.curators).toEqual({});
+		expect(result.vaults).toEqual([]);
+	});
+
+	it('drops malformed recent posts without failing the curator', () => {
+		const curator = {
+			...validCurator,
+			recent_posts: [{ link: 42 }]
+		};
+		const result = curatorInfoSchema.parse(curator);
+		expect(result.recent_posts).toEqual([]);
+		expect(result.name).toBe('Steakhouse Financial');
+	});
+});

--- a/src/lib/top-vaults/schemas.ts
+++ b/src/lib/top-vaults/schemas.ts
@@ -132,8 +132,11 @@ export const curatorInfoSchema = z.object({
 	long_description: z.string().nullable().optional(),
 	/** Logo URLs by theme variant */
 	logos: curatorLogosSchema,
-	/** Recent posts from the curator's feeds (may be empty) */
-	recent_posts: curatorRecentPostSchema.array().default([])
+	/**
+	 * Recent posts from the curator's feeds (may be empty). Sourced from external
+	 * feeds — `.catch([])` drops malformed posts rather than failing the curator.
+	 */
+	recent_posts: curatorRecentPostSchema.array().catch([]).default([])
 });
 export type CuratorInfo = z.infer<typeof curatorInfoSchema>;
 
@@ -151,12 +154,13 @@ export const vaultInfoSchema = z.object({
 	protocol_slug: z.string(),
 
 	// --- Curator ---
+	// (defaults keep transitional payloads without curator keys parseable)
 	/** URL-safe slug of the curator managing this vault; null if uncurated */
-	curator_slug: z.string().nullable(),
+	curator_slug: z.string().nullable().default(null),
 	/** Display name of the curator managing this vault; null if uncurated */
-	curator_name: z.string().nullable(),
+	curator_name: z.string().nullable().default(null),
 	/** Whether the curator is the protocol itself (self-curated); null if uncurated */
-	protocol_curator: z.boolean().nullable(),
+	protocol_curator: z.boolean().nullable().default(null),
 
 	// --- Lifetime performance metrics ---
 	/** Lifetime gross absolute return as a decimal (e.g. 0.15 = 15%) */
@@ -462,8 +466,12 @@ export const topVaultsSchema = z.object({
 	 * break parsing of the (critical) vaults array.
 	 */
 	core3_protocols: z.record(z.string(), core3ProtocolSchema).catch({}).default({}),
-	/** Curator metadata keyed by curator slug; referenced by vault.curator_slug */
-	curators: z.record(z.string(), curatorInfoSchema).default({})
+	/**
+	 * Curator metadata keyed by curator slug; referenced by vault.curator_slug.
+	 * Partly built from external feeds — `.catch({})` guarantees a malformed
+	 * payload here can never break parsing of the (critical) vaults array.
+	 */
+	curators: z.record(z.string(), curatorInfoSchema).catch({}).default({})
 });
 export type TopVaults = z.infer<typeof topVaultsSchema>;
 

--- a/src/lib/top-vaults/schemas.ts
+++ b/src/lib/top-vaults/schemas.ts
@@ -84,8 +84,10 @@ export type PeriodMetrics = z.infer<typeof periodMetricsSchema>;
 export const curatorRecentPostSchema = z.object({
 	/** Post title; may be null for sources that don't provide one (e.g. tweets) */
 	title: z.string().nullable(),
-	/** Short text excerpt of the post */
+	/** Short text excerpt of the post (capped at 200 characters upstream) */
 	snippet: z.string(),
+	/** Full post content, untruncated; may be absent for some sources */
+	full_text: z.string().nullable().optional(),
 	/** Canonical link to the post */
 	link: z.string(),
 	/** Where the post came from (e.g. "linkedin", "twitter", "rss") */
@@ -124,6 +126,10 @@ export const curatorInfoSchema = z.object({
 	protocol_curator: z.boolean(),
 	/** Canonical feeder/protocol id this curator maps to, null if none */
 	canonical_feeder_id: z.string().nullable(),
+	/** Short plain-text description shown at the top of the about box */
+	short_description: z.string().nullable().optional(),
+	/** Long description (markdown) revealed by the "View more" control */
+	long_description: z.string().nullable().optional(),
 	/** Logo URLs by theme variant */
 	logos: curatorLogosSchema,
 	/** Recent posts from the curator's feeds (may be empty) */

--- a/src/lib/top-vaults/schemas.ts
+++ b/src/lib/top-vaults/schemas.ts
@@ -80,6 +80,57 @@ export const periodMetricsSchema = z.object({
 });
 export type PeriodMetrics = z.infer<typeof periodMetricsSchema>;
 
+/** A post/update surfaced from a curator's social or RSS feed. */
+export const curatorRecentPostSchema = z.object({
+	/** Post title; may be null for sources that don't provide one (e.g. tweets) */
+	title: z.string().nullable(),
+	/** Short text excerpt of the post */
+	snippet: z.string(),
+	/** Canonical link to the post */
+	link: z.string(),
+	/** Where the post came from (e.g. "linkedin", "twitter", "rss") */
+	source_type: z.string(),
+	/** ISO datetime the post was published (format may vary by source) */
+	published_at: z.string()
+});
+export type CuratorRecentPost = z.infer<typeof curatorRecentPostSchema>;
+
+/** Curator logo URLs (absolute), one per theme variant; any may be null. */
+export const curatorLogosSchema = z.object({
+	generic: z.string().nullable(),
+	dark: z.string().nullable(),
+	light: z.string().nullable()
+});
+
+/**
+ * Metadata for a vault curator — the firm or protocol that selects and manages
+ * a vault's strategy. Keyed by slug in the top-level `curators` map of the
+ * top-vaults dataset and referenced from each vault via `curator_slug`.
+ */
+export const curatorInfoSchema = z.object({
+	/** URL-safe identifier (e.g. "steakhouse-financial") */
+	slug: z.string(),
+	/** Display name (e.g. "Steakhouse Financial") */
+	name: z.string(),
+	/** Homepage URL, null if unknown */
+	website: z.string().nullable(),
+	/** Twitter/X profile URL, null if unknown */
+	twitter: z.string().nullable(),
+	/** LinkedIn profile URL, null if unknown */
+	linkedin: z.string().nullable(),
+	/** RSS feed URL, null if unknown */
+	rss: z.string().nullable(),
+	/** Whether the curator is the protocol itself (self-curated) */
+	protocol_curator: z.boolean(),
+	/** Canonical feeder/protocol id this curator maps to, null if none */
+	canonical_feeder_id: z.string().nullable(),
+	/** Logo URLs by theme variant */
+	logos: curatorLogosSchema,
+	/** Recent posts from the curator's feeds (may be empty) */
+	recent_posts: curatorRecentPostSchema.array().default([])
+});
+export type CuratorInfo = z.infer<typeof curatorInfoSchema>;
+
 /**
  * Full vault information returned by the backend top-vaults API.
  * Contains identity, on-chain metadata, performance metrics, fees, and period results.
@@ -92,6 +143,14 @@ export const vaultInfoSchema = z.object({
 	vault_slug: z.string(),
 	/** URL-safe slug for the protocol (e.g. "aave-v3") */
 	protocol_slug: z.string(),
+
+	// --- Curator ---
+	/** URL-safe slug of the curator managing this vault; null if uncurated */
+	curator_slug: z.string().nullable(),
+	/** Display name of the curator managing this vault; null if uncurated */
+	curator_name: z.string().nullable(),
+	/** Whether the curator is the protocol itself (self-curated); null if uncurated */
+	protocol_curator: z.boolean().nullable(),
 
 	// --- Lifetime performance metrics ---
 	/** Lifetime gross absolute return as a decimal (e.g. 0.15 = 15%) */
@@ -396,7 +455,9 @@ export const topVaultsSchema = z.object({
 	 * data — `.catch({})` guarantees a malformed/changed payload here can never
 	 * break parsing of the (critical) vaults array.
 	 */
-	core3_protocols: z.record(z.string(), core3ProtocolSchema).catch({}).default({})
+	core3_protocols: z.record(z.string(), core3ProtocolSchema).catch({}).default({}),
+	/** Curator metadata keyed by curator slug; referenced by vault.curator_slug */
+	curators: z.record(z.string(), curatorInfoSchema).default({})
 });
 export type TopVaults = z.infer<typeof topVaultsSchema>;
 

--- a/src/routes/trading-view/vaults/VaultGroupMiniChart.svelte
+++ b/src/routes/trading-view/vaults/VaultGroupMiniChart.svelte
@@ -347,6 +347,8 @@ average TVL-weighted return as a line series.
 <style>
 	.protocol-mini-chart {
 		display: grid;
+		/* chart surface absorbs any extra height when stretched to match sibling content */
+		grid-template-rows: auto 1fr auto;
 		gap: 0.5rem;
 		min-height: 17rem;
 		padding: 0.875rem;

--- a/src/routes/trading-view/vaults/[vault=slug]/VaultPageHeader.svelte
+++ b/src/routes/trading-view/vaults/[vault=slug]/VaultPageHeader.svelte
@@ -2,6 +2,7 @@
 	import type { VaultInfo } from '$lib/top-vaults/schemas';
 	import Button from '$lib/components/Button.svelte';
 	import PageHeader from '$lib/components/PageHeader.svelte';
+	import UpdateInfoButton from '$lib/top-vaults/UpdateInfoButton.svelte';
 	import { hasSupportedProtocol } from '$lib/top-vaults/helpers';
 
 	interface Props {
@@ -24,13 +25,16 @@
 	{/snippet}
 
 	{#snippet cta()}
-		{#if vault.link}
-			<span class="external-link">
-				<Button href={vault.link} target="_blank" rel="noreferrer">
-					View on {externalSiteName}
-				</Button>
-			</span>
-		{/if}
+		<span class="cta-actions">
+			{#if vault.link}
+				<span class="external-link">
+					<Button href={vault.link} target="_blank" rel="noreferrer">
+						View on {externalSiteName}
+					</Button>
+				</span>
+			{/if}
+			<UpdateInfoButton size="md" />
+		</span>
 	{/snippet}
 </PageHeader>
 
@@ -39,6 +43,13 @@
 {/if}
 
 <style>
+	.cta-actions {
+		display: inline-flex;
+		flex-wrap: wrap;
+		align-items: center;
+		gap: 0.75rem;
+	}
+
 	.external-link {
 		@media (--viewport-sm-down) {
 			display: none;
@@ -49,6 +60,10 @@
 		margin: 0;
 		font: var(--f-ui-lg-roman);
 		color: var(--c-text-light);
+
+		@media (--viewport-md-up) {
+			margin-top: 1rem;
+		}
 	}
 
 	.page-title {

--- a/src/routes/trading-view/vaults/curators/+page.server.ts
+++ b/src/routes/trading-view/vaults/curators/+page.server.ts
@@ -1,0 +1,66 @@
+import type { VaultGroup } from '$lib/top-vaults/schemas.js';
+import { getCachedTopVaults } from '$lib/top-vaults/cache';
+import { calculateTvlWeightedApy, isBlacklisted, meetsMinTvl } from '$lib/top-vaults/helpers.js';
+import { sortOptions } from '$lib/top-vaults/VaultGroupTable.svelte';
+import { getNumberParam, getStringParam } from '$lib/helpers/url-params';
+import type { MarketShareChartItem } from '../market-share-pie';
+
+export async function load({ fetch, url: { searchParams } }) {
+	const { vaults, curators } = await getCachedTopVaults(fetch);
+
+	const eligibleVaults = vaults.filter((v) => !isBlacklisted(v) && meetsMinTvl(v));
+
+	const groups = eligibleVaults.reduce<Record<string, VaultGroup>>((acc, vault) => {
+		const slug = vault.curator_slug;
+		if (!slug) return acc;
+
+		acc[slug] ??= {
+			slug,
+			name: curators[slug]?.name ?? vault.curator_name ?? slug,
+			vault_count: 0,
+			tvl: 0,
+			avg_apy: null
+		};
+		acc[slug].vault_count++;
+		acc[slug].tvl += vault.current_nav ?? 0;
+
+		return acc;
+	}, {});
+
+	// Calculate TVL-weighted average APY for each curator group
+	const curatorGroups: VaultGroup[] = Object.values(groups).map((group) => ({
+		...group,
+		avg_apy: calculateTvlWeightedApy(eligibleVaults.filter((v) => v.curator_slug === group.slug))
+	}));
+
+	// Curator logos are absolute URLs embedded in the dataset; pass a slug → URL
+	// map to the client so the table and chart can render them.
+	const curatorLogos: Record<string, string> = {};
+	for (const group of curatorGroups) {
+		const logoUrl = curators[group.slug]?.logos.generic;
+		if (logoUrl) curatorLogos[group.slug] = logoUrl;
+	}
+
+	const chartCurators: MarketShareChartItem[] = curatorGroups.map((group) => ({
+		slug: group.slug,
+		label: group.name,
+		name: group.name,
+		tvl: group.tvl,
+		avgApy: group.avg_apy ?? null,
+		logoUrl: curatorLogos[group.slug],
+		href: `/trading-view/vaults/curators/${group.slug}`
+	}));
+
+	const options = {
+		page: getNumberParam(searchParams, 'page', 0),
+		sort: getStringParam(searchParams, 'sort', sortOptions.keys),
+		direction: getStringParam(searchParams, 'direction', sortOptions.directions)
+	};
+
+	return {
+		curators: curatorGroups,
+		curatorLogos,
+		chartCurators,
+		options
+	};
+}

--- a/src/routes/trading-view/vaults/curators/+page.svelte
+++ b/src/routes/trading-view/vaults/curators/+page.svelte
@@ -1,0 +1,155 @@
+<!--
+Vault curators index — lists every curator managing at least one vault, with
+aggregate TVL, vault count and average APY, plus a market-share pie chart.
+-->
+<script lang="ts">
+	import type { ComponentProps } from 'svelte';
+	import { goto } from '$app/navigation';
+	import { resolve } from '$app/paths';
+	import { page } from '$app/state';
+	import HeroBanner from '$lib/components/HeroBanner.svelte';
+	import Section from '$lib/components/Section.svelte';
+	import VaultGroupTable from '$lib/top-vaults/VaultGroupTable.svelte';
+	import VaultListingsSelector from '$lib/top-vaults/VaultListingsSelector.svelte';
+	import { MetaTags, JsonLd } from 'svelte-meta-tags';
+	import MarketSharePieChart from '../MarketSharePieChart.svelte';
+	import MarketShareWidgetBox from '../MarketShareWidgetBox.svelte';
+
+	let { data } = $props();
+	let { curators, curatorLogos, chartCurators, options } = $derived(data);
+
+	const onChange: ComponentProps<typeof VaultGroupTable>['onChange'] = async (params, scrollToTop) => {
+		// eslint-disable-next-line svelte/no-navigation-without-resolve
+		await goto('?' + new URLSearchParams(params), { noScroll: true });
+		scrollToTop();
+	};
+
+	function getHref(slug: string) {
+		return resolve(`/trading-view/vaults/curators/${slug}`);
+	}
+
+	const title = 'DeFi stablecoin vaults by curator';
+	const description =
+		'DeFi stablecoin vaults grouped by curator. Curators select and manage vault strategies. TVL represents stablecoin deposits across a curator’s vaults. APY represents the yield of last thirty days.';
+	const glossaryLinks = {
+		defi: resolve('/glossary/defi'),
+		vault: resolve('/glossary/vault'),
+		stablecoin: resolve('/glossary/stablecoin'),
+		tvl: resolve('/glossary/total-value-locked-tvl'),
+		apy: resolve('/glossary/apy')
+	};
+	let pageUrl = $derived(new URL(page.url.pathname, page.url.origin).href);
+</script>
+
+<MetaTags
+	{title}
+	{description}
+	canonical={pageUrl}
+	openGraph={{ siteName: 'Trading Strategy', url: pageUrl, title, description, type: 'website' }}
+	twitter={{ site: '@TradingProtocol', cardType: 'summary', title, description }}
+/>
+
+<JsonLd
+	schema={{
+		'@context': 'http://schema.org',
+		'@type': 'CollectionPage',
+		name: title,
+		description,
+		url: pageUrl,
+		provider: { '@type': 'Organization', name: 'Trading Strategy' },
+		mainEntity: {
+			'@type': 'ItemList',
+			numberOfItems: curators.length
+		}
+	}}
+/>
+
+<main class="curator-index-page">
+	<Section tag="header">
+		<div class="header-stack">
+			<VaultListingsSelector />
+
+			<div class="curator-index-header">
+				<div class="intro-column">
+					<HeroBanner>
+						{#snippet title()}
+							<span>DeFi vaults by curator</span>
+						{/snippet}
+						{#snippet subtitle()}
+							<a class="body-link" href={glossaryLinks.defi}>DeFi</a>
+							<a class="body-link" href={glossaryLinks.stablecoin}>stablecoin</a>
+							<a class="body-link" href={glossaryLinks.vault}>vaults</a>
+							grouped by curator. Curators select and manage vault strategies.
+							<a class="body-link" href={glossaryLinks.tvl}>TVL</a> represents stablecoin deposits across a curator’s
+							vaults.
+							<a class="body-link" href={glossaryLinks.apy}>APY</a>
+							represents the yield of last thirty days.
+						{/snippet}
+					</HeroBanner>
+				</div>
+
+				<div class="chart-column">
+					<MarketShareWidgetBox title="Market share by TVL">
+						<MarketSharePieChart
+							items={chartCurators}
+							groupLabel="Curator"
+							groupLabelPlural="curators"
+							testId="curator-tvl-pie-chart"
+						/>
+					</MarketShareWidgetBox>
+				</div>
+			</div>
+		</div>
+	</Section>
+
+	<Section padding="sm">
+		<VaultGroupTable
+			groupLabel="Curator"
+			wideName
+			rows={curators}
+			getLogoHref={(slug) => curatorLogos[slug]}
+			{...options}
+			{onChange}
+			{getHref}
+		/>
+	</Section>
+</main>
+
+<style>
+	.curator-index-page {
+		.header-stack {
+			display: grid;
+			gap: 1rem;
+		}
+
+		.curator-index-header {
+			display: grid;
+			grid-template-columns: minmax(0, 1fr) minmax(25rem, 40rem);
+			gap: 1.5rem;
+			align-items: stretch;
+		}
+
+		.intro-column {
+			display: grid;
+			align-content: start;
+		}
+
+		.chart-column {
+			display: grid;
+		}
+
+		.chart-column :global(.metrics-box) {
+			height: 100%;
+		}
+
+		.chart-column :global(.market-share-pie-chart) {
+			align-self: stretch;
+		}
+
+		@media (--viewport-sm-down) {
+			.curator-index-header {
+				grid-template-columns: 1fr;
+			}
+		}
+	}
+</style>

--- a/src/routes/trading-view/vaults/curators/[curator=slug]/+page.server.ts
+++ b/src/routes/trading-view/vaults/curators/[curator=slug]/+page.server.ts
@@ -1,0 +1,16 @@
+import { error } from '@sveltejs/kit';
+import { getCachedTopVaults } from '$lib/top-vaults/cache';
+
+export async function load({ params, fetch }) {
+	const { curator } = params;
+	const { curators } = await getCachedTopVaults(fetch);
+
+	const curatorInfo = curators[curator];
+	if (!curatorInfo) error(404, 'Curator not found');
+
+	return {
+		curatorSlug: curator,
+		curatorName: curatorInfo.name,
+		curator: curatorInfo
+	};
+}

--- a/src/routes/trading-view/vaults/curators/[curator=slug]/+page.svelte
+++ b/src/routes/trading-view/vaults/curators/[curator=slug]/+page.svelte
@@ -14,11 +14,13 @@ with an "about" panel and a TVL/return mini chart.
 	let { curatorSlug, curatorName, curator } = $derived(data);
 
 	let topVaults = $state<TopVaults>();
+	let totalVaultCount = $state<number>();
 	let loading = $state(!hasVaultCache());
 
 	$effect(() => {
 		fetchAllVaultData()
 			.then((allData) => {
+				totalVaultCount = allData.vaults.length;
 				topVaults = {
 					...allData,
 					vaults: allData.vaults.filter((v) => v.curator_slug === curatorSlug)
@@ -73,17 +75,17 @@ with an "about" panel and a TVL/return mini chart.
 
 <TopVaultsPage
 	{topVaults}
+	{totalVaultCount}
 	{loading}
 	curatorMetadata={curator}
 	title="Top {curatorName} vaults"
-	subtitle="Stablecoin vaults curated by {curatorName}"
 	showFilters
 	defaultTvlKey="10k"
 	defaultSort="tvl"
 >
 	{#snippet detailAside()}
 		<VaultGroupMiniChart
-			title="All {curatorName} vaults"
+			title="{curatorName}: returns and TVL"
 			dataUrl="/trading-view/vaults/curators/{curatorSlug}/chart-data"
 			compareLabel="Compare all curators"
 			compareHref="/trading-view/vaults/curators"

--- a/src/routes/trading-view/vaults/curators/[curator=slug]/+page.svelte
+++ b/src/routes/trading-view/vaults/curators/[curator=slug]/+page.svelte
@@ -1,0 +1,92 @@
+<!--
+Vault listing for a single curator — all vaults managed by the curator,
+with an "about" panel and a TVL/return mini chart.
+-->
+<script lang="ts">
+	import type { TopVaults } from '$lib/top-vaults/schemas';
+	import { fetchAllVaultData, hasVaultCache } from '$lib/top-vaults/client-cache';
+	import { page } from '$app/state';
+	import TopVaultsPage from '$lib/top-vaults/TopVaultsPage.svelte';
+	import { MetaTags, JsonLd } from 'svelte-meta-tags';
+	import VaultGroupMiniChart from '../../VaultGroupMiniChart.svelte';
+
+	let { data } = $props();
+	let { curatorSlug, curatorName, curator } = $derived(data);
+
+	let topVaults = $state<TopVaults>();
+	let loading = $state(!hasVaultCache());
+
+	$effect(() => {
+		fetchAllVaultData()
+			.then((allData) => {
+				topVaults = {
+					...allData,
+					vaults: allData.vaults.filter((v) => v.curator_slug === curatorSlug)
+				};
+			})
+			.catch((e) => console.error('Failed to load vault data:', e))
+			.finally(() => (loading = false));
+	});
+
+	let title = $derived(`Top ${curatorName} vaults`);
+	let description = $derived(`Stablecoin vaults curated by ${curatorName}, ranked by performance.`);
+	let pageUrl = $derived(new URL(page.url.pathname, page.url.origin).href);
+	let logoUrl = $derived(curator.logos.generic ? new URL(curator.logos.generic, page.url.origin).href : undefined);
+</script>
+
+<MetaTags
+	{title}
+	{description}
+	canonical={pageUrl}
+	openGraph={{
+		siteName: 'Trading Strategy',
+		url: pageUrl,
+		title,
+		description,
+		images: logoUrl ? [{ url: logoUrl }] : [],
+		type: 'website'
+	}}
+	twitter={{
+		site: '@TradingProtocol',
+		cardType: logoUrl ? 'summary_large_image' : 'summary',
+		title,
+		description,
+		image: logoUrl ?? undefined
+	}}
+/>
+
+<JsonLd
+	schema={{
+		'@context': 'http://schema.org',
+		'@type': 'CollectionPage',
+		name: title,
+		description,
+		url: pageUrl,
+		provider: { '@type': 'Organization', name: 'Trading Strategy' },
+		image: logoUrl ?? undefined,
+		mainEntity: {
+			'@type': 'ItemList',
+			numberOfItems: topVaults?.vaults.length ?? 0
+		}
+	}}
+/>
+
+<TopVaultsPage
+	{topVaults}
+	{loading}
+	curatorMetadata={curator}
+	title="Top {curatorName} vaults"
+	subtitle="Stablecoin vaults curated by {curatorName}"
+	showFilters
+	defaultTvlKey="10k"
+	defaultSort="tvl"
+>
+	{#snippet detailAside()}
+		<VaultGroupMiniChart
+			title="All {curatorName} vaults"
+			dataUrl="/trading-view/vaults/curators/{curatorSlug}/chart-data"
+			compareLabel="Compare all curators"
+			compareHref="/trading-view/vaults/curators"
+		/>
+	{/snippet}
+</TopVaultsPage>

--- a/src/routes/trading-view/vaults/curators/[curator=slug]/+page.svelte
+++ b/src/routes/trading-view/vaults/curators/[curator=slug]/+page.svelte
@@ -30,7 +30,7 @@ with an "about" panel and a TVL/return mini chart.
 			.finally(() => (loading = false));
 	});
 
-	let title = $derived(`Top ${curatorName} vaults`);
+	let title = $derived(`Top ${curatorName} stablecoin vaults`);
 	let description = $derived(`Stablecoin vaults curated by ${curatorName}, ranked by performance.`);
 	let pageUrl = $derived(new URL(page.url.pathname, page.url.origin).href);
 	let logoUrl = $derived(curator.logos.generic ? new URL(curator.logos.generic, page.url.origin).href : undefined);
@@ -78,7 +78,7 @@ with an "about" panel and a TVL/return mini chart.
 	{totalVaultCount}
 	{loading}
 	curatorMetadata={curator}
-	title="Top {curatorName} vaults"
+	title="Top {curatorName} stablecoin vaults"
 	showFilters
 	defaultTvlKey="10k"
 	defaultSort="tvl"

--- a/src/routes/trading-view/vaults/curators/[curator=slug]/chart-data/+server.ts
+++ b/src/routes/trading-view/vaults/curators/[curator=slug]/chart-data/+server.ts
@@ -1,0 +1,49 @@
+import { error, json } from '@sveltejs/kit';
+import { buildProtocolMiniChartPayload, type ProtocolMiniChartPayload } from '$lib/echarts/protocol-mini-chart';
+import {
+	getMockVaultGroupMiniChartRows,
+	isEligibleVaultGroupMiniChartVault,
+	getVaultGroupMiniChartRows,
+	VAULT_GROUP_MINI_CHART_CACHE_TTL_SECONDS
+} from '$lib/echarts/vault-group-mini-chart-server';
+import { getCachedTopVaults } from '$lib/top-vaults/cache';
+
+const CACHE_VERSION = 'curator-mini-chart-v1';
+const cache = new Map<string, { payload: ProtocolMiniChartPayload; expires: number; version: string }>();
+
+async function getCachedChartData(curatorSlug: string, fetch: Fetch) {
+	const cacheKey = `${CACHE_VERSION}:${curatorSlug}`;
+	const now = Date.now();
+	const cached = cache.get(cacheKey);
+	if (cached && cached.version === CACHE_VERSION && now < cached.expires) return cached.payload;
+
+	const { vaults } = await getCachedTopVaults(fetch);
+	const curatorVaults = vaults.filter((vault) => vault.curator_slug === curatorSlug);
+	if (curatorVaults.length === 0) error(404, 'Curator not found');
+
+	const eligibleVaults = curatorVaults.filter(isEligibleVaultGroupMiniChartVault);
+	const rows =
+		import.meta.env.MODE === 'test'
+			? getMockVaultGroupMiniChartRows(eligibleVaults)
+			: await getVaultGroupMiniChartRows(eligibleVaults.map((vault) => vault.id));
+	const payload = buildProtocolMiniChartPayload(rows, eligibleVaults.length, VAULT_GROUP_MINI_CHART_CACHE_TTL_SECONDS);
+
+	cache.set(cacheKey, {
+		payload,
+		expires: now + VAULT_GROUP_MINI_CHART_CACHE_TTL_SECONDS * 1000,
+		version: CACHE_VERSION
+	});
+
+	return payload;
+}
+
+export async function GET({ params, fetch }) {
+	const payload = await getCachedChartData(params.curator, fetch);
+
+	return json(payload, {
+		headers: {
+			'cache-control': `public, max-age=${VAULT_GROUP_MINI_CHART_CACHE_TTL_SECONDS}`,
+			vary: 'Accept-Encoding'
+		}
+	});
+}

--- a/src/routes/trading-view/vaults/sitemap.xml/+server.ts
+++ b/src/routes/trading-view/vaults/sitemap.xml/+server.ts
@@ -66,6 +66,13 @@ export async function GET({ fetch, setHeaders, url }) {
 		stream.write({ url: `${basePath}/chains/${slug}`, priority });
 	}
 
+	// Curator index + individual curator pages
+	const curatorSlugs = new Set(eligibleVaults.map((v) => v.curator_slug).filter(Boolean) as string[]);
+	stream.write({ url: `${basePath}/curators`, priority });
+	for (const slug of curatorSlugs) {
+		stream.write({ url: `${basePath}/curators/${slug}`, priority });
+	}
+
 	stream.end();
 
 	setHeaders({

--- a/tests/integration/sitemap-index.test.ts
+++ b/tests/integration/sitemap-index.test.ts
@@ -83,6 +83,13 @@ test.describe('vaults sitemap', () => {
 		expect(chainPages.length).toBeGreaterThan(0);
 	});
 
+	test('should include curator index and individual curator pages', async () => {
+		expect(urls.some((url) => url.endsWith('/trading-view/vaults/curators'))).toBe(true);
+
+		const curatorPages = urls.filter((url) => /\/trading-view\/vaults\/curators\/[a-z0-9-]+$/.test(url));
+		expect(curatorPages.length).toBeGreaterThan(0);
+	});
+
 	test('should include static vault sub-pages', async () => {
 		const expectedSubPages = [
 			'/trading-view/vaults/all',

--- a/tests/integration/trading-view/vaults/group-market-share-pages.test.ts
+++ b/tests/integration/trading-view/vaults/group-market-share-pages.test.ts
@@ -14,6 +14,13 @@ const pages = [
 		heading: /DeFi vaults by chain/,
 		widgetTestId: 'chain-tvl-pie-chart',
 		headerSelector: '.chain-index-header'
+	},
+	{
+		name: 'curators index page',
+		url: '/trading-view/vaults/curators',
+		heading: /DeFi vaults by curator/,
+		widgetTestId: 'curator-tvl-pie-chart',
+		headerSelector: '.curator-index-header'
 	}
 ] as const;
 

--- a/tests/mocks/top-vaults/list.mock.ts
+++ b/tests/mocks/top-vaults/list.mock.ts
@@ -99,6 +99,9 @@ const returnLeaders = [
 	createTestVault('Return leader alpha', {
 		chain: 'ethereum',
 		protocol: 'Yearn',
+		curator_slug: 'steakhouse-financial',
+		curator_name: 'Steakhouse Financial',
+		protocol_curator: false,
 		current_nav: 800_000,
 		peak_nav: 900_000,
 		one_month_returns: 0.04,
@@ -112,6 +115,9 @@ const returnLeaders = [
 	createTestVault('Return leader beta', {
 		chain: 'arbitrum',
 		protocol: 'Morpho',
+		curator_slug: 'gauntlet',
+		curator_name: 'Gauntlet',
+		protocol_curator: false,
 		current_nav: 780_000,
 		peak_nav: 850_000,
 		one_month_returns: 0.035,
@@ -125,6 +131,9 @@ const returnLeaders = [
 	createTestVault('Return leader gamma', {
 		chain: 'base',
 		protocol: 'Compound',
+		curator_slug: 're7-labs',
+		curator_name: 'RE7 Labs',
+		protocol_curator: false,
 		current_nav: 760_000,
 		peak_nav: 830_000,
 		one_month_returns: 0.03,
@@ -437,10 +446,60 @@ const parquetMatchedVaults = [
 	})
 ];
 
+// Curator metadata for the by-curator pages; keyed by slug and referenced
+// from the curated returnLeaders vaults above.
+const curators = {
+	'steakhouse-financial': {
+		slug: 'steakhouse-financial',
+		name: 'Steakhouse Financial',
+		website: 'https://example.com/steakhouse',
+		twitter: 'https://x.com/steakhouse',
+		linkedin: null,
+		rss: null,
+		protocol_curator: false,
+		canonical_feeder_id: null,
+		logos: { generic: null, dark: null, light: null },
+		recent_posts: [
+			{
+				title: 'Latest market update',
+				snippet: 'A summary of recent curation activity.',
+				link: 'https://example.com/steakhouse/post-1',
+				source_type: 'rss',
+				published_at: '2026-01-05T00:00:00'
+			}
+		]
+	},
+	gauntlet: {
+		slug: 'gauntlet',
+		name: 'Gauntlet',
+		website: 'https://example.com/gauntlet',
+		twitter: null,
+		linkedin: 'https://example.com/gauntlet/linkedin',
+		rss: null,
+		protocol_curator: false,
+		canonical_feeder_id: null,
+		logos: { generic: null, dark: null, light: null },
+		recent_posts: []
+	},
+	're7-labs': {
+		slug: 're7-labs',
+		name: 'RE7 Labs',
+		website: null,
+		twitter: null,
+		linkedin: null,
+		rss: null,
+		protocol_curator: false,
+		canonical_feeder_id: null,
+		logos: { generic: null, dark: null, light: null },
+		recent_posts: []
+	}
+};
+
 export default defineMock({
 	url: '/api/top-vaults/vaults.json',
 	body: {
 		generated_at: new Date().toISOString(),
+		curators,
 		vaults: [
 			yamlStrategyVault,
 			morphoFlaggedBlacklistedVault,


### PR DESCRIPTION
## Why

The vault dataset (`top_vaults_by_chain.json`) now includes curator metadata (a top-level `curators` map keyed by slug, plus per-vault `curator_slug` / `curator_name` / `protocol_curator`). Curators select and manage vault strategies, so we want to browse vaults by curator the same way we already browse by protocol and by chain, and give each curator its own listing page with their descriptions, social feed and a returns/TVL chart.

## Lessons learnt

- **Curator data shape:** `curators` is a top-level **map** (`Record<slug, CuratorInfo>`), not an array, and each vault references it via flat `curator_slug` (null when uncurated; ~969/4125 vaults are curated, no orphan references). Curator logos (`logos.generic`) are absolute URLs and may be null; CSP only restricts `frame-ancestors`, so external logo URLs render directly without a proxy.
- **Guard external data at the schema:** curator metadata is partly built from external feeds, so the `curators` record uses `.catch({}).default({})` (the `core3_protocols` pattern) — a malformed payload can never fail `topVaultsSchema.parse()` and 503 every top-vaults route. `recent_posts` additionally catches to `[]` so one bad post only drops that curator's feed, and the per-vault curator fields default to null so transitional payloads parse. Covered by `schemas.test.ts`.
- **Feed snippets are capped upstream at 200 chars**, cut mid-word with no ellipsis — but the payload also carries untruncated `full_text` (Zod strips undeclared fields, so it had to be added to the schema to be usable). Tweets render `full_text` whole; other sources (RSS articles run to ~25k chars) are capped at 400 chars on a word boundary. Posts that clean to empty (link-only tweets) are filtered out, content is de-duplicated across syndicated feeds (LinkedIn/Twitter/RSS), and t.co URLs are stripped.
- **Timestamp normalisation:** feed `published_at` values are sometimes timezone-less, but appending `Z` after a naive `includes('Z') || includes('+')` check corrupted ISO timestamps with negative offsets (`-04:00`). The check must be an anchored suffix regex: `/([zZ]|[+-]\d\d:?\d\d)$/`.
- **Stable aside heights beat stretchy grids:** stretching the chart aside to match the left column means any expandable widget ("View more", "Show N more") distorts the chart. Pinning the aside to a design-constant height (28rem ≈ the typical collapsed column) keeps the chart readable through all interactions.
- **`vite preview` route quirk:** newly added routes (the `curators` pages) 404 under `pnpm run preview` even though they resolve correctly in `pnpm run dev` and in the production adapter-node manifest (verified by replaying the route match in Node). CLAUDE.md was updated to mandate `pnpm run dev` for development/verification. ⚠️ Because the integration-test harness runs against `vite preview`, the new curator entries in `group-market-share-pages.test.ts` and `sitemap-index.test.ts` may fail in CI under preview while the feature works everywhere else — flagging for reviewer decision (keep, skip, or root-cause the preview behaviour).
- The shared `Tooltip` popup is a disabled `<button>` (non-interactive), so the "Update info" tooltip can't contain a clickable link; the whole button is the link to `/community` instead.

## Summary

- **Schema** (`schemas.ts`): added `curatorInfoSchema` (+ `curatorLogosSchema`, `curatorRecentPostSchema` with `full_text`, `short_description` / `long_description`) and the top-level `curators` map, all guarded with `.catch`/defaults; added per-vault `curator_slug` / `curator_name` / `protocol_curator`; schema resilience unit tests.
- **By curator index** (`curators/+page.*`): grouped table (TVL-weighted APY, vault count, logos) + market-share pie, added "By curator" to the vault listings nav.
- **Per-curator page** (`curators/[curator=slug]/+page.*` + `chart-data`): "Top {curator} stablecoin vaults" listing filtered by curator (default-sorted by TVL, meta line shows the count out of the whole vault database), "About {curator}" box with the short description inline and the long description (markdown) + links behind "View more", a "Latest posts from {curator}" feed (full tweet text, 400-char cap for other sources, empty/link-only posts filtered, most-recent post shown with the rest foldable, relative timestamps, source icons), and a "{curator}: returns and TVL" mini-chart pinned to a stable height. Boxes stack vertically on tablet widths (≤1024px).
- **"Update info" button**: top-right on protocol and curator detail pages, and next to "View on {protocol}" on vault detail pages; links to the Community page with an explanatory Discord tooltip.
- **VaultGroupTable**: opt-in `wideName` prop so long curator names (e.g. "Janus Henderson Anemoy") don't wrap.
- **TopVaultsTable / TopVaultsPage**: optional `totalVaultCount` override for the listing meta; `VaultGroupMiniChart` chart surface stretches to fill its box.
- **Vault header**: extra top margin on the description in desktop mode.
- **Sitemap**: curator index + per-curator pages added.
- **Tests/mocks**: curator fixture data; curator entries in the market-share and sitemap integration tests; schema resilience tests.
- **CHANGELOG**: feature entry (2026-06-09).
