### PR TITLE
fix: widen vault group mini chart on all listing pages, curator page SEO metadata

### DIFF
--- a/src/lib/stablecoin-metadata/StablecoinDetailHeader.svelte
+++ b/src/lib/stablecoin-metadata/StablecoinDetailHeader.svelte
@@ -102,7 +102,8 @@ the stablecoin's vaults. The chart is hidden on mobile.
 <style>
 	.stablecoin-detail-header {
 		display: grid;
-		grid-template-columns: 1fr 1fr;
+		/* give the chart column more room, at the expense of the description column */
+		grid-template-columns: minmax(0, 1fr) minmax(26rem, 44rem);
 		gap: 1.5rem;
 		align-items: stretch;
 
@@ -118,7 +119,9 @@ the stablecoin's vaults. The chart is hidden on mobile.
 			min-height: unset;
 		}
 
-		@media (--viewport-sm-down) {
+		/* on tablet widths the two-column layout makes the box content unreadable —
+		   stack the description and chart boxes vertically as on mobile */
+		@media (--viewport-md-down) {
 			grid-template-columns: 1fr;
 
 			.chart-column:empty {

--- a/src/lib/top-vaults/TopVaultsPage.svelte
+++ b/src/lib/top-vaults/TopVaultsPage.svelte
@@ -244,7 +244,7 @@
 
 		.hero-layout {
 			display: grid;
-			grid-template-columns: minmax(0, 1fr) minmax(22rem, 34rem);
+			grid-template-columns: minmax(0, 1fr) minmax(26rem, 44rem);
 			gap: 1rem;
 			align-items: start;
 
@@ -279,9 +279,11 @@
 			gap: 1rem;
 		}
 
+		/* give the chart aside more room, at the expense of the about/description
+		   column */
 		.detail-overview {
 			display: grid;
-			grid-template-columns: minmax(0, 1fr) minmax(22rem, 34rem);
+			grid-template-columns: minmax(0, 1fr) minmax(26rem, 44rem);
 			gap: 1rem;
 			align-items: stretch;
 		}
@@ -301,12 +303,6 @@
 			align-content: start;
 		}
 
-		/* give the chart aside more room on curator pages, at the expense of the
-		   about/description column */
-		.curator-overview {
-			grid-template-columns: minmax(0, 1fr) minmax(26rem, 44rem);
-		}
-
 		@media (--viewport-lg-up) {
 			.curator-overview {
 				align-items: start;
@@ -317,19 +313,19 @@
 			}
 		}
 
-		/* on tablet widths the two-column layout makes the box content unreadable —
-		   stack the about, posts and chart boxes vertically as on mobile */
-		@media (--viewport-md-down) {
-			.curator-overview {
-				grid-template-columns: 1fr;
-			}
+		.detail-overview-single .detail-aside {
+			grid-column: 2;
 		}
 
-		.detail-overview-single {
-			grid-template-columns: minmax(0, 1fr) minmax(22rem, 34rem);
+		/* on tablet widths the two-column layout makes the box content unreadable —
+		   stack the description and chart boxes vertically as on mobile */
+		@media (--viewport-md-down) {
+			.detail-overview {
+				grid-template-columns: 1fr;
+			}
 
-			.detail-aside {
-				grid-column: 2;
+			.detail-overview-single .detail-aside {
+				grid-column: auto;
 			}
 		}
 
@@ -337,14 +333,6 @@
 			.hero-layout {
 				grid-template-columns: 1fr;
 				align-items: stretch;
-			}
-
-			.detail-overview {
-				grid-template-columns: 1fr;
-			}
-
-			.detail-overview-single .detail-aside {
-				grid-column: auto;
 			}
 		}
 	}

--- a/src/routes/trading-view/vaults/curators/[curator=slug]/+page.server.ts
+++ b/src/routes/trading-view/vaults/curators/[curator=slug]/+page.server.ts
@@ -1,16 +1,24 @@
 import { error } from '@sveltejs/kit';
 import { getCachedTopVaults } from '$lib/top-vaults/cache';
+import { isBlacklisted, meetsMinTvl } from '$lib/top-vaults/helpers.js';
 
 export async function load({ params, fetch }) {
 	const { curator } = params;
-	const { curators } = await getCachedTopVaults(fetch);
+	const { vaults, curators } = await getCachedTopVaults(fetch);
 
 	const curatorInfo = curators[curator];
 	if (!curatorInfo) error(404, 'Curator not found');
 
+	// aggregate stats for server-rendered SEO metadata; same eligibility rules
+	// as the curators index listing
+	const eligibleVaults = vaults.filter((v) => v.curator_slug === curator && !isBlacklisted(v) && meetsMinTvl(v));
+	const tvl = eligibleVaults.reduce((acc, v) => acc + (v.current_nav ?? 0), 0);
+
 	return {
 		curatorSlug: curator,
 		curatorName: curatorInfo.name,
-		curator: curatorInfo
+		curator: curatorInfo,
+		vaultCount: eligibleVaults.length,
+		tvl
 	};
 }

--- a/src/routes/trading-view/vaults/curators/[curator=slug]/+page.svelte
+++ b/src/routes/trading-view/vaults/curators/[curator=slug]/+page.svelte
@@ -9,9 +9,10 @@ with an "about" panel and a TVL/return mini chart.
 	import TopVaultsPage from '$lib/top-vaults/TopVaultsPage.svelte';
 	import { MetaTags, JsonLd } from 'svelte-meta-tags';
 	import VaultGroupMiniChart from '../../VaultGroupMiniChart.svelte';
+	import { formatDollar } from '$lib/helpers/formatters';
 
 	let { data } = $props();
-	let { curatorSlug, curatorName, curator } = $derived(data);
+	let { curatorSlug, curatorName, curator, vaultCount, tvl } = $derived(data);
 
 	let topVaults = $state<TopVaults>();
 	let totalVaultCount = $state<number>();
@@ -30,10 +31,22 @@ with an "about" panel and a TVL/return mini chart.
 			.finally(() => (loading = false));
 	});
 
-	let title = $derived(`Top ${curatorName} stablecoin vaults`);
-	let description = $derived(`Stablecoin vaults curated by ${curatorName}, ranked by performance.`);
+	/** Ensure a plain-text fragment reads as a full sentence when concatenated */
+	function asSentence(text: string) {
+		const trimmed = text.trim();
+		return /[.!?]$/.test(trimmed) ? trimmed : `${trimmed}.`;
+	}
+
+	let title = $derived(`Top ${curatorName} stablecoin vaults | Trading Strategy`);
+	let description = $derived.by(() => {
+		const stats =
+			vaultCount > 0 ? ` ${vaultCount} ${vaultCount === 1 ? 'vault' : 'vaults'} with ${formatDollar(tvl, 0)} TVL.` : '';
+		const about = curator.short_description ? ` ${asSentence(curator.short_description)}` : '';
+		return `Stablecoin vaults curated by ${curatorName}, ranked by returns and TVL.${stats}${about}`;
+	});
 	let pageUrl = $derived(new URL(page.url.pathname, page.url.origin).href);
 	let logoUrl = $derived(curator.logos.generic ? new URL(curator.logos.generic, page.url.origin).href : undefined);
+	let socialProfileUrls = $derived([curator.twitter, curator.linkedin].filter((url) => url != null));
 </script>
 
 <MetaTags
@@ -45,7 +58,7 @@ with an "about" panel and a TVL/return mini chart.
 		url: pageUrl,
 		title,
 		description,
-		images: logoUrl ? [{ url: logoUrl }] : [],
+		images: logoUrl ? [{ url: logoUrl, alt: `${curatorName} logo` }] : [],
 		type: 'website'
 	}}
 	twitter={{
@@ -66,9 +79,16 @@ with an "about" panel and a TVL/return mini chart.
 		url: pageUrl,
 		provider: { '@type': 'Organization', name: 'Trading Strategy' },
 		image: logoUrl ?? undefined,
+		about: {
+			'@type': 'Organization',
+			name: curatorName,
+			url: curator.website ?? undefined,
+			logo: logoUrl ?? undefined,
+			sameAs: socialProfileUrls.length > 0 ? socialProfileUrls : undefined
+		},
 		mainEntity: {
 			'@type': 'ItemList',
-			numberOfItems: topVaults?.vaults.length ?? 0
+			numberOfItems: vaultCount
 		}
 	}}
 />

