### PR TITLE
Fix blog timestamp relative text

### DIFF
--- a/src/lib/components/BlogPostTile.svelte
+++ b/src/lib/components/BlogPostTile.svelte
@@ -65,7 +65,7 @@ Display a blog post tile - e.g., on main blog roll or home page preview
 
 	<div class="content">
 		<div class="info">
-			<Timestamp date={post.published_at}>
+			<Timestamp date={post.published_at} relative>
 				{#snippet children({ parsedDate, relativeStr })}
 					{parsedDate?.toDateString()}, {relativeStr}
 				{/snippet}

--- a/src/routes/blog/[slug=slug]/+page.svelte
+++ b/src/routes/blog/[slug=slug]/+page.svelte
@@ -21,7 +21,7 @@
 		<header>
 			<SocialLinks --justify-content="space-between" />
 			<h1>{post.title}</h1>
-			<Timestamp date={post.published_at}>
+			<Timestamp date={post.published_at} relative>
 				{#snippet children({ parsedDate, relativeStr })}
 					{parsedDate?.toDateString()}, {relativeStr}
 				{/snippet}


### PR DESCRIPTION
## Why

Blog post timestamps rendered a comma before an empty relative date because the templates used `relativeStr` without enabling relative timestamp formatting.

## Lessons learnt

When using the `Timestamp` snippet API, pass `relative` whenever the snippet renders `relativeStr`.

## Summary

- Enabled relative timestamp formatting on the blog post detail header.
- Enabled relative timestamp formatting on blog post tiles.