### PR TITLE
fix: align vault group APY and metric copy

### DIFF
--- a/src/lib/curator/CuratorDescription.svelte
+++ b/src/lib/curator/CuratorDescription.svelte
@@ -42,6 +42,9 @@ the vault protocol description widget. Sourced from the top-vaults dataset
 	);
 	let totalTvl = $derived(calculateTotalTvl(statsVaults));
 	let averageApy = $derived(calculateTvlWeightedApy(statsVaults));
+	let vaultCountLabel = $derived(`${statsVaults.length} ${statsVaults.length === 1 ? 'vault' : 'vaults'}`);
+	let totalTvlLabel = $derived(`${formatDollar(totalTvl, 1)} TVL`);
+	let averageApyLabel = $derived(averageApy == null ? null : `${formatPercent(averageApy, 1)} APY`);
 
 	let expanded = $state(false);
 
@@ -65,9 +68,9 @@ the vault protocol description widget. Sourced from the top-vaults dataset
 					<p>
 						{#if curator.short_description}{curator.short_description}{/if}
 						{#if statsVaults.length}
-							{curator.name} has {statsVaults.length}
-							{statsVaults.length === 1 ? 'vault' : 'vaults'}, with {formatDollar(totalTvl, 1)} TVL{#if averageApy != null}{' '}and
-								{formatPercent(averageApy, 1)} APY for the last 30 days{/if}.
+							{curator.name} has
+							<strong>{vaultCountLabel}</strong>, with <strong>{totalTvlLabel}</strong>{#if averageApyLabel}{' '}and
+								<strong>{averageApyLabel}</strong> for the last 30 days{/if}.
 						{/if}
 					</p>
 				{/if}
@@ -121,6 +124,11 @@ the vault protocol description widget. Sourced from the top-vaults dataset
 
 			p {
 				margin: 0;
+			}
+
+			strong {
+				color: var(--c-text);
+				font-weight: 600;
 			}
 		}
 

--- a/src/lib/echarts/protocol-mini-chart.test.ts
+++ b/src/lib/echarts/protocol-mini-chart.test.ts
@@ -63,4 +63,17 @@ describe('buildProtocolMiniChartPayload', () => {
 		});
 		expect(latest?.tvl).toBe(100);
 	});
+
+	test('uses table-compatible APY override for the latest point', () => {
+		const rows = [...createRows('vault-a', 100, 1, 1.01), ...createRows('vault-b', 300, 1, 1.02)];
+		const payload = buildProtocolMiniChartPayload(rows, 2, 3600, {
+			generatedAt: new Date('2026-02-01T00:00:00Z'),
+			latestApyRows: [
+				{ id: 'vault-a', tvl: 100, apy: 0.03 },
+				{ id: 'vault-b', tvl: 300, apy: 0.05 }
+			]
+		});
+
+		expect(payload.points.at(-1)?.apy).toBeCloseTo(0.045);
+	});
 });

--- a/src/lib/echarts/protocol-mini-chart.ts
+++ b/src/lib/echarts/protocol-mini-chart.ts
@@ -14,6 +14,12 @@ export interface ProtocolMiniChartDailyRow {
 	sharePrice: number;
 }
 
