### PR TITLE
Core3 links and vocabulary fine tuning

### DIFF
--- a/src/lib/components/EntitySymbol.svelte
+++ b/src/lib/components/EntitySymbol.svelte
@@ -4,11 +4,14 @@
 	export let label = '';
 	export let logoUrl: MaybeString = undefined;
 	export let size = '1.25em';
+	export let showPlaceholder = false;
 </script>
 
 <div class="entity-symbol" style:--image-size={size}>
 	{#if logoUrl}
 		<img class="logo" src={logoUrl} alt={label} use:removeOnError />
+	{:else if showPlaceholder}
+		<span class="placeholder-logo" aria-hidden="true"></span>
 	{/if}
 	{#if label || $$slots.default}
 		<div class="label">
@@ -26,6 +29,15 @@
 		.logo {
 			width: var(--image-size);
 			height: var(--image-size);
+		}
+
+		.placeholder-logo {
+			box-sizing: border-box;
+			width: var(--image-size);
+			height: var(--image-size);
+			border: 1px solid var(--c-text-ultra-light);
+			border-radius: 50%;
+			flex: 0 0 var(--image-size);
 		}
 	}
 </style>

--- a/src/lib/top-vaults/Core3Ratings.svelte
+++ b/src/lib/top-vaults/Core3Ratings.svelte
@@ -6,7 +6,7 @@ individual vault detail page and the protocol listing page; only render it when
 the protocol actually has a CORE3 rating.
 
 The header carries the rating grade badge next to the title. Below, a two-column
-layout shows the rating metrics (risk score, confidence, rank) on the left and
+layout shows the rating metrics (Probability of Loss, confidence, rank) on the left and
 protocol context (data coverage, category, market cap) on the right.
 
 Pass `protocolSlug` to link the protocol name to its page (e.g. from a vault
@@ -22,7 +22,12 @@ page); omit it on the protocol page itself to render the name as plain text.
 	import type { Core3Protocol } from '$lib/top-vaults/schemas';
 	import MetricsBox from '$lib/components/MetricsBox.svelte';
 	import Tooltip from '$lib/components/Tooltip.svelte';
-	import { getCore3RankingUrl, getCore3RatingTone, getCore3ReportUrl } from '$lib/top-vaults/helpers';
+	import {
+		CORE3_METHODOLOGY_URL,
+		getCore3RankingUrl,
+		getCore3RatingTone,
+		getCore3ReportUrl
+	} from '$lib/top-vaults/helpers';
 	import { formatDollar, formatNumber } from '$lib/helpers/formatters';
 	import { resolve } from '$app/paths';
 	import IconQuestionCircle from '~icons/local/question-circle';
@@ -97,8 +102,8 @@ page); omit it on the protocol page itself to render the name as plain text.
 								<th>
 									<Tooltip>
 										<!-- eslint-disable-next-line svelte/no-navigation-without-resolve -->
-										<a slot="trigger" class="metric-link" href={rankingUrl} target="_blank" rel="noreferrer">
-											Risk score
+										<a slot="trigger" class="metric-link" href={CORE3_METHODOLOGY_URL} target="_blank" rel="noreferrer">
+											Probability of Loss
 											<IconQuestionCircle />
 										</a>
 										<svelte:fragment slot="popup">
@@ -122,6 +127,7 @@ page); omit it on the protocol page itself to render the name as plain text.
 											<p>
 												The total is then scaled by 1.0–1.3× for factors such as protocol longevity, past incidents and
 												category leadership.
+												<a href={CORE3_METHODOLOGY_URL} target="_blank" rel="noreferrer">Read CORE3 methodology</a>.
 											</p>
 										</svelte:fragment>
 									</Tooltip>

--- a/src/lib/top-vaults/Core3RiskCell.svelte
+++ b/src/lib/top-vaults/Core3RiskCell.svelte
@@ -13,7 +13,7 @@ for protocols that have no CORE3 rating.
 <script lang="ts">
 	import { resolve } from '$app/paths';
 	import Tooltip from '$lib/components/Tooltip.svelte';
