### PR TITLE
feat: surface DEX datasets on pricing page and add free vault data sa…

### DIFF
--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -245,6 +245,16 @@ export const vaultProtocolMetadataUrl = config((url: string) => {
 }, 'VAULT_PROTOCOL_METADATA_URL');
 
 /**
+ * Origin of the public CDN that hosts the free, login-less sample datasets.
+ * Optional — defaults to the production CDN so no per-environment config is
+ * required; override via TS_PUBLIC_SAMPLE_DATA_URL if the host ever changes.
+ */
+export const sampleDataUrl = config(
+	(url: string) => url || 'https://vault-protocol-metadata.tradingstrategy.ai',
+	'SAMPLE_DATA_URL'
+);
+
+/**
  * Stablecoin metadata base URL (same R2 bucket as vault protocol metadata,
  * referred to as R2_VAULT_METADATA_PUBLIC_URL elsewhere)
  */

--- a/src/routes/api/[file]/+server.ts
+++ b/src/routes/api/[file]/+server.ts
@@ -1,0 +1,47 @@
+import { error } from '@sveltejs/kit';
+import { vaultProtocolMetadataUrl } from '$lib/config';
+import type { RequestHandler } from './$types';
+
+/**
+ * Free, login-less sample dataset downloads.
+ *
+ * The files live on the public vault-protocol-metadata CDN, but we proxy them
+ * server-side so the underlying host is never exposed in the client and users
+ * cannot probe the bucket for other objects. Only the whitelisted sample files
+ * are reachable; any other name returns 404.
+ *
+ * Files are streamed (not buffered) because the samples are tens of MB.
+ */
+const SAMPLE_FILES: Record<string, string> = {
+	'vault-metadata.sample.json': 'application/json',
+	'vault-historical.sample.parquet': 'application/vnd.apache.parquet'
+};
+
+const baseUrl = vaultProtocolMetadataUrl ? new URL(vaultProtocolMetadataUrl).origin : undefined;
+
+export const GET: RequestHandler = async ({ params, fetch }) => {
+	const { file } = params;
+	const contentType = SAMPLE_FILES[file];
+
+	if (!contentType) {
+		throw error(404, 'Not found');
+	}
+
+	if (!baseUrl) {
+		throw error(500, 'Sample data source is not configured');
+	}
+
+	const upstream = await fetch(`${baseUrl}/${file}`);
+
+	if (!upstream.ok || !upstream.body) {
+		throw error(502, 'Failed to fetch sample file');
+	}
+
+	return new Response(upstream.body, {
+		headers: {
+			'content-type': contentType,
+			'content-disposition': `attachment; filename="${file}"`,
+			'cache-control': 'public, max-age=86400'
+		}
+	});
+};

--- a/src/routes/api/[file]/+server.ts
+++ b/src/routes/api/[file]/+server.ts
@@ -1,5 +1,5 @@
 import { error } from '@sveltejs/kit';
