### PR TITLE
Show clock hours in vault chart tooltips on intraday views

### DIFF
--- a/src/lib/charts/ChartContainer.svelte
+++ b/src/lib/charts/ChartContainer.svelte
@@ -17,7 +17,7 @@
 		range: [Date, Date] | undefined;
 	}
 
-	interface Props extends ComponentProps<typeof TvChart> {
+	interface Props extends Omit<ComponentProps<typeof TvChart>, 'tooltip'> {
 		data: [number, number][] | undefined;
 		formatValue: Formatter<number>;
 		boxed?: boolean;
@@ -25,6 +25,7 @@
 		title?: Snippet<[TimeSpan]> | string;
 		subtitle?: Snippet | string;
 		series: Snippet<[SeriesSnippetOptions]>;
+		tooltip?: Snippet<[ActiveTooltipParams, TooltipData, TimeSpan]>;
 		footer?: Snippet;
 	}
 
@@ -88,7 +89,15 @@
 		{/if}
 	{/snippet}
 
-	<TvChart options={merge({ ...chartOptions }, options)} {...restProps} tooltip={tooltip ?? defaultTooltip}>
+	{#snippet tooltipWithTimeSpan(params: ActiveTooltipParams, seriesData: TooltipData)}
+		{#if tooltip}
+			{@render tooltip(params, seriesData, timeSpan)}
+		{:else}
+			{@render defaultTooltip(params, seriesData)}
+		{/if}
+	{/snippet}
+
+	<TvChart options={merge({ ...chartOptions }, options)} {...restProps} tooltip={tooltipWithTimeSpan}>
 		{@render series({
 			data: resampledData,
 			timeSpan,

--- a/src/lib/top-vaults/VaultPriceChart.svelte
+++ b/src/lib/top-vaults/VaultPriceChart.svelte
@@ -267,7 +267,7 @@ so relative performance is comparable on a single axis.
 			{/if}
 		{/snippet}
 
-		{#snippet tooltip({ point, time }, seriesData)}
+		{#snippet tooltip({ point, time }, seriesData, timeSpan)}
 			{#if showCryptoBenchmarks}
 				{@const price = getSeriesValuePoint(seriesData, 'vault-price')}
 				{@const btc = getBenchmarkCustomValues(seriesData[1])}
@@ -276,7 +276,7 @@ so relative performance is comparable on a single axis.
 				{@const tvl = getSeriesValuePoint(seriesData, 'tvl')}
 				{#if price || btc || eth || tvl}
 					<ChartTooltip {point}>
-						<div class="tooltip-date">{formatDate(time as number, '1d')}</div>
+						<div class="tooltip-date">{formatDate(time as number, timeSpan.timeBucket)}</div>
 						<dl class="tooltip-items">
 							<dt>1M ann return:</dt>
 							<dd>{formatPercent(price?.customValues?.annualizedReturn, 1, 1, { signDisplay: 'exceptZero' })}</dd>
@@ -305,7 +305,7 @@ so relative performance is comparable on a single axis.
 				{@const tvl = getSeriesValuePoint(seriesData, 'tvl')}
 				{#if price || treasury || tvl}
 					<ChartTooltip {point}>
-						<div class="tooltip-date">{formatDate(time as number, '1d')}</div>
+						<div class="tooltip-date">{formatDate(time as number, timeSpan.timeBucket)}</div>
 						<dl class="tooltip-items">
 							<dt>1M ann return:</dt>
 							<dd>{formatPercent(price?.customValues?.annualizedReturn, 1, 1, { signDisplay: 'exceptZero' })}</dd>

--- a/src/lib/top-vaults/VaultUtilisationChart.svelte
+++ b/src/lib/top-vaults/VaultUtilisationChart.svelte
@@ -94,10 +94,10 @@ separator line at the 80% threshold.
 					/>
 				{/snippet}
 
-				{#snippet tooltip({ point, time }, [utilisation])}
+				{#snippet tooltip({ point, time }, [utilisation], timeSpan)}
 					{#if utilisation}
 						<ChartTooltip {point}>
-							<div class="tooltip-date">{formatDate(time as number, '1d')}</div>
+							<div class="tooltip-date">{formatDate(time as number, timeSpan.timeBucket)}</div>
 							<dl class="tooltip-items">
 								<dt>Utilisation:</dt>
 								<dd>{formatValue(utilisation.value)}</dd>


### PR DESCRIPTION
## Why

Hyperliquid vault price data has been intraday since April 2026 (bars every ~20–105 minutes for top vaults), and the 1M chart view resamples to 4h buckets — but the chart tooltip date was hardcoded to daily format, so users couldn't tell which intraday bar they were hovering over.

## Lessons learnt

- The vault prices parquet (`cleaned-vault-prices-1h.parquet`) switched from daily midnight snapshots to intraday poll-based timestamps in April 2026; older history only resolves to daily bars.
- `formatDate()` in `src/lib/charts/helpers.ts` already handles intraday rendering (date + HH:MM UTC) based on the time bucket — the tooltips just weren't passing the active bucket.
- `ChartContainer` tooltip snippets previously had no access to the selected time span; it is now passed as a third snippet argument, which stays backwards-compatible with two-param snippets.

## Summary

- `ChartContainer.svelte`: pass the active `timeSpan` to the `tooltip` snippet as a third argument via a wrapper snippet.
- `VaultPriceChart.svelte`: tooltip date uses `timeSpan.timeBucket` instead of hardcoded `'1d'` in both perp and non-perp branches, so the 1M view (4h buckets) shows e.g. "27 May 2026, 20:00 UTC". The treasury "Rate date" stays daily (FRED publishes daily rates).
- `VaultUtilisationChart.svelte`: same fix for the utilisation chart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)