### PR TITLE
fix: include all vault curators, protocols and stablecoins in sitemap

### DIFF
--- a/src/routes/trading-view/vaults/sitemap.xml/+server.ts
+++ b/src/routes/trading-view/vaults/sitemap.xml/+server.ts
@@ -4,9 +4,10 @@
  */
 import { SitemapStream } from 'sitemap';
 import { fetchTopVaults } from '$lib/top-vaults/client';
-import { isBlacklisted, meetsMinTvl, resolveVaultDetails } from '$lib/top-vaults/helpers';
+import { isBlacklisted, resolveVaultDetails } from '$lib/top-vaults/helpers';
 import { getChain } from '$lib/helpers/chain';
 import { fetchStablecoinMetadataIndex } from '$lib/stablecoin-metadata/client';
+import { buildStablecoinMetadataLookup, resolveStablecoinSlug } from '$lib/stablecoin-metadata/helpers';
 
 const basePath = 'trading-view/vaults';
 const priority = 0.8;
@@ -23,7 +24,10 @@ const staticSubPages = [
 ];
 
 export async function GET({ fetch, setHeaders, url }) {
-	const [{ vaults }, stablecoinIndex] = await Promise.all([fetchTopVaults(fetch), fetchStablecoinMetadataIndex(fetch)]);
+	const [{ vaults, curators }, stablecoinIndex] = await Promise.all([
+		fetchTopVaults(fetch),
+		fetchStablecoinMetadataIndex(fetch)
+	]);
 
 	const stream = new SitemapStream({ hostname: url.origin });
 
@@ -32,24 +36,35 @@ export async function GET({ fetch, setHeaders, url }) {
 		stream.write({ url: `${basePath}/${page}`, priority });
 	}
 
+	const listedVaults = vaults.filter((v) => !isBlacklisted(v));
+
 	// Individual vault detail pages
-	for (const vault of vaults) {
-		if (!isBlacklisted(vault)) {
-			stream.write({ url: resolveVaultDetails(vault), priority });
-		}
+	for (const vault of listedVaults) {
+		stream.write({ url: resolveVaultDetails(vault), priority });
 	}
 
-	const eligibleVaults = vaults.filter((v) => !isBlacklisted(v) && meetsMinTvl(v));
-
-	// Protocol index + individual protocol pages
-	const protocolSlugs = new Set(eligibleVaults.map((v) => v.protocol_slug));
+	// Protocol index + individual protocol pages. Protocol detail pages render
+	// for any protocol with at least one listed vault, regardless of TVL.
+	const protocolSlugs = new Set(listedVaults.map((v) => v.protocol_slug));
 	stream.write({ url: `${basePath}/protocols`, priority });
 	for (const slug of protocolSlugs) {
 		stream.write({ url: `${basePath}/protocols/${slug}`, priority });
 	}
 
-	// Stablecoin index + individual stablecoin pages
-	const denominationSlugs = new Set(eligibleVaults.filter((v) => v.stablecoinish).map((v) => v.denomination_slug));
+	// Stablecoin index + individual stablecoin pages, using the same canonical
+	// slug resolution as the stablecoins index page links (raw denomination
+	// slugs may be aliases of a canonical metadata slug).
+	const metadataLookup = buildStablecoinMetadataLookup(stablecoinIndex);
+	const denominationSlugs = new Set<string>();
+	for (const vault of listedVaults) {
+		if (!vault.stablecoinish) continue;
+		const slug =
+			resolveStablecoinSlug(
+				{ slug: vault.denomination_slug, symbol: vault.denomination, name: vault.normalised_denomination },
+				metadataLookup
+			) ?? vault.denomination_slug;
+		if (slug) denominationSlugs.add(slug);
+	}
 	// Include zero-vault stablecoins from metadata index
 	for (const meta of stablecoinIndex) {
 		denominationSlugs.add(meta.slug);
@@ -60,16 +75,17 @@ export async function GET({ fetch, setHeaders, url }) {
 	}
 
 	// Chain index + individual chain pages
-	const chainSlugs = new Set(eligibleVaults.map((v) => getChain(v.chain_id)?.slug).filter(Boolean) as string[]);
+	const chainSlugs = new Set(listedVaults.map((v) => getChain(v.chain_id)?.slug).filter(Boolean) as string[]);
 	stream.write({ url: `${basePath}/chains`, priority });
 	for (const slug of chainSlugs) {
 		stream.write({ url: `${basePath}/chains/${slug}`, priority });
 	}
 
-	// Curator index + individual curator pages
-	const curatorSlugs = new Set(eligibleVaults.map((v) => v.curator_slug).filter(Boolean) as string[]);
+	// Curator index + individual curator pages. The curator metadata map is the
+	// source of truth: detail pages render for every curator in the map (even
+	// with no eligible vaults) and 404 for slugs outside it.
 	stream.write({ url: `${basePath}/curators`, priority });
-	for (const slug of curatorSlugs) {
+	for (const slug of Object.keys(curators)) {
 		stream.write({ url: `${basePath}/curators/${slug}`, priority });
 	}
 


### PR DESCRIPTION
## Why

The vaults sitemap derived curator, protocol, stablecoin and chain page entries from the min-TVL-filtered vault list, so vault group pages that render fine were silently missing from the sitemap: 9 curators, 5 protocols and 1 chain on current live data. It also emitted raw stablecoin denomination slugs rather than the canonical slugs the stablecoins index links to, producing duplicate alias URLs (e.g. `aa_falconxusdc` alongside canonical `aa-falconxusdc`).

## Lessons learnt

- Each vault group detail page has its own existence rule, and the sitemap must mirror it rather than re-deriving from filtered vault lists: curator pages 404 only when the slug is missing from the dataset's `curators` metadata map; protocol pages match against all vaults with no TVL filter; stablecoin pages accept any slug reachable via `resolveStablecoinSlug` or the stablecoin metadata index; chain pages only require a known chain slug.
- A vault-derived `curator_slug` absent from the curator metadata map produces a 404 URL, so the metadata map is the single source of truth for curator sitemap entries.
- Verify sitemap changes by diffing slug sets against the production sitemap and spot-checking added/removed URLs with HTTP status codes — the URL count arithmetic should reconcile exactly.

## Summary

- Curator entries now come from the dataset's `curators` metadata map instead of eligible vaults (+9 curators on live data, none lost).
- Protocol and chain entries now derive from all non-blacklisted vaults, dropping only the min-TVL filter (+5 protocols, +1 chain; all spot-checked 200).
- Stablecoin entries now use the same canonical slug resolution (`resolveStablecoinSlug` + metadata lookup) as the stablecoins index page, deduplicating raw alias slugs (−1 duplicate URL).
- Removed the now-unused `meetsMinTvl` import.

🤖 Generated with [Claude Code](https://claude.com/claude-code)