--- a/src/routes/trading-view/vaults/curators/[curator=slug]/+page.svelte
+++ b/src/routes/trading-view/vaults/curators/[curator=slug]/+page.svelte
@@ -31,19 +31,33 @@ with an "about" panel and a TVL/return mini chart.
 			.finally(() => (loading = false));
 	});
 
+	/** Google truncates search snippets around this length; keep the meta description within it */
+	const META_DESCRIPTION_MAX_LENGTH = 160;
+
 	/** Ensure a plain-text fragment reads as a full sentence when concatenated */
 	function asSentence(text: string) {
 		const trimmed = text.trim();
 		return /[.!?]$/.test(trimmed) ? trimmed : `${trimmed}.`;
 	}
 
+	/** Clip text at a word boundary (with an ellipsis) so it fits within maxLength */
+	function clipAtWord(text: string, maxLength: number) {
+		if (text.length <= maxLength) return text;
+		const clipped = text.slice(0, maxLength - 1);
+		const lastSpace = clipped.lastIndexOf(' ');
+		return `${clipped.slice(0, lastSpace > 0 ? lastSpace : maxLength - 1).replace(/[,;:.]$/, '')}…`;
+	}
+
 	let title = $derived(`Top ${curatorName} stablecoin vaults | Trading Strategy`);
