### PR TITLE
fix: CORE3 branding, project profile URLs and UTM tracking on vault pages

### DIFF
--- a/src/lib/top-vaults/Core3Ratings.svelte
+++ b/src/lib/top-vaults/Core3Ratings.svelte
@@ -1,9 +1,9 @@
 <!--
 @component
-Displays the third-party Core3 protocol risk rating for a protocol. The rating is
+Displays the third-party CORE3 protocol risk rating for a protocol. The rating is
 protocol-level, so it applies to every vault on that protocol. Used on both the
 individual vault detail page and the protocol listing page; only render it when
-the protocol actually has a Core3 rating.
+the protocol actually has a CORE3 rating.
 
 The header carries the rating grade badge next to the title. Below, a two-column
 layout shows the rating metrics (risk score, confidence, rank) on the left and
@@ -58,7 +58,7 @@ page); omit it on the protocol page itself to render the name as plain text.
 	{#if rating}
 		<div class="grade" data-tone={ratingTone}>{rating}</div>
 	{/if}
-	<h2>Core3 risk rating</h2>
+	<h2>CORE3 risk rating</h2>
 {/snippet}
 
 <MetricsBox class={boxClass}>
@@ -80,12 +80,12 @@ page); omit it on the protocol page itself to render the name as plain text.
 			</header>
 
 			<p class="intro">
-				Risk rating by Core3 for {#if protocolSlug}<a href={resolve(`/trading-view/vaults/protocols/${protocolSlug}`)}
+				Risk rating by CORE3 for {#if protocolSlug}<a href={resolve(`/trading-view/vaults/protocols/${protocolSlug}`)}
 						>{protocolName}</a
 					>{:else}{protocolName}{/if}. The rating applies to all vaults on this protocol.
 				{#if reportUrl}
 					<!-- eslint-disable-next-line svelte/no-navigation-without-resolve -->
-					<a href={reportUrl} target="_blank" rel="noreferrer">View full rating on the Core3 website</a>.
+					<a href={reportUrl} target="_blank" rel="noreferrer">View full rating on the CORE3 website</a>.
 				{/if}
 			</p>
 
@@ -103,7 +103,7 @@ page); omit it on the protocol page itself to render the name as plain text.
 										</a>
 										<svelte:fragment slot="popup">
 											<p>
-												Core3's Probability of Loss (PoL) estimates how likely users or token holders are to suffer a
+												CORE3's Probability of Loss (PoL) estimates how likely users or token holders are to suffer a
 												financially material loss, excluding market price moves.
 											</p>
 											<p>
@@ -141,12 +141,12 @@ page); omit it on the protocol page itself to render the name as plain text.
 									<Tooltip>
 										<!-- eslint-disable-next-line svelte/no-navigation-without-resolve -->
 										<a slot="trigger" class="metric-link" href={rankingUrl} target="_blank" rel="noreferrer">
-											Core3 rank
+											CORE3 rank
 											<IconQuestionCircle />
 										</a>
 										<svelte:fragment slot="popup">
-											Where this protocol ranks among all DeFi protocols rated by Core3, ordered by risk (1 = best).
-											Opens the Core3 ranking page.
+											Where this protocol ranks among all DeFi protocols rated by CORE3, ordered by risk (1 = best).
+											Opens the CORE3 ranking page.
 										</svelte:fragment>
 									</Tooltip>
 								</th>
@@ -342,7 +342,7 @@ page); omit it on the protocol page itself to render the name as plain text.
 		}
 	}
 
-	/* Cap the Core3 metric tooltips and give the score breakdown a real bullet list */
+	/* Cap the CORE3 metric tooltips and give the score breakdown a real bullet list */
 	:global(.core3-ratings .tooltip .popup) {
 		max-width: 400px;
 	}

--- a/src/lib/top-vaults/Core3RiskCell.svelte
+++ b/src/lib/top-vaults/Core3RiskCell.svelte
@@ -1,8 +1,8 @@
 <!--
 @component
-Table cell showing a protocol's Core3 risk rating letter (e.g. "AA", "BB"),
+Table cell showing a protocol's CORE3 risk rating letter (e.g. "AA", "BB"),
 colour-coded by tone, with a tooltip explaining the rating. Renders an em dash
-for protocols that have no Core3 rating.
+for protocols that have no CORE3 rating.
 
 @example
 
