### PR TITLE
fix: exclude label-blacklisted vaults from APY

### DIFF
--- a/src/lib/top-vaults/helpers.test.ts
+++ b/src/lib/top-vaults/helpers.test.ts
@@ -15,7 +15,8 @@ import {
 	getCore3ReportUrl,
 	getCore3RankingUrl,
 	getCore3ScoreTone,
-	getCore3CategoryScores
+	getCore3CategoryScores,
+	calculateTvlWeightedApy
 } from './helpers';
 import type { Core3Protocol } from './schemas';
 import { createTestVault } from './test-utils';
@@ -25,6 +26,11 @@ describe('isBlacklisted', () => {
 		const vault = createTestVault('Test vault', { risk: 'Blacklisted' });
 		expect(vault.risk_numeric).toBe(999);
 		expect(isBlacklisted(vault)).toBe(true);
+	});
+
+	test('returns true when only the risk label is blacklisted', () => {
+		const vault = createTestVault('Test vault', { risk: 'High' });
+		expect(isBlacklisted({ ...vault, risk: 'Blacklisted', risk_numeric: null })).toBe(true);
 	});
 
 	test('returns false for non-blacklisted vaults', () => {
@@ -37,6 +43,40 @@ describe('isBlacklisted', () => {
 		const vault = createTestVault('Test vault');
 		expect(vault.risk_numeric).toBeNull();
 		expect(isBlacklisted(vault)).toBe(false);
+	});
+});
+
+describe('calculateTvlWeightedApy', () => {
+	test('excludes blacklisted vaults from the weighted average', () => {
+		const included = createTestVault('Included vault', {
+			current_nav: 100_000,
+			one_month_cagr: 0.1
+		});
+		const blacklisted = createTestVault('Blacklisted vault', {
+			current_nav: 900_000,
+			one_month_cagr: 1,
+			risk: 'Blacklisted'
+		});
+
+		expect(calculateTvlWeightedApy([included, blacklisted])).toBe(0.1);
+	});
+
+	test('excludes label-only blacklisted vaults from the weighted average', () => {
+		const included = createTestVault('Included vault', {
+			current_nav: 100_000,
+			one_month_cagr: 0.1
+		});
+		const blacklisted = {
+			...createTestVault('Blacklisted label vault', {
+				current_nav: 900_000,
+				one_month_cagr: 1,
+				risk: 'High'
+			}),
+			risk: 'Blacklisted',
+			risk_numeric: null
+		};
+
+		expect(calculateTvlWeightedApy([included, blacklisted])).toBe(0.1);
 	});
 });
 

--- a/src/lib/top-vaults/helpers.ts
+++ b/src/lib/top-vaults/helpers.ts
@@ -146,10 +146,10 @@ export function resolveVaultDetails(vault: Pick<VaultInfo, 'vault_slug'>) {
 }
 
 /**
- * Determine if vault is blacklisted
+ * Determine if vault is blacklisted.
  */
-export function isBlacklisted(vault: Pick<VaultInfo, 'risk_numeric'>) {
-	return vault.risk_numeric === 999;
+export function isBlacklisted(vault: Pick<VaultInfo, 'risk_numeric'> & Partial<Pick<VaultInfo, 'risk'>>) {
+	return vault.risk_numeric === 999 || vault.risk?.toLowerCase() === 'blacklisted';
 }
 
 const unsupportedProtocolNames = ['<protocol not yet identified>', '<unknown erc-7450>'] as const;

--- a/src/lib/top-vaults/schemas.ts
+++ b/src/lib/top-vaults/schemas.ts
@@ -458,6 +458,7 @@ export type SlimVaultInfo = Pick<
 	| 'current_nav'
 	| 'one_month_cagr'
 	| 'one_month_cagr_net'
+	| 'risk'
 	| 'risk_numeric'
 	| 'stablecoinish'
 >;
@@ -499,6 +500,7 @@ export const slimVaultKeys = [
 	'current_nav',
 	'one_month_cagr',
 	'one_month_cagr_net',
+	'risk',
 	'risk_numeric',
 	'stablecoinish'
 ] as const satisfies readonly (keyof SlimVaultInfo)[];


### PR DESCRIPTION
## Why

Vault group average APY should exclude blacklisted vaults even when the upstream payload only carries the `Blacklisted` risk label and omits the numeric `999` sentinel.

## Lessons learnt

The chains vault page already builds Avg. APY from `calculateTvlWeightedApy()` over the eligible vault set. Making the shared blacklist helper accept both blacklist representations keeps chain, protocol, stablecoin and slim-client consumers aligned.

## Summary

- Treat vaults with `risk: Blacklisted` as blacklisted even when `risk_numeric` is missing.
- Include `risk` in the slim vault payload keys so label-based checks survive slimming.
- Add unit coverage for numeric and label-only blacklist exclusion from TVL-weighted APY.