### PR TITLE
perf: speed up mobile LCP on trading-view token & pair pages

### DIFF
--- a/src/app.html
+++ b/src/app.html
@@ -3,7 +3,15 @@
 	<head>
 		<meta charset="utf-8" />
 		<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1" />
-		<link rel="stylesheet" href="/fonts/fonts5.css" />
+		<!--
+			Load the font stylesheet non-render-blocking. fonts5.css is purely @font-face
+			declarations, so deferring it lets text paint immediately (font-display: swap
+			handles the swap-in) instead of blocking first paint on the font CSS download.
+			The media="print" → onload="all" trick is the standard non-blocking pattern;
+			the <noscript> fallback keeps fonts working without JS.
+		-->
+		<link rel="stylesheet" href="/fonts/fonts5.css" media="print" onload="this.media = 'all'" />
+		<noscript><link rel="stylesheet" href="/fonts/fonts5.css" /></noscript>
 		%sveltekit.head%
 	</head>
 	<body>

--- a/src/lib/components/PageHeader.svelte
+++ b/src/lib/components/PageHeader.svelte
@@ -56,7 +56,6 @@ strings) or named slots (for nested markup); `description` can be a prop or defa
 
 		.multiline {
 			display: grid;
-			font-weight: 700;
 		}
 
 		small {

--- a/src/routes/trading-view/[chain=slug]/[exchange]/[pair]/+page.svelte
+++ b/src/routes/trading-view/[chain=slug]/[exchange]/[pair]/+page.svelte
@@ -6,7 +6,6 @@ Render the pair trading page
   be moved to SvelteKit routing query parameter
 -->
 <script lang="ts">
-	import type { ComponentProps } from 'svelte';
 	import { page } from '$app/state';
 	import { replaceState } from '$app/navigation';
 	import { captureException } from '@sentry/sveltekit';
@@ -18,7 +17,8 @@ Render the pair trading page
 	import Breadcrumbs from '$lib/breadcrumb/Breadcrumbs.svelte';
 	import InfoTable from './InfoTable.svelte';
 	import InfoSummary from './InfoSummary.svelte';
-	import PairCandleChart from '$lib/charts/PairCandleChart.svelte';
+	// The chart component is lazy-loaded in the markup below (see {#await import(...)})
+	// so the heavy lightweight-charts bundle stays off the critical path.
 	import TimePeriodSummaryTable from './TimePeriodSummaryTable.svelte';
 	import { getTokenTaxInformation } from '$lib/helpers/tokentax';
 	import { formatSwapFee } from '$lib/helpers/formatters';
@@ -47,7 +47,7 @@ Render the pair trading page
 	// svelte-ignore state_referenced_locally
 	let timeBucket = new OptionGroup(timeBucketEnum.options, page.state.timeBucket ?? data.timeBucket);
 
-	const handleTimeBucketChange: ComponentProps<typeof PairCandleChart>['onchange'] = ({ name, value }) => {
+	const handleTimeBucketChange = ({ name, value }: { name: string | undefined; value: string }) => {
 		if (name !== 'timeBucket') return;
 		const { success, data: timeBucket } = timeBucketEnum.safeParse(value);
 		if (success) replaceState(`?${new URLSearchParams({ timeBucket })}`, { timeBucket });
@@ -125,14 +125,16 @@ Render the pair trading page
 
 	<section class="ds-container charts">
 		<svelte:boundary onerror={(e) => captureException(e)}>
-			<PairCandleChart
-				chainSlug={summary.chain_slug}
-				exchangeType={summary.exchange_type}
-				pairId={summary.pair_id}
-				pairSymbol={summary.pair_symbol}
-				{timeBucket}
-				onchange={handleTimeBucketChange}
-			/>
+			{#await import('$lib/charts/PairCandleChart.svelte') then { default: PairCandleChart }}
+				<PairCandleChart
+					chainSlug={summary.chain_slug}
+					exchangeType={summary.exchange_type}
+					pairId={summary.pair_id}
+					pairSymbol={summary.pair_symbol}
+					{timeBucket}
+					onchange={handleTimeBucketChange}
+				/>
+			{/await}
 
 			{#snippet failed(error)}
 				<Alert status="error" title="Render error">

--- a/src/routes/trading-view/[chain=slug]/[exchange]/[pair]/+page.ts
+++ b/src/routes/trading-view/[chain=slug]/[exchange]/[pair]/+page.ts
@@ -13,9 +13,12 @@ export async function load({ fetch, params, setHeaders, url }) {
 	const timeBucket = timeBucketEnum.catch('1d').parse(timeBucketParam);
 
 	// Cache the pair data pages for 30 minutes at the Cloudflare edge so the
-	// pages are served really fast if they get popular, and also for speed test
+	// pages are served really fast if they get popular, and also for speed test.
+	// stale-while-revalidate lets the edge serve a cached copy instantly (then
+	// refresh in the background) for the long tail of rarely-hit pair URLs,
+	// which avoids a cold SSR round-trip dominating mobile LCP.
 	setHeaders({
-		'cache-control': 'public, max-age=1800' // 30 minutes: 30 * 60 = 1800
+		'cache-control': 'public, max-age=1800, stale-while-revalidate=86400' // 30 min fresh, 1 day stale
 	});
 
 	return {

--- a/src/routes/trading-view/[chain=slug]/tokens/[token]/+page.ts
+++ b/src/routes/trading-view/[chain=slug]/tokens/[token]/+page.ts
@@ -19,16 +19,25 @@ async function searchLendingReserves(fetch: Fetch, chain: string, address: strin
 }
 
 export async function load({ params, fetch, setHeaders }) {
-	const { chain, token } = params;
+	const { chain, token: address } = params;
 
-	// Cache the pair data pages for 30 minutes at the Cloudflare edge so the
-	// pages are served really fast if they get popular, and also for speed test
+	// Cache the token data pages for 30 minutes at the Cloudflare edge so the
+	// pages are served really fast if they get popular, and also for speed test.
+	// stale-while-revalidate lets the edge serve a cached copy instantly (then
+	// refresh in the background) for the long tail of rarely-hit token URLs,
+	// which avoids a cold SSR round-trip dominating mobile LCP.
 	setHeaders({
-		'cache-control': 'public, max-age=1800' // 30 minutes: 30 * 60 = 1800
+		'cache-control': 'public, max-age=1800, stale-while-revalidate=86400' // 30 min fresh, 1 day stale
 	});
 
-	return {
-		token: await fetchPublicApi<TokenDetails>(fetch, 'token/details', { chain_slug: chain, address: token }),
-		reserves: await searchLendingReserves(fetch, chain, token)
-	};
+	// These two requests are independent (the reserve search keys off the URL
+	// address, not the token/details response), so fetch them in parallel rather
+	// than as a waterfall — the SSR response, and therefore the LCP heading,
+	// is gated by the slower of the two instead of their sum.
+	const [token, reserves] = await Promise.all([
+		fetchPublicApi<TokenDetails>(fetch, 'token/details', { chain_slug: chain, address }),
+		searchLendingReserves(fetch, chain, address)
+	]);
+
+	return { token, reserves };
 }


### PR DESCRIPTION
## Why

Google Search Console flagged a mobile Core Web Vitals issue — *LCP longer than 2.5s* — affecting 411 URLs, with the worst offenders being trading-view token detail pages (`/trading-view/[chain]/tokens/[address]`) and trading-pair pages (`/trading-view/[chain]/[exchange]/[pair]`), measured at 2.6–3.4s.

Investigation showed the LCP element on these pages is the `<h1>` page heading (text), not the chart. A third affected URL group is a static `/docs/` page with no SvelteKit and no chart, yet equally slow — which points the diagnosis at factors shared across all pages: server response time (TTFB), edge-cache reuse, and render-blocking web fonts, rather than the chart/JS bundle.

## Lessons learnt

- **LCP on these pages is text, gated by TTFB + render-blocking resources — not the chart.** The largest element is the heading; the chart is below the fold. Optimise the path to first text paint.
- **`font-display: swap` means font *preloading* does not move the LCP timestamp.** With swap, the heading paints immediately in a fallback font; the web-font swap is a later repaint. An earlier attempt to preload specific weights was dropped — it added fragile, design-token-coupled file references and per-page "preloaded but not used" warnings for zero LCP gain. The real font lever is that the font stylesheet was *render-blocking*; making it non-blocking is what helps.
- **`fonts5.css` is purely `@font-face`**, so it can safely load non-render-blocking (`media="print"` → `onload`) without affecting element geometry.
- **The token loader had a needless SSR waterfall**: `token/details` and the Typesense `reserves` search were awaited sequentially, but the reserve search keys off the URL address, not the token response — they are independent and can run in parallel.
- **The long tail kills edge-cache reuse.** With 411 rarely-hit URLs, a plain `max-age` mostly misses the cache → cold SSR per visit. `stale-while-revalidate` serves a cached copy instantly and refreshes in the background.
- **CSP here only enforces `frame-ancestors: self`** (no `script-src`), so the inline `onload` non-blocking-CSS pattern is permitted; a `<noscript>` fallback covers JS-off.

## Summary

- **`tokens/[token]/+page.ts`** — fetch `token` and `reserves` in parallel via `Promise.all` instead of a sequential waterfall, so SSR (and the LCP heading) is gated by the slower call, not the sum.
- **Both `+page.ts` loaders** (token + pair) — add `stale-while-revalidate=86400` to the cache header so the Cloudflare edge serves the long tail of URLs instantly while refreshing in the background.
- **`[exchange]/[pair]/+page.svelte`** — lazy-load the below-the-fold `PairCandleChart` via `{#await import(...)}`, moving `lightweight-charts` off the page's static critical path (verified split into a dynamically-imported client chunk).
- **`app.html`** — load `fonts5.css` non-render-blocking (`media="print"` → `onload="this.media='all'"`) with a `<noscript>` fallback, removing a render-blocking resource from first paint.
- **`PageHeader.svelte`** — consolidate the heading to a single weight: dropped the `.multiline` `font-weight: 700` override so all page headers use their `--f-h1-medium` (600) design token, instead of mixing 600 and 700.

🤖 Generated with [Claude Code](https://claude.com/claude-code)