### PR TITLE
Self-host ECharts runtime asset

### DIFF
--- a/docs/cache-invalidation.md
+++ b/docs/cache-invalidation.md
@@ -16,6 +16,22 @@ The frontend uses Cloudflare CDN caching with TTL-based expiration. There is no 
 | `/glossary`                 | Dynamic | TTL from server-side cache         |
 | Sitemaps (`sitemap*.xml`)   | 10 min  |                                    |
 
+## Static build assets
+
+SvelteKit build assets under `/_app/immutable/` are content-hashed and served with long-lived immutable cache headers, for example:
+
+```text
+cache-control: public, max-age=31536000, immutable
+```
+
+This includes the self-hosted ECharts browser bundle emitted from the `echarts` npm package. Because the URL changes when the content changes, these assets are safe for Cloudflare and browsers to cache for a year.
+
+After deployment, verify an emitted ECharts asset through Cloudflare with:
+
+```bash
+curl -sI "https://tradingstrategy.ai/_app/immutable/assets/<echarts-file>.js" | grep -i cache-control
+```
+
 ## Purging the cache
 
 ### After a release

--- a/docs/dependencies.md
+++ b/docs/dependencies.md
@@ -12,6 +12,7 @@ This document lists key dependencies used in the Trading Strategy frontend appli
 | `zod`                     | Schema validation          |
 | `date-fns`                | Date manipulation          |
 | `d3-array`, `d3-time`     | Data utilities for charts  |
+| `echarts`                 | ECharts browser runtime    |
 | `svelte-headless-table`   | Table component foundation |
 | `micromark`               | Markdown parsing           |
 

--- a/docs/echarts.md
+++ b/docs/echarts.md
@@ -45,11 +45,13 @@ Instead we:
 1. Wait until the front page widget is near the viewport using `svelte-inview`
 2. Dynamically import the Svelte component that contains the ECharts implementation
 3. Fetch `/top-vaults/chart-data` on the client
-4. Inject the ECharts runtime from jsDelivr only when the chart is actually needed
+4. Inject the first-party ECharts runtime asset only when the chart is actually needed
 
 This keeps the initial front page payload smaller and avoids paying the charting cost for users who never scroll to that section.
 
-The runtime loader now lives in `src/lib/echarts/runtime.ts` and uses a cached `echartsPromise` plus `window.echarts` detection so the script is only loaded once per page.
+The runtime loader now lives in `src/lib/echarts/runtime.ts` and uses a cached `echartsPromise` plus `window.echarts` detection so the script is only loaded once per page. The loader gets its script URL from `resolveEChartsScriptUrl()`, which currently points at the Vite-emitted `echarts/dist/echarts.min.js` asset from the `echarts` npm package.
+
+Because the script is emitted into `/_app/immutable/assets/`, SvelteKit serves it with long-lived immutable cache headers. Cloudflare can then cache the ECharts runtime as a first-party JavaScript asset instead of relying on a third-party CDN hostname.
 
 ## Front page flow
 
@@ -60,7 +62,7 @@ The front page widget flow is:
 3. The component imports `VaultEcosystemChartECharts.svelte`
 4. The component fetches `/top-vaults/chart-data`
 5. `VaultEcosystemChartECharts.svelte` adapts the payload into the shared chart point format
-6. `src/lib/echarts/CumulativeTvlApyChart.svelte` loads the ECharts CDN runtime
+6. `src/lib/echarts/CumulativeTvlApyChart.svelte` loads the first-party ECharts runtime asset
 7. The shared renderer initialises ECharts and renders the compact homepage variant
 
 The front page widget also receives `savingsRate` and `treasuryRate` from the page data so benchmark lines can be drawn without an extra client-side reference-rate request.
@@ -196,10 +198,9 @@ The home page test checks that the page:
 The standalone page test checks that the page:
 
 - renders the ECharts canvas on the cumulative TVL / APY route
+- loads ECharts from a first-party immutable build asset
 - keeps the existing chart controls and navigation shell intact
 - does not emit browser `pageerror` exceptions
-
-This test currently uses the real CDN runtime instead of stubbing ECharts.
 
 ## Lessons learnt
 

