### PR TITLE
fix: prevent Cloudflare from caching SvelteKit route resolution responses

### DIFF
--- a/scripts/server.js
+++ b/scripts/server.js
@@ -14,6 +14,28 @@ import express from 'express';
 // Polka does not work https://github.com/sveltejs/kit/issues/6363
 const app = express();
 
+/**
+ * Prevent caching of SvelteKit's server-side route resolution responses
+ * (`<path>/__route.js`, generated because `router.resolution` is `server`
+ * in svelte.config.js).
+ *
+ * SvelteKit answers these requests before the `handle` hook runs and sends
+ * no cache-control header, while Cloudflare caches any URL ending in `.js`
+ * by default. After a deployment, a stale cached response points an
+ * already-loaded page at chunks from the previous build, crashing
+ * client-side navigation with "Cannot read properties of undefined
+ * (reading 'env')" and a client-rendered 500 error page.
+ *
+ * The SvelteKit handler only sets content-type on these responses, so a
+ * header set here is preserved.
+ */
+app.use((req, res, next) => {
+	if (req.path.endsWith('/__route.js')) {
+		res.setHeader('cache-control', 'private, no-cache');
+	}
+	next();
+});
+
 // Install SvelteKit server-side renderer
 app.use(handler);
 


### PR DESCRIPTION
## Why

Production users intermittently hit a client-rendered 500 error page with `TypeError: Cannot read properties of undefined (reading 'env')` when navigating to vault pages (curators, protocols, etc.) after a deployment.

Root cause: `svelte.config.js` uses `router.resolution: 'server'`, so every client-side navigation fetches `<path>/__route.js` from the server — a small script listing the build's content-hashed chunks to import for that route. SvelteKit serves these responses with no `cache-control` header, and Cloudflare caches any URL ending in `.js` by default (verified live: `cf-cache-status: EXPIRED` plus an injected `cache-control: max-age=14400`). After a deploy, the page HTML comes from the new build (defining `globalThis.__sveltekit_<new>`), but a stale cached `__route.js` still points at the previous build's chunks. The old build's `$env/dynamic/public` chunk reads `globalThis.__sveltekit_<old>.env`, which is undefined on the new page — the navigation throws, and SvelteKit renders the error page with status 500.

## Lessons learnt

- SvelteKit answers route resolution requests in `respond()` **before** the `handle` hook runs, so `hooks.server.ts` cannot set headers on them. The only in-app layer above it is our custom Express wrapper (`scripts/server.js`). The SvelteKit handler only sets `content-type` on these responses, so a header pre-set via `res.setHeader()` survives.
- Cloudflare's default file-extension caching applies to dynamic endpoints whose path merely ends in `.js`; `__data.json` is unaffected because `.json` is not on the default extension list.
- Entries already cached by Cloudflare stay stale until their 4-hour TTL expires; a one-time purge of `*__route.js*` after deploying stops the current errors immediately.
- This is an upstream SvelteKit gap — `router.resolution: 'server'` responses ship with no cache-control — worth an upstream issue so the workaround can eventually be dropped.

## Summary

- Added Express middleware in `scripts/server.js` that sets `cache-control: private, no-cache` on any request path ending in `/__route.js`, so neither Cloudflare nor browsers cache route resolution responses across deployments.
- Verified against a production build: `__route.js` now carries the header, immutable chunks keep `public,max-age=31536000,immutable`, and regular pages are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)