-import { vaultProtocolMetadataUrl } from '$lib/config';
+import { sampleDataUrl } from '$lib/config';
 import type { RequestHandler } from './$types';
 
 /**
@@ -17,7 +17,7 @@ const SAMPLE_FILES: Record<string, string> = {
 	'vault-historical.sample.parquet': 'application/vnd.apache.parquet'
 };
 
-const baseUrl = vaultProtocolMetadataUrl ? new URL(vaultProtocolMetadataUrl).origin : undefined;
+const baseUrl = new URL(sampleDataUrl).origin;
 
 export const GET: RequestHandler = async ({ params, fetch }) => {
 	const { file } = params;
@@ -25,10 +25,6 @@ export const GET: RequestHandler = async ({ params, fetch }) => {
 
 	if (!contentType) {
 		throw error(404, 'Not found');
-	}
-
-	if (!baseUrl) {
-		throw error(500, 'Sample data source is not configured');
 	}
 
 	const upstream = await fetch(`${baseUrl}/${file}`);

--- a/src/routes/pricing/+page.svelte
+++ b/src/routes/pricing/+page.svelte
@@ -249,13 +249,8 @@ Pricing page with Basic and Pro tier comparison
 						<td class="check"><IconCheck /></td>
 					</tr>
 					<tr>
-						<td><a class="feature-link" href="/trading-view/backtesting">Historical DEX trading data</a></td>
+						<td><a class="feature-link" href="/trading-view/backtesting">DEX price data</a></td>
 						<td class="check"><IconCheck /></td>
-						<td class="check"><IconCheck /></td>
-					</tr>
-					<tr>
-						<td><a class="feature-link" href="/trading-view/vaults/datasets">DEX price data</a></td>
-						<td class="dash">—</td>
 						<td class="check"><IconCheck /></td>
 					</tr>
 					<tr>

--- a/src/routes/pricing/+page.svelte
+++ b/src/routes/pricing/+page.svelte
@@ -249,6 +249,16 @@ Pricing page with Basic and Pro tier comparison
 						<td class="check"><IconCheck /></td>
 					</tr>
 					<tr>
+						<td><a class="feature-link" href="/trading-view/backtesting">Historical DEX trading data</a></td>
+						<td class="check"><IconCheck /></td>
+						<td class="check"><IconCheck /></td>
+					</tr>
+					<tr>
+						<td><a class="feature-link" href="/trading-view/vaults/datasets">DEX price data</a></td>
+						<td class="dash">—</td>
+						<td class="check"><IconCheck /></td>
+					</tr>
+					<tr>
 						<td>
 							<Tooltip>
 								<span slot="trigger" class="underline">AI ready</span>
@@ -257,11 +267,6 @@ Pricing page with Basic and Pro tier comparison
 								</svelte:fragment>
 							</Tooltip>
 						</td>
-						<td class="dash">—</td>
-						<td class="check"><IconCheck /></td>
-					</tr>
-					<tr>
-						<td>Historical data</td>
 						<td class="dash">—</td>
 						<td class="check"><IconCheck /></td>
 					</tr>
@@ -474,6 +479,15 @@ Pricing page with Basic and Pro tier comparison
 
 	.dash {
 		color: var(--c-text-ultra-light);
+	}
+
+	.feature-link {
+		color: inherit;
+		text-decoration: underline;
+
+		&:hover {
+			color: var(--c-text-light);
+		}
 	}
 
 	.data-fields-panel {

--- a/src/routes/pricing/+page.svelte
+++ b/src/routes/pricing/+page.svelte
@@ -266,6 +266,11 @@ Pricing page with Basic and Pro tier comparison
 						<td class="check"><IconCheck /></td>
 					</tr>
 					<tr>
+						<td>Historical data</td>
+						<td class="dash">—</td>
+						<td class="check"><IconCheck /></td>
+					</tr>
+					<tr>
 						<td>Raw data files</td>
 						<td class="dash">—</td>
 						<td class="check"><IconCheck /></td>

--- a/src/routes/trading-view/vaults/datasets/+page.server.ts
+++ b/src/routes/trading-view/vaults/datasets/+page.server.ts
@@ -144,6 +144,9 @@ export async function load({ fetch, setHeaders, url }) {
 		};
 	});
 
+	// Show free samples above the paid datasets (stable sort keeps each group's order)
+	enriched.sort((a, b) => Number(b.free ?? false) - Number(a.free ?? false));
+
 	setHeaders({
 		'cache-control': 'public, max-age=600'
 	});

--- a/src/routes/trading-view/vaults/datasets/+page.server.ts
+++ b/src/routes/trading-view/vaults/datasets/+page.server.ts
@@ -1,8 +1,12 @@
 import { error } from '@sveltejs/kit';
 import { headTopVaults, headVaultPrices } from '$lib/top-vaults/server-config';
 import { isR2Configured } from '$lib/r2/client';
+import { vaultProtocolMetadataUrl } from '$lib/config';
 
 const documentationUrl = 'https://tradingstrategy.ai/docs/overview/defi-vault-data.html';
+
+/** Origin of the public CDN that hosts the free sample files (host kept server-side). */
+const sampleBaseUrl = vaultProtocolMetadataUrl ? new URL(vaultProtocolMetadataUrl).origin : undefined;
 
 type VaultDatasetDefinition = {
 	/** Stable identifier used for list rendering and logging */
@@ -21,6 +25,10 @@ type VaultDatasetDefinition = {
 	documentation: string;
 	/** Public-facing download URL (points to our proxy, not the CDN) */
 	downloadUrl: string;
+	/** Free sample — downloadable without an API key (proxied via /api) */
+	free?: boolean;
+	/** CDN object name used server-side to read freshness metadata for samples */
+	sampleFile?: string;
 };
 
 type VaultDataset = VaultDatasetDefinition & {
@@ -28,11 +36,34 @@ type VaultDataset = VaultDatasetDefinition & {
 	lastUpdatedAt: string | null;
 };
 
+const SAMPLE_DESCRIPTION = 'Limited data sample covering only vaults on the Ethereum blockchain';
+
+/**
+ * HEAD a public sample file to read its size and last-modified date.
+ * Degrades to nulls on any failure so the page still renders.
+ */
+async function headSample(fetch: typeof globalThis.fetch, file: string) {
+	if (!sampleBaseUrl) return { size: null, lastModified: null };
+	try {
+		const res = await fetch(`${sampleBaseUrl}/${file}`, { method: 'HEAD' });
+		if (!res.ok) return { size: null, lastModified: null };
+		const len = res.headers.get('content-length');
+		const lastModified = res.headers.get('last-modified');
+		return {
+			size: len ? Number(len) : null,
+			lastModified: lastModified ? new Date(lastModified) : null
+		};
+	} catch {
+		return { size: null, lastModified: null };
+	}
+}
+
 /**
  * Build the vault datasets page payload.
  *
  * Defines the frontend-owned dataset catalogue and enriches each entry with
- * server-side freshness metadata from R2.
+ * server-side freshness metadata (R2 for the licensed datasets, the public CDN
+ * for the free samples).
  */
 export async function load({ fetch, setHeaders, url }) {
 	if (!isR2Configured()) {
@@ -63,17 +94,45 @@ export async function load({ fetch, setHeaders, url }) {
 			format: 'Parquet',
 			documentation: documentationUrl,
 			downloadUrl: '/trading-view/vaults/datasets/download/vault-prices'
+		},
+		{
+			id: 'vault-metadata-sample',
+			name: 'Vault metadata (sample)',
+			description: SAMPLE_DESCRIPTION,
+			instructions: 'A free metadata sample you can download instantly without an API key.',
+			filename: 'vault-metadata.sample.json',
+			format: 'JSON',
+			documentation: documentationUrl,
+			downloadUrl: '/api/vault-metadata.sample.json',
+			free: true,
+			sampleFile: 'vault-metadata.sample.json'
+		},
+		{
+			id: 'vault-prices-sample',
+			name: 'Vault prices (sample)',
+			description: SAMPLE_DESCRIPTION,
+			instructions: 'A free price-history sample you can download instantly without an API key.',
+			filename: 'vault-historical.sample.parquet',
+			format: 'Parquet',
+			documentation: documentationUrl,
+			downloadUrl: '/api/vault-historical.sample.parquet',
+			free: true,
+			sampleFile: 'vault-historical.sample.parquet'
 		}
 	];
 
-	const [topVaultsMeta, vaultPricesMeta] = await Promise.all([
+	const [topVaultsMeta, vaultPricesMeta, metadataSampleMeta, pricesSampleMeta] = await Promise.all([
 		headTopVaults(fetch).catch(() => ({ size: null, lastModified: null })),
-		headVaultPrices(fetch).catch(() => ({ size: null, lastModified: null }))
+		headVaultPrices(fetch).catch(() => ({ size: null, lastModified: null })),
+		headSample(fetch, 'vault-metadata.sample.json'),
+		headSample(fetch, 'vault-historical.sample.parquet')
 	]);
 
 	const metadataMap: Record<string, { size: number | null; lastModified: Date | null }> = {
 		'vault-metadata': topVaultsMeta,
-		'vault-prices': vaultPricesMeta
+		'vault-prices': vaultPricesMeta,
+		'vault-metadata-sample': metadataSampleMeta,
+		'vault-prices-sample': pricesSampleMeta
 	};
 
 	const enriched: VaultDataset[] = datasets.map((dataset) => {

--- a/src/routes/trading-view/vaults/datasets/+page.server.ts
+++ b/src/routes/trading-view/vaults/datasets/+page.server.ts
@@ -1,12 +1,12 @@
 import { error } from '@sveltejs/kit';
 import { headTopVaults, headVaultPrices } from '$lib/top-vaults/server-config';
 import { isR2Configured } from '$lib/r2/client';
-import { vaultProtocolMetadataUrl } from '$lib/config';
+import { sampleDataUrl } from '$lib/config';
 
 const documentationUrl = 'https://tradingstrategy.ai/docs/overview/defi-vault-data.html';
 
 /** Origin of the public CDN that hosts the free sample files (host kept server-side). */
-const sampleBaseUrl = vaultProtocolMetadataUrl ? new URL(vaultProtocolMetadataUrl).origin : undefined;
+const sampleBaseUrl = new URL(sampleDataUrl).origin;
 
 type VaultDatasetDefinition = {
 	/** Stable identifier used for list rendering and logging */

--- a/src/routes/trading-view/vaults/datasets/+page.svelte
+++ b/src/routes/trading-view/vaults/datasets/+page.svelte
@@ -174,7 +174,10 @@ Vault datasets download page
 							</td>
 							<td class="links">
 								<a class="action-link" href={row.documentation} rel="external">Documentation</a>
-								{#if validApiKey}
+								{#if row.free}
+									<!-- eslint-disable-next-line svelte/no-navigation-without-resolve -->
+									<a class="action-link" href={row.downloadUrl} download>Download</a>
+								{:else if validApiKey}
 									<!-- eslint-disable-next-line svelte/no-navigation-without-resolve -->
 									<a class="action-link" target="_blank" rel="noreferrer" href={getDownloadUrl(row.downloadUrl)}>
 										Download
@@ -196,7 +199,7 @@ Vault datasets download page
 		<p>Programmatically access the data. Requires a valid API key you can enter above.</p>
 
 		<div class="curl-example">
-			<pre><code>{getCombinedCurlCommand(data.datasets)}</code></pre>
+			<pre><code>{getCombinedCurlCommand(data.datasets.filter((d) => !d.free))}</code></pre>
 		</div>
 	</Section>
 </main>

--- a/src/routes/trading-view/vaults/datasets/+page.svelte
+++ b/src/routes/trading-view/vaults/datasets/+page.svelte
@@ -146,6 +146,7 @@ Vault datasets download page
 			<table class="datatable sm">
 				<thead>
 					<tr class="col-headers">
+						<th class="plan">Plan</th>
 						<th class="name">Name</th>
 						<th class="description">Description</th>
 						<th>Format</th>
@@ -158,6 +159,7 @@ Vault datasets download page
 				<tbody>
 					{#each data.datasets as row (row.id)}
 						<tr>
+							<td class="plan">{row.free ? 'Free' : 'PRO'}</td>
 							<td class="name">
 								<strong>{row.name}</strong>
 								<p class="filename">{row.filename}</p>

--- a/tests/integration/pricing.test.ts
+++ b/tests/integration/pricing.test.ts
@@ -34,7 +34,8 @@ test.describe('pricing page', () => {
 		await expect(page.getByRole('heading', { name: 'Feature comparison' })).toBeVisible();
 	});
 
-	test('Historical data is listed as Pro-only feature', async ({ page }) => {
-		await expect(page.getByRole('cell', { name: 'Historical data' })).toBeVisible();
+	test('lists DEX dataset rows in the comparison table', async ({ page }) => {
+		await expect(page.getByRole('cell', { name: 'Historical DEX trading data' })).toBeVisible();
+		await expect(page.getByRole('cell', { name: 'DEX price data' })).toBeVisible();
 	});
 });

--- a/tests/integration/pricing.test.ts
+++ b/tests/integration/pricing.test.ts
@@ -34,8 +34,9 @@ test.describe('pricing page', () => {
 		await expect(page.getByRole('heading', { name: 'Feature comparison' })).toBeVisible();
 	});
 
-	test('lists DEX dataset rows in the comparison table', async ({ page }) => {
-		await expect(page.getByRole('cell', { name: 'Historical DEX trading data' })).toBeVisible();
-		await expect(page.getByRole('cell', { name: 'DEX price data' })).toBeVisible();
+	test('lists DEX price data row linking to backtesting', async ({ page }) => {
+		const cell = page.getByRole('cell', { name: 'DEX price data' });
+		await expect(cell).toBeVisible();
+		await expect(cell.getByRole('link')).toHaveAttribute('href', '/trading-view/backtesting');
 	});
 });

--- a/tests/integration/trading-view/vaults/datasets.test.ts
+++ b/tests/integration/trading-view/vaults/datasets.test.ts
@@ -20,7 +20,7 @@ test.describe('vault datasets page', () => {
 	});
 
 	test('shows dataset catalogue table with all expected columns', async ({ page }) => {
-		for (const col of ['Name', 'Description', 'Format', 'Size', 'Last updated', 'Links']) {
+		for (const col of ['Plan', 'Name', 'Description', 'Format', 'Size', 'Last updated', 'Links']) {
 			await expect(page.getByRole('columnheader', { name: col })).toBeVisible();
 		}
 	});
@@ -103,7 +103,8 @@ test.describe('vault datasets page', () => {
 	test('download links include api-key query param after validation', async ({ page }) => {
 		await page.getByLabel('Enter API key to enable download').fill(VALID_API_KEY);
 		await page.getByRole('button', { name: 'Enter' }).click();
-		const link = page.locator('td.links a.action-link').filter({ hasText: 'Download' }).first();
+		// Target a paid (gated) download link — free sample links use /api and carry no key
+		const link = page.locator('td.links a.action-link[href*="/datasets/download/"]').first();
 		const href = await link.getAttribute('href');
 		expect(href).toContain(`api-key=${VALID_API_KEY}`);
 	});

--- a/tests/integration/trading-view/vaults/datasets.test.ts
+++ b/tests/integration/trading-view/vaults/datasets.test.ts
@@ -26,8 +26,13 @@ test.describe('vault datasets page', () => {
 	});
 
 	test('lists vault metadata and vault prices datasets', async ({ page }) => {
-		await expect(page.getByRole('cell', { name: /Vault metadata/ })).toBeVisible();
-		await expect(page.getByRole('cell', { name: /Vault prices/ })).toBeVisible();
+		await expect(page.getByText('Vault metadata', { exact: true })).toBeVisible();
+		await expect(page.getByText('Vault prices', { exact: true })).toBeVisible();
+	});
+
+	test('lists free sample datasets', async ({ page }) => {
+		await expect(page.getByText('Vault metadata (sample)', { exact: true })).toBeVisible();
+		await expect(page.getByText('Vault prices (sample)', { exact: true })).toBeVisible();
 	});
 
 	test('shows expected filenames in dataset table', async ({ page }) => {
@@ -36,8 +41,8 @@ test.describe('vault datasets page', () => {
 	});
 
 	test('shows JSON and Parquet format labels', async ({ page }) => {
-		await expect(page.getByRole('cell', { name: 'JSON', exact: true })).toBeVisible();
-		await expect(page.getByRole('cell', { name: 'Parquet', exact: true })).toBeVisible();
+		await expect(page.getByRole('cell', { name: 'JSON', exact: true }).first()).toBeVisible();
+		await expect(page.getByRole('cell', { name: 'Parquet', exact: true }).first()).toBeVisible();
 	});
 
 	// --- API key form (unauthenticated state) ---


### PR DESCRIPTION
 ## Summary
  
  - **Pricing comparison table:** add `Historical DEX trading data` (Free + Pro,
    → `/trading-view/backtesting`) and `DEX price data` (Pro → `/trading-view/vaults/datasets`)
    
  - **Vault datasets catalogue:** add two free sample rows (`Vault metadata
    (sample)` JSON, `Vault prices (sample)` Parquet) with always-enabled,
    no-API-key downloads and real file sizes (fetched via HEAD); excluded from the
    API-key curl section.
  - **New `/api/[file]` endpoint:** server-side proxy that streams the whitelisted
    sample files from the CDN so the underlying host is never exposed to clients.