-	let description = $derived.by(() => {
+	let fullDescription = $derived.by(() => {
 		const stats =
 			vaultCount > 0 ? ` ${vaultCount} ${vaultCount === 1 ? 'vault' : 'vaults'} with ${formatDollar(tvl, 0)} TVL.` : '';
 		const about = curator.short_description ? ` ${asSentence(curator.short_description)}` : '';
 		return `Stablecoin vaults curated by ${curatorName}, ranked by returns and TVL.${stats}${about}`;
 	});
+	// search-snippet meta description: same content clipped to fit; social cards
+	// and JSON-LD carry the full curator blurb
+	let metaDescription = $derived(clipAtWord(fullDescription, META_DESCRIPTION_MAX_LENGTH));
 	let pageUrl = $derived(new URL(page.url.pathname, page.url.origin).href);
 	let logoUrl = $derived(curator.logos.generic ? new URL(curator.logos.generic, page.url.origin).href : undefined);
 	let socialProfileUrls = $derived([curator.twitter, curator.linkedin].filter((url) => url != null));
@@ -51,13 +65,13 @@ with an "about" panel and a TVL/return mini chart.
 
 <MetaTags
 	{title}
-	{description}
+	description={metaDescription}
 	canonical={pageUrl}
 	openGraph={{
 		siteName: 'Trading Strategy',
 		url: pageUrl,
 		title,
-		description,
+		description: fullDescription,
 		images: logoUrl ? [{ url: logoUrl, alt: `${curatorName} logo` }] : [],
 		type: 'website'
 	}}
@@ -65,7 +79,7 @@ with an "about" panel and a TVL/return mini chart.
 		site: '@TradingProtocol',
 		cardType: logoUrl ? 'summary_large_image' : 'summary',
 		title,
-		description,
+		description: fullDescription,
 		image: logoUrl ?? undefined
 	}}
 />
@@ -75,7 +89,7 @@ with an "about" panel and a TVL/return mini chart.
 		'@context': 'http://schema.org',
 		'@type': 'CollectionPage',
 		name: title,
-		description,
+		description: fullDescription,
 		url: pageUrl,
 		provider: { '@type': 'Organization', name: 'Trading Strategy' },
 		image: logoUrl ?? undefined,


### PR DESCRIPTION
## Why

The mini returns/TVL chart expansion shipped for curator pages in #1266 left protocol, chain and stablecoin detail pages with the old narrow chart column, so the same chart rendered cramped depending on which page you viewed it on. Curator detail pages also rendered weak SEO metadata: a brandless title, a generic one-line description, and JSON-LD whose vault count was always 0 in the server-rendered HTML because it read client-side state.

## Lessons learnt

- All vault group listing pages funnel through `TopVaultsPage.svelte`, but the chart column width was defined in three places (`.hero-layout` for chain pages, `.detail-overview` for protocol/curator pages, plus a curator-only override) and a fourth in `StablecoinDetailHeader.svelte` — widening "the chart" means touching all of them.
- The colour/font polish from #1266 lives in the shared `VaultGroupMiniChart` component, so it already applied to every page; no per-page colour work was needed.
- JSON-LD values that come from `$state` populated in `$effect` are rendered as their initial values in SSR HTML — crawler-visible metadata must come from the server `load`.
- Curator logo URLs in the top-vaults dataset are already absolute; `new URL(value, origin)` passes them through unchanged so it is safe for both absolute and relative values.
- Fresh worktrees do not inherit gitignored `.env`/`.env.local`; the dev server fails with "Neither R2 nor TS_PRIVATE_TOP_VAULTS_URL is configured" until they are copied from the main checkout.

## Summary

- Chart layout: the base `.detail-overview` grid (protocol pages and the single-aside fallback), the chain-page `.hero-layout`, and the stablecoin detail header all widen the chart column from `minmax(22rem, 34rem)`/`1fr` to the curator pages' `minmax(26rem, 44rem)`, shrinking the left description column. The now-redundant curator-only override was removed.
- Tablet: the "stack columns on tablet widths" rule that previously covered only curator pages now covers all detail overviews and the stablecoin header, since the wider chart makes two columns unreadable there.
- Curator detail SEO: title gains the `| Trading Strategy` brand suffix; the meta description combines a keyword-rich lead, server-computed stats ("13 vaults with $2B TVL") and the curator's own short description; Open Graph image gains an alt text; JSON-LD gains an `about` Organization node (name, website, logo, `sameAs` Twitter/LinkedIn) and a server-rendered `numberOfItems`.
- Curator page server load now aggregates eligible vault count and TVL (same eligibility rules as the curators index) for the metadata.

🤖 Generated with [Claude Code](https://claude.com/claude-code)