### PR TITLE
Change protocol vault page metadata title to "vaults and yields"

### DIFF
--- a/src/routes/trading-view/vaults/protocols/[protocol=slug]/+page.svelte
+++ b/src/routes/trading-view/vaults/protocols/[protocol=slug]/+page.svelte
@@ -27,7 +27,7 @@
 			.finally(() => (loading = false));
 	});
 
-	let title = $derived(`${protocolName} vault comparison`);
+	let title = $derived(`${protocolName} vaults and yields`);
 	let description = $derived(protocolMetadata?.short_description ?? `Top stablecoin vaults on ${protocolName}`);
 	let pageUrl = $derived(new URL(page.url.pathname, page.url.origin).href);
 	let logoUrl = $derived.by(() => {


### PR DESCRIPTION
## Why

The protocol vault pages (e.g. `/trading-view/vaults/protocols/ember`) used the metadata title `<Protocol> vault comparison`. The desired wording is `<Protocol> vaults and yields`, which better reflects the page content and improves SEO/social sharing metadata.

## Lessons learnt

The metadata `title` on `[protocol=slug]/+page.svelte` is a single shared `$derived` template that also feeds the OpenGraph, Twitter, and JSON-Ld tags. Changing it updates the title for every protocol page consistently, not just one protocol.

## Summary

- Changed the derived metadata title template from `${protocolName} vault comparison` to `${protocolName} vaults and yields` in `src/routes/trading-view/vaults/protocols/[protocol=slug]/+page.svelte`.