### PR TITLE
feat: add Core3 protocol risk ratings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Weblog of stuff
 
+- Add Core3 protocol risk ratings — a rating box on vault detail and protocol pages, plus a Core3 column on the protocols listing (2026-06-10)
 - Revamp pricing page with liquid glass table, Creem checkout, updated copy and dataset links (2026-05-08)
 - Add AI ready feature and data fields section to pricing page (2026-05-07)
 - Add historical TVL chart controls for market share and shorter daily history views (2026-05-05)

--- a/src/lib/top-vaults/Core3Ratings.svelte
+++ b/src/lib/top-vaults/Core3Ratings.svelte
@@ -1,0 +1,361 @@
+<!--
+@component
+Displays the third-party Core3 protocol risk rating for a protocol. The rating is
+protocol-level, so it applies to every vault on that protocol. Used on both the
+individual vault detail page and the protocol listing page; only render it when
+the protocol actually has a Core3 rating.
+
+The header carries the rating grade badge next to the title. Below, a two-column
+layout shows the rating metrics (risk score, confidence, rank) on the left and
+protocol context (data coverage, category, market cap) on the right.
+
+Pass `protocolSlug` to link the protocol name to its page (e.g. from a vault
+page); omit it on the protocol page itself to render the name as plain text.
+
+@example
+
+```svelte
+  <Core3Ratings {core3} protocolName="Morpho" protocolSlug="morpho" />
+```
+-->
+<script lang="ts">
+	import type { Core3Protocol } from '$lib/top-vaults/schemas';
+	import MetricsBox from '$lib/components/MetricsBox.svelte';
+	import Tooltip from '$lib/components/Tooltip.svelte';
+	import { getCore3RankingUrl, getCore3RatingTone, getCore3ReportUrl } from '$lib/top-vaults/helpers';
+	import { formatDollar, formatNumber } from '$lib/helpers/formatters';
+	import { resolve } from '$app/paths';
+	import IconQuestionCircle from '~icons/local/question-circle';
+	import IconChevronDown from '~icons/local/chevron-down';
+
+	interface Props {
+		core3: Core3Protocol;
+		/** Protocol display name shown in the intro */
+		protocolName: string;
+		/** When provided, the protocol name links to the protocol page; omit on the protocol page itself */
+		protocolSlug?: string;
+		/** When true, the box collapses to just the grade and title with a "View more" toggle */
+		collapsible?: boolean;
+	}
+
+	let { core3, protocolName, protocolSlug, collapsible = false }: Props = $props();
+
+	let expanded = $state(false);
+	// Collapsed: only render the grade + title summary, and the whole box opens it
+	let collapsed = $derived(collapsible && !expanded);
+	let boxClass = $derived(collapsed ? 'core3-ratings core3-collapsed' : 'core3-ratings');
+
+	let rating = $derived(core3.pol?.rating ?? null);
+	let ratingTone = $derived(getCore3RatingTone(rating));
+
+	let reportUrl = $derived(getCore3ReportUrl(core3));
+	let rankingUrl = $derived(getCore3RankingUrl(core3));
+	let dataCoverage = $derived(core3.data_coverage?.percentage);
+	let marketCap = $derived(core3.market_cap?.in_usd);
+</script>
+
+{#snippet ratingHeader()}
+	{#if rating}
+		<div class="grade" data-tone={ratingTone}>{rating}</div>
+	{/if}
+	<h2>Core3 risk rating</h2>
+{/snippet}
+
+<MetricsBox class={boxClass}>
+	{#if collapsed}
+		<!-- Collapsed: the whole box is the toggle, so clicking anywhere opens it -->
+		<button type="button" class="box-header collapsed-summary" aria-expanded="false" onclick={() => (expanded = true)}>
+			{@render ratingHeader()}
+			<span class="toggle" aria-hidden="true">View more <IconChevronDown /></span>
+		</button>
+	{:else}
+		<div class="content">
+			<header class="box-header">
+				{@render ratingHeader()}
+				{#if collapsible}
+					<button type="button" class="toggle" aria-expanded="true" onclick={() => (expanded = false)}>
+						View less <IconChevronDown />
+					</button>
+				{/if}
+			</header>
+
+			<p class="intro">
+				Risk rating by Core3 for {#if protocolSlug}<a href={resolve(`/trading-view/vaults/protocols/${protocolSlug}`)}
+						>{protocolName}</a
+					>{:else}{protocolName}{/if}. The rating applies to all vaults on this protocol.{#if reportUrl}{' '}<a
+						href={reportUrl}
+						target="_blank"
+						rel="noreferrer">View full rating on the Core3 website</a
+					>.{/if}
+			</p>
+
+			<div class="columns">
+				<table class="data">
+					<tbody>
+						{#if core3.pol?.score != null}
+							<tr>
+								<th>
+									<Tooltip>
+										<a slot="trigger" class="metric-link" href={rankingUrl} target="_blank" rel="noreferrer">
+											Risk score
+											<IconQuestionCircle />
+										</a>
+										<svelte:fragment slot="popup">
+											<p>
+												Core3's Probability of Loss (PoL) estimates how likely users or token holders are to suffer a
+												financially material loss, excluding market price moves.
+											</p>
+											<p>
+												The scale runs 0–100 — lower is better — and maps to a letter grade from AA (lowest risk) down
+												to D.
+											</p>
+											<p>It is a weighted aggregate of risk categories:</p>
+											<ul>
+												<li>Security — 35%</li>
+												<li>Operational — 20%</li>
+												<li>Financial — 15%</li>
+												<li>Reputational — 10%</li>
+												<li>Regulatory — 5%</li>
+												<li>Dependency — 15% (coming soon)</li>
+											</ul>
+											<p>
+												The total is then scaled by 1.0–1.3× for factors such as protocol longevity, past incidents and
+												category leadership.
+											</p>
+										</svelte:fragment>
+									</Tooltip>
+								</th>
+								<td>{formatNumber(core3.pol.score, 2, 2)}</td>
+							</tr>
+						{/if}
+						{#if core3.pol?.confidence}
+							<tr>
+								<th>Confidence</th>
+								<td>{core3.pol.confidence}</td>
+							</tr>
+						{/if}
+						{#if core3.rank != null}
+							<tr>
+								<th>
+									<Tooltip>
+										<a slot="trigger" class="metric-link" href={rankingUrl} target="_blank" rel="noreferrer">
+											Core3 rank
+											<IconQuestionCircle />
+										</a>
+										<svelte:fragment slot="popup">
+											Where this protocol ranks among all DeFi protocols rated by Core3, ordered by risk (1 = best).
+											Opens the Core3 ranking page.
+										</svelte:fragment>
+									</Tooltip>
+								</th>
+								<td>#{core3.rank}</td>
+							</tr>
+						{/if}
+					</tbody>
+				</table>
+
+				<table class="data">
+					<tbody>
+						{#if dataCoverage != null}
+							<tr>
+								<th>Data coverage</th>
+								<td>{formatNumber(dataCoverage, 1, 1)}%</td>
+							</tr>
+						{/if}
+						{#if core3.category?.name}
+							<tr>
+								<th>Category</th>
+								<td>{core3.category.name}</td>
+							</tr>
+						{/if}
+						{#if marketCap}
+							<tr>
+								<th>Market cap</th>
+								<td>{formatDollar(marketCap, 1, 1, { notation: 'compact' })}</td>
+							</tr>
+						{/if}
+					</tbody>
+				</table>
+			</div>
+		</div>
+	{/if}
+</MetricsBox>
+
+<style>
+	.content {
+		display: grid;
+		gap: 1.25rem;
+	}
+
+	.box-header {
+		display: flex;
+		align-items: center;
+		gap: 0.875rem;
+
+		h2 {
+			margin: 0;
+			font: var(--f-ui-sm-bold);
+			font-size: 1rem;
+			letter-spacing: 0.06em;
+			text-transform: uppercase;
+			color: var(--c-text-light);
+
+			@media (--viewport-sm-down) {
+				font-size: 0.875rem;
+			}
+		}
+
+		.toggle {
+			margin-left: auto;
+			display: inline-flex;
+			align-items: center;
+			gap: 0.25rem;
+			padding: 0;
+			border: none;
+			background: none;
+			cursor: pointer;
+			font: var(--f-ui-sm-medium);
+			color: var(--c-text-light);
+			text-decoration: underline;
+			white-space: nowrap;
+
+			:global(.icon) {
+				transition: rotate 0.15s ease;
+			}
+
+			&[aria-expanded='true'] :global(.icon) {
+				rotate: 180deg;
+			}
+		}
+	}
+
+	/* When collapsed the whole box is one button: drop the MetricsBox padding so
+	   the button fills the box edge-to-edge and the entire component is clickable */
+	:global(.core3-ratings.core3-collapsed) {
+		padding: 0;
+	}
+
+	.collapsed-summary {
+		width: 100%;
+		padding: var(--padding, 1.25rem);
+		border: none;
+		border-radius: var(--radius-md);
+		background: none;
+		text-align: left;
+		color: inherit;
+		cursor: pointer;
+
+		&:hover .toggle {
+			color: var(--c-text);
+		}
+	}
+
+	.grade {
+		--c-rating: var(--c-text-light);
+		display: grid;
+		place-items: center;
+		min-width: 3.25rem;
+		padding: 0.25rem 0.75rem;
+		border-radius: var(--radius-md);
+		border: 2px solid color-mix(in srgb, var(--c-rating), transparent 55%);
+		background: color-mix(in srgb, var(--c-rating), transparent 88%);
+		font: var(--f-heading-md-medium);
+		color: color-mix(in srgb, var(--c-text), var(--c-rating) 80%);
+
+		&[data-tone='excellent'] {
+			--c-rating: var(--c-success);
+		}
+		&[data-tone='good'] {
+			--c-rating: color-mix(in srgb, var(--c-success), var(--c-warning));
+		}
+		&[data-tone='fair'] {
+			--c-rating: var(--c-warning);
+		}
+		&[data-tone='poor'] {
+			--c-rating: var(--c-error);
+		}
+	}
+
+	.intro {
+		margin: 0;
+		font: var(--f-ui-md-roman);
+		color: var(--c-text-extra-light);
+
+		a {
+			text-decoration: underline;
+			font-weight: 500;
+			color: var(--c-text-light);
+		}
+	}
+
+	.columns {
+		display: grid;
+		gap: var(--gap, 1.5rem);
+		align-items: start;
+
+		@media (--viewport-md-up) {
+			grid-template-columns: 1fr 1fr;
+		}
+	}
+
+	table.data {
+		width: 100%;
+		border-collapse: collapse;
+
+		tr {
+			border-top: 1px solid var(--c-box-3);
+
+			&:first-child {
+				border-top: none;
+			}
+		}
+
+		th,
+		td {
+			padding: 0.625rem 0;
+			font: var(--f-ui-md-roman);
+			text-align: left;
+		}
+
+		th {
+			color: var(--c-text-extra-light);
+			font-weight: normal;
+		}
+
+		td {
+			text-align: right;
+			color: var(--c-text-light);
+		}
+
+		.metric-link {
+			display: inline-flex;
+			align-items: center;
+			gap: 0.25rem;
+			color: var(--c-text-light);
+			text-decoration: underline;
+
+			:global(.icon) {
+				color: var(--c-text-extra-light);
+			}
+		}
+	}
+
+	/* Cap the Core3 metric tooltips and give the score breakdown a real bullet list */
+	:global(.core3-ratings .tooltip .popup) {
+		max-width: 400px;
+	}
+
+	:global(.core3-ratings .tooltip .popup ul) {
+		margin: 0 0 0.5em;
+		padding-left: 1.25em;
+		list-style: disc;
+	}
+
+	:global(.core3-ratings .tooltip .popup li) {
+		margin-bottom: 0.2em;
+	}
+
+	:global(.core3-ratings .tooltip .popup p:last-child) {
+		margin-bottom: 0;
+	}
+</style>

--- a/src/lib/top-vaults/Core3Ratings.svelte
+++ b/src/lib/top-vaults/Core3Ratings.svelte
@@ -82,11 +82,11 @@ page); omit it on the protocol page itself to render the name as plain text.
 			<p class="intro">
 				Risk rating by Core3 for {#if protocolSlug}<a href={resolve(`/trading-view/vaults/protocols/${protocolSlug}`)}
 						>{protocolName}</a
-					>{:else}{protocolName}{/if}. The rating applies to all vaults on this protocol.{#if reportUrl}{' '}<a
-						href={reportUrl}
-						target="_blank"
-						rel="noreferrer">View full rating on the Core3 website</a
-					>.{/if}
+					>{:else}{protocolName}{/if}. The rating applies to all vaults on this protocol.
+				{#if reportUrl}
+					<!-- eslint-disable-next-line svelte/no-navigation-without-resolve -->
+					<a href={reportUrl} target="_blank" rel="noreferrer">View full rating on the Core3 website</a>.
+				{/if}
 			</p>
 
 			<div class="columns">
@@ -96,6 +96,7 @@ page); omit it on the protocol page itself to render the name as plain text.
 							<tr>
 								<th>
 									<Tooltip>
+										<!-- eslint-disable-next-line svelte/no-navigation-without-resolve -->
 										<a slot="trigger" class="metric-link" href={rankingUrl} target="_blank" rel="noreferrer">
 											Risk score
 											<IconQuestionCircle />
@@ -138,6 +139,7 @@ page); omit it on the protocol page itself to render the name as plain text.
 							<tr>
 								<th>
 									<Tooltip>
+										<!-- eslint-disable-next-line svelte/no-navigation-without-resolve -->
 										<a slot="trigger" class="metric-link" href={rankingUrl} target="_blank" rel="noreferrer">
 											Core3 rank
 											<IconQuestionCircle />

--- a/src/lib/top-vaults/Core3RiskCell.svelte
+++ b/src/lib/top-vaults/Core3RiskCell.svelte
@@ -1,0 +1,73 @@
+<!--
+@component
+Table cell showing a protocol's Core3 risk rating letter (e.g. "AA", "BB"),
+colour-coded by tone, with a tooltip explaining the rating. Renders an em dash
+for protocols that have no Core3 rating.
+
+@example
+
+```svelte
+  <Core3RiskCell rating="BB" slug="morpho" />
+```
+-->
+<script lang="ts">
+	import { resolve } from '$app/paths';
+	import Tooltip from '$lib/components/Tooltip.svelte';
+	import { getCore3RatingTone } from './helpers';
+
+	interface Props {
+		rating?: string | null;
+		/** Protocol slug — the tooltip "View more" link points to this protocol's page */
+		slug?: string;
+	}
+
+	let { rating, slug }: Props = $props();
+
+	let tone = $derived(getCore3RatingTone(rating));
+</script>
+
+{#if rating}
+	<span class="core3-risk-cell">
+		<Tooltip>
+			<svelte:fragment slot="trigger">
+				<span class="rating" data-tone={tone}>{rating}</span>
+			</svelte:fragment>
+			<svelte:fragment slot="popup">
+				Core3's protocol risk rating (Probability of Loss): a third-party estimate of how likely users are to suffer a
+				financially material loss, graded from AA (lowest risk) down to D.
+				{#if slug}<a href={resolve(`/trading-view/vaults/protocols/${slug}`)}>View more</a>{/if}
+			</svelte:fragment>
+		</Tooltip>
+	</span>
+{:else}
+	<span class="empty">–</span>
+{/if}
+
+<style>
+	.rating {
+		--c-rating: var(--c-text-light);
+		font-weight: 600;
+		color: color-mix(in srgb, var(--c-text), var(--c-rating) 80%);
+
+		&[data-tone='excellent'] {
+			--c-rating: var(--c-success);
+		}
+		&[data-tone='good'] {
+			--c-rating: color-mix(in srgb, var(--c-success), var(--c-warning));
+		}
+		&[data-tone='fair'] {
+			--c-rating: var(--c-warning);
+		}
+		&[data-tone='poor'] {
+			--c-rating: var(--c-error);
+		}
+	}
+
+	.empty {
+		color: var(--c-text-extra-light);
+	}
+
+	:global(.core3-risk-cell .tooltip .popup) {
+		max-width: 400px;
+	}
+</style>

--- a/src/lib/top-vaults/TopVaultsPage.svelte
+++ b/src/lib/top-vaults/TopVaultsPage.svelte
@@ -47,6 +47,8 @@
 		loading?: boolean;
 		/** Optional right-hand content for listing detail page overview panels */
 		detailAside?: Snippet;
+		/** Optional content rendered above the vaults table (and its status line) */
+		beforeTable?: Snippet;
 	}
 
 	let {
@@ -69,7 +71,8 @@
 		defaultSort,
 		defaultDirection,
 		loading = false,
-		detailAside
+		detailAside,
+		beforeTable
 	}: Props = $props();
 
 	let renderDetailAsideInHero = $derived(chain && detailAside && !protocolMetadata && !stablecoinMetadata);
@@ -136,6 +139,8 @@
 					</aside>
 				</div>
 			{/if}
+
+			{@render beforeTable?.()}
 
 			{#if loading}
 				<TopVaultsTable

--- a/src/lib/top-vaults/TopVaultsTable.svelte
+++ b/src/lib/top-vaults/TopVaultsTable.svelte
@@ -107,7 +107,7 @@
 		loading?: boolean;
 	}
 
-	const emptyTopVaults: TopVaults = { generated_at: new Date().toISOString(), vaults: [] };
+	const emptyTopVaults: TopVaults = { generated_at: new Date().toISOString(), vaults: [], core3_protocols: {} };
 	const SKELETON_ROW_COUNT = 10;
 
 	let {

--- a/src/lib/top-vaults/VaultGroupTable.svelte
+++ b/src/lib/top-vaults/VaultGroupTable.svelte
@@ -19,6 +19,7 @@
 	import TableRowTarget from '$lib/components/datatable/TableRowTarget.svelte';
 	import EntitySymbol from '$lib/components/EntitySymbol.svelte';
 	import RiskCell from './RiskCell.svelte';
+	import Core3RiskCell from './Core3RiskCell.svelte';
 	import { formatDollar, formatPercent } from '$lib/helpers/formatters';
 
 	type DataTableProps = Omit<ComponentProps<typeof DataTable>, 'tableViewModel'>;
@@ -27,6 +28,7 @@
 		rows?: VaultGroup[];
 		groupLabel: string;
 		includeRisk?: boolean;
+		includeCore3Risk?: boolean;
 		includeFullName?: boolean;
 		getLogoHref?: (slug: string) => string | undefined;
 		page?: number;
@@ -39,6 +41,7 @@
 		rows,
 		groupLabel,
 		includeRisk = false,
+		includeCore3Risk = false,
 		includeFullName = false,
 		getLogoHref,
 		page: pageIndex = 0,
@@ -58,7 +61,11 @@
 		tableRowsStore.set(tableRows);
 	});
 
-	const hiddenColumns = [...(includeRisk ? [] : ['risk']), ...(includeFullName ? [] : ['full_name'])];
+	const hiddenColumns = [
+		...(includeRisk ? [] : ['risk']),
+		...(includeCore3Risk ? [] : ['core3_risk']),
+		...(includeFullName ? [] : ['full_name'])
+	];
 
 	// svelte-ignore state_referenced_locally
 	const table = createTable(tableRowsStore, {
@@ -90,6 +97,13 @@
 			header: 'Name',
 			accessor: 'fullName',
 			cell: ({ value }) => value ?? '',
+			plugins: { sort: { disable: true } }
+		}),
+		table.column({
+			id: 'core3_risk',
+			header: 'Core3',
+			accessor: (row) => ({ rating: row.core3_rating ?? null, slug: row.slug }),
+			cell: ({ value }) => createRender(Core3RiskCell, { rating: value.rating, slug: value.slug }),
 			plugins: { sort: { disable: true } }
 		}),
 		table.column({
@@ -157,7 +171,7 @@
 			:global(:is(th, td)) {
 				width: 20%;
 
-				&:not(:is(.name, .risk, .full_name)) {
+				&:not(:is(.name, .risk, .core3_risk, .full_name)) {
 					text-align: right;
 				}
 			}
@@ -178,6 +192,21 @@
 
 				:global(.name) {
 					width: 36%;
+				}
+
+				:global(.cta) {
+					width: 12rem;
+				}
+			}
+
+			/* protocols page shows both the Core3 risk and technical risk columns */
+			:global(:has(.core3_risk)) {
+				:global(:is(th, td)) {
+					width: 13%;
+				}
+
+				:global(.name) {
+					width: 28%;
 				}
 
 				:global(.cta) {

--- a/src/lib/top-vaults/VaultGroupTable.svelte
+++ b/src/lib/top-vaults/VaultGroupTable.svelte
@@ -1,6 +1,6 @@
 <script module lang="ts">
 	export const sortOptions = {
-		keys: ['tvl', 'avg_apy', 'vault_count', 'name', 'risk'],
+		keys: ['tvl', 'avg_apy', 'vault_count', 'name', 'risk', 'core3_risk'],
 		directions: ['desc', 'asc']
 	} as const;
 
@@ -102,9 +102,15 @@
 		table.column({
 			id: 'core3_risk',
 			header: 'Core3',
-			accessor: (row) => ({ rating: row.core3_rating ?? null, slug: row.slug }),
+			accessor: (row) => ({ rating: row.core3_rating ?? null, slug: row.slug, score: row.core3_score ?? null }),
 			cell: ({ value }) => createRender(Core3RiskCell, { rating: value.rating, slug: value.slug }),
-			plugins: { sort: { disable: true } }
+			plugins: {
+				sort: {
+					// lower score = better rating; unrated protocols sort last
+					getSortValue: (v) => v.score ?? Infinity,
+					invert: true
+				}
+			}
 		}),
 		table.column({
 			id: 'risk',
@@ -152,7 +158,7 @@
 <style>
 	.vault-protocol-table {
 		/* flip the sort indicator on columns that use inverted sort */
-		:global(:is(th.name, th.risk) .icon) {
+		:global(:is(th.name, th.risk, th.core3_risk) .icon) {
 			rotate: 180deg;
 		}
 

--- a/src/lib/top-vaults/VaultGroupTable.svelte
+++ b/src/lib/top-vaults/VaultGroupTable.svelte
@@ -191,28 +191,15 @@
 				width: max(calc(20vw), 12rem);
 			}
 
-			:global(:has(.risk)) {
+			/* layout with a leading rating column (technical risk and/or Core3); the
+			   percentage widths must sum to 100% so the cells fill the table edge-to-edge */
+			:global(:has(:is(.risk, .core3_risk))) {
 				:global(:is(th, td)) {
 					width: 16%;
 				}
 
 				:global(.name) {
 					width: 36%;
-				}
-
-				:global(.cta) {
-					width: 12rem;
-				}
-			}
-
-			/* protocols page shows both the Core3 risk and technical risk columns */
-			:global(:has(.core3_risk)) {
-				:global(:is(th, td)) {
-					width: 13%;
-				}
-
-				:global(.name) {
-					width: 28%;
 				}
 
 				:global(.cta) {

--- a/src/lib/top-vaults/helpers.ts
+++ b/src/lib/top-vaults/helpers.ts
@@ -1,4 +1,4 @@
-import type { FeeMode, SlimVaultInfo, VaultInfo } from './schemas';
+import type { Core3Protocol, FeeMode, SlimVaultInfo, VaultInfo } from './schemas';
 import { slimVaultKeys } from './schemas';
 import { resolve } from '$app/paths';
 import { vaultSparklinesUrl } from '$lib/config';
@@ -346,6 +346,49 @@ export function rankVaultsBy<V extends Record<string, unknown>>(keys: (keyof V)[
 		}
 		return 0;
 	};
+}
+
+/**
+ * Resolve the public Core3 report URL for a rated protocol.
+ *
+ * The upstream `link` field is malformed — it concatenates the Core3 slug
+ * directly onto the origin without a path separator (e.g.
+ * `https://core3.ioinverse-finance`). We repair it by inserting the missing
+ * slash. Returns `undefined` when no usable link is present.
+ */
+export function getCore3ReportUrl(core3: Pick<Core3Protocol, 'link'>): string | undefined {
+	const link = core3.link;
+	if (!link) return undefined;
+	const origin = 'https://core3.io';
+	if (link.startsWith(`${origin}/`)) return link;
+	if (link.startsWith(origin)) return `${origin}/${link.slice(origin.length)}`;
+	return link;
+}
+
+/** Qualitative tone for a Core3 letter grade, used for colour-coding. */
+export type Core3RatingTone = 'excellent' | 'good' | 'fair' | 'poor' | 'unknown';
+
+/**
+ * Map a Core3 letter grade to a qualitative tone for colour-coding.
+ * Scale, best to worst: AAA, AA, A, BBB, BB, B, CCC, CC, C, DDD, DD, D.
+ */
+export function getCore3RatingTone(rating: string | null | undefined): Core3RatingTone {
+	const r = rating?.toUpperCase() ?? '';
+	if (r.startsWith('A')) return 'excellent';
+	if (r.startsWith('B')) return 'good';
+	if (r.startsWith('C')) return 'fair';
+	if (r.startsWith('D')) return 'poor';
+	return 'unknown';
+}
+
+/**
+ * Resolve the Core3 ranking (leaderboard) URL that a protocol's Core3 rank
+ * refers to. Core3 splits its ranking into projects and exchanges, so we pick
+ * the list matching the protocol's Core3 category.
+ */
+export function getCore3RankingUrl(core3: Pick<Core3Protocol, 'category'>): string {
+	const isExchange = /exchange/i.test(core3.category?.name ?? '');
+	return `https://core3.io/ratings/${isExchange ? 'exchanges' : 'projects'}`;
 }
 
 /**

--- a/src/lib/top-vaults/schemas.ts
+++ b/src/lib/top-vaults/schemas.ts
@@ -424,4 +424,6 @@ export interface VaultGroup {
 	risk_numeric?: number | null;
 	/** Core3 protocol risk rating letter (e.g. "AA", "BB") — only present on protocol groups with a Core3 rating */
 	core3_rating?: string | null;
+	/** Core3 numeric risk score (lower = better) — used to sort the Core3 rating column */
+	core3_score?: number | null;
 }

--- a/src/lib/top-vaults/schemas.ts
+++ b/src/lib/top-vaults/schemas.ts
@@ -275,6 +275,54 @@ export const vaultInfoSchema = z.object({
 });
 export type VaultInfo = z.infer<typeof vaultInfoSchema>;
 
+/**
+ * Core3 protocol-level risk rating (https://core3.io).
+ *
+ * Third-party rating data sourced by the backend and keyed in the top-vaults
+ * payload by protocol slug (matching {@link VaultInfo.protocol_slug}). Surfaced
+ * on the vault detail page. All fields are permissive because this is external
+ * data we do not control — see {@link topVaultsSchema} for the `.catch` safety net.
+ */
+export const core3PolSchema = z.object({
+	/** Numeric risk score — lower is better (best protocols ≈ 13, worst ≈ 87) */
+	score: nullableNumber,
+	/** Letter grade, best to worst: AA, A, BBB, BB, B, CCC, CC, C, D */
+	rating: z.string().nullable(),
+	/** Confidence in the rating (e.g. "Exceptional", "High", "Moderate", "Low") */
+	confidence: z.string().nullable()
+});
+export type Core3Pol = z.infer<typeof core3PolSchema>;
+
+export const core3ProtocolSchema = z.object({
+	/** Core3 protocol slug (may differ from our protocol_slug) */
+	slug: z.string(),
+	/** Protocol display name on Core3 */
+	name: z.string(),
+	/** Overall Core3 rank across all rated protocols (1 = best) */
+	rank: z.int().nullable().optional(),
+	/** Headline rating object (grade, score, confidence) */
+	pol: core3PolSchema.nullable().optional(),
+	/** Protocol ticker (e.g. "INV") */
+	ticker: z.string().nullable().optional(),
+	/** Core3 protocol report URL — note: upstream omits the path slash, fixed in the helper */
+	link: z.string().nullable().optional(),
+	/** Core3 category (e.g. "Decentralized Finance") */
+	category: z.object({ name: z.string().nullable() }).nullable().optional(),
+	/** Share of Core3's data points populated for this protocol, as a percentage */
+	data_coverage: z.object({ percentage: nullableNumber }).nullable().optional(),
+	/** Market-cap snapshot; `in_usd` is a numeric string */
+	market_cap: z
+		.object({
+			in_usd: z.string().nullable().optional(),
+			change_24h_percentage: nullableNumber.optional()
+		})
+		.nullable()
+		.optional(),
+	/** Chains the protocol is deployed on */
+	chains: z.object({ name: z.string() }).array().optional()
+});
+export type Core3Protocol = z.infer<typeof core3ProtocolSchema>;
+
 /** Slim vault info with only the fields needed for listing/summary views (e.g., landing page). */
 export type SlimVaultInfo = Pick<
 	VaultInfo,
@@ -342,7 +390,13 @@ export const topVaultsSchema = z.object({
 	/** When the backend last regenerated the vault dataset */
 	generated_at: isoDateTime,
 	/** All tracked vaults with full performance and metadata */
-	vaults: vaultInfoSchema.array()
+	vaults: vaultInfoSchema.array(),
+	/**
+	 * Core3 protocol risk ratings, keyed by protocol slug. External third-party
+	 * data — `.catch({})` guarantees a malformed/changed payload here can never
+	 * break parsing of the (critical) vaults array.
+	 */
+	core3_protocols: z.record(z.string(), core3ProtocolSchema).catch({}).default({})
 });
 export type TopVaults = z.infer<typeof topVaultsSchema>;
 
@@ -368,4 +422,6 @@ export interface VaultGroup {
 	risk?: string | null;
 	/** Numeric risk score — only present on protocol groups */
 	risk_numeric?: number | null;
+	/** Core3 protocol risk rating letter (e.g. "AA", "BB") — only present on protocol groups with a Core3 rating */
+	core3_rating?: string | null;
 }

--- a/src/routes/trading-view/vaults/[vault=slug]/+page.server.ts
+++ b/src/routes/trading-view/vaults/[vault=slug]/+page.server.ts
@@ -7,7 +7,7 @@ import { fetchVaultProtocolMetadata } from '$lib/vault-protocol/client';
 import { error, redirect } from '@sveltejs/kit';
 
 export async function load({ params, fetch }) {
-	const { vaults, generated_at } = await getCachedTopVaults(fetch);
+	const { vaults, generated_at, core3_protocols } = await getCachedTopVaults(fetch);
 
 	const vault = vaults.find((v) => {
 		// redirect to canonical vault path if someone tries old vault id URL
@@ -23,6 +23,9 @@ export async function load({ params, fetch }) {
 	const chain = getChain(vault.chain_id);
 	if (!chain) error(404, 'Chain not found');
 
+	// Core3 ratings are keyed by protocol slug; null when the protocol is unrated
+	const core3 = core3_protocols[vault.protocol_slug] ?? null;
+
 	const [protocolMetadata, stablecoinMetadataIndex] = await Promise.all([
 		fetchVaultProtocolMetadata(fetch, vault.protocol_slug, vault.protocol),
 		fetchStablecoinMetadataIndex(fetch)
@@ -35,5 +38,5 @@ export async function load({ params, fetch }) {
 		vault.normalised_denomination
 	);
 
-	return { vault, chain, protocolMetadata, stablecoinMetadata, generated_at };
+	return { vault, chain, protocolMetadata, stablecoinMetadata, generated_at, core3 };
 }

--- a/src/routes/trading-view/vaults/[vault=slug]/+page.svelte
+++ b/src/routes/trading-view/vaults/[vault=slug]/+page.svelte
@@ -16,12 +16,13 @@
 	import VaultPeriodicMetrics from './VaultPeriodicMetrics.svelte';
 	import VaultProtocolInfo from './VaultProtocolInfo.svelte';
 	import VaultRankings from './VaultRankings.svelte';
+	import Core3Ratings from '$lib/top-vaults/Core3Ratings.svelte';
 	import IconDiscord from '~icons/local/discord';
 	import { getMorphoFlags, hasSupportedProtocol, isBlacklisted } from '$lib/top-vaults/helpers';
 	import { getVaultProtocolLogoUrl } from '$lib/vault-protocol/helpers.js';
 
 	let { data } = $props();
-	let { vault, chain, protocolMetadata, stablecoinMetadata, generated_at } = $derived(data);
+	let { vault, chain, protocolMetadata, stablecoinMetadata, generated_at, core3 } = $derived(data);
 	let morphoFlags = $derived(getMorphoFlags(vault));
 	let notesDuplicateMorphoFlags = $derived(
 		morphoFlags.length > 0 && vault.notes?.startsWith('Morpho has flagged this vault with the following issues:')
@@ -112,6 +113,10 @@
 		{/if}
 
 		<VaultPeriodicMetrics {vault} {chain} />
+
+		{#if core3}
+			<Core3Ratings {core3} protocolName={vault.protocol} protocolSlug={vault.protocol_slug} />
+		{/if}
 
 		<VaultTechnicalDetailsTable {vault} {chain} {stablecoinMetadata} {generated_at} />
 	</Section>

--- a/src/routes/trading-view/vaults/protocols/+page.server.ts
+++ b/src/routes/trading-view/vaults/protocols/+page.server.ts
@@ -27,7 +27,8 @@ export async function load({ fetch, url: { searchParams } }) {
 			avg_apy: null,
 			risk: vault.risk,
 			risk_numeric: vault.risk_numeric,
-			core3_rating: core3_protocols[slug]?.pol?.rating ?? null
+			core3_rating: core3_protocols[slug]?.pol?.rating ?? null,
+			core3_score: core3_protocols[slug]?.pol?.score ?? null
 		};
 		acc[slug].vault_count++;
 		acc[slug].tvl += vault.current_nav ?? 0;

--- a/src/routes/trading-view/vaults/protocols/+page.server.ts
+++ b/src/routes/trading-view/vaults/protocols/+page.server.ts
@@ -12,7 +12,7 @@ import { getVaultProtocolLogoUrl } from '$lib/vault-protocol/helpers.js';
 import type { MarketShareChartItem } from '../market-share-pie';
 
 export async function load({ fetch, url: { searchParams } }) {
-	const { vaults } = await getCachedTopVaults(fetch);
+	const { vaults, core3_protocols } = await getCachedTopVaults(fetch);
 
 	const eligibleVaults = vaults.filter((v) => !isBlacklisted(v) && meetsMinTvl(v));
 
@@ -26,7 +26,8 @@ export async function load({ fetch, url: { searchParams } }) {
 			tvl: 0,
 			avg_apy: null,
 			risk: vault.risk,
-			risk_numeric: vault.risk_numeric
+			risk_numeric: vault.risk_numeric,
+			core3_rating: core3_protocols[slug]?.pol?.rating ?? null
 		};
 		acc[slug].vault_count++;
 		acc[slug].tvl += vault.current_nav ?? 0;

--- a/src/routes/trading-view/vaults/protocols/+page.svelte
+++ b/src/routes/trading-view/vaults/protocols/+page.svelte
@@ -100,7 +100,7 @@
 	<Section padding="sm">
 		<VaultGroupTable
 			groupLabel="Protocol"
-			includeRisk
+			includeCore3Risk
 			getLogoHref={getVaultProtocolLogoUrl}
 			rows={protocols}
 			{...options}

--- a/src/routes/trading-view/vaults/protocols/[protocol=slug]/+page.server.ts
+++ b/src/routes/trading-view/vaults/protocols/[protocol=slug]/+page.server.ts
@@ -5,7 +5,7 @@ import { getProtocolDisplayName } from '$lib/top-vaults/helpers.js';
 
 export async function load({ params, fetch }) {
 	const { protocol } = params;
-	const { vaults } = await getCachedTopVaults(fetch);
+	const { vaults, core3_protocols } = await getCachedTopVaults(fetch);
 
 	const protocolVault = vaults.find((v) => v.protocol_slug === protocol);
 	if (!protocolVault) error(404, 'Vault protocol not found');
@@ -15,6 +15,7 @@ export async function load({ params, fetch }) {
 	return {
 		protocolSlug: protocol,
 		protocolName: getProtocolDisplayName(protocolVault.protocol),
-		protocolMetadata
+		protocolMetadata,
+		core3: core3_protocols[protocol] ?? null
 	};
 }

--- a/src/routes/trading-view/vaults/protocols/[protocol=slug]/+page.svelte
+++ b/src/routes/trading-view/vaults/protocols/[protocol=slug]/+page.svelte
@@ -5,11 +5,12 @@
 	import { getVaultProtocolLogoUrl } from '$lib/vault-protocol/helpers.js';
 	import { page } from '$app/state';
 	import TopVaultsPage from '$lib/top-vaults/TopVaultsPage.svelte';
+	import Core3Ratings from '$lib/top-vaults/Core3Ratings.svelte';
 	import { MetaTags, JsonLd } from 'svelte-meta-tags';
 	import VaultGroupMiniChart from '../../VaultGroupMiniChart.svelte';
 
 	let { data } = $props();
-	let { protocolSlug, protocolName, protocolMetadata } = $derived(data);
+	let { protocolSlug, protocolName, protocolMetadata, core3 } = $derived(data);
 
 	let topVaults = $state<TopVaults>();
 	let loading = $state(!hasVaultCache());
@@ -89,5 +90,11 @@
 			compareLabel="Compare all protocols"
 			compareHref="/trading-view/vaults/historical-tvl-protocol"
 		/>
+	{/snippet}
+
+	{#snippet beforeTable()}
+		{#if core3}
+			<Core3Ratings {core3} {protocolName} collapsible />
+		{/if}
 	{/snippet}
 </TopVaultsPage>


### PR DESCRIPTION
## Why

Core3 ([core3.io](https://core3.io)) publishes third-party DeFi protocol risk ratings — a "Probability of Loss" (PoL) score and letter grade (AA → D). The backend now includes this data in the top-vaults dataset (`core3_protocols`, keyed by protocol slug). Surfacing it gives users an independent risk signal alongside our own technical risk framework when evaluating vaults and protocols.

## Lessons learnt

- **Resilience for external data:** `core3_protocols` is third-party data we don't control, so the Zod schema wraps it with `.catch({})` at the record level — a malformed or changed Core3 payload can never break parsing of the critical `vaults` array.
- **Upstream `link` is malformed** (missing the path slash, e.g. `https://core3.ioinverse-finance`); `getCore3ReportUrl()` repairs it.
- **`pol` = Probability of Loss:** scale 0–100 where *lower is better*, mapped to letter grades AA→D. The category weights and explanation shown in tooltips come from Core3's published methodology (`/methodology/projects`), not guesswork.
- **`resolve()` + lint:** SvelteKit's `resolve()` is strictly typed to known route ids, and the `svelte/no-navigation-without-resolve` rule only accepts it *inline* in the `href`. Internal links therefore build the path as a template literal directly in the attribute. Genuinely external core3.io links can't use `resolve()` — same pre-existing lint pattern as `TableRowTarget`.
- **Client payload:** `core3_protocols` rides along in the client-facing `/top-vaults/all-data` response, but it's only ~20 entries vs 4k+ vaults and compresses well.

## Summary

- **Shared `Core3Ratings.svelte` box** — grade badge + two-column metrics (risk score, confidence, Core3 rank / data coverage, category, market cap), with detailed methodology tooltips (capped at 400px, proper bullet list) and a link to the full Core3 report.
  - On **vault detail pages**: always expanded; protocol name links to the protocol page.
  - On **protocol pages**: rendered above the table status line, **collapsed by default** to just the grade + "Core3 risk rating" label; the whole box is clickable (pointer cursor) to expand.
- **New "Core3" column on the protocols listing** (`Core3RiskCell.svelte`) — colour-coded rating letter with a tooltip and a "View more" link to the protocol page. (Replaces the technical-risk column in that listing.)
- **Schema:** added `core3_protocols` record + `Core3Protocol`/`Core3Pol` types, and `core3_rating` on `VaultGroup`.
- **Helpers:** `getCore3ReportUrl`, `getCore3RankingUrl`, `getCore3RatingTone`.
- **Loaders/plumbing:** thread `core3` data into the vault, protocol, and protocols-listing loaders; `TopVaultsPage` gains a `beforeTable` snippet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)