--- a/package.json
+++ b/package.json
@@ -82,6 +82,7 @@
     "dd-trace": "^5.87.0",
     "dequal": "^2.0.3",
     "devalue": "^5.6.3",
+    "echarts": "5.6.0",
     "express": "^5.2.1",
     "js-yaml": "^4.1.1",
     "lightweight-charts": "^5.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -70,6 +70,9 @@ importers:
       devalue:
         specifier: ^5.6.3
         version: 5.6.3
+      echarts:
+        specifier: 5.6.0
+        version: 5.6.0
       express:
         specifier: ^5.2.1
         version: 5.2.1
@@ -1366,6 +1369,7 @@ packages:
 
   '@metamask/sdk-communication-layer@0.32.0':
     resolution: {integrity: sha512-dmj/KFjMi1fsdZGIOtbhxdg3amxhKL/A5BqSU4uh/SyDKPub/OT+x5pX8bGjpTL1WPWY/Q0OIlvFyX3VWnT06Q==}
+    deprecated: No longer maintained, superseded by https://docs.metamask.io/metamask-connect
     peerDependencies:
       cross-fetch: ^4.0.0
       eciesjs: '*'
@@ -1384,12 +1388,14 @@ packages:
 
   '@metamask/sdk-install-modal-web@0.32.0':
     resolution: {integrity: sha512-TFoktj0JgfWnQaL3yFkApqNwcaqJ+dw4xcnrJueMP3aXkSNev2Ido+WVNOg4IIMxnmOrfAC9t0UJ0u/dC9MjOQ==}
+    deprecated: No longer maintained, superseded by https://docs.metamask.io/metamask-connect
 
   '@metamask/sdk-install-modal-web@0.32.1':
     resolution: {integrity: sha512-MGmAo6qSjf1tuYXhCu2EZLftq+DSt5Z7fsIKr2P+lDgdTPWgLfZB1tJKzNcwKKOdf6q9Qmmxn7lJuI/gq5LrKw==}
 
   '@metamask/sdk@0.32.0':
     resolution: {integrity: sha512-WmGAlP1oBuD9hk4CsdlG1WJFuPtYJY+dnTHJMeCyohTWD2GgkcLMUUuvu9lO1/NVzuOoSi1OrnjbuY1O/1NZ1g==}
+    deprecated: No longer maintained, superseded by https://docs.metamask.io/metamask-connect
 
   '@metamask/sdk@0.33.1':
     resolution: {integrity: sha512-1mcOQVGr9rSrVcbKPNVzbZ8eCl1K0FATsYH3WJ/MH4WcZDWGECWrXJPNMZoEAkLxWiMe8jOQBumg2pmcDa9zpQ==}
@@ -3883,6 +3889,9 @@ packages:
   duplexify@4.1.3:
     resolution: {integrity: sha512-M3BmBhwJRZsSx38lZyhE53Csddgzl5R7xGJNk7CVddZD6CcmwMCH8J+7AprIrQKH7TonKxaCjcv27Qmf+sQ+oA==}
 
+  echarts@5.6.0:
+    resolution: {integrity: sha512-oTbVTsXfKuEhxftHqL5xprgLoc0k7uScAwtryCgWF6hPYFLRwOUHiFmHGCBKP5NPFNkDVopOieyUqYGH8Fa3kA==}
+
   eciesjs@0.4.17:
     resolution: {integrity: sha512-TOOURki4G7sD1wDCjj7NfLaXZZ49dFOeEb5y39IXpb8p0hRzVvfvzZHOi5JcT+PpyAbi/Y+lxPb8eTag2WYH8w==}
     engines: {bun: '>=1', deno: '>=2', node: '>=16'}
@@ -5968,6 +5977,9 @@ packages:
   tslib@1.14.1:
     resolution: {integrity: sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==}
 
+  tslib@2.3.0:
+    resolution: {integrity: sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg==}
+
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
@@ -6515,6 +6527,9 @@ packages:
 
   zod@4.3.6:
     resolution: {integrity: sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==}