@@ -33,7 +33,7 @@ for protocols that have no Core3 rating.
 				<span class="rating" data-tone={tone}>{rating}</span>
 			</svelte:fragment>
 			<svelte:fragment slot="popup">
-				Core3's protocol risk rating (Probability of Loss): a third-party estimate of how likely users are to suffer a
+				CORE3's protocol risk rating (Probability of Loss): a third-party estimate of how likely users are to suffer a
 				financially material loss, graded from AA (lowest risk) down to D.
 				{#if slug}<a href={resolve(`/trading-view/vaults/protocols/${slug}`)}>View more</a>{/if}
 			</svelte:fragment>

--- a/src/lib/top-vaults/VaultGroupTable.svelte
+++ b/src/lib/top-vaults/VaultGroupTable.svelte
@@ -104,7 +104,7 @@
 		}),
 		table.column({
 			id: 'core3_risk',
-			header: 'Core3',
+			header: 'CORE3',
 			accessor: (row) => ({ rating: row.core3_rating ?? null, slug: row.slug, score: row.core3_score ?? null }),
 			cell: ({ value }) => createRender(Core3RiskCell, { rating: value.rating, slug: value.slug }),
 			plugins: {
@@ -194,7 +194,7 @@
 				width: max(calc(20vw), 12rem);
 			}
 
-			/* layout with a leading rating column (technical risk and/or Core3); the
+			/* layout with a leading rating column (technical risk and/or CORE3); the
 			   percentage widths must sum to 100% so the cells fill the table edge-to-edge */
 			:global(:has(:is(.risk, .core3_risk))) {
 				:global(:is(th, td)) {

--- a/src/lib/top-vaults/helpers.test.ts
+++ b/src/lib/top-vaults/helpers.test.ts
@@ -8,7 +8,9 @@ import {
 	getFormattedLockup,
 	getFormattedFeeMode,
 	getFeeModeLabel,
-	getFeeModeDescription
+	getFeeModeDescription,
+	getCore3ReportUrl,
+	getCore3RankingUrl
 } from './helpers';
 import { createTestVault } from './test-utils';
 
@@ -208,5 +210,33 @@ describe('getFeeModeDescription', () => {
 
 	test('returns description for feeless', () => {
 		expect(getFeeModeDescription('feeless')).toContain('No fees');
+	});
+});
+
+describe('getCore3ReportUrl', () => {
+	test('builds the project profile URL from the CORE3 slug with the UTM source', () => {
+		expect(getCore3ReportUrl({ slug: 'sky' })).toBe('https://core3.io/projects/sky?utm_source=tradingstrategy');
+	});
+
+	test('returns undefined when the slug is missing', () => {
+		expect(getCore3ReportUrl({ slug: '' })).toBeUndefined();
+	});
+});
+
+describe('getCore3RankingUrl', () => {
+	test('returns the projects ranking URL with the UTM source for non-exchange categories', () => {
+		expect(getCore3RankingUrl({ category: { name: 'Decentralized Finance' } })).toBe(
+			'https://core3.io/ratings/projects?utm_source=tradingstrategy'
+		);
+	});
+
+	test('returns the exchanges ranking URL for exchange categories', () => {
+		expect(getCore3RankingUrl({ category: { name: 'Decentralized Exchange' } })).toBe(
+			'https://core3.io/ratings/exchanges?utm_source=tradingstrategy'
+		);
+	});
+
+	test('defaults to the projects ranking when category is missing', () => {
+		expect(getCore3RankingUrl({})).toBe('https://core3.io/ratings/projects?utm_source=tradingstrategy');
 	});
 });

--- a/src/lib/top-vaults/helpers.ts
+++ b/src/lib/top-vaults/helpers.ts
@@ -348,28 +348,28 @@ export function rankVaultsBy<V extends Record<string, unknown>>(keys: (keyof V)[
 	};
 }
 
+/** UTM query string appended to all outbound CORE3 links so CORE3 can attribute referral traffic. */
+const CORE3_UTM = 'utm_source=tradingstrategy';
+
 /**
- * Resolve the public Core3 report URL for a rated protocol.
+ * Resolve the public CORE3 project profile URL for a rated protocol, e.g.
+ * `https://core3.io/projects/sky?utm_source=tradingstrategy`.
  *
- * The upstream `link` field is malformed — it concatenates the Core3 slug
- * directly onto the origin without a path separator (e.g.
- * `https://core3.ioinverse-finance`). We repair it by inserting the missing
- * slash. Returns `undefined` when no usable link is present.
+ * Built from the CORE3 `slug` rather than the upstream `link` field, which is
+ * malformed (it concatenates the slug directly onto the origin without the
+ * `/projects/` path, e.g. `https://core3.ioinverse-finance`). Returns
+ * `undefined` when the slug is missing.
  */
-export function getCore3ReportUrl(core3: Pick<Core3Protocol, 'link'>): string | undefined {
-	const link = core3.link;
-	if (!link) return undefined;
-	const origin = 'https://core3.io';
-	if (link.startsWith(`${origin}/`)) return link;
-	if (link.startsWith(origin)) return `${origin}/${link.slice(origin.length)}`;
-	return link;
+export function getCore3ReportUrl(core3: Pick<Core3Protocol, 'slug'>): string | undefined {
+	if (!core3.slug) return undefined;
+	return `https://core3.io/projects/${core3.slug}?${CORE3_UTM}`;
 }
 
-/** Qualitative tone for a Core3 letter grade, used for colour-coding. */
+/** Qualitative tone for a CORE3 letter grade, used for colour-coding. */
 export type Core3RatingTone = 'excellent' | 'good' | 'fair' | 'poor' | 'unknown';
 
 /**
- * Map a Core3 letter grade to a qualitative tone for colour-coding.
+ * Map a CORE3 letter grade to a qualitative tone for colour-coding.
  * Scale, best to worst: AAA, AA, A, BBB, BB, B, CCC, CC, C, DDD, DD, D.
  */
 export function getCore3RatingTone(rating: string | null | undefined): Core3RatingTone {
@@ -382,13 +382,13 @@ export function getCore3RatingTone(rating: string | null | undefined): Core3Rati
 }
 
 /**
- * Resolve the Core3 ranking (leaderboard) URL that a protocol's Core3 rank
- * refers to. Core3 splits its ranking into projects and exchanges, so we pick
- * the list matching the protocol's Core3 category.
+ * Resolve the CORE3 ranking (leaderboard) URL that a protocol's CORE3 rank
+ * refers to. CORE3 splits its ranking into projects and exchanges, so we pick
+ * the list matching the protocol's CORE3 category.
  */
 export function getCore3RankingUrl(core3: Pick<Core3Protocol, 'category'>): string {
 	const isExchange = /exchange/i.test(core3.category?.name ?? '');
-	return `https://core3.io/ratings/${isExchange ? 'exchanges' : 'projects'}`;
+	return `https://core3.io/ratings/${isExchange ? 'exchanges' : 'projects'}?${CORE3_UTM}`;
 }
 
 /**

--- a/src/lib/top-vaults/schemas.ts
+++ b/src/lib/top-vaults/schemas.ts
@@ -345,7 +345,7 @@ export const vaultInfoSchema = z.object({
 export type VaultInfo = z.infer<typeof vaultInfoSchema>;
 
 /**
- * Core3 protocol-level risk rating (https://core3.io).
+ * CORE3 protocol-level risk rating (https://core3.io).
  *
  * Third-party rating data sourced by the backend and keyed in the top-vaults
  * payload by protocol slug (matching {@link VaultInfo.protocol_slug}). Surfaced
@@ -363,21 +363,21 @@ export const core3PolSchema = z.object({
 export type Core3Pol = z.infer<typeof core3PolSchema>;
 
 export const core3ProtocolSchema = z.object({
-	/** Core3 protocol slug (may differ from our protocol_slug) */
+	/** CORE3 protocol slug (may differ from our protocol_slug) */
 	slug: z.string(),
-	/** Protocol display name on Core3 */
+	/** Protocol display name on CORE3 */
 	name: z.string(),
-	/** Overall Core3 rank across all rated protocols (1 = best) */
+	/** Overall CORE3 rank across all rated protocols (1 = best) */
 	rank: z.int().nullable().optional(),
 	/** Headline rating object (grade, score, confidence) */
 	pol: core3PolSchema.nullable().optional(),
 	/** Protocol ticker (e.g. "INV") */
 	ticker: z.string().nullable().optional(),
-	/** Core3 protocol report URL — note: upstream omits the path slash, fixed in the helper */
+	/** CORE3 protocol report URL — malformed upstream (omits the path); we build profile URLs from `slug` instead */
 	link: z.string().nullable().optional(),
-	/** Core3 category (e.g. "Decentralized Finance") */
+	/** CORE3 category (e.g. "Decentralized Finance") */
 	category: z.object({ name: z.string().nullable() }).nullable().optional(),
-	/** Share of Core3's data points populated for this protocol, as a percentage */
+	/** Share of CORE3's data points populated for this protocol, as a percentage */
 	data_coverage: z.object({ percentage: nullableNumber }).nullable().optional(),
 	/** Market-cap snapshot; `in_usd` is a numeric string */
 	market_cap: z
@@ -461,7 +461,7 @@ export const topVaultsSchema = z.object({
 	/** All tracked vaults with full performance and metadata */
 	vaults: vaultInfoSchema.array(),
 	/**
-	 * Core3 protocol risk ratings, keyed by protocol slug. External third-party
+	 * CORE3 protocol risk ratings, keyed by protocol slug. External third-party
 	 * data — `.catch({})` guarantees a malformed/changed payload here can never
 	 * break parsing of the (critical) vaults array.
 	 */
@@ -497,8 +497,8 @@ export interface VaultGroup {
 	risk?: string | null;
 	/** Numeric risk score — only present on protocol groups */
 	risk_numeric?: number | null;
-	/** Core3 protocol risk rating letter (e.g. "AA", "BB") — only present on protocol groups with a Core3 rating */
+	/** CORE3 protocol risk rating letter (e.g. "AA", "BB") — only present on protocol groups with a CORE3 rating */
 	core3_rating?: string | null;
-	/** Core3 numeric risk score (lower = better) — used to sort the Core3 rating column */
+	/** CORE3 numeric risk score (lower = better) — used to sort the CORE3 rating column */
 	core3_score?: number | null;
 }

--- a/src/routes/trading-view/vaults/[vault=slug]/+page.server.ts
+++ b/src/routes/trading-view/vaults/[vault=slug]/+page.server.ts
@@ -23,7 +23,7 @@ export async function load({ params, fetch }) {
 	const chain = getChain(vault.chain_id);
 	if (!chain) error(404, 'Chain not found');
 
-	// Core3 ratings are keyed by protocol slug; null when the protocol is unrated
+	// CORE3 ratings are keyed by protocol slug; null when the protocol is unrated
 	const core3 = core3_protocols[vault.protocol_slug] ?? null;
 
 	const [protocolMetadata, stablecoinMetadataIndex] = await Promise.all([


### PR DESCRIPTION
## Why

CORE3 (11 June 2026) requested branding and link corrections for the recently merged integration:

- All instances of "Core3" should read "CORE3"
- Project links should point to the project profile URL `https://core3.io/projects/<slug>` — the previous implementation sent users to `https://core3.io/<slug>`, which is incorrect
- All outbound CORE3 links should carry `utm_source=tradingstrategy` so both teams can attribute referral traffic

## Lessons learnt

- The upstream CORE3 `link` field is doubly unusable: it omits the path separator (`https://core3.ioinverse-finance`) *and*, even repaired, points at the wrong path (`/<slug>` instead of `/projects/<slug>`). Building the URL from the CORE3 `slug` field is the reliable approach; the schema comment on `link` now records this.
- The CORE3 rating box is collapsible on protocol pages, so browser verification of its outbound links requires expanding it first — a collapsed box renders no links.
- Code identifiers (`Core3Ratings`, `core3_rating`, `getCore3ReportUrl`, CSS classes) were deliberately left in the old casing; only user-facing copy and doc comments changed. A rename would churn imports and CSS for no user benefit.

## Summary

- `getCore3ReportUrl` now builds `https://core3.io/projects/<slug>?utm_source=tradingstrategy` from the CORE3 slug instead of repairing the malformed upstream `link`
- `getCore3RankingUrl` (risk score / rank leaderboard links) now appends `utm_source=tradingstrategy`
- All user-facing "Core3" strings renamed to "CORE3": rating box heading, intro copy, tooltips, rank metric, and the protocols directory column header
- Doc comments updated to the new branding
- Added unit tests for both URL helpers

Verified in the browser on all three affected page types: vault detail (`/trading-view/vaults/staked-usds` → `https://core3.io/projects/sky?utm_source=tradingstrategy`, matching CORE3's example), protocol detail (`/trading-view/vaults/protocols/morpho`), and the protocols directory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)