### PR TITLE
chore: set vault metadata cache ttl to 1 hour

### DIFF
--- a/docs/vault-data-optimisation-plan.md
+++ b/docs/vault-data-optimisation-plan.md
@@ -7,7 +7,7 @@ The landing page vault data was optimised in PR #1171 by pre-computing aggregate
 ## Completed (PR #1171)
 
 - Landing page embeds only top 30 slim vaults + pre-computed aggregates (~15 KB vs ~1.3 MB)
-- `/top-vaults/chart-data` endpoint with in-memory Brotli cache (2h TTL)
+- `/top-vaults/chart-data` endpoint with in-memory Brotli cache (1h TTL)
 - Integration tests for compressed/uncompressed responses
 
 ## Candidates for optimisation
@@ -59,6 +59,6 @@ Fetches full vaults only to match YAML strategies by `address`. Could:
 
 ## Implementation notes
 
-- The `/top-vaults/chart-data` endpoint already has an in-memory cache with 2h TTL and Brotli pre-compression. Other server-side code could import the same caching function rather than creating a new endpoint.
+- The `/top-vaults/chart-data` endpoint already has an in-memory cache with 1h TTL and Brotli pre-compression. Other server-side code could import the same caching function rather than creating a new endpoint.
 - The vault detail page is the only route that genuinely needs full `VaultInfo`. All listing/summary views work with `SlimVaultInfo`.
 - Chart pages with `ssr=false` don't embed data in HTML at all — they fetch client-side. These could use the chart-data endpoint directly.

--- a/docs/vault-data-source.md
+++ b/docs/vault-data-source.md
@@ -145,6 +145,6 @@ FRED (fred.stlouisfed.org)
 
 For local development, ensure R2 credentials are set in `.env.local`. All data sources will work automatically:
 
-- Top vaults JSON is fetched on first page load and cached in memory
+- Top vaults JSON is fetched on first page load and cached in memory for 1 hour
 - Vault prices parquet (~150 MB) is downloaded on first metrics request and cached locally with a 1-hour refresh interval
 - Treasury benchmark data is fetched from FRED on demand (no credentials needed) and cached for 24 hours

--- a/src/lib/top-vaults/cache.ts
+++ b/src/lib/top-vaults/cache.ts
@@ -1,7 +1,7 @@
 import { fetchTopVaults } from './client';
 import type { TopVaults } from './schemas';
 
-const CACHE_TTL_MS = 2 * 60 * 60 * 1000; // 2 hours
+const CACHE_TTL_MS = 60 * 60 * 1000; // 1 hour
 
 let cache: { data: TopVaults; expires: number } | null = null;
 

--- a/src/routes/top-vaults/all-data/+server.ts
+++ b/src/routes/top-vaults/all-data/+server.ts
@@ -4,7 +4,7 @@ import { getCachedTopVaults } from '$lib/top-vaults/cache';
 
 const compress = promisify(brotliCompress);
 
-const CACHE_TTL_MS = 2 * 60 * 60 * 1000; // 2 hours
+const CACHE_TTL_MS = 60 * 60 * 1000; // 1 hour
 
 let brCache: { json: string; br: Uint8Array; expires: number } | null = null;
 
@@ -25,7 +25,7 @@ async function getCachedAllData(fetch: Fetch) {
 }
 
 const cacheHeaders = {
-	'cache-control': 'public, max-age=7200',
+	'cache-control': 'public, max-age=3600',
 	'content-type': 'application/json',
 	vary: 'Accept-Encoding'
 };

--- a/src/routes/top-vaults/chart-data/+server.ts
+++ b/src/routes/top-vaults/chart-data/+server.ts
@@ -5,7 +5,7 @@ import { slimVault } from '$lib/top-vaults/helpers';
 
 const compress = promisify(brotliCompress);
 
-const CACHE_TTL_MS = 2 * 60 * 60 * 1000; // 2 hours
+const CACHE_TTL_MS = 60 * 60 * 1000; // 1 hour
 
 let cache: { json: string; br: Uint8Array; expires: number } | null = null;
 
@@ -26,7 +26,7 @@ async function getCachedChartData(fetch: Fetch) {
 }
 
 const cacheHeaders = {
-	'cache-control': 'public, max-age=7200',
+	'cache-control': 'public, max-age=3600',
 	'content-type': 'application/json',
 	vary: 'Accept-Encoding'
 };

--- a/tests/integration/top-vaults/chart-data.test.ts
+++ b/tests/integration/top-vaults/chart-data.test.ts
@@ -5,7 +5,7 @@ test.describe('/top-vaults/chart-data', () => {
 		const response = await request.get('/top-vaults/chart-data');
 		expect(response.status()).toBe(200);
 		expect(response.headers()['content-type']).toContain('application/json');
-		expect(response.headers()['cache-control']).toBe('public, max-age=7200');
+		expect(response.headers()['cache-control']).toBe('public, max-age=3600');
 
 		const data = await response.json();
 		expect(data.vaults).toBeInstanceOf(Array);


### PR DESCRIPTION
## Why

Vault metadata JSON should refresh on the same one-hour cadence as the vault prices parquet file, reducing worst-case staleness for frontend vault data.

## Lessons learnt

The parquet cache was already using a one-hour local refresh interval; only the top-vault JSON in-memory and HTTP response cache still used a two-hour TTL.

## Summary

- Changed top-vault metadata in-memory caches from 2 hours to 1 hour.
- Changed `/top-vaults/all-data` and `/top-vaults/chart-data` `Cache-Control` max-age from 7200s to 3600s.
- Updated the focused integration expectation and vault data docs.