-	import { getCore3RatingTone } from './helpers';
+	import { CORE3_METHODOLOGY_URL, getCore3RatingTone } from './helpers';
 
 	interface Props {
 		rating?: string | null;
@@ -35,6 +35,7 @@ for protocols that have no CORE3 rating.
 			<svelte:fragment slot="popup">
 				CORE3's protocol risk rating (Probability of Loss): a third-party estimate of how likely users are to suffer a
 				financially material loss, graded from AA (lowest risk) down to D.
+				<a href={CORE3_METHODOLOGY_URL} target="_blank" rel="noreferrer">View methodology</a>
 				{#if slug}<a href={resolve(`/trading-view/vaults/protocols/${slug}`)}>View more</a>{/if}
 			</svelte:fragment>
 		</Tooltip>

--- a/src/lib/top-vaults/VaultGroupTable.svelte
+++ b/src/lib/top-vaults/VaultGroupTable.svelte
@@ -91,7 +91,11 @@
 			accessor: (row) => ({ name: row.name, slug: row.slug }),
 			// prettier-ignore
 			cell: ({ value }) => getLogoHref
-					? createRender(EntitySymbol, { label: value.name, logoUrl: getLogoHref(value.slug) })
+					? createRender(EntitySymbol, {
+							label: value.name,
+							logoUrl: getLogoHref(value.slug),
+							showPlaceholder: value.name === 'Unknown' && !getLogoHref(value.slug)
+						})
 					: value.name,
 			plugins: { sort: { getSortValue: (v) => v.name, invert: true } }
 		}),

--- a/src/lib/top-vaults/helpers.test.ts
+++ b/src/lib/top-vaults/helpers.test.ts
@@ -1,5 +1,6 @@
 import { describe, test, expect } from 'vitest';
 import {
+	CORE3_METHODOLOGY_URL,
 	isBlacklisted,
 	hasSupportedProtocol,
 	getProtocolDisplayName,
@@ -217,6 +218,12 @@ describe('getFeeModeDescription', () => {
 });
 
 describe('getCore3ReportUrl', () => {
+	test('exposes the tracked project methodology URL', () => {
+		expect(CORE3_METHODOLOGY_URL).toBe(
+			'https://www.google.com/url?q=https://core3.io/methodology/projects?utm_source%3Dtradingstrategy%26utm_medium%3Dpartner%26utm_campaign%3Dintegration&sa=D&source=editors&ust=1781772908308421&usg=AOvVaw3vPHUEkPOHLmLd7zIbj5sS'
+		);
+	});
+
 	test('builds the project profile URL from the CORE3 slug with the UTM source', () => {
 		expect(getCore3ReportUrl({ slug: 'sky' })).toBe('https://core3.io/projects/sky?utm_source=tradingstrategy');
 	});

--- a/src/lib/top-vaults/helpers.ts
+++ b/src/lib/top-vaults/helpers.ts
@@ -373,6 +373,10 @@ export function rankVaultsBy<V extends Record<string, unknown>>(keys: (keyof V)[
 /** UTM query string appended to all outbound CORE3 links so CORE3 can attribute referral traffic. */
 const CORE3_UTM = 'utm_source=tradingstrategy';
 
+/** CORE3 project methodology page, routed through the partner tracking URL provided by CORE3. */
+export const CORE3_METHODOLOGY_URL =
+	'https://www.google.com/url?q=https://core3.io/methodology/projects?utm_source%3Dtradingstrategy%26utm_medium%3Dpartner%26utm_campaign%3Dintegration&sa=D&source=editors&ust=1781772908308421&usg=AOvVaw3vPHUEkPOHLmLd7zIbj5sS';
+
 /**
  * Resolve the public CORE3 project profile URL for a rated protocol, e.g.
  * `https://core3.io/projects/sky?utm_source=tradingstrategy`.


### PR DESCRIPTION
## Why

Core3 methodology references need to route through the tracked partner methodology URL, and the Core3 UI vocabulary should use the product term “Probability of Loss” instead of the generic “Risk score”. The curator listing also needed a placeholder icon so the Unknown row aligns with logo-backed curator rows.

## Lessons learnt

Core3 outbound destinations are split between report/ranking helpers and methodology copy. Keeping the methodology URL centralised avoids silently mixing those link types in tooltips and popups.

## Summary

- Added a blank circle placeholder icon mode for entity symbols and enabled it for Unknown grouped-table entries without logos.
- Centralised the tracked Core3 methodology URL and used it from Core3 tooltip/popup methodology links.
- Renamed the detailed Core3 metric label from “Risk score” to “Probability of Loss”.
- Added a focused unit assertion for the Core3 methodology URL.