### PR TITLE
fix: curator page copy and vault group chart polish

### DIFF
--- a/src/lib/top-vaults/TopVaultsPage.svelte
+++ b/src/lib/top-vaults/TopVaultsPage.svelte
@@ -301,6 +301,12 @@
 			align-content: start;
 		}
 
+		/* give the chart aside more room on curator pages, at the expense of the
+		   about/description column */
+		.curator-overview {
+			grid-template-columns: minmax(0, 1fr) minmax(26rem, 44rem);
+		}
+
 		@media (--viewport-lg-up) {
 			.curator-overview {
 				align-items: start;

--- a/src/routes/trading-view/vaults/VaultGroupMiniChart.svelte
+++ b/src/routes/trading-view/vaults/VaultGroupMiniChart.svelte
@@ -30,7 +30,7 @@ average TVL-weighted return as a line series.
 	interface TooltipParam {
 		axisValueLabel?: string;
 		seriesName?: string;
-		data?: number | null;
+		data?: number | null | [string, number];
 		color?: string;
 	}
 
@@ -46,10 +46,12 @@ average TVL-weighted return as a line series.
 	let chartError = $state<string | null>(null);
 	let loadedDataUrl = $state<string | null>(null);
 
-	const tvlColour = '#14b8a6';
-	const returnColour = '#f59e0b';
+	const tvlColour = '#3b82f6';
+	const returnUpColour = '#22c55e';
+	const returnDownColour = '#ef4444';
 	const axisTextColour = '#d5deea';
 	const gridColour = 'rgba(148, 163, 184, 0.18)';
+	const axisFontSize = 12;
 
 	let points = $derived(chartData?.points ?? []);
 	let hasPoints = $derived(points.length > 0);
@@ -96,7 +98,8 @@ average TVL-weighted return as a line series.
 	function buildTooltip(params: TooltipParam[]) {
 		const date = params[0]?.axisValueLabel ?? '';
 		const tvl = params.find((param) => param.seriesName === 'TVL')?.data;
-		const averageReturn = params.find((param) => param.seriesName === 'Average TVL-weighted return')?.data;
+		const returnData = params.find((param) => param.seriesName === 'Average TVL-weighted return')?.data;
+		const averageReturn = Array.isArray(returnData) ? returnData[1] : returnData;
 
 		return [
 			`<div style="margin-bottom: 0.35rem; color: #ffffff; font-family: ${chartFontFamily}; font-weight: 700;">${formatDateLabel(date)}</div>`,
@@ -130,14 +133,31 @@ average TVL-weighted return as a line series.
 
 		const dates = points.map((point) => point.date);
 		const tvlSeries = points.map((point) => point.tvl);
-		const returnSeries = points.map((point) => point.apy);
+		// [date, value] pairs with nulls dropped — the sign-based visualMap cannot
+		// handle null points (ECharts throws while splitting the line into segments)
+		const returnSeries = points
+			.filter((point) => point.apy != null)
+			.map((point) => [point.date, point.apy] as [string, number]);
 
 		chartInstance = echartsApi.init(chartContainer);
 		chartInstance.setOption({
 			animationDuration: 300,
 			animationEasing: 'quadraticOut',
 			backgroundColor: 'transparent',
-			color: [tvlColour, returnColour],
+			color: [tvlColour, returnUpColour],
+			// colour the return line by sign: green above zero, red at/below zero;
+			// pieces need finite bounds — open-ended pieces crash the ECharts line
+			// gradient renderer ("Cannot read properties of undefined (reading 'coord')")
+			visualMap: {
+				show: false,
+				seriesIndex: 1,
+				dimension: 1,
+				pieces: [
+					{ gt: 0, lte: 1e9, color: returnUpColour },
+					{ gt: -1e9, lte: 0, color: returnDownColour }
+				],
+				outOfRange: { color: returnUpColour }
+			},
 			grid: {
 				top: 8,
 				right: 8,
@@ -163,8 +183,8 @@ average TVL-weighted return as a line series.
 				textStyle: {
 					color: '#f8fafc',
 					fontFamily: chartFontFamily,
-					fontSize: 12,
-					lineHeight: 18
+					fontSize: 13,
+					lineHeight: 19
 				},
 				formatter: (params: TooltipParam[]) => buildTooltip(params)
 			},
@@ -177,7 +197,7 @@ average TVL-weighted return as a line series.
 				axisLabel: {
 					color: axisTextColour,
 					fontFamily: chartFontFamily,
-					fontSize: 10,
+					fontSize: axisFontSize,
 					hideOverlap: true,
 					margin: 8,
 					formatter: (value: string) => formatAxisDate(value)
@@ -193,7 +213,7 @@ average TVL-weighted return as a line series.
 					axisLabel: {
 						color: axisTextColour,
 						fontFamily: chartFontFamily,
-						fontSize: 10,
+						fontSize: axisFontSize,
 						formatter: (value: number) => formatUsd(value)
 					},
 					splitLine: { lineStyle: { color: gridColour } }
@@ -201,12 +221,12 @@ average TVL-weighted return as a line series.
 				{
 					type: 'value',
 					position: 'right',
-					axisLine: { show: true, lineStyle: { color: withAlpha(returnColour, 0.75) } },
-					axisTick: { show: true, lineStyle: { color: withAlpha(returnColour, 0.48) } },
+					axisLine: { show: true, lineStyle: { color: withAlpha(returnUpColour, 0.75) } },
+					axisTick: { show: true, lineStyle: { color: withAlpha(returnUpColour, 0.48) } },
 					axisLabel: {
 						color: axisTextColour,
 						fontFamily: chartFontFamily,
-						fontSize: 10,
+						fontSize: axisFontSize,
 						formatter: (value: number) => formatReturn(value)
 					},
 					splitLine: { show: false }
@@ -239,8 +259,8 @@ average TVL-weighted return as a line series.
 					connectNulls: true,
 					symbol: 'circle',
 					symbolSize: 4,
-					lineStyle: { width: 2, color: returnColour },
-					itemStyle: { color: returnColour },
+					// line colour comes from the sign-based visualMap above
+					lineStyle: { width: 2 },
 					data: returnSeries
 				}
 			]

--- a/src/routes/trading-view/vaults/curators/+page.svelte
+++ b/src/routes/trading-view/vaults/curators/+page.svelte
@@ -28,9 +28,9 @@ aggregate TVL, vault count and average APY, plus a market-share pie chart.
 		return resolve(`/trading-view/vaults/curators/${slug}`);
 	}
 
-	const title = 'DeFi stablecoin vaults by curator';
+	const title = 'Stablecoin vault curators';
 	const description =
-		'DeFi stablecoin vaults grouped by curator. Curators select and manage vault strategies. TVL represents stablecoin deposits across a curator’s vaults. APY represents the yield of last thirty days.';
+		'Curator rankings for DeFi stablecoin vaults. Curators select and manage vault strategies. TVL represents stablecoin deposits across a curator’s vaults. APY represents the yield of last thirty days.';
 	const glossaryLinks = {
 		defi: resolve('/glossary/defi'),
 		vault: resolve('/glossary/vault'),
@@ -73,13 +73,13 @@ aggregate TVL, vault count and average APY, plus a market-share pie chart.
 				<div class="intro-column">
 					<HeroBanner>
 						{#snippet title()}
-							<span>DeFi vaults by curator</span>
+							<span>Stablecoin vault curators</span>
 						{/snippet}
 						{#snippet subtitle()}
+							Curator rankings for
 							<a class="body-link" href={glossaryLinks.defi}>DeFi</a>
 							<a class="body-link" href={glossaryLinks.stablecoin}>stablecoin</a>
-							<a class="body-link" href={glossaryLinks.vault}>vaults</a>
-							grouped by curator. Curators select and manage vault strategies.
+							<a class="body-link" href={glossaryLinks.vault}>vaults</a>. Curators select and manage vault strategies.
 							<a class="body-link" href={glossaryLinks.tvl}>TVL</a> represents stablecoin deposits across a curator’s
 							vaults.
 							<a class="body-link" href={glossaryLinks.apy}>APY</a>

--- a/tests/integration/trading-view/vaults/group-market-share-pages.test.ts
+++ b/tests/integration/trading-view/vaults/group-market-share-pages.test.ts
@@ -18,7 +18,7 @@ const pages = [
 	{
 		name: 'curators index page',
 		url: '/trading-view/vaults/curators',
-		heading: /DeFi vaults by curator/,
+		heading: /Stablecoin vault curators/,
 		widgetTestId: 'curator-tvl-pie-chart',
 		headerSelector: '.curator-index-header'
 	}


### PR DESCRIPTION
## Why

The curators index title and description read awkwardly for what is effectively a ranking page, and the per-curator detail chart was hard to read: the chart column was narrow, axis labels tiny, and the amber return line did not communicate whether returns were positive or negative at a glance.

## Lessons learnt

- ECharts 5.6.0 crashes with `Cannot read properties of undefined (reading 'coord')` when a `visualMap` with open-ended pieces (`{ gt: 0 }` / `{ lte: 0 }`) is applied to a line series — the line gradient renderer needs finite piece bounds, e.g. `{ gt: 0, lte: 1e9 }`.
- The same renderer also cannot handle `null` points in the series data; feeding `[date, value]` pairs with nulls dropped keeps category-axis alignment and avoids the crash (`connectNulls` is not enough).
- `VaultGroupMiniChart` is shared by protocol, chain and curator pages, so colour/font changes apply everywhere; the column-width change is scoped to `.curator-overview` only.

## Summary

- Curators index: title changed to "Stablecoin vault curators", description lead changed to "Curator rankings for DeFi stablecoin vaults" (meta tags and hero banner).
- Curator detail pages: chart aside widened from `minmax(22rem, 34rem)` to `minmax(26rem, 44rem)`, taking space from the description column.
- Vault group mini chart: return line is now coloured by sign via a sign-based `visualMap` (green above zero, red at/below zero); TVL line/area/axis changed from teal to blue; axis label font bumped 10px → 12px and tooltip 12px → 13px.

🤖 Generated with [Claude Code](https://claude.com/claude-code)