+
+  zrender@5.6.1:
+    resolution: {integrity: sha512-OFXkDJKcrlx5su2XbzJvj/34Q3m6PvyCZkVPHGYpcCJ52ek4U/ymZyfuV1nKE23AyBJ51E/6Yr0mhZ7xGTO4ag==}
 
   zustand@5.0.0:
     resolution: {integrity: sha512-LE+VcmbartOPM+auOjCCLQOsQ05zUTp8RkgwRzefUk+2jISdMMFnxvyTjA4YNWr5ZGXYbVsEMZosttuxUBkojQ==}
@@ -12267,6 +12282,11 @@ snapshots:
       readable-stream: 3.6.2
       stream-shift: 1.0.3
 
+  echarts@5.6.0:
+    dependencies:
+      tslib: 2.3.0
+      zrender: 5.6.1
+
   eciesjs@0.4.17:
     dependencies:
       '@ecies/ciphers': 0.2.5(@noble/ciphers@1.3.0)
@@ -14727,6 +14747,8 @@ snapshots:
 
   tslib@1.14.1: {}
 
+  tslib@2.3.0: {}
+
   tslib@2.8.1: {}
 
   turnstile-types@1.2.3: {}
@@ -15280,6 +15302,10 @@ snapshots:
   zod@3.25.76: {}
 
   zod@4.3.6: {}
+
+  zrender@5.6.1:
+    dependencies:
+      tslib: 2.3.0
 
   zustand@5.0.0(@types/react@19.2.4)(react@18.3.1)(use-sync-external-store@1.4.0(react@18.3.1)):
     optionalDependencies:

