### PR TITLE
fix: increase blog excerpt clamp

### DIFF
--- a/src/lib/components/BlogPostTile.svelte
+++ b/src/lib/components/BlogPostTile.svelte
@@ -75,7 +75,7 @@ Display a blog post tile - e.g., on main blog roll or home page preview
 				<a class="title-link" href="/blog/{post.slug}">{post.title}</a>
 			</h3>
 
-			<p class="truncate lines-3">{post.excerpt}</p>
+			<p class="excerpt truncate lines-9">{post.excerpt}</p>
 		</div>
 
 		<div class="cta">
@@ -153,6 +153,12 @@ Display a blog post tile - e.g., on main blog roll or home page preview
 			font: var(--f-ui-md-roman);
 			letter-spacing: var(--f-ui-md-spacing, normal);
 			color: var(--c-text-light);
+		}
+
+		.excerpt {
+			@media (--viewport-sm-down) {
+				-webkit-line-clamp: 11;
+			}
 		}
 	}
 

--- a/src/lib/components/css/truncate.css
+++ b/src/lib/components/css/truncate.css
@@ -15,4 +15,9 @@
 		display: -webkit-box;
 		-webkit-line-clamp: 3;
 	}
+
+	&.lines-9 {
+		display: -webkit-box;
+		-webkit-line-clamp: 9;
+	}
 }


### PR DESCRIPTION
Why
Blog post excerpts on the home page and blog index were capped at three rendered lines, which cut off longer descriptions such as the Tau Labs podcast post.

Lessons learnt
The blog excerpt limit is controlled by the shared BlogPostTile line clamp, so changes there affect both the front page blog roll and the blog index.

Summary
- Increased blog excerpt clamp from 3 to 9 lines on larger viewports.
- Added a mobile override allowing 11 lines for narrower cards.
- Added a reusable lines-9 truncate utility.