### PR TITLE
Fix brittle live-data tests

### DIFF
--- a/src/lib/reference-rates.test.ts
+++ b/src/lib/reference-rates.test.ts
@@ -20,10 +20,11 @@ const USER_AGENT = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:133.0) Gecko/20
 
 const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
 
-// FRED rate-limits/blocks requests from CI runner IPs (GitHub Actions), so these
-// live-network tests fail intermittently there (the fetch returns null). Skip them
-// in CI; they still run locally, where they verify the real FRED CSV export.
-const SKIP_FRED_IN_CI = !!process.env.CI;
+// Live reference-rate providers rate-limit/block requests from CI runner IPs
+// (GitHub Actions), so these tests fail intermittently there (the fetch returns
+// null). Skip them in CI; they still run locally, where they verify the real
+// provider exports.
+const SKIP_LIVE_REFERENCE_RATES_IN_CI = !!process.env.CI;
 
 async function fetchFredCsvLatest(seriesId: string): Promise<number | null> {
 	try {
@@ -42,7 +43,7 @@ async function fetchFredCsvLatest(seriesId: string): Promise<number | null> {
 	}
 }
 
-describe.skipIf(SKIP_FRED_IN_CI)('fetchFredCsvLatest', () => {
+describe.skipIf(SKIP_LIVE_REFERENCE_RATES_IN_CI)('fetchFredCsvLatest', () => {
 	test(
 		'should fetch SNDR (national savings rate) and return a number',
 		async () => {
@@ -98,7 +99,7 @@ async function fetchTreasuryNoteRate(): Promise<number | null> {
 	}
 }
 
-describe('fetchTreasuryNoteRate', () => {
+describe.skipIf(SKIP_LIVE_REFERENCE_RATES_IN_CI)('fetchTreasuryNoteRate', () => {
 	test(
 		'should fetch Treasury note rate and return a number',
 		async () => {

--- a/tests/e2e/trading-view/exchange-details.test.ts
+++ b/tests/e2e/trading-view/exchange-details.test.ts
@@ -8,7 +8,7 @@ test.describe('exchange details page', () => {
 	test('should include exchange summary info', async ({ page }) => {
 		const exchangeInfo = page.getByTestId('exchange-info');
 		await expect(exchangeInfo).toHaveText(/Name Uniswap/i);
-		await expect(exchangeInfo).toHaveText(/Volume 30d \$[\d.,]+B/);
+		await expect(exchangeInfo).toHaveText(/Volume 30d \$[\d.,]+[MB]/);
 		await expect(exchangeInfo).toHaveText(/Volume all-time \$[\d.,]+B/);
 		await expect(exchangeInfo).toHaveText(/Trading pairs [\d,]/);
 		await expect(exchangeInfo).toHaveText(/Tracked trading pairs [\d,]/);

--- a/tests/integration/trading-view/pair-details.test.ts
+++ b/tests/integration/trading-view/pair-details.test.ts
@@ -1,5 +1,4 @@
 import { expect, test } from '@playwright/test';
-import { a } from 'vitest/dist/chunks/suite.BMWOKiTe.js';
 
 test.describe('trading pair details page', () => {
 	test.beforeEach(async ({ page }) => {
@@ -8,8 +7,8 @@ test.describe('trading pair details page', () => {
 
 	test('should include pair info', async ({ page }) => {
 		const pairInfo = page.getByTestId('pair-info');
-		await expect(pairInfo).toContainText('Price 0.116 USD');
-		await expect(pairInfo).toContainText('Token price 0.0000870 ETH');
+		await expect(pairInfo).toContainText(/Price [\d.,]+ USD/);
+		await expect(pairInfo).toContainText(/Token price [\d.,]+\s+ETH/);
 	});
 
 	test('should include TradingView chart canvas elements', async ({ page }) => {


### PR DESCRIPTION
## Why

The Core3 PR CI failures were unrelated to the application changes and came from tests that depend on live external data. The follow-up makes those expectations resilient to current provider behaviour and live market values.

## Lessons learnt

Tests that hit live public services or market data need to avoid exact values and fixed display units. CI runners can also be rate-limited by public data providers, so live provider checks should be local-only unless they use controlled fixtures.

## Summary

- Skip all live reference-rate provider tests in CI, including the Treasury Fiscal Data API check.
- Allow Uniswap 30d volume assertions to pass for million or billion display units.
- Remove an accidental internal Vitest import from the pair details integration test.
- Relax pair detail price assertions to verify formatted price fields instead of exact live values.