### PR TITLE
CORE3 risk charts for stablecoin vaults

### DIFF
--- a/src/lib/echarts/core3-risk.test.ts
+++ b/src/lib/echarts/core3-risk.test.ts
@@ -1,0 +1,222 @@
+import { describe, expect, test } from 'vitest';
+import {
+	buildCore3RiskPayload,
+	CORE3_RISK_MIN_TVL,
+	CORE3_RISK_OUTLIER_THRESHOLD,
+	type Core3RiskPayload
+} from './core3-risk';
+
+function createVault(overrides: Record<string, unknown> = {}) {
+	return {
+		id: 'vault',
+		name: 'Vault',
+		vault_slug: 'vault',
+		protocol_slug: 'aave',
+		lifetime_return: null,
+		lifetime_return_net: null,
+		cagr: null,
+		cagr_net: null,
+		three_months_returns: null,
+		three_months_returns_net: null,
+		three_months_cagr: 0.04,
+		three_months_cagr_net: null,
+		three_months_sharpe: null,
+		three_months_sharpe_net: null,
+		three_months_volatility: null,
+		one_month_returns: null,
+		one_month_returns_net: null,
+		one_month_cagr: 0.03,
+		one_month_cagr_net: null,
+		denomination: 'USDC',
+		normalised_denomination: 'USD Coin',
+		denomination_slug: 'usdc',
+		share_token: 'A',
+		chain: 'Ethereum',
+		peak_nav: 120,
+		current_nav: 100_000,
+		years: null,
+		mgmt_fee: null,
+		perf_fee: null,
+		deposit_fee: null,
+		withdraw_fee: null,
+		fee_mode: null,
+		fee_internalised: null,
+		gross_fees: null,
+		net_fees: null,
+		lockup: null,
+		event_count: null,
+		protocol: 'Aave',
+		risk: 'Low',
+		risk_numeric: 20,
+		start_date: '2025-01-01T00:00:00',
+		end_date: '2026-01-01T00:00:00',
+		address: '0x1111111111111111111111111111111111111111',
+		share_token_address: null,
+		denomination_token_address: null,
+		chain_id: 1,
+		stablecoinish: true,
+		first_updated_at: null,
+		first_updated_block: null,
+		last_updated_at: '2026-01-01T00:00:00',
+		last_updated_block: 1,
+		last_share_price: null,
+		features: [],
+		flags: [],
+		notes: null,
+		deposit_closed_reason: null,
+		redemption_closed_reason: null,
+		deposit_next_open: null,
+		redemption_next_open: null,
+		link: null,
+		trading_strategy_link: null,
+		fee_label: null,
+		deposit_ui_link: null,
+		vault_page_link: null,
+		share_token_link: null,
+		deposit_manager_link: null,
+		badges: [],
+		period_results: [],
+		...overrides
+	} as any;
+}
+
+function getBand(payload: Core3RiskPayload, key: string) {
+	const band = payload.bands.find((item) => item.key === key);
+	if (!band) throw new Error(`Missing band ${key}`);
+	return band;
+}
+
+describe('buildCore3RiskPayload', () => {
+	test('groups stablecoin vault TVL by CORE3 score band and computes coverage', () => {
+		const payload = buildCore3RiskPayload(
+			[
+				createVault({
+					id: 'a',
+					name: 'Aave USDC',
+					vault_slug: 'aave-usdc',
+					current_nav: 100_000,
+					three_months_cagr: 0.06
+				}),
+				createVault({
+					id: 'b',
+					name: 'Spark USDC',
+					vault_slug: 'spark-usdc',
+					protocol: 'Spark',
+					protocol_slug: 'spark',
+					current_nav: 300_000,
+					three_months_cagr: 0.03
+				}),
+				createVault({
+					id: 'c',
+					name: 'Unrated USDC',
+					vault_slug: 'unrated-usdc',
+					protocol: 'Unrated',
+					protocol_slug: 'unrated',
+					current_nav: 200_000,
+					three_months_cagr: 0.01
+				})
+			],
+			{
+				aave: {
+					slug: 'aave',
+					name: 'Aave',
+					pol: { score: 18, rating: 'AA', confidence: 'High' }
+				},
+				spark: {
+					slug: 'spark',
+					name: 'Spark',
+					pol: { score: 42, rating: 'BBB', confidence: 'Moderate' }
+				}
+			} as any,
+			12,
+			new Date('2026-06-18T12:00:00Z')
+		);
+
+		expect(payload.generatedAt).toBe('2026-06-18T12:00:00.000Z');
+		expect(payload.meta.includedVaults).toBe(3);
+		expect(payload.meta.coveredVaults).toBe(2);
+		expect(payload.meta.uncoveredVaults).toBe(1);
+		expect(payload.meta.totalStablecoinTvl).toBe(600_000);
+		expect(payload.meta.coveredStablecoinTvl).toBe(400_000);
+		expect(payload.meta.uncoveredStablecoinTvl).toBe(200_000);
+		expect(payload.meta.uncoveredStablecoinTvlShare).toBeCloseTo(1 / 3);
+
+		expect(getBand(payload, '0-20')).toMatchObject({
+			tvl: 100_000,
+			vaultCount: 1,
+			protocolCount: 1,
+			weightedThreeMonthCagr: 0.06
+		});
+		expect(getBand(payload, '40-60')).toMatchObject({
+			tvl: 300_000,
+			vaultCount: 1,
+			protocolCount: 1,
+			weightedThreeMonthCagr: 0.03
+		});
+		expect(getBand(payload, 'not-covered')).toMatchObject({
+			tvl: 200_000,
+			vaultCount: 1,
+			protocolCount: 1,
+			weightedThreeMonthCagr: 0.01
+		});
+
+		expect(payload.scatterPoints).toHaveLength(2);
+		expect(payload.scatterPoints[0]).toMatchObject({
+			name: 'Aave USDC',
+			core3Score: 18,
+			core3Rating: 'AA',
+			threeMonthCagr: 0.06,
+			href: '/trading-view/vaults/aave-usdc'
+		});
+	});
+
+	test('uses compact per-vault CORE3 data when the protocol map has no rating', () => {
+		const payload = buildCore3RiskPayload(
+			[
+				createVault({
+					current_nav: 150_000,
+					core3: {
+						risk_score: 65,
+						risk_rating_label: 'CCC',
+						confidence: 'Low'
+					}
+				})
+			],
+			{},
+			0
+		);
+
+		expect(payload.meta.coveredVaults).toBe(1);
+		expect(getBand(payload, '60-80').tvl).toBe(150_000);
+		expect(payload.scatterPoints[0]).toMatchObject({
+			core3Score: 65,
+			core3Rating: 'CCC',
+			core3Confidence: 'Low'
+		});
+	});
+
+	test('excludes non-stablecoin, small, blacklisted and outlier vaults', () => {
+		const payload = buildCore3RiskPayload(
+			[
+				createVault({ id: 'valid', current_nav: CORE3_RISK_MIN_TVL }),
+				createVault({ id: 'small', current_nav: CORE3_RISK_MIN_TVL - 1 }),
+				createVault({ id: 'volatile', stablecoinish: false, current_nav: 500_000 }),
+				createVault({ id: 'blacklisted', risk_numeric: 999, current_nav: 500_000 }),
+				createVault({ id: 'outlier', current_nav: CORE3_RISK_OUTLIER_THRESHOLD + 1 })
+			],
+			{
+				aave: {
+					slug: 'aave',
+					name: 'Aave',
+					pol: { score: 22, rating: 'A', confidence: 'High' }
+				}
+			} as any,
+			0
+		);
+
+		expect(payload.meta.includedVaults).toBe(1);
+		expect(payload.meta.excludedBlacklistedVaults).toBe(1);
+		expect(payload.meta.excludedOutlierVaults).toBe(1);
+		expect(payload.meta.totalStablecoinTvl).toBe(CORE3_RISK_MIN_TVL);
+	});
+});