+export interface ProtocolMiniChartLatestApyRow {
+	id: string;
+	tvl: number;
+	apy: number | null;
+}
+
 export interface ProtocolMiniChartPoint {
 	date: string;
 	tvl: number;
@@ -44,6 +50,11 @@ interface FilledVaultPoint {
 	dayMs: number;
 	tvl: number;
 	sharePrice: number;
+}
+
+interface ProtocolMiniChartOptions {
+	generatedAt?: Date;
+	latestApyRows?: ProtocolMiniChartLatestApyRow[];
 }
 
 function normaliseDay(value: string | Date) {
@@ -104,12 +115,39 @@ function buildFilledVaultSeries(rows: NormalisedDailyRow[], allDays: string[]) {
 	return filled;
 }
 
+function resolveOptions(optionsOrGeneratedAt?: Date | ProtocolMiniChartOptions): Required<ProtocolMiniChartOptions> {
+	if (optionsOrGeneratedAt instanceof Date) {
+		return { generatedAt: optionsOrGeneratedAt, latestApyRows: [] };
+	}
+
+	return {
+		generatedAt: optionsOrGeneratedAt?.generatedAt ?? new Date(),
+		latestApyRows: optionsOrGeneratedAt?.latestApyRows ?? []
+	};
+}
+
+function getLatestApyOverride(rows: ProtocolMiniChartLatestApyRow[]) {
+	let weightedSum = 0;
+	let weight = 0;
+
+	for (const row of rows) {
+		if (!Number.isFinite(row.tvl) || row.tvl <= 0) continue;
+		if (row.apy == null || !Number.isFinite(row.apy) || row.apy > MAX_APY_THRESHOLD) continue;
+
+		weightedSum += row.tvl * row.apy;
+		weight += row.tvl;
+	}
+
+	return weight > 0 ? weightedSum / weight : null;
+}
+
 export function buildProtocolMiniChartPayload(
 	rows: ProtocolMiniChartDailyRow[],
 	vaultCount: number,
 	cacheTtlSeconds: number,
-	generatedAt = new Date()
+	optionsOrGeneratedAt?: Date | ProtocolMiniChartOptions
 ): ProtocolMiniChartPayload {
+	const { generatedAt, latestApyRows } = resolveOptions(optionsOrGeneratedAt);
 	let excludedOutlierPoints = 0;
 	const normalisedRows = rows
 		.map((row): NormalisedDailyRow | null => {
@@ -177,6 +215,10 @@ export function buildProtocolMiniChartPayload(
 			apy: apyWeight > 0 ? apyWeightedSum / apyWeight : null
 		};
 	});
+	const latestApyOverride = getLatestApyOverride(latestApyRows);
+	if (latestApyOverride != null && points.length > 0) {
+		points[points.length - 1] = { ...points[points.length - 1], apy: latestApyOverride };
+	}
 
 	return {
 		generatedAt: generatedAt.toISOString(),

--- a/src/lib/echarts/vault-group-mini-chart-server.ts
+++ b/src/lib/echarts/vault-group-mini-chart-server.ts
@@ -1,11 +1,19 @@
 import { DuckDBConnection } from '@duckdb/node-api';
-import type { ProtocolMiniChartDailyRow } from './protocol-mini-chart';
+import type { ProtocolMiniChartDailyRow, ProtocolMiniChartLatestApyRow } from './protocol-mini-chart';
 import type { VaultInfo } from '$lib/top-vaults/schemas';
 import { ensureVaultPricesParquet } from '$lib/top-vaults/vault-prices-parquet';
 
 export { isEligibleVaultGroupMiniChartVault } from '$lib/top-vaults/helpers';
 
 export const VAULT_GROUP_MINI_CHART_CACHE_TTL_SECONDS = 60 * 60;
+
+export function getVaultGroupMiniChartLatestApyRows(vaults: VaultInfo[]): ProtocolMiniChartLatestApyRow[] {
+	return vaults.map((vault) => ({
+		id: vault.id,
+		tvl: vault.current_nav ?? 0,
+		apy: vault.one_month_cagr_net ?? vault.one_month_cagr
+	}));
+}
 
 export function getMockVaultGroupMiniChartRows(vaults: VaultInfo[]): ProtocolMiniChartDailyRow[] {
 	const days = Array.from({ length: 120 }, (_, index) => {
@@ -54,7 +62,7 @@ export async function getVaultGroupMiniChartRows(vaultIds: string[]): Promise<Pr
 					AND share_price > 0
 					AND COALESCE(tvl_filtering_mask, FALSE) = FALSE
 				GROUP BY 1, 2
-				HAVING day < current_date
+				HAVING day <= current_date
 				ORDER BY 2, 1
 			`,
 			{ parquetFile, ...params }

--- a/src/routes/trading-view/vaults/VaultGroupDescription.svelte
+++ b/src/routes/trading-view/vaults/VaultGroupDescription.svelte
@@ -77,6 +77,10 @@ excluded vault count from the loaded vault data.
 	// the TVL outlier guard applies here too
 	let eligibleVaults = $derived(statsVaults.filter(isEligibleVaultGroupMiniChartVault));
 	let averageYield = $derived(calculateTvlWeightedApy(eligibleVaults));
+	let vaultCountLabel = $derived(`${statsVaults.length} stablecoin ${statsVaults.length === 1 ? 'vault' : 'vaults'}`);
+	let totalTvlLabel = $derived(`${formatDollar(totalTvl, 1)} TVL`);
+	let protocolCountLabel = $derived(`${protocolCount} ${protocolCount === 1 ? 'protocol' : 'protocols'}`);
+	let averageYieldLabel = $derived(averageYield == null ? null : formatPercent(averageYield, 1));
 	// relative to the statsVaults count shown in the copy, so the two paragraphs
 	// stay arithmetically consistent (shown count − excluded = listed vaults)
 	let excludedVaultCount = $derived(statsVaults.length - eligibleVaults.length);
@@ -87,9 +91,8 @@ excluded vault count from the loaded vault data.
 		<p>
 			{subject}
 			{verbPhrase}
-			{statsVaults.length} stablecoin {statsVaults.length === 1 ? 'vault' : 'vaults'} with {formatDollar(totalTvl, 1)}
-			TVL across {protocolCount}
-			{protocolCount === 1 ? 'protocol' : 'protocols'}.
+			<strong>{vaultCountLabel}</strong> with
+			<strong>{totalTvlLabel}</strong> across <strong>{protocolCountLabel}</strong>.
 			{#if largestVaults.length}
 				The largest {largestVaults.length === 1 ? 'vault is' : 'vaults are'}
 				{#each largestVaults as vault, index (vault.vault_slug)}{index > 0 ? ', ' : ''}<a
@@ -104,8 +107,8 @@ excluded vault count from the loaded vault data.
 								: ', '}<a href={resolve(`/trading-view/vaults/protocols/${protocol.slug}`)}>{protocol.name}</a
 						>{/each}{/if}.
 			{/if}
-			{#if averageYield != null}
-				The last 30 days' average yield is {formatPercent(averageYield, 1)}.
+			{#if averageYieldLabel}
+				The last 30 days' average yield is <strong>{averageYieldLabel}</strong>.
 			{/if}
 		</p>
 		{#if excludedVaultCount > 0}
@@ -131,6 +134,11 @@ excluded vault count from the loaded vault data.
 			& + p {
 				margin-top: 0.75rem;
 			}
+		}
+
+		strong {
+			color: var(--c-text);
+			font-weight: 600;
 		}
 
 		a {

--- a/src/routes/trading-view/vaults/VaultGroupMiniChart.svelte
+++ b/src/routes/trading-view/vaults/VaultGroupMiniChart.svelte
@@ -3,9 +3,10 @@
 Compact dual-axis chart for vault group detail pages.
 
 Shows historical protocol TVL as an area series and TVL-weighted one-month
-average return (gross of fees) as a line series. Only vaults eligible for
-the group chart (not blacklisted, above minimum TVL, within the default
-risk filter) are included — the tooltip states the included vault count.
+average return as a line series. The latest return point matches the table's
+net-over-gross metric where available. Only vaults eligible for the group chart
+(not blacklisted, above minimum TVL, within the default risk filter) are included
+— the tooltip states the included vault count.
 
 @example
 
@@ -109,7 +110,7 @@ risk filter) are included — the tooltip states the included vault count.
 			`<div style="margin-bottom: 0.35rem; color: #ffffff; font-family: ${chartFontFamily}; font-weight: 700;">${formatDateLabel(date)}</div>`,
 			`<div style="color: #d5deea; font-family: ${chartFontFamily}; display: flex; justify-content: space-between; gap: 1rem;"><span>${tvlLabel}</span><strong>${typeof tvl === 'number' ? formatUsd(tvl) : 'n/a'}</strong></div>`,
 			`<div style="color: #d5deea; font-family: ${chartFontFamily}; display: flex; justify-content: space-between; gap: 1rem;"><span>Average TVL-weighted return</span><strong>${typeof averageReturn === 'number' ? formatReturn(averageReturn) : 'n/a'}</strong></div>`,
-			`<div style="width: 14rem; max-width: 14rem; white-space: normal; overflow-wrap: anywhere; margin-top: 0.45rem; color: #94a3b8; font-family: ${chartFontFamily}; font-size: 0.78rem; line-height: 1.35;">Return is annualised from each vault's trailing 1 month share-price return, weighted by that vault's TVL. Returns are gross of fees and only include vaults eligible for this chart.</div>`
+			`<div style="width: 14rem; max-width: 14rem; white-space: normal; overflow-wrap: anywhere; margin-top: 0.45rem; color: #94a3b8; font-family: ${chartFontFamily}; font-size: 0.78rem; line-height: 1.35;">Return is annualised from each vault's trailing 1 month share-price return, weighted by that vault's TVL. The latest point uses the same net-over-gross return metric as the table where available.</div>`
 		].join('');
 	}
 

--- a/src/routes/trading-view/vaults/chains/[chain=slug]/chart-data/+server.ts
+++ b/src/routes/trading-view/vaults/chains/[chain=slug]/chart-data/+server.ts
@@ -2,6 +2,7 @@ import { error, json } from '@sveltejs/kit';
 import { buildProtocolMiniChartPayload, type ProtocolMiniChartPayload } from '$lib/echarts/protocol-mini-chart';
 import {
 	getMockVaultGroupMiniChartRows,
+	getVaultGroupMiniChartLatestApyRows,
 	isEligibleVaultGroupMiniChartVault,
 	getVaultGroupMiniChartRows,
 	VAULT_GROUP_MINI_CHART_CACHE_TTL_SECONDS
@@ -9,7 +10,7 @@ import {
 import { getChainsBySlug } from '$lib/helpers/chain';
 import { getCachedTopVaults } from '$lib/top-vaults/cache';
 
-const CACHE_VERSION = 'chain-mini-chart-v3';
+const CACHE_VERSION = 'chain-mini-chart-v4';
 const cache = new Map<string, { payload: ProtocolMiniChartPayload; expires: number; version: string }>();
 
 async function getCachedChartData(chainSlug: string, fetch: Fetch) {
@@ -31,7 +32,9 @@ async function getCachedChartData(chainSlug: string, fetch: Fetch) {
 		import.meta.env.MODE === 'test'
 			? getMockVaultGroupMiniChartRows(eligibleVaults)
 			: await getVaultGroupMiniChartRows(eligibleVaults.map((vault) => vault.id));
-	const payload = buildProtocolMiniChartPayload(rows, eligibleVaults.length, VAULT_GROUP_MINI_CHART_CACHE_TTL_SECONDS);
+	const payload = buildProtocolMiniChartPayload(rows, eligibleVaults.length, VAULT_GROUP_MINI_CHART_CACHE_TTL_SECONDS, {
+		latestApyRows: getVaultGroupMiniChartLatestApyRows(eligibleVaults)
+	});
 
 	cache.set(cacheKey, {
 		payload,

--- a/src/routes/trading-view/vaults/curators/[curator=slug]/chart-data/+server.ts
+++ b/src/routes/trading-view/vaults/curators/[curator=slug]/chart-data/+server.ts
@@ -2,13 +2,14 @@ import { error, json } from '@sveltejs/kit';
 import { buildProtocolMiniChartPayload, type ProtocolMiniChartPayload } from '$lib/echarts/protocol-mini-chart';
 import {
 	getMockVaultGroupMiniChartRows,
+	getVaultGroupMiniChartLatestApyRows,
 	isEligibleVaultGroupMiniChartVault,
 	getVaultGroupMiniChartRows,
 	VAULT_GROUP_MINI_CHART_CACHE_TTL_SECONDS
 } from '$lib/echarts/vault-group-mini-chart-server';
 import { getCachedTopVaults } from '$lib/top-vaults/cache';
 
-const CACHE_VERSION = 'curator-mini-chart-v1';
+const CACHE_VERSION = 'curator-mini-chart-v2';
 const cache = new Map<string, { payload: ProtocolMiniChartPayload; expires: number; version: string }>();
 
 async function getCachedChartData(curatorSlug: string, fetch: Fetch) {
@@ -26,7 +27,9 @@ async function getCachedChartData(curatorSlug: string, fetch: Fetch) {
 		import.meta.env.MODE === 'test'
 			? getMockVaultGroupMiniChartRows(eligibleVaults)
 			: await getVaultGroupMiniChartRows(eligibleVaults.map((vault) => vault.id));
-	const payload = buildProtocolMiniChartPayload(rows, eligibleVaults.length, VAULT_GROUP_MINI_CHART_CACHE_TTL_SECONDS);
+	const payload = buildProtocolMiniChartPayload(rows, eligibleVaults.length, VAULT_GROUP_MINI_CHART_CACHE_TTL_SECONDS, {
+		latestApyRows: getVaultGroupMiniChartLatestApyRows(eligibleVaults)
+	});
 
 	cache.set(cacheKey, {
 		payload,

--- a/src/routes/trading-view/vaults/protocols/[protocol=slug]/chart-data/+server.ts
+++ b/src/routes/trading-view/vaults/protocols/[protocol=slug]/chart-data/+server.ts
@@ -2,13 +2,14 @@ import { error, json } from '@sveltejs/kit';
 import { buildProtocolMiniChartPayload, type ProtocolMiniChartPayload } from '$lib/echarts/protocol-mini-chart';
 import {
 	getMockVaultGroupMiniChartRows,
+	getVaultGroupMiniChartLatestApyRows,
 	isEligibleVaultGroupMiniChartVault,
 	getVaultGroupMiniChartRows,
 	VAULT_GROUP_MINI_CHART_CACHE_TTL_SECONDS
 } from '$lib/echarts/vault-group-mini-chart-server';
 import { getCachedTopVaults } from '$lib/top-vaults/cache';
 
-const CACHE_VERSION = 'protocol-mini-chart-v3';
+const CACHE_VERSION = 'protocol-mini-chart-v4';
 const cache = new Map<string, { payload: ProtocolMiniChartPayload; expires: number; version: string }>();
 
 async function getCachedChartData(protocolSlug: string, fetch: Fetch) {
@@ -26,7 +27,9 @@ async function getCachedChartData(protocolSlug: string, fetch: Fetch) {
 		import.meta.env.MODE === 'test'
 			? getMockVaultGroupMiniChartRows(eligibleVaults)
 			: await getVaultGroupMiniChartRows(eligibleVaults.map((vault) => vault.id));
-	const payload = buildProtocolMiniChartPayload(rows, eligibleVaults.length, VAULT_GROUP_MINI_CHART_CACHE_TTL_SECONDS);
+	const payload = buildProtocolMiniChartPayload(rows, eligibleVaults.length, VAULT_GROUP_MINI_CHART_CACHE_TTL_SECONDS, {
+		latestApyRows: getVaultGroupMiniChartLatestApyRows(eligibleVaults)
+	});
 
 	cache.set(cacheKey, {
 		payload,

--- a/src/routes/trading-view/vaults/stablecoins/[denomination=slug]/chart-data/+server.ts
+++ b/src/routes/trading-view/vaults/stablecoins/[denomination=slug]/chart-data/+server.ts
@@ -2,6 +2,7 @@ import { error, json } from '@sveltejs/kit';
 import { buildProtocolMiniChartPayload, type ProtocolMiniChartPayload } from '$lib/echarts/protocol-mini-chart';
 import {
 	getMockVaultGroupMiniChartRows,
+	getVaultGroupMiniChartLatestApyRows,
 	isEligibleVaultGroupMiniChartVault,
 	getVaultGroupMiniChartRows,
 	VAULT_GROUP_MINI_CHART_CACHE_TTL_SECONDS
@@ -10,7 +11,7 @@ import { fetchStablecoinMetadataIndex } from '$lib/stablecoin-metadata/client';
 import { buildStablecoinMetadataLookup, resolveStablecoinSlug } from '$lib/stablecoin-metadata/helpers';
 import { getCachedTopVaults } from '$lib/top-vaults/cache';
 
-const CACHE_VERSION = 'stablecoin-mini-chart-v3';
+const CACHE_VERSION = 'stablecoin-mini-chart-v4';
 const cache = new Map<string, { payload: ProtocolMiniChartPayload; expires: number; version: string }>();
 
 async function getCachedChartData(denominationSlug: string, fetch: Fetch) {
@@ -42,7 +43,9 @@ async function getCachedChartData(denominationSlug: string, fetch: Fetch) {
 		import.meta.env.MODE === 'test'
 			? getMockVaultGroupMiniChartRows(eligibleVaults)
 			: await getVaultGroupMiniChartRows(eligibleVaults.map((vault) => vault.id));
-	const payload = buildProtocolMiniChartPayload(rows, eligibleVaults.length, VAULT_GROUP_MINI_CHART_CACHE_TTL_SECONDS);
+	const payload = buildProtocolMiniChartPayload(rows, eligibleVaults.length, VAULT_GROUP_MINI_CHART_CACHE_TTL_SECONDS, {
+		latestApyRows: getVaultGroupMiniChartLatestApyRows(eligibleVaults)
+	});
 
 	cache.set(cacheKey, {
 		payload,


### PR DESCRIPTION
## Why

Vault group mini charts could show a stale final APY that disagreed with the table metric, especially when the latest complete-day sample and the current top-vault metric used different one-month windows. The description boxes also needed their key vault count, TVL, APY and protocol-count figures to be easier to scan.

## Lessons learnt

The historical APY line is derived from share-price history, but the latest value users compare against the table should use the same net-over-gross one-month metric as the table when available. Lagoon-style sparse update schedules can make a one-day cutoff visibly change the annualised APY.

## Summary

- Include current-day vault group chart samples and override the latest APY point with the table-compatible TVL-weighted monthly APY.
- Update chart tooltip copy to describe the latest-point metric source.
- Bold key metric phrases in curator and vault group description boxes, including vault count, TVL, APY/yield and protocol count.
- Add unit coverage for the latest APY override.