### PR TITLE
fix: support compact CORE3 vault ratings

### DIFF
--- a/src/lib/top-vaults/helpers.test.ts
+++ b/src/lib/top-vaults/helpers.test.ts
@@ -9,9 +9,12 @@ import {
 	getFormattedFeeMode,
 	getFeeModeLabel,
 	getFeeModeDescription,
+	getCore3PolForVault,
+	getCore3ProtocolForVault,
 	getCore3ReportUrl,
 	getCore3RankingUrl
 } from './helpers';
+import type { Core3Protocol } from './schemas';
 import { createTestVault } from './test-utils';
 
 describe('isBlacklisted', () => {
@@ -238,5 +241,112 @@ describe('getCore3RankingUrl', () => {
 
 	test('defaults to the projects ranking when category is missing', () => {
 		expect(getCore3RankingUrl({})).toBe('https://core3.io/ratings/projects?utm_source=tradingstrategy');
+	});
+});
+
+describe('getCore3PolForVault', () => {
+	test('prefers the full top-level protocol record', () => {
+		const vault = createTestVault('Test vault', {
+			protocol: 'Morpho',
+			core3: {
+				risk_score: 42,
+				risk_rating_label: 'CCC',
+				confidence: 'Low'
+			}
+		});
+		const protocols: Record<string, Core3Protocol> = {
+			morpho: {
+				slug: 'morpho',
+				name: 'Morpho',
+				pol: {
+					score: 22.16,
+					rating: 'BBB',
+					confidence: 'High'
+				}
+			}
+		};
+
+		expect(getCore3PolForVault(vault, protocols)).toEqual({
+			score: 22.16,
+			rating: 'BBB',
+			confidence: 'High'
+		});
+	});
+
+	test('falls back to compact per-vault Core3 data', () => {
+		const vault = createTestVault('Test vault', {
+			protocol: 'Morpho',
+			core3: {
+				risk_score: 22.16,
+				risk_rating_label: 'BBB',
+				confidence: 'High'
+			}
+		});
+
+		expect(getCore3PolForVault(vault, {})).toEqual({
+			score: 22.16,
+			rating: 'BBB',
+			confidence: 'High'
+		});
+	});
+
+	test('returns null when neither Core3 shape has headline data', () => {
+		const vault = createTestVault('Test vault', { protocol: 'Morpho' });
+
+		expect(getCore3PolForVault(vault, {})).toBeNull();
+	});
+});
+
+describe('getCore3ProtocolForVault', () => {
+	test('adapts compact per-vault Core3 data for display components', () => {
+		const vault = createTestVault('Test vault', {
+			protocol: 'Morpho',
+			core3: {
+				risk_score: 22.16,
+				risk_rating_label: 'BBB',
+				confidence: 'High',
+				core3_ranking: 39,
+				data_coverage: 76.7,
+				market_cap: 1_253_724_481
+			}
+		});
+
+		expect(getCore3ProtocolForVault(vault, {})).toEqual({
+			slug: '',
+			name: 'Morpho',
+			rank: 39,
+			pol: {
+				score: 22.16,
+				rating: 'BBB',
+				confidence: 'High'
+			},
+			data_coverage: { percentage: 76.7 },
+			market_cap: { in_usd: '1253724481' }
+		});
+	});
+
+	test('falls back to compact per-vault data when top-level protocol pol is null', () => {
+		const vault = createTestVault('Test vault', {
+			protocol: 'Morpho',
+			core3: {
+				risk_score: 22.16,
+				risk_rating_label: 'BBB',
+				confidence: 'High'
+			}
+		});
+		const protocols: Record<string, Core3Protocol> = {
+			morpho: {
+				slug: 'morpho-core3',
+				name: 'Morpho',
+				pol: null
+			}
+		};
+
+		expect(getCore3ProtocolForVault(vault, protocols)?.pol).toEqual({
+			score: 22.16,
+			rating: 'BBB',
+			confidence: 'High'
+		});
+		expect(getCore3ProtocolForVault(vault, protocols)?.slug).toBe('');
 	});
 });

--- a/src/lib/top-vaults/helpers.ts
+++ b/src/lib/top-vaults/helpers.ts
@@ -1,4 +1,4 @@
-import type { Core3Protocol, FeeMode, SlimVaultInfo, VaultInfo } from './schemas';
+import type { Core3Pol, Core3Protocol, FeeMode, SlimVaultInfo, VaultInfo } from './schemas';
 import { slimVaultKeys } from './schemas';
 import { resolve } from '$app/paths';
 import { vaultSparklinesUrl } from '$lib/config';
@@ -411,6 +411,66 @@ export function getCore3RatingTone(rating: string | null | undefined): Core3Rati
 export function getCore3RankingUrl(core3: Pick<Core3Protocol, 'category'>): string {
 	const isExchange = /exchange/i.test(core3.category?.name ?? '');
 	return `https://core3.io/ratings/${isExchange ? 'exchanges' : 'projects'}?${CORE3_UTM}`;
+}
+
+/**
+ * Resolve the headline CORE3 rating fields for a vault.
+ *
+ * Prefer the full protocol record because it contains the canonical CORE3 slug
+ * and contextual metadata. Fall back to the compact per-vault `core3` block
+ * emitted by newer vault data exports.
+ */
+export function getCore3PolForVault(
+	vault: Pick<VaultInfo, 'core3' | 'protocol_slug'>,
+	core3Protocols: Record<string, Core3Protocol>
+): Core3Pol | null {
+	const protocolPol = core3Protocols[vault.protocol_slug]?.pol;
+	if (protocolPol) return protocolPol;
+
+	const vaultCore3 = vault.core3;
+	if (!vaultCore3) return null;
+
+	const hasRating = vaultCore3.risk_rating_label != null;
+	const hasScore = vaultCore3.risk_score != null;
+	const hasConfidence = vaultCore3.confidence != null;
+	if (!hasRating && !hasScore && !hasConfidence) return null;
+
+	return {
+		score: vaultCore3.risk_score ?? null,
+		rating: vaultCore3.risk_rating_label ?? null,
+		confidence: vaultCore3.confidence ?? null
+	};
+}
+
+/**
+ * Resolve a full-enough CORE3 protocol record for display components.
+ *
+ * If the top-level `core3_protocols` map has the protocol, return it. Otherwise
+ * adapt the compact per-vault CORE3 summary into the subset used by the UI.
+ */
+export function getCore3ProtocolForVault(
+	vault: Pick<VaultInfo, 'core3' | 'protocol' | 'protocol_slug'>,
+	core3Protocols: Record<string, Core3Protocol>
+): Core3Protocol | null {
+	const protocolRecord = core3Protocols[vault.protocol_slug];
+	if (protocolRecord?.pol) return protocolRecord;
+
+	const pol = getCore3PolForVault(vault, core3Protocols);
+	if (!pol) return null;
+
+	return {
+		slug: '',
+		name: vault.protocol,
+		rank: vault.core3?.core3_ranking ?? null,
+		pol,
+		data_coverage: { percentage: vault.core3?.data_coverage ?? null },
+		market_cap:
+			vault.core3?.market_cap != null
+				? {
+						in_usd: String(vault.core3.market_cap)
+					}
+				: undefined
+	};
 }
 
 /**

--- a/src/lib/top-vaults/schemas.ts
+++ b/src/lib/top-vaults/schemas.ts
@@ -80,6 +80,29 @@ export const periodMetricsSchema = z.object({
 });
 export type PeriodMetrics = z.infer<typeof periodMetricsSchema>;
 
+/**
+ * Compact per-vault CORE3 summary emitted by the vault data pipeline.
+ *
+ * The backend also exposes the full protocol records under `core3_protocols`.
+ * This compact shape gives the frontend a fallback when a payload contains
+ * per-vault ratings but the top-level map is missing or partially malformed.
+ */
+export const core3VaultSchema = z.object({
+	/** Overall Probability of Loss score, 0 (lowest risk) to 100 (highest risk) */
+	risk_score: nullableNumber.optional(),
+	/** Market-cap snapshot in USD */
+	market_cap: nullableNumber.optional(),
+	/** CORE3 global rank (1 = lowest risk) */
+	core3_ranking: z.int().nullable().optional(),
+	/** Share of CORE3 data points populated, as a percentage */
+	data_coverage: nullableNumber.optional(),
+	/** Confidence in the rating (e.g. "Exceptional", "High", "Moderate", "Low") */
+	confidence: z.string().nullable().optional(),
+	/** Credit-style PoL rating label, e.g. "AA", "BBB", "D" */
+	risk_rating_label: z.string().nullable().optional()
+});
+export type Core3Vault = z.infer<typeof core3VaultSchema>;
+
 /** A post/update surfaced from a curator's social or RSS feed. */
 export const curatorRecentPostSchema = z.object({
 	/** Post title; may be null for sources that don't provide one (e.g. tweets) */
@@ -340,7 +363,15 @@ export const vaultInfoSchema = z.object({
 			morpho_market_flags: z.string().array()
 		})
 		.nullable()
-		.optional()
+		.optional(),
+
+	/**
+	 * Compact CORE3 protocol risk summary attached to each vault.
+	 *
+	 * This duplicates the headline fields in `core3_protocols[protocol_slug]`
+	 * and is kept as a fallback for payloads where the top-level map changes.
+	 */
+	core3: core3VaultSchema.nullable().optional()
 });
 export type VaultInfo = z.infer<typeof vaultInfoSchema>;
 
@@ -465,7 +496,16 @@ export const topVaultsSchema = z.object({
 	 * data — `.catch({})` guarantees a malformed/changed payload here can never
 	 * break parsing of the (critical) vaults array.
 	 */
-	core3_protocols: z.record(z.string(), core3ProtocolSchema).catch({}).default({}),
+	core3_protocols: z
+		.record(z.string(), core3ProtocolSchema.or(z.unknown().transform(() => null)))
+		.transform((records) => {
+			const entries = Object.entries(records).filter(
+				(entry): entry is [string, z.infer<typeof core3ProtocolSchema>] => entry[1] !== null
+			);
+			return Object.fromEntries(entries);
+		})
+		.catch({})
+		.default({}),
 	/**
 	 * Curator metadata keyed by curator slug; referenced by vault.curator_slug.
 	 * Partly built from external feeds — `.catch({})` guarantees a malformed

--- a/src/routes/trading-view/vaults/[vault=slug]/+page.server.ts
+++ b/src/routes/trading-view/vaults/[vault=slug]/+page.server.ts
@@ -2,7 +2,7 @@ import { getChain } from '$lib/helpers/chain';
 import { fetchStablecoinMetadataIndex } from '$lib/stablecoin-metadata/client';
 import { buildStablecoinMetadataLookup, findStablecoinMetadata } from '$lib/stablecoin-metadata/helpers';
 import { getCachedTopVaults } from '$lib/top-vaults/cache';
-import { resolveVaultDetails } from '$lib/top-vaults/helpers.js';
+import { getCore3ProtocolForVault, resolveVaultDetails } from '$lib/top-vaults/helpers.js';
 import { fetchVaultProtocolMetadata } from '$lib/vault-protocol/client';
 import { error, redirect } from '@sveltejs/kit';
 
@@ -23,8 +23,7 @@ export async function load({ params, fetch }) {
 	const chain = getChain(vault.chain_id);
 	if (!chain) error(404, 'Chain not found');
 
-	// CORE3 ratings are keyed by protocol slug; null when the protocol is unrated
-	const core3 = core3_protocols[vault.protocol_slug] ?? null;
+	const core3 = getCore3ProtocolForVault(vault, core3_protocols);
 
 	const [protocolMetadata, stablecoinMetadataIndex] = await Promise.all([
 		fetchVaultProtocolMetadata(fetch, vault.protocol_slug, vault.protocol),

--- a/src/routes/trading-view/vaults/protocols/+page.server.ts
+++ b/src/routes/trading-view/vaults/protocols/+page.server.ts
@@ -2,6 +2,7 @@ import type { VaultGroup } from '$lib/top-vaults/schemas.js';
 import { getCachedTopVaults } from '$lib/top-vaults/cache';
 import {
 	calculateTvlWeightedApy,
+	getCore3PolForVault,
 	getProtocolDisplayName,
 	isBlacklisted,
 	meetsMinTvl
@@ -18,6 +19,7 @@ export async function load({ fetch, url: { searchParams } }) {
 
 	const protocols = eligibleVaults.reduce<Record<string, VaultGroup>>((acc, vault) => {
 		const slug = vault.protocol_slug;
+		const core3Pol = getCore3PolForVault(vault, core3_protocols);
 
 		acc[slug] ??= {
 			slug,
@@ -27,9 +29,11 @@ export async function load({ fetch, url: { searchParams } }) {
 			avg_apy: null,
 			risk: vault.risk,
 			risk_numeric: vault.risk_numeric,
-			core3_rating: core3_protocols[slug]?.pol?.rating ?? null,
-			core3_score: core3_protocols[slug]?.pol?.score ?? null
+			core3_rating: core3Pol?.rating ?? null,
+			core3_score: core3Pol?.score ?? null
 		};
+		acc[slug].core3_rating ??= core3Pol?.rating ?? null;
+		acc[slug].core3_score ??= core3Pol?.score ?? null;
 		acc[slug].vault_count++;
 		acc[slug].tvl += vault.current_nav ?? 0;
 

--- a/src/routes/trading-view/vaults/protocols/[protocol=slug]/+page.server.ts
+++ b/src/routes/trading-view/vaults/protocols/[protocol=slug]/+page.server.ts
@@ -1,7 +1,7 @@
 import { error } from '@sveltejs/kit';
 import { getCachedTopVaults } from '$lib/top-vaults/cache';
 import { fetchVaultProtocolMetadata } from '$lib/vault-protocol/client';
-import { getProtocolDisplayName } from '$lib/top-vaults/helpers.js';
+import { getCore3ProtocolForVault, getProtocolDisplayName } from '$lib/top-vaults/helpers.js';
 
 export async function load({ params, fetch }) {
 	const { protocol } = params;
@@ -11,11 +11,16 @@ export async function load({ params, fetch }) {
 	if (!protocolVault) error(404, 'Vault protocol not found');
 
 	const protocolMetadata = await fetchVaultProtocolMetadata(fetch, protocol, protocolVault.protocol);
+	const core3 =
+		vaults
+			.filter((v) => v.protocol_slug === protocol)
+			.map((vault) => getCore3ProtocolForVault(vault, core3_protocols))
+			.find((rating) => rating !== null) ?? null;
 
 	return {
 		protocolSlug: protocol,
 		protocolName: getProtocolDisplayName(protocolVault.protocol),
 		protocolMetadata,
-		core3: core3_protocols[protocol] ?? null
+		core3
 	};
 }


### PR DESCRIPTION
## Why

The Core3 ratings UI assumed ratings only came from the top-level `core3_protocols[protocol_slug].pol` record. The current top vaults export also carries compact per-vault Core3 data under `vault.core3`, and a partially changed or malformed top-level map could hide ratings that are still present in the vault records.

## Lessons learnt

The production R2 payload currently exposes both shapes: full protocol records in `core3_protocols` and compact per-vault records in `vault.core3`. UI loaders should prefer the richer protocol record, but keep the compact vault record as a compatibility fallback.

## Summary

- Add a schema for compact per-vault Core3 data and parse `core3_protocols` per record so one malformed entry does not drop the whole map.
- Add helper functions that resolve Core3 headline ratings and display records from either payload shape.
- Use those helpers on vault detail, protocol detail, and protocol listing pages.
- Add focused unit coverage for top-level preference and compact fallback behaviour.