--- a/src/lib/echarts/core3-risk.ts
+++ b/src/lib/echarts/core3-risk.ts
@@ -1,0 +1,264 @@
+import { getChain } from '$lib/helpers/chain';
+import { getLogoUrl } from '$lib/helpers/assets';
+import { isBlacklisted, getCore3PolForVault, getCore3ReportUrl } from '$lib/top-vaults/helpers';
+import type { Core3Pol, Core3Protocol, VaultInfo } from '$lib/top-vaults/schemas';
+import { getVaultProtocolLogoUrl } from '$lib/vault-protocol/helpers';
+import { VAULT_TVL_OUTLIER_THRESHOLD } from './tvl-outliers';
+
+export const CORE3_RISK_CACHE_TTL_SECONDS = 2 * 60 * 60;
+export const CORE3_RISK_MIN_TVL = 50_000;
+export const CORE3_RISK_OUTLIER_THRESHOLD = VAULT_TVL_OUTLIER_THRESHOLD;
+
+export interface Core3RiskScatterPoint {
+	id: string;
+	name: string;
+	vaultSlug: string;
+	href: string;
+	protocol: string;
+	protocolSlug: string;
+	protocolLogoUrl?: string;
+	chain: string;
+	chainId: number;
+	chainLogoUrl?: string;
+	denomination: string;
+	tvl: number;
+	threeMonthCagr: number | null;
+	oneMonthCagr: number | null;
+	core3Score: number;
+	core3Rating: string | null;
+	core3Confidence: string | null;
+	core3ReportUrl?: string;
+}
+
+export interface Core3RiskBand {
+	key: string;
+	label: string;
+	minScore: number | null;
+	maxScore: number | null;
+	tvl: number;
+	vaultCount: number;
+	protocolCount: number;
+	weightedThreeMonthCagr: number | null;
+	weightedOneMonthCagr: number | null;
+}
+
+export interface Core3RiskPayload {
+	generatedAt: string;
+	durationMs: number;
+	cacheTtlSeconds: number;
+	scatterPoints: Core3RiskScatterPoint[];
+	bands: Core3RiskBand[];
+	meta: {
+		includedVaults: number;
+		coveredVaults: number;
+		uncoveredVaults: number;
+		totalStablecoinTvl: number;
+		coveredStablecoinTvl: number;
+		uncoveredStablecoinTvl: number;
+		uncoveredStablecoinTvlShare: number;
+		excludedBlacklistedVaults: number;
+		excludedOutlierVaults: number;
+		minTvl: number;
+	};
+}
+
+interface BandAccumulator extends Core3RiskBand {
+	protocols: Set<string>;
+	threeMonthWeightedSum: number;
+	threeMonthWeight: number;
+	oneMonthWeightedSum: number;
+	oneMonthWeight: number;
+}
+
+const SCORE_BANDS = [
+	{ key: '0-20', label: '0-20', minScore: 0, maxScore: 20 },
+	{ key: '20-40', label: '20-40', minScore: 20, maxScore: 40 },
+	{ key: '40-60', label: '40-60', minScore: 40, maxScore: 60 },
+	{ key: '60-80', label: '60-80', minScore: 60, maxScore: 80 },
+	{ key: '80-100', label: '80-100', minScore: 80, maxScore: 100 },
+	{ key: 'not-covered', label: 'Not covered', minScore: null, maxScore: null }
+] as const;
+
+function createBandAccumulator(band: (typeof SCORE_BANDS)[number]): BandAccumulator {
+	return {
+		...band,
+		tvl: 0,
+		vaultCount: 0,
+		protocolCount: 0,
+		weightedThreeMonthCagr: null,
+		weightedOneMonthCagr: null,
+		protocols: new Set<string>(),
+		threeMonthWeightedSum: 0,
+		threeMonthWeight: 0,
+		oneMonthWeightedSum: 0,
+		oneMonthWeight: 0
+	};
+}
+
+function getScoreBandKey(score: number | null | undefined): string {
+	if (score == null || !Number.isFinite(score)) return 'not-covered';
+	if (score < 20) return '0-20';
+	if (score < 40) return '20-40';
+	if (score < 60) return '40-60';
+	if (score < 80) return '60-80';
+	return '80-100';
+}
+
+function getReturn(vault: Pick<VaultInfo, 'three_months_cagr_net' | 'three_months_cagr'>): number | null {
+	const value = vault.three_months_cagr_net ?? vault.three_months_cagr;
+	return value != null && Number.isFinite(value) && Math.abs(value) <= 10 ? value : null;
+}
+
+function getOneMonthReturn(vault: Pick<VaultInfo, 'one_month_cagr_net' | 'one_month_cagr'>): number | null {
+	const value = vault.one_month_cagr_net ?? vault.one_month_cagr;
+	return value != null && Number.isFinite(value) && Math.abs(value) <= 10 ? value : null;
+}
+
+function addVaultToBand(band: BandAccumulator, vault: VaultInfo, tvl: number, threeMonthCagr: number | null) {
+	const oneMonthCagr = getOneMonthReturn(vault);
+	band.tvl += tvl;
+	band.vaultCount += 1;
+	band.protocols.add(vault.protocol_slug);
+
+	if (threeMonthCagr != null) {
+		band.threeMonthWeightedSum += tvl * threeMonthCagr;
+		band.threeMonthWeight += tvl;
+	}
+
+	if (oneMonthCagr != null) {
+		band.oneMonthWeightedSum += tvl * oneMonthCagr;
+		band.oneMonthWeight += tvl;
+	}
+}
+
+function finaliseBand(band: BandAccumulator): Core3RiskBand {
+	return {
+		key: band.key,
+		label: band.label,
+		minScore: band.minScore,
+		maxScore: band.maxScore,
+		tvl: band.tvl,
+		vaultCount: band.vaultCount,
+		protocolCount: band.protocols.size,
+		weightedThreeMonthCagr: band.threeMonthWeight > 0 ? band.threeMonthWeightedSum / band.threeMonthWeight : null,
+		weightedOneMonthCagr: band.oneMonthWeight > 0 ? band.oneMonthWeightedSum / band.oneMonthWeight : null
+	};
+}
+
+function buildScatterPoint(
+	vault: VaultInfo,
+	pol: Core3Pol,
+	core3Protocol: Core3Protocol | undefined
+): Core3RiskScatterPoint | null {
+	const tvl = vault.current_nav ?? 0;
+	const threeMonthCagr = getReturn(vault);
+	if (!(tvl > 0) || threeMonthCagr == null || pol.score == null || !Number.isFinite(pol.score)) return null;
+
+	const chain = getChain(vault.chain_id);
+	const reportUrl = core3Protocol ? getCore3ReportUrl(core3Protocol) : undefined;
+
+	return {
+		id: vault.id,
+		name: vault.name,
+		vaultSlug: vault.vault_slug,
+		href: `/trading-view/vaults/${vault.vault_slug}`,
+		protocol: vault.protocol,
+		protocolSlug: vault.protocol_slug,
+		protocolLogoUrl: getVaultProtocolLogoUrl(vault.protocol_slug),
+		chain: chain?.name ?? vault.chain ?? `Chain ${vault.chain_id}`,
+		chainId: vault.chain_id,
+		chainLogoUrl: chain ? getLogoUrl('blockchain', chain.slug) : undefined,
+		denomination: vault.denomination ?? vault.normalised_denomination ?? 'Stablecoin',
+		tvl,
+		threeMonthCagr,
+		oneMonthCagr: getOneMonthReturn(vault),
+		core3Score: pol.score,
+		core3Rating: pol.rating,
+		core3Confidence: pol.confidence,
+		core3ReportUrl: reportUrl
+	};
+}
+
+export function buildCore3RiskPayload(
+	vaults: VaultInfo[],
+	core3Protocols: Record<string, Core3Protocol>,
+	durationMs: number,
+	generatedAt = new Date(),
+	options?: { minTvl?: number }
+): Core3RiskPayload {
+	const minTvl = options?.minTvl ?? CORE3_RISK_MIN_TVL;
+	const bandMap = new Map<string, BandAccumulator>(SCORE_BANDS.map((band) => [band.key, createBandAccumulator(band)]));
+	const scatterPoints: Core3RiskScatterPoint[] = [];
+
+	let includedVaults = 0;
+	let coveredVaults = 0;
+	let uncoveredVaults = 0;
+	let totalStablecoinTvl = 0;
+	let coveredStablecoinTvl = 0;
+	let uncoveredStablecoinTvl = 0;
+	let excludedBlacklistedVaults = 0;
+	let excludedOutlierVaults = 0;
+
+	for (const vault of vaults) {
+		if (isBlacklisted(vault)) {
+			excludedBlacklistedVaults += 1;
+			continue;
+		}
+
+		if (!vault.stablecoinish) continue;
+
+		const tvl = vault.current_nav ?? 0;
+		if (!Number.isFinite(tvl) || tvl <= 0 || tvl < minTvl) continue;
+
+		if (tvl > CORE3_RISK_OUTLIER_THRESHOLD) {
+			excludedOutlierVaults += 1;
+			continue;
+		}
+
+		const core3Protocol = core3Protocols[vault.protocol_slug];
+		const pol = getCore3PolForVault(vault, core3Protocols);
+		const score = pol?.score ?? null;
+		const band = bandMap.get(getScoreBandKey(score)) ?? bandMap.get('not-covered');
+		if (!band) continue;
+
+		const threeMonthCagr = getReturn(vault);
+		addVaultToBand(band, vault, tvl, threeMonthCagr);
+
+		includedVaults += 1;
+		totalStablecoinTvl += tvl;
+
+		if (score != null && Number.isFinite(score)) {
+			coveredVaults += 1;
+			coveredStablecoinTvl += tvl;
+			const point = pol ? buildScatterPoint(vault, pol, core3Protocol) : null;
+			if (point) scatterPoints.push(point);
+		} else {
+			uncoveredVaults += 1;
+			uncoveredStablecoinTvl += tvl;
+		}
+	}
+
+	const bands = SCORE_BANDS.map((band) => finaliseBand(bandMap.get(band.key) ?? createBandAccumulator(band)));
+
+	return {
+		generatedAt: generatedAt.toISOString(),
+		durationMs,
+		cacheTtlSeconds: CORE3_RISK_CACHE_TTL_SECONDS,
+		scatterPoints: scatterPoints.toSorted(
+			(left, right) => left.core3Score - right.core3Score || right.tvl - left.tvl || left.name.localeCompare(right.name)
+		),
+		bands,
+		meta: {
+			includedVaults,
+			coveredVaults,
+			uncoveredVaults,
+			totalStablecoinTvl,
+			coveredStablecoinTvl,
+			uncoveredStablecoinTvl,
+			uncoveredStablecoinTvlShare: totalStablecoinTvl > 0 ? uncoveredStablecoinTvl / totalStablecoinTvl : 0,
+			excludedBlacklistedVaults,
+			excludedOutlierVaults,
+			minTvl
+		}
+	};
+}