--- a/src/lib/echarts/runtime.ts
+++ b/src/lib/echarts/runtime.ts
@@ -1,4 +1,18 @@
-export const ECHARTS_CDN = 'https://cdn.jsdelivr.net/npm/echarts@5.6.0/dist/echarts.min.js';
+import echartsScriptAssetUrl from 'echarts/dist/echarts.min.js?url';
+
+const ECHARTS_SCRIPT_ATTRIBUTE = 'data-echarts-runtime';
+
+export const ECHARTS_PACKAGE_VERSION = '5.6.0';
+
+/**
+ * Resolve the first-party ECharts browser bundle location.
+ *
+ * Keep this as the single URL decision point so we can move the bundle to
+ * another asset host or route without touching chart components.
+ */
+export function resolveEChartsScriptUrl(): string {
+	return echartsScriptAssetUrl;
+}
 
 export interface EChartsClickParams {
 	data?: {
@@ -40,7 +54,8 @@ export async function loadECharts(): Promise<EChartsStatic> {
 	if (echartsPromise) return echartsPromise;
 
 	echartsPromise = new Promise<EChartsStatic>((resolvePromise, rejectPromise) => {
-		const existingScript = document.querySelector<HTMLScriptElement>(`script[src="${ECHARTS_CDN}"]`);
+		const scriptUrl = resolveEChartsScriptUrl();
+		const existingScript = document.querySelector<HTMLScriptElement>(`script[${ECHARTS_SCRIPT_ATTRIBUTE}]`);
 
 		const handleLoad = () => {
 			const loadedApi = getWindowECharts();
@@ -67,11 +82,12 @@ export async function loadECharts(): Promise<EChartsStatic> {
 		}
 
 		const script = document.createElement('script');
-		script.src = ECHARTS_CDN;
+		script.src = scriptUrl;
 		script.async = true;
+		script.setAttribute(ECHARTS_SCRIPT_ATTRIBUTE, 'true');
 		script.referrerPolicy = 'no-referrer';
 		script.addEventListener('load', handleLoad, { once: true });
-		script.addEventListener('error', () => rejectPromise(new Error('Failed to load ECharts from CDN.')), {
+		script.addEventListener('error', () => rejectPromise(new Error('Failed to load ECharts.')), {
 			once: true
 		});
 		document.head.append(script);

--- a/src/routes/diagnostics/echarts-vault-ecosystem/+page.svelte
+++ b/src/routes/diagnostics/echarts-vault-ecosystem/+page.svelte
@@ -8,13 +8,13 @@ ECharts diagnostics page for experimenting with the vault ecosystem chart.
 	import Button from '$lib/components/Button.svelte';
 	import HeroBanner from '$lib/components/HeroBanner.svelte';
 	import Section from '$lib/components/Section.svelte';
+	import { type EChartsInstance, type EChartsStatic, loadECharts } from '$lib/echarts/runtime';
 	import { chartFontFamily } from '$lib/scatter-plot/helpers';
 	import { isBlacklisted, resolveVaultDetails } from '$lib/top-vaults/helpers';
 	import type { SlimVaultInfo } from '$lib/top-vaults/schemas';
 	import { onMount, tick } from 'svelte';
 	import type { PageData } from './$types';
 
-	const ECHARTS_CDN = 'https://cdn.jsdelivr.net/npm/echarts@5.6.0/dist/echarts.min.js';
 	const MIN_TVL = 50_000;
 	const MAX_APY_THRESHOLD = 10;
 	const MIN_APY_CHART_VALUE = 0.01;
@@ -67,27 +67,6 @@ ECharts diagnostics page for experimenting with the vault ecosystem chart.
 		pctWorse: string;
 		url: string;
 	}
-
-	interface EChartsClickParams {
-		data?: {
-			url?: string;
-		} | null;
-	}
-
-	interface EChartsInstance {
-		setOption(option: unknown): void;
-		resize(): void;
-		dispose(): void;
-		on(eventName: 'click', handler: (params: EChartsClickParams) => void): void;
-		off(eventName?: string): void;
-	}
-
-	interface EChartsStatic {
-		init(element: HTMLDivElement): EChartsInstance;
-		getInstanceByDom(element: HTMLDivElement): EChartsInstance | undefined;
-	}
-
-	let echartsPromise: Promise<EChartsStatic> | null = null;
 
 	let { data }: { data: PageData } = $props();
 
@@ -168,56 +147,6 @@ ECharts diagnostics page for experimenting with the vault ecosystem chart.
 			`<div class="tooltip-row" style="${TOOLTIP_BODY_STYLE}"><strong>Earning less:</strong> ${formatUsd(point.worseTvl)} (${point.pctWorse}%)</div>`,
 			`<div class="tooltip-hint" style="${TOOLTIP_HINT_STYLE}"><span style="text-decoration: underline;">Click to open glossary entry</span></div>`
 		].join('');
-	}
-
-	function getWindowECharts(): EChartsStatic | undefined {
-		return (window as Window & { echarts?: EChartsStatic }).echarts;
-	}
-
-	async function loadECharts(): Promise<EChartsStatic> {
-		const existingApi = getWindowECharts();
-		if (existingApi) return existingApi;
-		if (echartsPromise) return echartsPromise;
-
-		echartsPromise = new Promise<EChartsStatic>((resolvePromise, rejectPromise) => {
-			const existingScript = document.querySelector<HTMLScriptElement>(`script[src="${ECHARTS_CDN}"]`);
-
-			const handleLoad = () => {
-				const loadedApi = getWindowECharts();
-				if (loadedApi) {
-					resolvePromise(loadedApi);
-					return;
-				}
-
-				rejectPromise(new Error('ECharts loaded but no global API was exposed.'));
-			};
-
-			if (existingScript) {
-				const loadedApi = getWindowECharts();
-				if (loadedApi) {
-					resolvePromise(loadedApi);
-					return;
-				}
-
-				existingScript.addEventListener('load', handleLoad, { once: true });
-				existingScript.addEventListener('error', () => rejectPromise(new Error('Failed to load ECharts.')), {
-					once: true
-				});
-				return;
-			}
-
-			const script = document.createElement('script');
-			script.src = ECHARTS_CDN;
-			script.async = true;
-			script.referrerPolicy = 'no-referrer';
-			script.addEventListener('load', handleLoad, { once: true });
-			script.addEventListener('error', () => rejectPromise(new Error('Failed to load ECharts from CDN.')), {
-				once: true
-			});
-			document.head.append(script);
-		});
-
-		return echartsPromise;
 	}
 
 	async function fetchChartData(signal?: AbortSignal): Promise<SlimVaultInfo[]> {

--- a/tests/integration/trading-view/vaults/cumulative-tvl-apy.test.ts
+++ b/tests/integration/trading-view/vaults/cumulative-tvl-apy.test.ts
@@ -15,11 +15,9 @@ async function expectNativeChartWatermark(page: Page, containerSelector: string)
 }
 
 test.describe('cumulative TVL/APY chart page', () => {
-	test.beforeEach(async ({ page }) => {
-		await page.goto('/trading-view/vaults/cumulative-tvl-apy');
-	});
-
 	test('renders the ECharts line chart', async ({ page }) => {
+		await page.goto('/trading-view/vaults/cumulative-tvl-apy');
+
 		const plotWrapper = page.getByTestId('vault-scatter-plot');
 		await expect(plotWrapper).toBeVisible();
 
@@ -29,13 +27,35 @@ test.describe('cumulative TVL/APY chart page', () => {
 	});
 
 	test('renders APY vs cumulative TVL line chart', async ({ page }) => {
+		await page.goto('/trading-view/vaults/cumulative-tvl-apy');
+
 		const plotWrapper = page.getByTestId('vault-scatter-plot');
 
 		const chart = plotWrapper.locator('.standalone-cumulative-tvl-apy-chart canvas');
 		await expect(chart).toBeVisible({ timeout: 15000 });
 	});
 
+	test('loads ECharts as an immutable first-party asset', async ({ page }) => {
+		await page.goto('/trading-view/vaults/cumulative-tvl-apy');
+
+		const chart = page.locator('.standalone-cumulative-tvl-apy-chart canvas');
+		await expect(chart).toBeVisible({ timeout: 15000 });
+
+		const scriptSrc = await page.locator('script[data-echarts-runtime]').getAttribute('src');
+		expect(scriptSrc).toBeTruthy();
+
+		const responseUrl = new URL(scriptSrc!, page.url());
+		expect(responseUrl.origin).toBe(new URL(page.url()).origin);
+		expect(responseUrl.pathname).toMatch(/^\/_app\/immutable\/assets\/echarts\.min\..+\.js$/);
+
+		const response = await page.request.get(responseUrl.toString());
+		expect(response.headers()['cache-control']).toContain('immutable');
+		expect(response.headers()['cache-control']).toContain('max-age=31536000');
+	});
+
 	test('has vault listings navigation with active Charts dropdown', async ({ page }) => {
+		await page.goto('/trading-view/vaults/cumulative-tvl-apy');
+
 		const nav = page.locator('.vault-listings-selector');
 		await expect(nav).toBeVisible();
 
@@ -48,6 +68,8 @@ test.describe('cumulative TVL/APY chart page', () => {
 	});
 
 	test('displays scatter plot selector with all chart links', async ({ page }) => {
+		await page.goto('/trading-view/vaults/cumulative-tvl-apy');
+
 		const selector = page.locator('.scatter-plot-selector');
 		await expect(selector).toBeVisible();
 		await expect(selector.locator('a')).toHaveCount(10);


### PR DESCRIPTION
## Why

ECharts was loaded from jsDelivr at runtime, which makes chart rendering depend on a third-party CDN hostname that may be blocked by Malaysian ISPs or other network filters. Serving the runtime as a first-party build asset keeps the lazy-loading behaviour while making the script available through the normal frontend deployment and Cloudflare proxy.

## Lessons learnt

SvelteKit emits `?url` package assets under `/_app/immutable/assets/` with content-hashed filenames and long-lived immutable cache headers. The built Node adapter returns `cache-control: public,max-age=31536000,immutable` for the emitted ECharts bundle, so Cloudflare can cache it safely as a first-party static asset.

## Summary

- Add `echarts@5.6.0` as a dependency and load `echarts/dist/echarts.min.js` through Vite instead of jsDelivr.
- Add `resolveEChartsScriptUrl()` as the single helper for changing the runtime location later.
- Reuse the shared ECharts runtime loader from the diagnostics page.
- Add an integration assertion that the ECharts runtime is same-origin, immutable, and served from `/_app/immutable/assets/`.
- Document the first-party ECharts asset and static cache header behaviour.