--- a/src/lib/scatter-plot/ScatterPlotSelector.svelte
+++ b/src/lib/scatter-plot/ScatterPlotSelector.svelte
@@ -17,6 +17,7 @@ Selector linking between vault scatter plot chart pages.
 		{ href: '/trading-view/vaults/yield-protocol', label: 'Yield / Protocol' },
 		{ href: '/trading-view/vaults/yield-chain', label: 'Yield / Chain' },
 		{ href: '/trading-view/vaults/current-peak-tvl', label: 'Current / Peak TVL' },
+		{ href: '/trading-view/vaults/core3-risk', label: 'CORE3 risk' },
 		{ href: '/trading-view/vaults/historical-tvl-chain', label: 'Historical TVL by chain' },
 		{ href: '/trading-view/vaults/historical-tvl-stablecoin', label: 'Historical TVL by stablecoin' },
 		{ href: '/trading-view/vaults/historical-tvl-protocol', label: 'Historical TVL by vault protocol' },

--- a/src/routes/trading-view/vaults/core3-risk/+page.svelte
+++ b/src/routes/trading-view/vaults/core3-risk/+page.svelte
@@ -1,0 +1,148 @@
+<!--
+CORE3 stablecoin vault risk chart page.
+-->
+<script lang="ts">
+	import { resolve } from '$app/paths';
+	import { page } from '$app/state';
+	import { formatUsd } from '$lib/echarts/cumulative-tvl-apy';
+	import type { Core3RiskPayload } from '$lib/echarts/core3-risk';
+	import Alert from '$lib/components/Alert.svelte';
+	import HeroBanner from '$lib/components/HeroBanner.svelte';
+	import Section from '$lib/components/Section.svelte';
+	import ScatterPlotSelector from '$lib/scatter-plot/ScatterPlotSelector.svelte';
+	import TopVaultsOptIn from '$lib/top-vaults/TopVaultsOptIn.svelte';
+	import VaultListingsSelector from '$lib/top-vaults/VaultListingsSelector.svelte';
+	import { CORE3_METHODOLOGY_URL } from '$lib/top-vaults/helpers';
+	import { JsonLd, MetaTags } from 'svelte-meta-tags';
+	import { onMount } from 'svelte';
+	import Core3RiskCharts from './Core3RiskCharts.svelte';
+
+	let chartData = $state<Core3RiskPayload | null>(null);
+	let chartLoading = $state(true);
+	let chartError = $state<string | null>(null);
+
+	const title = 'CORE3 risk charts for stablecoin vaults';
+	const description =
+		'Compare stablecoin vault returns and TVL by CORE3 protocol risk score, including the amount of stablecoin vault TVL not yet covered by CORE3.';
+	const chartDataVersion = 'core3-risk-v1';
+	let pageUrl = $derived(new URL(page.url.pathname, page.url.origin).href);
+	let uncoveredTvlText = $derived(
+		chartData ? formatUsd(chartData.meta.uncoveredStablecoinTvl) : 'the uncategorised share'
+	);
+	let uncoveredShareText = $derived(
+		chartData ? `${(chartData.meta.uncoveredStablecoinTvlShare * 100).toFixed(1)}%` : 'a live share'
+	);
+
+	onMount(() => {
+		let cancelled = false;
+
+		(async () => {
+			try {
+				chartLoading = true;
+				chartError = null;
+
+				const response = await fetch(resolve('/trading-view/vaults/core3-risk/chart-data') + `?v=${chartDataVersion}`);
+				if (!response.ok) throw new Error(`Failed to fetch CORE3 chart data: ${response.status}`);
+
+				const payload = (await response.json()) as Core3RiskPayload;
+				if (!cancelled) chartData = payload;
+			} catch (loadError) {
+				if (cancelled) return;
+				chartError = loadError instanceof Error ? loadError.message : 'Failed to load chart data.';
+			} finally {
+				if (!cancelled) chartLoading = false;
+			}
+		})();
+
+		return () => {
+			cancelled = true;
+		};
+	});
+</script>
+
+<MetaTags
+	{title}
+	{description}
+	canonical={pageUrl}
+	openGraph={{ siteName: 'Trading Strategy', url: pageUrl, title, description, type: 'website' }}
+	twitter={{ site: '@TradingProtocol', cardType: 'summary', title, description }}
+/>
+
+<JsonLd
+	schema={{
+		'@context': 'http://schema.org',
+		'@type': 'CollectionPage',
+		name: title,
+		description,
+		url: pageUrl,
+		provider: { '@type': 'Organization', name: 'Trading Strategy' },
+		mainEntity: {
+			'@type': 'ItemList',
+			numberOfItems: chartData?.scatterPoints.length ?? 0
+		}
+	}}
+/>
+
+<main class="core3-risk-page">
+	<div class="mobile-notice">
+		<Alert size="sm" status="warning">These charts are best viewed on a large screen.</Alert>
+	</div>
+
+	<Section tag="header">
+		<VaultListingsSelector />
+		<HeroBanner>
+			{#snippet subtitle()}
+				CORE3 is a third-party protocol risk rating that estimates Probability of Loss for DeFi protocols. This view
+				covers <a href={resolve('/glossary/stablecoin')}>stablecoin</a>
+				<a href={resolve('/glossary/vault')}>vaults</a> only. CORE3 does not yet cover {uncoveredTvlText}
+				({uncoveredShareText}) of eligible stablecoin vault
+				<a href={resolve('/glossary/total-value-locked-tvl')}>TVL</a> shown here.
+			{/snippet}
+			{#snippet title()}
+				<span>CORE3 risk charts for stablecoin vaults</span>
+			{/snippet}
+		</HeroBanner>
+	</Section>
+
+	<Section padding="sm" class="chart-section">
+		<Core3RiskCharts data={chartData} dataLoading={chartLoading} error={chartError} />
+		<ScatterPlotSelector />
+		<p class="methodology">
+			CORE3 scores are protocol-level Probability of Loss estimates. Lower scores are better.
+			<a href={CORE3_METHODOLOGY_URL} target="_blank" rel="noreferrer">Read the CORE3 methodology.</a>
+		</p>
+	</Section>
+
+	<Section>
+		<TopVaultsOptIn />
+	</Section>
+</main>
+
+<style>
+	.core3-risk-page {
+		:global(.subtitle a) {
+			text-decoration: underline;
+		}
+	}
+
+	.mobile-notice {
+		display: none;
+
+		@media (max-width: 768px) {
+			display: block;
+			padding: 1rem var(--container-padding, 1rem);
+		}
+	}
+
+	.methodology {
+		margin-top: 1rem;
+		font: var(--f-ui-sm-roman);
+		color: var(--c-text-extra-light);
+		text-align: center;
+
+		a {
+			color: var(--c-text-light);
+			text-decoration: underline;
+		}
+	}
+</style>

--- a/src/routes/trading-view/vaults/core3-risk/+page.ts
+++ b/src/routes/trading-view/vaults/core3-risk/+page.ts
@@ -1,0 +1,1 @@
+export const ssr = false;

--- a/src/routes/trading-view/vaults/core3-risk/Core3RiskCharts.svelte
+++ b/src/routes/trading-view/vaults/core3-risk/Core3RiskCharts.svelte
@@ -1,0 +1,595 @@
+<!--
+@component
+Two ECharts visualisations for stablecoin vault returns and TVL by CORE3 protocol risk score.
+
+- Hexbin chart: vault 3M annualised return by CORE3 score, sized by TVL
+- Bar chart: stablecoin vault TVL by CORE3 score band, including unrated TVL
+
+@example
+
+```svelte
+	<Core3RiskCharts data={chartData} dataLoading={loading} error={error} />
+```
+-->
+<script lang="ts">
+	import { browser } from '$app/environment';
+	import { escapeHtml, formatRate, formatUsd } from '$lib/echarts/cumulative-tvl-apy';
+	import type { Core3RiskBand, Core3RiskPayload } from '$lib/echarts/core3-risk';
+	import { type EChartsStatic, loadECharts } from '$lib/echarts/runtime';
+	import ScatterPlotShell from '$lib/scatter-plot/ScatterPlotShell.svelte';
+	import { chartFontFamily, minReturnLog } from '$lib/scatter-plot/helpers';
+	import { onMount, tick } from 'svelte';
+
+	interface Props {
+		data: Core3RiskPayload | null;
+		dataLoading?: boolean;
+		error?: string | null;
+	}
+
+	type BandDatum = Core3RiskBand & {
+		value: number;
+		itemStyle: { color: string };
+	};
+
+	type BinnedReturnDatum = {
+		value: [number, number, number, number, number];
+		vaultCount: number;
+		totalTvl: number;
+		weightedReturn: number | null;
+		averageScore: number;
+		topProtocols: string[];
+		topVaults: Array<{ name: string; protocol: string; tvl: number; href: string }>;
+		itemStyle: { color: string };
+	};
+
+	let { data, dataLoading = false, error = null }: Props = $props();
+
+	let hexbinContainer = $state<HTMLDivElement | null>(null);
+	let bandContainer = $state<HTMLDivElement | null>(null);
+	let hexbinInstance = $state<ReturnType<EChartsStatic['init']> | null>(null);
+	let bandInstance = $state<ReturnType<EChartsStatic['init']> | null>(null);
+	let echartsApi = $state<EChartsStatic | null>(null);
+	let resizeObserver = $state<ResizeObserver | null>(null);
+	let runtimeReady = $state(false);
+	let chartError = $state<string | null>(null);
+	let viewportWidth = $state(1440);
+
+	let effectiveError = $derived(error ?? chartError);
+	let hasData = $derived(Boolean(data && (data.scatterPoints.length > 0 || data.bands.some((band) => band.tvl > 0))));
+
+	const scoreColourStops = [
+		{ score: 20, colour: '#22c55e' },
+		{ score: 40, colour: '#84cc16' },
+		{ score: 60, colour: '#facc15' },
+		{ score: 80, colour: '#f97316' },
+		{ score: Number.POSITIVE_INFINITY, colour: '#ef4444' }
+	] as const;
+	const maxReturnAxisPercent = 500;
+	const scoreBucketSize = 10;
+	const returnBuckets = [0.01, 0.03, 0.1, 0.3, 1, 3, 10, 30, 100, 300, 500] as const;
+	const hexagonSymbol = 'path://M0,-1 L0.866,-0.5 L0.866,0.5 L0,1 L-0.866,0.5 L-0.866,-0.5 Z';
+
+	function getScoreColour(score: number | null | undefined) {
+		if (score == null || !Number.isFinite(score)) return '#64748b';
+		return scoreColourStops.find((stop) => score < stop.score)?.colour ?? '#ef4444';
+	}
+
+	function getBandColour(band: Core3RiskBand) {
+		if (band.key === 'not-covered') return '#64748b';
+		return getScoreColour(band.minScore == null ? null : band.minScore + 1);
+	}
+
+	function formatScore(score: number | null | undefined) {
+		return score == null || !Number.isFinite(score) ? 'n/a' : score.toFixed(1).replace(/\.0$/, '');
+	}
+
+	function formatReturn(value: number | null | undefined) {
+		return formatRate(value == null ? null : value * 100, 1);
+	}
+
+	function getPlottedReturnPercent(value: number | null | undefined) {
+		if (value == null || !Number.isFinite(value)) return minReturnLog;
+		return Math.min(Math.max(value * 100, minReturnLog), maxReturnAxisPercent);
+	}
+
+	function formatShare(value: number) {
+		if (!Number.isFinite(value)) return '0.0%';
+		return `${(value * 100).toFixed(1)}%`;
+	}
+
+	function formatReturnPercent(value: number | null | undefined) {
+		return formatRate(value ?? null, 1);
+	}
+
+	function getReturnBucketIndex(value: number) {
+		for (let index = 0; index < returnBuckets.length - 1; index++) {
+			if (value >= returnBuckets[index] && value < returnBuckets[index + 1]) return index;
+		}
+		return returnBuckets.length - 2;
+	}
+
+	function getScoreBucketIndex(score: number) {
+		return Math.min(Math.floor(score / scoreBucketSize), 9);
+	}
+
+	function buildMetricRow(label: string, value: string) {
+		return `<div style="color: #d5deea; font-family: ${chartFontFamily}; display: flex; justify-content: space-between; gap: 1rem;"><span>${label}</span><strong>${value}</strong></div>`;
+	}
+
+	function buildBandTooltip(band: BandDatum) {
+		const share = data && data.meta.totalStablecoinTvl > 0 ? band.tvl / data.meta.totalStablecoinTvl : 0;
+
+		return [
+			`<div style="margin-bottom: 0.45rem; color: #ffffff; font-family: ${chartFontFamily}; font-size: 1rem; font-weight: 700;">CORE3 score ${escapeHtml(band.label)}</div>`,
+			buildMetricRow('Stablecoin vault TVL', formatUsd(band.tvl)),
+			buildMetricRow('Share of stablecoin TVL', formatShare(share)),
+			buildMetricRow('Vaults', String(band.vaultCount)),
+			buildMetricRow('Protocols', String(band.protocolCount)),
+			buildMetricRow('TVL-weighted 3M return', formatReturn(band.weightedThreeMonthCagr)),
+			buildMetricRow('TVL-weighted 1M return', formatReturn(band.weightedOneMonthCagr)),
+			band.key === 'not-covered'
+				? `<div style="margin-top: 0.45rem; color: #94a3b8; font-family: ${chartFontFamily};">This TVL belongs to stablecoin vaults whose protocol does not yet have a CORE3 score in our data.</div>`
+				: `<div style="margin-top: 0.45rem; color: #94a3b8; font-family: ${chartFontFamily};">Scores are CORE3 Probability of Loss bands; lower is better.</div>`
+		].join('');
+	}
+
+	function buildBinnedTooltip(point: BinnedReturnDatum) {
+		const topVaultRows = point.topVaults
+			.map(
+				(vault) =>
+					`<div style="display: grid; grid-template-columns: minmax(0, 1fr) auto; gap: 0.75rem; color: #d5deea; font-family: ${chartFontFamily};"><span style="min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;">${escapeHtml(vault.name)} <span style="color: #94a3b8;">${escapeHtml(vault.protocol)}</span></span><strong>${formatUsd(vault.tvl)}</strong></div>`
+			)
+			.join('');
+
+		return [
+			`<div style="width: 22rem; max-width: calc(100vw - 2rem); box-sizing: border-box; white-space: normal; overflow-wrap: break-word;">`,
+			`<div style="margin-bottom: 0.55rem; color: #ffffff; font-family: ${chartFontFamily}; font-size: 1rem; font-weight: 700;">~${formatReturnPercent(point.weightedReturn)} return at ${formatScore(point.averageScore)} PoL score</div>`,
+			`<div style="display: grid; gap: 0.25rem;">`,
+			buildMetricRow('Vaults', String(point.vaultCount)),
+			buildMetricRow('Total TVL', formatUsd(point.totalTvl)),
+			buildMetricRow(
+				'TVL-weighted 3M return',
+				formatReturn(point.weightedReturn == null ? null : point.weightedReturn / 100)
+			),
+			buildMetricRow('Average CORE3 score', formatScore(point.averageScore)),
+			point.topProtocols.length ? buildMetricRow('Top protocols', escapeHtml(point.topProtocols.join(', '))) : '',
+			`</div>`,
+			topVaultRows
+				? `<div style="margin-top: 0.65rem; padding-top: 0.55rem; border-top: 1px solid #334155;"><div style="margin-bottom: 0.3rem; color: #94a3b8; font-family: ${chartFontFamily}; font-size: 0.78rem; font-weight: 700; text-transform: uppercase; letter-spacing: 0.04em;">Largest vaults by TVL</div><div style="display: grid; gap: 0.2rem;">${topVaultRows}</div></div>`
+				: '',
+			`<div style="margin-top: 0.55rem; color: #94a3b8; font-family: ${chartFontFamily}; line-height: 1.35; white-space: normal; overflow-wrap: break-word;">Hex size follows total TVL. Colour follows average CORE3 score.</div>`,
+			`</div>`
+		].join('');
+	}
+
+	function buildBandData(): BandDatum[] {
+		if (!data) return [];
+		return data.bands.map((band) => ({
+			...band,
+			value: band.tvl,
+			itemStyle: { color: getBandColour(band) }
+		}));
+	}
+
+	function buildBinnedReturnData() {
+		const bins = new Map<
+			string,
+			{
+				scoreIndex: number;
+				returnIndex: number;
+				totalTvl: number;
+				vaultCount: number;
+				weightedReturnSum: number;
+				scoreSum: number;
+				protocolCounts: Map<string, number>;
+				vaults: Array<{ name: string; protocol: string; tvl: number; href: string }>;
+			}
+		>();
+
+		for (const point of data?.scatterPoints ?? []) {
+			const plottedReturn = getPlottedReturnPercent(point.threeMonthCagr);
+			const scoreIndex = getScoreBucketIndex(point.core3Score);
+			const returnIndex = getReturnBucketIndex(plottedReturn);
+			const key = `${scoreIndex}:${returnIndex}`;
+			const bin = bins.get(key) ?? {
+				scoreIndex,
+				returnIndex,
+				totalTvl: 0,
+				vaultCount: 0,
+				weightedReturnSum: 0,
+				scoreSum: 0,
+				protocolCounts: new Map<string, number>(),
+				vaults: []
+			};
+
+			bin.totalTvl += point.tvl;
+			bin.vaultCount += 1;
+			bin.weightedReturnSum += point.tvl * plottedReturn;
+			bin.scoreSum += point.core3Score;
+			bin.protocolCounts.set(point.protocol, (bin.protocolCounts.get(point.protocol) ?? 0) + 1);
+			bin.vaults.push({ name: point.name, protocol: point.protocol, tvl: point.tvl, href: point.href });
+			bins.set(key, bin);
+		}
+
+		return [...bins.values()].map((bin) => {
+			const scoreCenter = bin.scoreIndex * scoreBucketSize + scoreBucketSize / 2;
+			const returnMin = returnBuckets[bin.returnIndex];
+			const returnMax = returnBuckets[bin.returnIndex + 1];
+			const returnCenter = Math.sqrt(returnMin * returnMax);
+			const weightedReturn = bin.totalTvl > 0 ? bin.weightedReturnSum / bin.totalTvl : null;
+			const averageScore = bin.scoreSum / bin.vaultCount;
+			const topProtocols = [...bin.protocolCounts.entries()]
+				.toSorted((left, right) => right[1] - left[1] || left[0].localeCompare(right[0]))
+				.slice(0, 3)
+				.map(([protocol]) => protocol);
+			const topVaults = bin.vaults
+				.toSorted((left, right) => right.tvl - left.tvl || left.name.localeCompare(right.name))
+				.slice(0, 3);
+
+			return {
+				value: [scoreCenter, returnCenter, bin.vaultCount, bin.totalTvl, weightedReturn ?? 0],
+				vaultCount: bin.vaultCount,
+				totalTvl: bin.totalTvl,
+				weightedReturn,
+				averageScore,
+				topProtocols,
+				topVaults,
+				itemStyle: { color: getScoreColour(averageScore) }
+			} satisfies BinnedReturnDatum;
+		});
+	}
+
+	function getTvlSymbolSize(tvl: number, maxTvl: number) {
+		if (!Number.isFinite(tvl) || tvl <= 0 || !Number.isFinite(maxTvl) || maxTvl <= 0) return 8;
+		return 8 + Math.sqrt(tvl / maxTvl) * 34;
+	}
+
+	function buildBaseTooltip() {
+		return {
+			trigger: 'item',
+			appendToBody: true,
+			backgroundColor: '#111827',
+			borderColor: '#1f2937',
+			borderWidth: 1,
+			padding: 12,
+			textStyle: {
+				color: '#f8fafc',
+				fontFamily: chartFontFamily,
+				fontSize: 14,
+				lineHeight: 20
+			}
+		};
+	}
+
+	function destroyCharts() {
+		resizeObserver?.disconnect();
+		resizeObserver = null;
+		hexbinInstance?.dispose();
+		bandInstance?.dispose();
+		hexbinInstance = null;
+		bandInstance = null;
+	}
+
+	function attachResizeHandling() {
+		resizeObserver?.disconnect();
+		if (!hexbinContainer || !bandContainer) return;
+
+		resizeObserver = new ResizeObserver(() => {
+			hexbinInstance?.resize();
+			bandInstance?.resize();
+		});
+		resizeObserver.observe(hexbinContainer);
+		resizeObserver.observe(bandContainer);
+	}
+
+	async function renderCharts() {
+		if (!hexbinContainer || !bandContainer || !echartsApi) return;
+
+		if (!data || !hasData) {
+			chartError = null;
+			destroyCharts();
+			return;
+		}
+
+		echartsApi.getInstanceByDom(hexbinContainer)?.dispose();
+		echartsApi.getInstanceByDom(bandContainer)?.dispose();
+		destroyCharts();
+
+		const isMobile = viewportWidth <= 768;
+		const binnedData = buildBinnedReturnData();
+		const bandData = buildBandData();
+		const maxBinTvl = Math.max(...binnedData.map((point) => point.totalTvl), 0);
+
+		hexbinInstance = echartsApi.init(hexbinContainer);
+		bandInstance = echartsApi.init(bandContainer);
+
+		hexbinInstance.setOption({
+			animationDuration: 350,
+			animationEasing: 'quadraticOut',
+			backgroundColor: 'transparent',
+			grid: {
+				top: isMobile ? 44 : 42,
+				right: isMobile ? 16 : 28,
+				bottom: isMobile ? 46 : 52,
+				left: isMobile ? 52 : 72,
+				containLabel: false
+			},
+			tooltip: {
+				...buildBaseTooltip(),
+				formatter: (params: { data?: BinnedReturnDatum }) => (params.data ? buildBinnedTooltip(params.data) : '')
+			},
+			xAxis: {
+				type: 'value',
+				name: 'CORE3 score',
+				nameLocation: 'middle',
+				nameGap: 30,
+				min: 0,
+				max: 100,
+				axisLabel: { color: '#cbd5e1', fontFamily: chartFontFamily, fontSize: isMobile ? 11 : 12 },
+				nameTextStyle: { color: '#d5deea', fontFamily: chartFontFamily, fontSize: isMobile ? 11 : 12, fontWeight: 700 },
+				splitLine: { lineStyle: { color: 'rgba(148, 163, 184, 0.16)' } }
+			},
+			yAxis: {
+				type: 'log',
+				name: '3M annualised return',
+				nameLocation: 'middle',
+				nameGap: isMobile ? 38 : 52,
+				min: minReturnLog,
+				max: maxReturnAxisPercent,
+				logBase: 10,
+				axisLabel: {
+					color: '#cbd5e1',
+					fontFamily: chartFontFamily,
+					fontSize: isMobile ? 11 : 12,
+					formatter: (value: number) => (value >= 1 ? `${value.toFixed(0)}%` : `${value.toFixed(2)}%`)
+				},
+				nameTextStyle: { color: '#d5deea', fontFamily: chartFontFamily, fontSize: isMobile ? 11 : 12, fontWeight: 700 },
+				splitLine: { lineStyle: { color: 'rgba(148, 163, 184, 0.16)' } }
+			},
+			series: [
+				{
+					name: 'Hexbin density',
+					type: 'scatter',
+					symbol: hexagonSymbol,
+					data: binnedData,
+					symbolSize: (value: [number, number, number, number]) => getTvlSymbolSize(value[3], maxBinTvl),
+					emphasis: {
+						focus: 'self',
+						itemStyle: {
+							borderColor: '#f8fafc',
+							borderWidth: 2,
+							shadowBlur: 14,
+							shadowColor: 'rgba(15, 23, 42, 0.55)'
+						}
+					}
+				}
+			]
+		});
+
+		bandInstance.setOption({
+			animationDuration: 350,
+			animationEasing: 'quadraticOut',
+			backgroundColor: 'transparent',
+			grid: {
+				top: 26,
+				right: isMobile ? 12 : 24,
+				bottom: isMobile ? 54 : 48,
+				left: isMobile ? 52 : 72,
+				containLabel: false
+			},
+			tooltip: {
+				...buildBaseTooltip(),
+				formatter: (params: { data?: BandDatum }) => (params.data ? buildBandTooltip(params.data) : '')
+			},
+			xAxis: {
+				type: 'category',
+				data: bandData.map((band) => band.label),
+				axisLabel: { color: '#cbd5e1', fontFamily: chartFontFamily, fontSize: isMobile ? 10 : 12 },
+				axisLine: { lineStyle: { color: 'rgba(148, 163, 184, 0.35)' } },
+				axisTick: { show: false }
+			},
+			yAxis: {
+				type: 'value',
+				name: 'Stablecoin vault TVL',
+				nameLocation: 'middle',
+				nameGap: isMobile ? 38 : 52,
+				axisLabel: {
+					color: '#cbd5e1',
+					fontFamily: chartFontFamily,
+					fontSize: isMobile ? 11 : 12,
+					formatter: (value: number) => formatUsd(value)
+				},
+				nameTextStyle: { color: '#d5deea', fontFamily: chartFontFamily, fontSize: isMobile ? 11 : 12, fontWeight: 700 },
+				splitLine: { lineStyle: { color: 'rgba(148, 163, 184, 0.16)' } }
+			},
+			series: [
+				{
+					name: 'TVL',
+					type: 'bar',
+					data: bandData,
+					barMaxWidth: 54,
+					label: {
+						show: !isMobile,
+						position: 'top',
+						color: '#e2e8f0',
+						fontFamily: chartFontFamily,
+						fontSize: 12,
+						fontWeight: 700,
+						formatter: (params: { data?: BandDatum }) =>
+							params.data && params.data.tvl > 0 ? formatUsd(params.data.tvl) : ''
+					},
+					itemStyle: {
+						borderRadius: [5, 5, 0, 0]
+					},
+					emphasis: {
+						itemStyle: {
+							shadowBlur: 12,
+							shadowColor: 'rgba(15, 23, 42, 0.5)'
+						}
+					}
+				}
+			]
+		});
+
+		attachResizeHandling();
+		chartError = null;
+	}
+
+	onMount(() => {
+		if (!browser) return;
+
+		let disposed = false;
+		const handleWindowResize = () => {
+			viewportWidth = window.innerWidth;
+			hexbinInstance?.resize();
+			bandInstance?.resize();
+		};
+		viewportWidth = window.innerWidth;
+		window.addEventListener('resize', handleWindowResize);
+
+		(async () => {
+			try {
+				echartsApi = await loadECharts();
+				if (disposed) return;
+
+				runtimeReady = true;
+				await tick();
+				if (disposed) return;
+
+				await renderCharts();
+			} catch (loadError) {
+				if (disposed) return;
+				chartError = loadError instanceof Error ? loadError.message : 'Failed to initialise charts.';
+			}
+		})();
+
+		return () => {
+			disposed = true;
+			window.removeEventListener('resize', handleWindowResize);
+			destroyCharts();
+		};
+	});
+
+	$effect(() => {
+		data;
+		dataLoading;
+		error;
+		viewportWidth;
+		if (!runtimeReady || !echartsApi || !hexbinContainer || !bandContainer || dataLoading || error) return;
+
+		let cancelled = false;
+		void tick().then(async () => {
+			if (cancelled) return;
+			await renderCharts();
+		});
+
+		return () => {
+			cancelled = true;
+		};
+	});
+</script>
+
+<div class="core3-risk-charts">
+	<section class="chart-section" aria-labelledby="core3-returns-heading">
+		<h2 id="core3-returns-heading">Returns by CORE3 Probability of Loss</h2>
+		<div class="chart-panel">
+			<ScatterPlotShell
+				loading={dataLoading}
+				error={effectiveError}
+				showMinTvlControl={false}
+				className="core3-risk-shell"
+			>
+				{#snippet chartContent()}
+					<div bind:this={hexbinContainer} class="chart-container binned-chart"></div>
+				{/snippet}
+			</ScatterPlotShell>
+		</div>
+	</section>
+
+	<section class="chart-section" aria-labelledby="core3-tvl-heading">
+		<h2 id="core3-tvl-heading">TVL by CORE3 Probability of Loss</h2>
+		<div class="chart-panel">
+			<ScatterPlotShell
+				loading={dataLoading}
+				error={effectiveError}
+				showMinTvlControl={false}
+				className="core3-risk-shell"
+			>
+				{#snippet chartContent()}
+					<div bind:this={bandContainer} class="chart-container band-chart"></div>
+				{/snippet}
+			</ScatterPlotShell>
+		</div>
+	</section>
+
+	{#if data && !dataLoading && !effectiveError}
+		<p class="coverage-note">
+			CORE3 currently leaves {formatUsd(data.meta.uncoveredStablecoinTvl)} ({formatShare(
+				data.meta.uncoveredStablecoinTvlShare
+			)}) of eligible stablecoin vault TVL uncovered on this page.
+		</p>
+	{/if}
+</div>
+
+<style>
+	.core3-risk-charts {
+		display: grid;
+		gap: clamp(1.25rem, 2.6vw, 2rem);
+	}
+
+	:global(.core3-risk-shell .chart-surface) {
+		min-height: 360px;
+	}
+
+	.chart-section,
+	.chart-panel {
+		min-width: 0;
+	}
+
+	h2 {
+		margin: 0 0 var(--space-sm);
+		font: var(--f-heading-lg-medium);
+		color: var(--c-text);
+		letter-spacing: var(--f-heading-lg-spacing, normal);
+	}
+
+	.chart-container {
+		width: 100%;
+		min-height: 330px;
+	}
+
+	.binned-chart {
+		min-height: 390px;
+	}
+
+	.band-chart {
+		min-height: 310px;
+	}
+
+	.coverage-note {
+		margin: 0.85rem auto 0;
+		max-width: 58rem;
+		text-align: center;
+		font: var(--f-ui-sm-roman);
+		color: var(--c-text-extra-light);
+	}
+
+	@media (--viewport-sm-down) {
+		:global(.core3-risk-shell .chart-surface) {
+			min-height: 360px;
+			margin-inline: calc(-1 * var(--space-md));
+			width: calc(100% + (2 * var(--space-md)));
+		}
+
+		h2 {
+			font: var(--f-heading-md-medium);
+			letter-spacing: var(--f-heading-md-spacing, normal);
+		}
+
+		.chart-container,
+		.binned-chart,
+		.band-chart {
+			min-height: 330px;
+		}
+	}
+</style>

--- a/src/routes/trading-view/vaults/core3-risk/chart-data/+server.ts
+++ b/src/routes/trading-view/vaults/core3-risk/chart-data/+server.ts
@@ -1,0 +1,50 @@
+import { promisify } from 'node:util';
+import { brotliCompress, constants } from 'node:zlib';
+import { buildCore3RiskPayload, CORE3_RISK_CACHE_TTL_SECONDS, type Core3RiskPayload } from '$lib/echarts/core3-risk';
+import { getCachedTopVaults } from '$lib/top-vaults/cache';
+
+const compress = promisify(brotliCompress);
+const CACHE_TTL_MS = CORE3_RISK_CACHE_TTL_SECONDS * 1000;
+const CACHE_VERSION = 'core3-risk-v1';
+
+const cache = new Map<string, { json: string; br: Uint8Array; expires: number; version: string }>();
+
+async function getCachedChartData(fetch: Fetch) {
+	const now = Date.now();
+	const cacheKey = CACHE_VERSION;
+	const existing = cache.get(cacheKey);
+	if (existing && existing.version === CACHE_VERSION && now < existing.expires) return existing;
+
+	const startedAt = performance.now();
+	const { vaults, core3_protocols } = await getCachedTopVaults(fetch);
+	const payload: Core3RiskPayload = buildCore3RiskPayload(vaults, core3_protocols, performance.now() - startedAt);
+	const jsonStr = JSON.stringify(payload);
+	const br = new Uint8Array(
+		await compress(new TextEncoder().encode(jsonStr), {
+			params: { [constants.BROTLI_PARAM_QUALITY]: 6 }
+		})
+	);
+
+	const value = { json: jsonStr, br, expires: now + CACHE_TTL_MS, version: CACHE_VERSION };
+	cache.set(cacheKey, value);
+	return value;
+}
+
+const cacheHeaders = {
+	'cache-control': `public, max-age=${CORE3_RISK_CACHE_TTL_SECONDS}`,
+	'content-type': 'application/json',
+	vary: 'Accept-Encoding'
+};
+
+export async function GET({ fetch, request }) {
+	const data = await getCachedChartData(fetch);
+	const acceptsBr = request.headers.get('accept-encoding')?.includes('br');
+
+	if (acceptsBr) {
+		return new Response(data.br as BodyInit, {
+			headers: { ...cacheHeaders, 'content-encoding': 'br' }
+		});
+	}
+
+	return new Response(data.json, { headers: cacheHeaders });
+}

--- a/tests/integration/trading-view/vaults/cumulative-tvl-apy.test.ts
+++ b/tests/integration/trading-view/vaults/cumulative-tvl-apy.test.ts
@@ -50,7 +50,7 @@ test.describe('cumulative TVL/APY chart page', () => {
 	test('displays scatter plot selector with all chart links', async ({ page }) => {
 		const selector = page.locator('.scatter-plot-selector');
 		await expect(selector).toBeVisible();
-		await expect(selector.locator('a')).toHaveCount(9);
+		await expect(selector.locator('a')).toHaveCount(10);
 	});
 
 	test('page has no JavaScript errors', async ({ page }) => {

--- a/tests/integration/trading-view/vaults/current-peak-tvl.test.ts
+++ b/tests/integration/trading-view/vaults/current-peak-tvl.test.ts
@@ -18,7 +18,7 @@ test.describe('vault current/peak TVL scatter plot page', () => {
 		// Scatter plot selector links
 		const selector = page.locator('.scatter-plot-selector');
 		await expect(selector).toBeVisible();
-		await expect(selector.locator('a')).toHaveCount(9);
+		await expect(selector.locator('a')).toHaveCount(10);
 
 		// Chart renders with Plotly
 		const plotWrapper = page.getByTestId('vault-scatter-plot');

--- a/tests/integration/trading-view/vaults/historical-tvl-chain.test.ts
+++ b/tests/integration/trading-view/vaults/historical-tvl-chain.test.ts
@@ -83,7 +83,7 @@ test.describe('historical vault TVL by chain page', () => {
 	test('displays scatter plot selector with all chart links', async ({ page }) => {
 		const selector = page.locator('.scatter-plot-selector');
 		await expect(selector).toBeVisible();
-		await expect(selector.locator('a')).toHaveCount(9);
+		await expect(selector.locator('a')).toHaveCount(10);
 	});
 
 	test('page has no JavaScript errors', async ({ page }) => {

--- a/tests/integration/trading-view/vaults/yield-chain.test.ts
+++ b/tests/integration/trading-view/vaults/yield-chain.test.ts
@@ -18,7 +18,7 @@ test.describe('vault yield / chain scatter plot page', () => {
 		// Scatter plot selector links
 		const selector = page.locator('.scatter-plot-selector');
 		await expect(selector).toBeVisible();
-		await expect(selector.locator('a')).toHaveCount(9);
+		await expect(selector.locator('a')).toHaveCount(10);
 
 		// Chart renders with Plotly
 		const plotWrapper = page.getByTestId('vault-scatter-plot');

--- a/tests/integration/trading-view/vaults/yield-protocol.test.ts
+++ b/tests/integration/trading-view/vaults/yield-protocol.test.ts
@@ -49,6 +49,6 @@ test.describe('vault yield / protocol scatter plot page', () => {
 	test('displays scatter plot selector with both chart links', async ({ page }) => {
 		const selector = page.locator('.scatter-plot-selector');
 		await expect(selector).toBeVisible();
-		await expect(selector.locator('a')).toHaveCount(9);
+		await expect(selector.locator('a')).toHaveCount(10);
 	});
 });


### PR DESCRIPTION
## Why

CORE3 protocol risk scores help compare stablecoin vault opportunity against protocol Probability of Loss. The frontend did not have a chart page that showed stablecoin vault returns and TVL by CORE3 coverage, including the amount of eligible TVL not yet covered by CORE3.

## Lessons learnt

Dense vault scatter plots become difficult to read with hundreds of vaults, so the returns chart uses a hexbin-style aggregation where size follows total TVL and the tooltip exposes the top vaults in each bin. Claude CLI ultrareview needs committed branch changes to see new files; the uncommitted worktree run only saw tracked changes, and the full branch review later timed out before producing verified findings.

## Summary

- Added a CORE3 stablecoin vault risk chart page under `/trading-view/vaults/core3-risk`.
- Added a cached chart-data endpoint and payload builder for stablecoin-only CORE3 coverage, returns, and TVL bands.
- Added two chart panels: hexbin returns by CORE3 Probability of Loss and TVL by CORE3 Probability of Loss.
- Added richer returns tooltips with average return/PoL, total TVL, top protocols, and the three largest vaults by TVL in each bin.
- Added unit coverage for CORE3 payload grouping, coverage accounting, compact CORE3 data, and exclusions.
