### PR TITLE
Add stablecoin rate metadata display

### DIFF
--- a/.claude/docs/agent-tricks-and-troubleshooting.md
+++ b/.claude/docs/agent-tricks-and-troubleshooting.md
@@ -1,0 +1,546 @@
+# Agent tricks and troubleshooting
+
+Read this document before invoking Claude CLI or Codex CLI from another agent.
+It contains local invocation details that are easy to get wrong, especially for
+non-interactive Claude review runs.
+
+This note covers practical ways to use Codex CLI and Claude CLI as local engineering agents, especially when one agent is used to review or debug the other agent's work.
+
+## Codex CLI
+
+Codex is useful for local repository work where the agent should inspect files, edit code, run tests, and keep working until a task is complete.
+
+Common commands:
+
+```shell
+codex
+codex "Explain this codebase"
+codex exec "Review the current diff for correctness bugs"
+codex exec --json "Summarise the failing tests"
+codex review
+codex doctor
+codex resume --last
+codex mcp list
+codex plugin list
+```
+
+Useful capabilities:
+
+- Interactive terminal UI for iterative coding and review.
+- Non-interactive automation with `codex exec`.
+- Local code review with `codex review` or `/review` inside the interactive UI.
+- Git-aware operation over the current worktree.
+- Sandbox and approval controls with `--sandbox` and `--ask-for-approval`.
+- Machine-readable automation output with `codex exec --json`.
+- MCP server management with `codex mcp`.
+- Plugin management with `codex plugin`.
+- Diagnostic checks with `codex doctor`.
+- Session continuation with `codex resume`.
+
+Recommended local patterns:
+
+```shell
+# Ask for a bounded review of local changes.
+codex exec "Review uncommitted changes for correctness bugs only"
+
+# Pass logs as context while keeping the prompt explicit.
+poetry run pytest tests/foo.py -q 2>&1 \
+  | codex exec "Explain the failure and suggest the smallest fix"
+
+# Run with explicit permissions in automation. `codex exec` selects the sandbox
+# directly and does not take `--ask-for-approval` (that is an interactive flag).
+codex exec --sandbox workspace-write "Fix the failing focused test"
+
+# Debug local setup.
+codex doctor
+```
+
+Use `codex exec` for CI-like or scripted work. It streams progress to stderr and final output to stdout, which makes it easier to pipe the result into files or other commands.
+
+Use interactive `codex` when the task needs back-and-forth decisions, screenshots, manual inspection, or careful approval of edits.
+
+### Always run Codex reviews in streaming mode
+
+Run every non-interactive Codex review (plan review, code review, sanity check)
+in streaming mode with `--json`. Plain text mode (`codex exec "..."`) only emits
+the final answer once the model has finished the entire review, and any
+`| tail`, `| head`, or capture-to-file buffers that final block until the pipe
+closes. When the run is backgrounded or captured, the output file then stays
+**0 bytes** until completion — indistinguishable from a hang, and you cannot see
+progress or interim tool calls.
+
+`--json` instead emits a JSONL event stream (reasoning, tool calls, and the final
+message) line-by-line as they happen, so a backgrounded run's file grows live and
+can be tailed for progress.
+
+```shell
+# Streaming read-only review. Note: DO NOT pipe through `tail`/`head` — that
+# reintroduces buffering. Write the raw JSONL stream to a file instead.
+codex exec --json --sandbox read-only \
+  "Review the uncommitted diff for correctness bugs only. Findings first with file:line." \
+  > /tmp/codex-review.jsonl
+
+# Follow progress live from another step (or when backgrounded):
+tail -f /tmp/codex-review.jsonl        # interactive shells only
+
+# Extract just the final assistant message from the JSONL when done:
+#   each line is a JSON event; the final answer is the last agent/message event.
+```
+
+When backgrounding a Codex review, always use `--json` and read the raw output
+file for interim events. If you instead run text mode in the background, the file
+will look empty (0 bytes) the whole time and you will not be able to tell a slow
+review from a stuck one.
+
+Redirect stdin from `/dev/null` for background/non-interactive runs. With an open
+stdin pipe, `codex exec` prints `Reading additional input from stdin...` and waits
+for EOF (it appends piped stdin as a `<stdin>` block), so the run stalls forever
+even though the prompt was passed as an argument. Always append `< /dev/null`:
+
+```shell
+codex exec --json --sandbox read-only "…prompt…" < /dev/null > /tmp/codex-review.jsonl
+```
+
+Approval flags: `codex exec` does **not** accept `--ask-for-approval` (that flag
+belongs to interactive `codex`). For non-interactive review runs pick the sandbox
+directly — `--sandbox read-only` needs no approval and is the correct choice for
+reviews. Use `--sandbox workspace-write` only when the run must edit files.
+
+```shell
+# Correct non-interactive review invocation (streaming, read-only, no approval flag).
+codex exec --json --sandbox read-only "Review uncommitted changes for correctness bugs only" \
+  > /tmp/codex-review.jsonl
+```
+
+## Claude CLI
+
+Claude CLI is useful for independent second opinions, code reviews, background agents, and checking whether another agent's change makes sense.
+
+Common commands:
+
+```shell
+claude
+claude -p "Review the current worktree diff"
+claude -p "Review the current worktree diff" --output-format stream-json --verbose
+claude auth status
+claude ultrareview master --timeout 15
+claude doctor
+claude agents
+claude mcp
+claude plugin list
+claude --help
+```
+
+Useful capabilities:
+
+- Interactive Claude Code session by default.
+- Non-interactive print mode with `-p` / `--print`.
+- Streaming automation output with `--output-format stream-json`.
+- Tool restrictions with `--allowedTools` and `--disallowedTools`.
+- Permission mode control with `--permission-mode`.
+- Custom or selected agents with `--agent` and `--agents`.
+- Cloud-hosted multi-agent review with `claude ultrareview`.
+- Safe mode for debugging broken customisations with `--safe-mode`.
+- Bare mode for minimal startup with `--bare`.
+- Debug logging with `--debug` or `--debug-file`.
+- MCP and plugin management.
+
+Important authentication note:
+
+- Do not use `--bare` to check whether Claude is signed in. Bare mode skips
+  keychain/OAuth credentials by design and only uses `ANTHROPIC_API_KEY` or an
+  `apiKeyHelper` from `--settings`. A signed-in Unix user can therefore see
+  `Not logged in` in `--bare` mode even though normal `claude -p` works.
+- Use normal mode for local signed-in accounts:
+
+```shell
+claude auth status
+claude -p "Say OK"
+```
+
+- Use `--safe-mode` instead of `--bare` when debugging broken customisations
+  but you still want normal auth, model selection and built-in permissions to
+  work.
+
+Recommended local patterns:
+
+```shell
+# Smoke-test non-interactive auth and startup.
+claude -p "Say OK"
+
+# Plain one-shot review. Good when you can wait for final buffered output.
+claude -p "Review the current git diff for correctness bugs"
+
+# Better for long reviews: stream progress and tool calls.
+claude -p "Review the current git diff for correctness bugs" \
+  --output-format stream-json \
+  --verbose
+
+# Restrict tools for a read-only review.
+claude -p "Review the current worktree diff. Do not edit files." \
+  --permission-mode bypassPermissions \
+  --dangerously-skip-permissions \
+  --allowedTools "Bash,Read,Grep,Glob"
+
+# Safer read-only review without broad bypass mode.
+claude -p "Review the current worktree diff. Do not edit files. Findings first." \
+  --permission-mode dontAsk \
+  --allowedTools "Bash(git status:*),Bash(git diff:*),Bash(sed:*),Bash(rg:*)"
+
+# Avoid pasting huge diffs into the prompt. Make Claude inspect files itself.
+claude -p "Review uncommitted changes. First run git diff --name-only, then inspect targeted diffs."
+
+# Run cloud review when account credits and PR/base context are available.
+claude ultrareview master --timeout 15
+```
+
+For long-running `claude -p` jobs, prefer `--output-format stream-json --verbose`. Text mode can look idle because useful output may be buffered until the final answer.
+
+If a broad review stalls, first verify that basic non-interactive mode and
+read-only Bash tools work before assuming auth is broken:
+
+```shell
+claude -p "Say OK"
+claude -p "Run git status --short and summarise it in one sentence." \
+  --allowedTools "Bash(git status:*)"
+```
+
+If these work but the broad review times out, shrink the request: ask Claude to
+inspect `git diff --name-only` first, review one file group at a time, or provide
+a concise summary of the proposed fix instead of embedding a large diff.
+
+### Reviewing a plan or document with Claude CLI
+
+For Markdown plan reviews, default to a no-tools inline text review after the
+relevant code has already been inspected by the primary agent. Do not start
+with a grounded tool-using Claude review for simple plan re-reviews; it can
+sit silently in `-p` mode or wait internally on tool/permission handling, and
+that repeats avoidable delays.
+
+Use this for ordinary plan re-review:
+
+```shell
+claude -p "$(sed '1iDo not use tools. Review only the plan text below. Return concise actionable findings, or say no blocking findings.\n' .claude/plans/my-plan.md)" \
+  --tools "" \
+  --permission-mode dontAsk \
+  --no-session-persistence \
+  --max-budget-usd 1
+```
+
+Use this for a final blocking-only pass after applying review feedback:
+
+```shell
+claude -p "$(sed '1iDo not use tools. Review only the updated plan text below. Return only blocking findings, or say no blocking findings.\n' .claude/plans/my-plan.md)" \
+  --tools "" \
+  --permission-mode dontAsk \
+  --no-session-persistence \
+  --max-budget-usd 1
+```
+
+Only use a grounded repository review when Claude specifically needs fresh code
+inspection, for example when the primary agent has not checked the relevant
+files or when the plan makes claims that need independent verification against
+the worktree. In that case, allow only read-only tools and make the scope
+explicit:
+
+```shell
+claude -p "Review .claude/plans/my-plan.md for correctness and completeness. Focus on implementation risks, missing code paths, and test gaps. Keep the review concise and actionable." \
+  --allowedTools Read,Grep,Glob,Bash \
+  --permission-mode dontAsk \
+  --output-format stream-json \
+  --verbose
+```
+
+If a grounded review produces no output after roughly a minute, stop it and
+switch to the no-tools inline review unless fresh repository inspection is
+strictly required.
+
+Notes:
+
+- Use `--tools ""` only when the prompt embeds all necessary context.
+- If you allow tools, use comma-separated tool names for `--allowedTools`.
+- `--permission-mode dontAsk` avoids interactive permission prompts in
+  non-interactive review runs.
+- `--no-session-persistence` keeps one-off reviews from polluting later
+  `claude --continue` sessions.
+- `--max-budget-usd` is optional but useful for bounded document reviews.
+
+## Cross-agent review patterns
+
+Use the other agent as a reviewer when:
+
+1. The change touches state accounting, execution, security, or money movement.
+2. The first agent wrote a large test or complex fixture.
+3. You want a second model to challenge assumptions before opening a pull request.
+4. You suspect the first agent is stuck in a local optimum.
+
+Good review prompt:
+
+```text
+Review the current uncommitted worktree diff for correctness bugs only.
+Do not run the full test suite.
+Do not paste the full git diff into context.
+First inspect git status --short, git diff --name-only, and targeted diffs.
+Focus on behavioural regressions and test fragility.
+Return findings first with file:line references.
+If there are no high-confidence bugs, say so clearly and list residual risks.
+```
+
+Avoid asking for broad "thoughts" on a large diff. Ask for a scoped review:
+
+- correctness bugs
+- behavioural regressions
+- missing tests
+- test fragility
+- security or money-movement risks
+- repository instruction compliance
+
+## Common failure modes
+
+### The command looks hung
+
+Symptoms:
+
+- `claude -p` prints nothing for a long time.
+- The terminal appears idle, but the process is still alive.
+
+Causes:
+
+- Text output is buffered until the final answer.
+- The model is doing a long review or reading a large diff.
+- The prompt caused the agent to paste a huge diff into context.
+- A subprocess is waiting for input or a permission decision.
+
+Avoid it:
+
+```shell
+claude -p "Review the current diff" --output-format stream-json --verbose
+```
+
+For Codex automation, use:
+
+```shell
+codex exec --json "Review the current diff"
+```
+
+Also constrain the prompt:
+
+```text
+Do not paste the full diff into context. Use git diff --name-only first, then inspect targeted hunks.
+```
+
+### The review consumes too much context
+
+Symptoms:
+
+- The model reads `git diff` for a large change and slows down.
+- Output includes truncated tool results.
+- The final answer misses important details.
+
+Avoid it:
+
+- Start with `git diff --stat` and `git diff --name-only`.
+- Inspect changed files with `sed`, `nl`, `rg`, or targeted `git diff -- path`.
+- Ask the reviewer to avoid full diff dumps.
+- Split reviews by topic or file group.
+
+Better prompt:
+
+```text
+Review only tradeexecutor/cli/testtrade.py and tradeexecutor/strategy/pandas_trader/position_manager.py first.
+Then inspect tests only if needed to validate coverage.
+```
+
+### The agent cannot use tools
+
+Symptoms:
+
+- Claude says it cannot inspect files.
+- Codex refuses to edit or run commands.
+- A non-interactive run exits after a permission problem.
+
+Avoid it:
+
+- For Codex, set the sandbox explicitly (`codex exec` selects the sandbox
+  directly; it has no `--ask-for-approval` flag):
+
+```shell
+codex exec --sandbox workspace-write "Run the focused test and fix failures"
+```
+
+- For Claude, set explicit permission mode and allowed tools:
+
+```shell
+claude -p "Read-only review" \
+  --permission-mode bypassPermissions \
+  --dangerously-skip-permissions \
+  --allowedTools "Bash,Read,Grep,Glob"
+```
+
+Use broad bypass modes only in trusted repositories or externally sandboxed environments.
+
+### The cloud review does not start
+
+Symptoms:
+
+- `claude ultrareview` exits immediately.
+- Error mentions usage credits or account limits.
+
+Example:
+
+```text
+Ultrareview could not launch: Usage credits exhausted.
+```
+
+Avoid it:
+
+- Fall back to local `claude -p`.
+- Use streaming output for visibility.
+- Narrow the review prompt to reduce cost.
+- Run local focused tests yourself and include the results in the final assessment.
+
+### The agent reviews the wrong tree
+
+Symptoms:
+
+- Findings refer to the parent repository instead of the worktree.
+- Tests import parent source instead of worktree source.
+- The branch name or status does not match expectations.
+
+Avoid it:
+
+```shell
+pwd
+git status --short --branch
+git rev-parse --show-toplevel
+```
+
+For this repository's worktrees, run tests through the parent Poetry environment but force worktree imports:
+
+```shell
+source .local-test.env && PYTHONPATH="$(pwd):$PYTHONPATH" poetry run pytest tests/path/to/test.py
+```
+
+### The agent misses repository instructions
+
+Symptoms:
+
+- Test docstrings do not follow repo rules.
+- Commands omit `source .local-test.env`.
+- Python style diverges from `AGENTS.md`.
+
+Avoid it:
+
+- Tell the reviewer to read `AGENTS.md` first.
+- Cite the relevant instruction in the prompt.
+- Ask specifically for "AGENTS.md compliance" as a review axis.
+
+Good prompt:
+
+```text
+Read AGENTS.md first. Review the new pytest tests for repository instruction compliance:
+docstring format, comments matching steps, type hints, and command invocation assumptions.
+```
+
+### The agent runs too much
+
+Symptoms:
+
+- Full test suite starts unexpectedly.
+- Long-running fork tests or Docker pulls start during review.
+- CI-like commands exceed local time budgets.
+
+Avoid it:
+
+- Say "do not run the full test suite".
+- Name the exact tests that may be run.
+- For review-only work, restrict tools to read-only commands.
+
+Example:
+
+```text
+Do not run tests. Inspect the code and tell me what focused tests should be run.
+```
+
+### The agent changes files during a review
+
+Symptoms:
+
+- A review command edits files.
+- Formatting or unrelated cleanup appears in `git diff`.
+
+Avoid it:
+
+- For Claude, omit edit tools from `--allowedTools`.
+- For Codex, ask for review only and use read-only sandbox:
+
+```shell
+codex exec --sandbox read-only "Review uncommitted changes for correctness bugs"
+```
+
+### Output is not machine-readable
+
+Symptoms:
+
+- Scripts cannot reliably parse the answer.
+- Progress messages are mixed with final output.
+
+Avoid it:
+
+- Codex: use `codex exec --json` for JSONL event streams.
+- Claude: use `claude -p --output-format json` for one result or `stream-json` for live events.
+- Ask for a schema when stable fields are needed.
+
+Claude example:
+
+```shell
+claude -p "Return {\"findings\": [...], \"risk\": \"...\"}" \
+  --json-schema '{"type":"object","properties":{"findings":{"type":"array"},"risk":{"type":"string"}},"required":["findings","risk"]}'
+```
+
+### Authentication or MCP setup is broken
+
+Symptoms:
+
+- `doctor` reports missing auth.
+- MCP servers show `needs-auth`.
+- Tools that depend on external services are absent.
+- `claude --bare -p "Say OK"` says `Not logged in`.
+
+Avoid it:
+
+```shell
+codex doctor
+codex mcp list
+claude auth status
+claude -p "Say OK"
+claude doctor
+claude mcp
+```
+
+Do not diagnose normal Claude CLI auth with `--bare`; it intentionally skips
+keychain/OAuth credentials. Use `claude auth status` and a normal `claude -p`
+smoke test instead.
+
+Do not assume missing MCP tools are model limitations. Check installation, auth, workspace policy, and whether the session needs restarting after a config change.
+
+## Practical checklist
+
+Before launching another agent:
+
+1. Confirm the working directory and branch.
+2. Decide whether the task is interactive, non-interactive, or cloud review.
+3. Restrict tools if it is a review.
+4. Prefer streaming JSON for long non-interactive jobs.
+5. Tell the agent not to paste huge diffs.
+6. Name the exact risk areas to review.
+7. Ask for file:line findings and residual risks.
+8. Run focused tests yourself when the reviewer cannot.
+
+After the agent finishes:
+
+1. Separate high-confidence findings from speculation.
+2. Verify any proposed bug against the code.
+3. Apply only fixes that match the original task.
+4. Re-run focused tests if code changed.
+5. Record useful failure modes in this document.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,6 +6,23 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 SvelteKit-based frontend for the Trading Strategy protocol, featuring automated trading strategies, market data exploration, and DeFi vault management. Uses Svelte 5 with runes and async components, TypeScript strict mode, and PostCSS for styling.
 
+## Reference docs for Claude
+
+Topic deep-dives live under `.claude/docs/`. Consult the relevant one before
+working on that area:
+
+| Doc                                                | Description                                                                                                |
+| -------------------------------------------------- | ---------------------------------------------------------------------------------------------------------- |
+| `.claude/docs/agent-tricks-and-troubleshooting.md` | **MANDATORY read before ANY Claude CLI or Codex CLI invocation** (reviews, sanity checks, or one-off runs) |
+
+## Agent review workflows
+
+- **BLOCKING REQUIREMENT: before running ANY `codex` / `codex exec` or `claude` CLI command — reviews, sanity checks, or one-off runs — you MUST first read `.claude/docs/agent-tricks-and-troubleshooting.md`.** Do not invoke either CLI until you have read it in the current session. This is not optional and applies even when the call "looks trivial".
+- Follow its recommended invocation patterns for plan reviews, code reviews, PR reviews, tool restrictions, timeouts, and handling silent or hanging agent runs.
+- Always run non-interactive Codex reviews in **streaming mode** (`codex exec --json`) written to a raw file — never plain text mode piped through `tail`/`head`, which buffers output until completion and makes the run look hung.
+- `codex exec` selects the sandbox directly (`--sandbox read-only` for reviews) and does **not** accept `--ask-for-approval` (that flag is interactive-only).
+- Do not fall back to generic `claude --help`, plugin docs, or ad-hoc CLI flags until the local troubleshooting doc has been checked.
+
 ## Language conventions
 
 - Use UK/British English: `visualise` not `visualize`, `colour` not `color`
@@ -114,6 +131,35 @@ Always develop and verify against the Vite dev server started with `pnpm run dev
 ```text
 http://127.0.0.1:5173/
 ```
+
+### Tailscale dev server previews
+
+When a user needs to preview an agent-hosted dev server from their own browser, expose the Vite dev server over Tailscale:
+
+```shell
+pnpm run dev --host 0.0.0.0
+```
+
+Find the Tailscale URL:
+
+```shell
+tailscale ip -4
+tailscale status --json | jq -r '.Self.DNSName'
+```
+
+Share the `*.ts.net` URL with the route being tested, for example:
+
+```text
+http://brian.tail71b97.ts.net:5173/trading-view/vaults/stablecoins/frax
+```
+
+If the DNS name is unavailable, share the Tailscale IP fallback:
+
+```text
+http://100.x.y.z:5173/trading-view/vaults/stablecoins/frax
+```
+
+`vite.config.ts` allows `.ts.net` in `server.allowedHosts` and `preview.allowedHosts` so remote agent previews are not blocked by Vite host validation. Keep this allowlist scoped to Tailscale hostnames; do not set `allowedHosts: true`.
 
 Use Chrome remote debugging MCP only when you specifically need to attach to an already running Chrome session, inspect the live DevTools state, or reuse a signed-in/manual browser context.
 

--- a/docs/tests.md
+++ b/docs/tests.md
@@ -96,6 +96,29 @@ This is configured in `vite.config.ts` (sets `cacheDir` and an env var) and `sve
 
 You can safely run the dev server and test builds concurrently without cache corruption.
 
+### Manual remote previews over Tailscale
+
+For manual browser checks from another machine, use the Vite dev server rather than Vite preview:
+
+```shell
+pnpm run dev --host 0.0.0.0
+```
+
+Then share the Tailscale DNS name or IP with the route being reviewed:
+
+```shell
+tailscale status --json | jq -r '.Self.DNSName'
+tailscale ip -4
+```
+
+Example:
+
+```text
+http://brian.tail71b97.ts.net:5173/trading-view/vaults/stablecoins/frax
+```
+
+The Vite config allows `.ts.net` hosts so agent-hosted remote dev previews work without disabling host validation globally.
+
 ### End-to-end tests
 
 E2e tests are smoke tests that run against the **live production API**. They require a **production

--- a/src/lib/components/datatable/DataTable.svelte
+++ b/src/lib/components/datatable/DataTable.svelte
@@ -40,6 +40,7 @@ See: https://svelte-headless-table.bryanmylee.com/docs/api/create-view-model
 		hasPagination?: boolean;
 		isResponsive?: boolean;
 		targetableRows?: boolean;
+		getRowClass?: (row: unknown) => string | undefined;
 		children?: Snippet;
 		onChange?: (params: DataTableChangeParams, scrollFn: () => void) => void;
 	}
@@ -54,6 +55,7 @@ See: https://svelte-headless-table.bryanmylee.com/docs/api/create-view-model
 		hasPagination = false,
 		isResponsive = false,
 		targetableRows = false,
+		getRowClass,
 		children,
 		onChange
 	}: Props = $props();
@@ -121,7 +123,13 @@ See: https://svelte-headless-table.bryanmylee.com/docs/api/create-view-model
 		{/if}
 	</TableHeader>
 
-	<TableBody attrs={$tableBodyAttrs} rows={hasPagination ? $pageRows : $rows} page={pluginStates.page} {targetableRows}>
+	<TableBody
+		attrs={$tableBodyAttrs}
+		rows={hasPagination ? $pageRows : $rows}
+		page={pluginStates.page}
+		{targetableRows}
+		{getRowClass}
+	>
 		{@render children?.()}
 	</TableBody>
 

--- a/src/lib/components/datatable/TableBody.svelte
+++ b/src/lib/components/datatable/TableBody.svelte
@@ -11,10 +11,11 @@
 		rows: BodyRow<any, any>[];
 		page: PaginationState | undefined;
 		targetableRows?: boolean;
+		getRowClass?: (row: unknown) => string | undefined;
 		children?: Snippet;
 	}
 
-	let { attrs, rows, page, targetableRows = false, children }: Props = $props();
+	let { attrs, rows, page, targetableRows = false, getRowClass, children }: Props = $props();
 
 	let pageIndex = $derived(page?.pageIndex);
 	let pageSize = $derived(page?.pageSize);
@@ -26,6 +27,11 @@
 			return $pageIndex * $pageSize + pageRowIndex + 1;
 		}
 	}
+
+	function resolveRowClass(row: BodyRow<any, any>) {
+		if (!row.isData()) return undefined;
+		return getRowClass?.(row.original);
+	}
 </script>
 
 <!-- --table-width needed for proper tr.targetable styling  -->
@@ -33,7 +39,13 @@
 	{@render children?.()}
 	{#each rows as row, pageRowIndex (row.id)}
 		<Subscribe rowAttrs={row.attrs()} let:rowAttrs>
-			<TableRow attrs={rowAttrs} cells={row.cells} index={getRowIndex(pageRowIndex)} targetable={targetableRows} />
+			<TableRow
+				attrs={rowAttrs}
+				cells={row.cells}
+				index={getRowIndex(pageRowIndex)}
+				targetable={targetableRows}
+				rowClass={resolveRowClass(row)}
+			/>
 		</Subscribe>
 	{/each}
 </tbody>

--- a/src/lib/components/datatable/TableRow.svelte
+++ b/src/lib/components/datatable/TableRow.svelte
@@ -8,12 +8,13 @@
 		// eslint-disable-next-line @typescript-eslint/no-explicit-any
 		cells: BodyCell<any, any>[];
 		targetable: boolean;
+		rowClass?: string;
 	}
 
-	let { index, attrs, cells, targetable = false }: Props = $props();
+	let { index, attrs, cells, targetable = false, rowClass }: Props = $props();
 </script>
 
-<tr {...attrs} data-row-index={index} class:targetable>
+<tr {...attrs} data-row-index={index} class={[attrs.class, targetable && 'targetable', rowClass]}>
 	{#each cells as cell (cell.id)}
 		<Subscribe cellAttrs={cell.attrs()} let:cellAttrs>
 			<!-- eslint-disable-next-line svelte/require-store-reactive-access -->

--- a/src/lib/stablecoin-metadata/StablecoinDescription.svelte
+++ b/src/lib/stablecoin-metadata/StablecoinDescription.svelte
@@ -14,6 +14,8 @@ with optional expandable long description and external links (homepage, Twitter,
 	import type { StablecoinMetadata } from './schemas';
 	import MetricsBox from '$lib/components/MetricsBox.svelte';
 	import Button from '$lib/components/Button.svelte';
+	import Timestamp from '$lib/components/Timestamp.svelte';
+	import { getStablecoinCoingeckoLink, getStablecoinNativeRate, isStablecoinDepegged } from './helpers';
 	import IconTwitter from '~icons/local/twitter';
 	import IconHome from '~icons/local/home';
 	import IconExternalLink from '~icons/local/external-link';
@@ -26,6 +28,42 @@ with optional expandable long description and external links (homepage, Twitter,
 
 	let expanded = $state(false);
 
+	let coingeckoHref = $derived(getStablecoinCoingeckoLink(metadata));
+	let rateTimestamp = $derived(metadata.usd_rate_updated_at ?? metadata.usd_rate_fetched_at);
+	let usdRateTimestamp = $derived(metadata.usd_rate_fetched_at ?? metadata.usd_rate_updated_at);
+	let depegged = $derived(isStablecoinDepegged(metadata));
+	let rateCurrency = $derived(metadata.peg_rate_currency ?? 'usd');
+	let isNonUsdRate = $derived(rateCurrency.toLowerCase() !== 'usd');
+
+	function formatRate(rate: number, currency: string) {
+		try {
+			return new Intl.NumberFormat('en', {
+				style: 'currency',
+				currency,
+				minimumFractionDigits: 2,
+				maximumFractionDigits: 2
+			}).format(rate);
+		} catch {
+			return `${new Intl.NumberFormat('en', {
+				minimumFractionDigits: 2,
+				maximumFractionDigits: 2
+			}).format(rate)} ${currency.toUpperCase()}`;
+		}
+	}
+
+	let formattedExchangeRate = $derived.by(() => {
+		const nativeRate = getStablecoinNativeRate(metadata);
+		if (nativeRate === undefined) return undefined;
+
+		return formatRate(nativeRate, rateCurrency);
+	});
+	let formattedUsdExchangeRate = $derived.by(() => {
+		const usdRate = metadata.usd_rate;
+		if (!isNonUsdRate || typeof usdRate !== 'number' || !Number.isFinite(usdRate)) return undefined;
+
+		return formatRate(usdRate, 'usd');
+	});
+
 	let hasExpandableContent = $derived(
 		metadata.long_description && metadata.long_description !== metadata.short_description
 	);
@@ -34,7 +72,7 @@ with optional expandable long description and external links (homepage, Twitter,
 		[
 			{ href: metadata.links.homepage, label: 'Homepage', Icon: IconHome },
 			{ href: metadata.links.twitter, label: 'Twitter', Icon: IconTwitter },
-			{ href: metadata.links.coingecko, label: 'CoinGecko', Icon: IconExternalLink },
+			{ href: coingeckoHref, label: 'CoinGecko', Icon: IconExternalLink },
 			{ href: metadata.links.defillama, label: 'DefiLlama', Icon: IconExternalLink }
 		].filter((link) => link.href)
 	);
@@ -50,6 +88,50 @@ with optional expandable long description and external links (homepage, Twitter,
 				</Button>
 			{/if}
 		</div>
+
+		{#if formattedExchangeRate || formattedUsdExchangeRate || coingeckoHref}
+			<div class="rate-details" class:depegged>
+				{#if formattedExchangeRate}
+					<div class="rate">
+						<span class="label">Stablecoin price</span>
+						<span class="value">1 {metadata.symbol} = {formattedExchangeRate}</span>
+						{#if rateTimestamp}
+							<span class="timestamp">
+								<Timestamp date={rateTimestamp} relative={{ strict: true }}>
+									{#snippet children({ dateStr, relativeStr })}
+										Fetched {dateStr} ({relativeStr})
+									{/snippet}
+								</Timestamp>
+							</span>
+						{/if}
+					</div>
+				{/if}
+
+				{#if formattedUsdExchangeRate}
+					<div class="rate">
+						<span class="label">USD exchange rate</span>
+						<span class="value">1 {metadata.symbol} = {formattedUsdExchangeRate}</span>
+						{#if usdRateTimestamp}
+							<span class="timestamp">
+								<Timestamp date={usdRateTimestamp} relative={{ strict: true }}>
+									{#snippet children({ dateStr, relativeStr })}
+										Fetched {dateStr} ({relativeStr})
+									{/snippet}
+								</Timestamp>
+							</span>
+						{/if}
+					</div>
+				{/if}
+
+				{#if coingeckoHref}
+					<!-- eslint-disable-next-line svelte/no-navigation-without-resolve -->
+					<a class="coingecko-link" href={coingeckoHref} target="_blank" rel="noreferrer">
+						<IconExternalLink --icon-size="1rem" />
+						<span>CoinGecko</span>
+					</a>
+				{/if}
+			</div>
+		{/if}
 
 		{#if expanded}
 			<div transition:slide>
@@ -88,6 +170,54 @@ with optional expandable long description and external links (homepage, Twitter,
 
 			p {
 				margin: 0;
+			}
+		}
+
+		.rate-details {
+			display: flex;
+			flex-wrap: wrap;
+			align-items: center;
+			gap: 0.75rem 1rem;
+			margin-top: 1rem;
+			padding-top: 1rem;
+			border-top: 1px solid var(--c-box-3);
+
+			&.depegged {
+				.value {
+					color: var(--c-bearish);
+				}
+			}
+		}
+
+		.rate {
+			display: flex;
+			flex-wrap: wrap;
+			align-items: baseline;
+			gap: 0.5rem;
+		}
+
+		.label,
+		.timestamp {
+			color: var(--c-text-extra-light);
+			font: var(--f-ui-sm-roman);
+		}
+
+		.value {
+			color: var(--c-text);
+			font: var(--f-ui-md-medium);
+		}
+
+		.coingecko-link {
+			display: inline-flex;
+			align-items: center;
+			gap: 0.4rem;
+			color: var(--c-text-light);
+			font: var(--f-ui-sm-medium);
+			text-decoration: none;
+			transition: color var(--time-sm);
+
+			&:hover {
+				color: var(--c-text);
 			}
 		}
 

--- a/src/lib/stablecoin-metadata/helpers.test.ts
+++ b/src/lib/stablecoin-metadata/helpers.test.ts
@@ -3,6 +3,9 @@ import {
 	buildStablecoinMetadataLookup,
 	findStablecoinMetadata,
 	formatStablecoinDisplayName,
+	getStablecoinCoingeckoLink,
+	getStablecoinNativeRate,
+	isStablecoinDepegged,
 	resolveStablecoinSlug
 } from './helpers';
 import type { StablecoinMetadata } from './schemas';
@@ -65,5 +68,62 @@ describe('stablecoin metadata helpers', () => {
 
 	test('does not append symbol when already present in display name', () => {
 		expect(formatStablecoinDisplayName('USD Coin (USDC)', 'USDC')).toBe('USD Coin (USDC)');
+	});
+
+	test('uses top-level CoinGecko link before legacy nested link', () => {
+		expect(
+			getStablecoinCoingeckoLink({
+				coingecko_link: 'https://www.coingecko.com/en/coins/usd-coin',
+				links: { coingecko: 'https://old.example/usdc' }
+			})
+		).toBe('https://www.coingecko.com/en/coins/usd-coin');
+	});
+
+	test('uses native peg-currency rate for depeg detection', () => {
+		expect(isStablecoinDepegged({ usd_rate: 1.12, peg_rate: 0.89, peg_rate_currency: 'eur' })).toBe(true);
+		expect(isStablecoinDepegged({ usd_rate: 1.12, peg_rate: 0.9, peg_rate_currency: 'eur' })).toBe(false);
+		expect(isStablecoinDepegged({ usd_rate: 1.12, peg_rate: 0.99, peg_rate_currency: 'eur' })).toBe(false);
+	});
+
+	test('does not mark stablecoins above peg as depegged', () => {
+		expect(isStablecoinDepegged({ usd_rate: 1.11, peg_rate: 1.11, peg_rate_currency: 'usd' })).toBe(false);
+	});
+
+	test('uses vault denomination native rate for depeg detection', () => {
+		expect(
+			isStablecoinDepegged({
+				denomination_token_rate: {
+					usd_rate: 1.14,
+					native_rate: 0.89,
+					native_rate_currency: 'eur'
+				}
+			})
+		).toBe(true);
+		expect(
+			isStablecoinDepegged({
+				denomination_token_rate: {
+					usd_rate: 1.14,
+					native_rate: 0.99,
+					native_rate_currency: 'eur'
+				}
+			})
+		).toBe(false);
+	});
+
+	test('uses USD rate as native rate for USD-pegged vault entries', () => {
+		expect(getStablecoinNativeRate({ denomination_token_rate: { usd_rate: 0.89 } })).toBe(0.89);
+		expect(isStablecoinDepegged({ denomination_token_rate: { usd_rate: 0.89 } })).toBe(true);
+	});
+
+	test('does not use USD fallback when a non-USD native currency is known', () => {
+		expect(getStablecoinNativeRate({ usd_rate: 0.7, peg_rate_currency: 'eur' })).toBeUndefined();
+		expect(isStablecoinDepegged({ usd_rate: 0.7, peg_rate_currency: 'eur' })).toBe(false);
+	});
+
+	test('treats explicit depeg timestamp as depegged only when no rate is available', () => {
+		expect(isStablecoinDepegged({ depegged_at: '2026-06-26T12:15:26' })).toBe(true);
+		expect(isStablecoinDepegged({ peg_rate: 0.99, peg_rate_currency: 'usd', depegged_at: '2026-06-26T12:15:26' })).toBe(
+			false
+		);
 	});
 });

--- a/src/lib/stablecoin-metadata/helpers.ts
+++ b/src/lib/stablecoin-metadata/helpers.ts
@@ -3,10 +3,28 @@ import { buildMetadataLogoProxyPath, type MetadataLogoOptions } from '$lib/metad
 import { slugify } from '$lib/helpers/slugify';
 import type { StablecoinMetadata } from './schemas';
 
+export const STABLECOIN_DEPEG_RATE_THRESHOLD = 0.9;
+
 interface StablecoinLookupInput {
 	slug?: string | null;
 	symbol?: string | null;
 	name?: string | null;
+}
+
+interface StablecoinRateInput {
+	usd_rate?: number | null;
+	peg_rate_currency?: string | null;
+	peg_rate?: number | null;
+	depegged_at?: string | null;
+	denomination_token_rate?: {
+		usd_rate?: number | null;
+		native_rate?: number | null;
+		native_rate_currency?: string | null;
+	} | null;
+	coingecko_link?: string | null;
+	links?: {
+		coingecko?: string | null;
+	};
 }
 
 export function formatStablecoinDisplayName(
@@ -104,6 +122,62 @@ export function resolveStablecoinSlug(
 	}
 
 	return undefined;
+}
+
+/**
+ * Return the CoinGecko URL for a stablecoin metadata record.
+ *
+ * @param metadata stablecoin metadata from the external metadata index
+ */
+export function getStablecoinCoingeckoLink(metadata: StablecoinRateInput | null | undefined): string | undefined {
+	return metadata?.coingecko_link ?? metadata?.links?.coingecko ?? undefined;
+}
+
+function isNonUsdCurrency(currency: string | null | undefined): boolean {
+	return Boolean(currency && currency.toLowerCase() !== 'usd');
+}
+
+function finiteRate(rate: number | null | undefined): number | undefined {
+	return typeof rate === 'number' && Number.isFinite(rate) ? rate : undefined;
+}
+
+/**
+ * Return the stablecoin rate in its native peg currency.
+ *
+ * Stablecoin metadata exposes this as `peg_rate`; vault entries expose the same
+ * value as `denomination_token_rate.native_rate`. USD-pegged vault entries only
+ * have `denomination_token_rate.usd_rate`, which is also their native rate.
+ *
+ * @param metadata stablecoin metadata, vault metadata, or a grouped row containing rate fields
+ */
+export function getStablecoinNativeRate(metadata: StablecoinRateInput | null | undefined): number | undefined {
+	const pegRate = finiteRate(metadata?.peg_rate);
+	if (pegRate !== undefined) return pegRate;
+
+	const vaultNativeRate = finiteRate(metadata?.denomination_token_rate?.native_rate);
+	if (vaultNativeRate !== undefined) return vaultNativeRate;
+
+	const hasNonUsdNativeCurrency =
+		isNonUsdCurrency(metadata?.peg_rate_currency) ||
+		isNonUsdCurrency(metadata?.denomination_token_rate?.native_rate_currency);
+	if (hasNonUsdNativeCurrency) return undefined;
+
+	const vaultUsdRate = finiteRate(metadata?.denomination_token_rate?.usd_rate);
+	if (vaultUsdRate !== undefined) return vaultUsdRate;
+
+	return finiteRate(metadata?.usd_rate);
+}
+
+/**
+ * Stablecoin is considered depegged when its native peg-currency rate is below 90%.
+ *
+ * @param metadata stablecoin metadata, vault metadata, or a grouped row containing rate fields
+ */
+export function isStablecoinDepegged(metadata: StablecoinRateInput | null | undefined): boolean {
+	const rate = getStablecoinNativeRate(metadata);
+	if (rate !== undefined) return rate < STABLECOIN_DEPEG_RATE_THRESHOLD;
+
+	return Boolean(metadata?.depegged_at);
 }
 
 /**

--- a/src/lib/stablecoin-metadata/schemas.ts
+++ b/src/lib/stablecoin-metadata/schemas.ts
@@ -1,5 +1,6 @@
 // Schema definitions for stablecoin metadata fetched from external API
 import { z } from 'zod';
+import { isoDateTime } from '$lib/schemas/utility';
 
 const stablecoinLinksSchema = z.object({
 	homepage: z.url().nullable(),
@@ -21,7 +22,19 @@ export const stablecoinMetadataSchema = z.object({
 	description: z.string(),
 	category: z.string(),
 	links: stablecoinLinksSchema,
-	logos: stablecoinLogosSchema
+	logos: stablecoinLogosSchema,
+	coingecko_id: z.string().nullable().optional(),
+	coingecko_link: z.url().nullable().optional(),
+	coingecko_id_source: z.string().nullable().optional(),
+	coingecko_id_verified_at: isoDateTime.nullable().optional(),
+	usd_rate: z.number().nullable().optional(),
+	usd_rate_fetched_at: isoDateTime.nullable().optional(),
+	usd_rate_updated_at: isoDateTime.nullable().optional(),
+	peg_rate: z.number().nullable().optional(),
+	peg_rate_currency: z.string().nullable().optional(),
+	rate_fetch_failed_at: isoDateTime.nullable().optional(),
+	rate_fetch_failed_reason: z.string().nullable().optional(),
+	depegged_at: isoDateTime.nullable().optional()
 });
 
 export type StablecoinMetadata = z.infer<typeof stablecoinMetadataSchema>;

--- a/src/lib/top-vaults/VaultGroupNameCell.svelte
+++ b/src/lib/top-vaults/VaultGroupNameCell.svelte
@@ -1,0 +1,55 @@
+<!--
+@component
+Vault group name cell with optional logo and warning marker.
+
+Used by group listing tables for protocol, chain, curator and stablecoin rows.
+
+@example
+
+```svelte
+  <VaultGroupNameCell label="USDC" logoUrl="/metadata-logo/stablecoin/usdc" />
+```
+-->
+<script lang="ts">
+	import EntitySymbol from '$lib/components/EntitySymbol.svelte';
+	import IconWarning from '~icons/local/warning';
+
+	interface Props {
+		label: string;
+		logoUrl?: string;
+		showPlaceholder?: boolean;
+		warningLabel?: string | null;
+	}
+
+	let { label, logoUrl, showPlaceholder = false, warningLabel = null }: Props = $props();
+
+	let isWarning = $derived(Boolean(warningLabel));
+</script>
+
+<EntitySymbol {label} {logoUrl} {showPlaceholder}>
+	<span class="group-name" class:warning={isWarning} title={warningLabel ?? undefined}>
+		{#if warningLabel}
+			<IconWarning --icon-size="1em" aria-hidden="true" />
+		{/if}
+		<span>{label}</span>
+	</span>
+</EntitySymbol>
+
+<style>
+	.group-name {
+		display: inline-flex;
+		align-items: center;
+		gap: 0.35rem;
+		min-width: 0;
+
+		&.warning {
+			color: var(--c-bearish);
+			font-weight: 600;
+		}
+
+		:global(svg) {
+			flex: 0 0 auto;
+			color: var(--c-bearish);
+		}
+	}
+</style>

--- a/src/lib/top-vaults/VaultGroupTable.svelte
+++ b/src/lib/top-vaults/VaultGroupTable.svelte
@@ -17,7 +17,7 @@
 	import { createRender } from '$lib/components/datatable/utils';
 	import DataTable from '$lib/components/datatable/DataTable.svelte';
 	import TableRowTarget from '$lib/components/datatable/TableRowTarget.svelte';
-	import EntitySymbol from '$lib/components/EntitySymbol.svelte';
+	import VaultGroupNameCell from './VaultGroupNameCell.svelte';
 	import RiskCell from './RiskCell.svelte';
 	import Core3RiskCell from './Core3RiskCell.svelte';
 	import { formatDollar, formatPercent } from '$lib/helpers/formatters';
@@ -37,6 +37,7 @@
 		sort?: SortOptions['keys'][number];
 		direction?: SortOptions['directions'][number];
 		getHref?: (slug: string) => string;
+		getWarningLabel?: (row: VaultGroup) => string | undefined;
 	}
 
 	let {
@@ -51,6 +52,7 @@
 		sort = sortOptions.keys[0],
 		direction = sortOptions.directions[0],
 		getHref = (slug: string) => `${page.url.pathname}/${slug}`,
+		getWarningLabel,
 		loading = false,
 		...restProps
 	}: Props = $props();
@@ -63,6 +65,10 @@
 	$effect(() => {
 		tableRowsStore.set(tableRows);
 	});
+
+	function getTableRowClass(row: unknown) {
+		return getWarningLabel?.(row as VaultGroup) ? 'depegged' : undefined;
+	}
 
 	const hiddenColumns = [
 		...(includeRisk ? [] : ['risk']),
@@ -89,21 +95,25 @@
 			id: 'name',
 			header: groupLabel,
 			accessor: (row) => ({ name: row.name, slug: row.slug }),
-			// prettier-ignore
-			cell: ({ value }) => getLogoHref
-					? createRender(EntitySymbol, {
-							label: value.name,
-							logoUrl: getLogoHref(value.slug),
-							showPlaceholder: value.name === 'Unknown' && !getLogoHref(value.slug)
-						})
-					: value.name,
+			cell: ({ value }) =>
+				createRender(VaultGroupNameCell, {
+					label: value.name,
+					logoUrl: getLogoHref?.(value.slug),
+					showPlaceholder: value.name === 'Unknown' && !getLogoHref?.(value.slug)
+				}),
 			plugins: { sort: { getSortValue: (v) => v.name, invert: true } }
 		}),
 		table.column({
 			id: 'full_name',
 			header: 'Name',
-			accessor: 'fullName',
-			cell: ({ value }) => value ?? '',
+			accessor: (row) => ({ fullName: row.fullName, warningLabel: getWarningLabel?.(row) }),
+			cell: ({ value }) =>
+				value.fullName || value.warningLabel
+					? createRender(VaultGroupNameCell, {
+							label: value.fullName ?? '',
+							warningLabel: value.warningLabel
+						})
+					: '',
 			plugins: { sort: { disable: true } }
 		}),
 		table.column({
@@ -159,7 +169,15 @@
 </script>
 
 <div class="vault-protocol-table" class:wide-name={wideName}>
-	<DataTable isResponsive hasPagination targetableRows {loading} {tableViewModel} {...restProps} />
+	<DataTable
+		isResponsive
+		hasPagination
+		targetableRows
+		{loading}
+		{tableViewModel}
+		getRowClass={getTableRowClass}
+		{...restProps}
+	/>
 </div>
 
 <style>
@@ -224,5 +242,10 @@
 				}
 			}
 		}
+	}
+
+	.vault-protocol-table :global(tr.depegged td),
+	.vault-protocol-table :global(tr.depegged td *) {
+		color: var(--c-bearish) !important;
 	}
 </style>

--- a/src/lib/top-vaults/schemas.ts
+++ b/src/lib/top-vaults/schemas.ts
@@ -103,6 +103,42 @@ export const core3VaultSchema = z.object({
 });
 export type Core3Vault = z.infer<typeof core3VaultSchema>;
 
+/**
+ * Latest exchange rate metadata for a vault denomination token.
+ *
+ * The backend attaches this to every vault as `denomination_token_rate`. For
+ * USD-pegged tokens, `usd_rate` is also the native rate. For non-USD pegs,
+ * `native_rate` is the rate in `native_rate_currency`, while `usd_rate` remains
+ * the dollar conversion rate.
+ */
+export const denominationTokenRateSchema = z.object({
+	/** CoinGecko id used by the collector, null when unknown */
+	coingecko_id: z.string().nullable(),
+	/** Source peg currency if one was explicitly detected */
+	source_currency: z.string().nullable(),
+	/** Latest denomination token rate in USD */
+	usd_rate: nullableNumber,
+	/** When the USD rate was fetched */
+	usd_rate_fetched_at: isoDateTime.nullable(),
+	/** Collector/source name for the USD rate */
+	usd_rate_source: z.string().nullable(),
+	/** Latest denomination token rate in its native peg currency */
+	native_rate: nullableNumber,
+	/** Native peg currency for `native_rate`, e.g. `eur`, `cad`, `jpy` */
+	native_rate_currency: z.string().nullable(),
+	/** When the native peg-currency rate was fetched */
+	native_rate_fetched_at: isoDateTime.nullable(),
+	/** Collector/source name for the native peg-currency rate */
+	native_rate_source: z.string().nullable(),
+	/** USD conversion rate for the source currency, when needed by the collector */
+	source_currency_usd_rate: nullableNumber,
+	/** When the source-currency USD conversion rate was fetched */
+	source_currency_usd_rate_fetched_at: isoDateTime.nullable(),
+	/** Collector/source name for the source-currency USD conversion rate */
+	source_currency_usd_rate_source: z.string().nullable()
+});
+export type DenominationTokenRate = z.infer<typeof denominationTokenRateSchema>;
+
 /** A post/update surfaced from a curator's social or RSS feed. */
 export const curatorRecentPostSchema = z.object({
 	/** Post title; may be null for sources that don't provide one (e.g. tweets) */
@@ -286,6 +322,8 @@ export const vaultInfoSchema = z.object({
 	chain_id: chainId,
 	/** Whether the denomination token is a stablecoin or stablecoin-like */
 	stablecoinish: z.boolean(),
+	/** Latest exchange rate metadata for the denomination token */
+	denomination_token_rate: denominationTokenRateSchema.nullable().optional().default(null),
 
 	// --- Block tracking ---
 	/** When the vault was first indexed */
@@ -565,4 +603,20 @@ export interface VaultGroup {
 	core3_rating?: string | null;
 	/** CORE3 numeric risk score (lower = better) — used to sort the CORE3 rating column */
 	core3_score?: number | null;
+	/** Latest stablecoin USD exchange rate — only present on stablecoin groups with metadata */
+	usd_rate?: number | null;
+	/** When the latest stablecoin USD exchange rate was updated by the source */
+	usd_rate_updated_at?: string | null;
+	/** When the latest stablecoin USD exchange rate was fetched */
+	usd_rate_fetched_at?: string | null;
+	/** Latest stablecoin exchange rate in its native peg currency */
+	peg_rate?: number | null;
+	/** Currency for the stablecoin peg rate, e.g. `usd`, `eur`, `cad` */
+	peg_rate_currency?: string | null;
+	/** Timestamp when the stablecoin was marked as depegged by the metadata export */
+	depegged_at?: string | null;
+	/** Latest exchange rate metadata from vault denomination token entries */
+	denomination_token_rate?: DenominationTokenRate | null;
+	/** CoinGecko page URL for stablecoin groups */
+	coingecko_link?: string | null;
 }

--- a/src/routes/trading-view/vaults/VaultGroupDescription.svelte
+++ b/src/routes/trading-view/vaults/VaultGroupDescription.svelte
@@ -92,13 +92,15 @@ excluded vault count from the loaded vault data.
 			{subject}
 			{verbPhrase}
 			<strong>{vaultCountLabel}</strong> with
-			<strong>{totalTvlLabel}</strong> across <strong>{protocolCountLabel}</strong>.
+			<strong>{totalTvlLabel}</strong>{#if protocolCount > 0}
+				{' '}
+				across <strong>{protocolCountLabel}</strong>{/if}.
 			{#if largestVaults.length}
 				The largest {largestVaults.length === 1 ? 'vault is' : 'vaults are'}
 				{#each largestVaults as vault, index (vault.vault_slug)}{index > 0 ? ', ' : ''}<a
 						href={resolveVaultDetails(vault)}>{vault.name}</a
-					>{/each}
-				{#if topProtocols.length}
+					>{/each}{#if topProtocols.length}
+					{' '}
 					and the most popular vault {topProtocols.length === 1 ? 'protocol is' : 'protocols are'}
 					{#each topProtocols as protocol, index (protocol.slug)}{index === 0
 							? ''

--- a/src/routes/trading-view/vaults/protocols/[protocol=slug]/+page.svelte
+++ b/src/routes/trading-view/vaults/protocols/[protocol=slug]/+page.svelte
@@ -27,7 +27,7 @@
 			.finally(() => (loading = false));
 	});
 
-	let title = $derived(`${protocolName} vault comparison`);
+	let title = $derived(`${protocolName} vaults and yields`);
 	let description = $derived(protocolMetadata?.short_description ?? `Top stablecoin vaults on ${protocolName}`);
 	let pageUrl = $derived(new URL(page.url.pathname, page.url.origin).href);
 	let logoUrl = $derived.by(() => {

--- a/src/routes/trading-view/vaults/stablecoins/+page.server.ts
+++ b/src/routes/trading-view/vaults/stablecoins/+page.server.ts
@@ -1,4 +1,4 @@
-import type { VaultGroup } from '$lib/top-vaults/schemas.js';
+import type { VaultGroup, VaultInfo } from '$lib/top-vaults/schemas.js';
 import { getCachedTopVaults } from '$lib/top-vaults/cache';
 import { calculateTvlWeightedApy, isBlacklisted, meetsMinTvl } from '$lib/top-vaults/helpers.js';
 import { sortOptions } from '$lib/top-vaults/VaultGroupTable.svelte';
@@ -6,10 +6,39 @@ import { getNumberParam, getStringParam } from '$lib/helpers/url-params';
 import { fetchStablecoinMetadataIndex } from '$lib/stablecoin-metadata/client';
 import {
 	buildStablecoinMetadataLookup,
+	getStablecoinCoingeckoLink,
 	getStablecoinLogoUrl,
 	resolveStablecoinSlug
 } from '$lib/stablecoin-metadata/helpers.js';
 import type { MarketShareChartItem } from '../market-share-pie';
+import type { StablecoinMetadata } from '$lib/stablecoin-metadata/schemas.js';
+
+function getStablecoinRateFields(metadata: StablecoinMetadata | undefined) {
+	return {
+		usd_rate: metadata?.usd_rate ?? null,
+		usd_rate_updated_at: metadata?.usd_rate_updated_at ?? null,
+		usd_rate_fetched_at: metadata?.usd_rate_fetched_at ?? null,
+		peg_rate: metadata?.peg_rate ?? null,
+		peg_rate_currency: metadata?.peg_rate_currency ?? null,
+		depegged_at: metadata?.depegged_at ?? null,
+		coingecko_link: getStablecoinCoingeckoLink(metadata) ?? null
+	};
+}
+
+function getVaultStablecoinRateFields(vault: VaultInfo) {
+	const rate = vault.denomination_token_rate;
+
+	return {
+		usd_rate: rate?.usd_rate ?? null,
+		usd_rate_updated_at: null,
+		usd_rate_fetched_at: rate?.usd_rate_fetched_at ?? null,
+		peg_rate: rate?.native_rate ?? rate?.usd_rate ?? null,
+		peg_rate_currency: rate?.native_rate_currency ?? (rate?.usd_rate != null ? 'usd' : null),
+		depegged_at: null,
+		denomination_token_rate: rate ?? null,
+		coingecko_link: null
+	};
+}
 
 export async function load({ fetch, url: { searchParams } }) {
 	const [{ vaults }, metadataIndex] = await Promise.all([
@@ -32,14 +61,16 @@ export async function load({ fetch, url: { searchParams } }) {
 				},
 				metadataLookup
 			) ?? vault.denomination_slug;
+		const metadata = metadataBySlug.get(slug);
 
 		acc[slug] ??= {
 			slug,
 			name: vault.normalised_denomination,
-			fullName: metadataBySlug.get(slug)?.name,
+			fullName: metadata?.name,
 			vault_count: 0,
 			tvl: 0,
-			avg_apy: null
+			avg_apy: null,
+			...(metadata ? getStablecoinRateFields(metadata) : getVaultStablecoinRateFields(vault))
 		};
 		acc[slug].vault_count++;
 		acc[slug].tvl += vault.current_nav ?? 0;
@@ -56,7 +87,8 @@ export async function load({ fetch, url: { searchParams } }) {
 				fullName: meta.name,
 				vault_count: 0,
 				tvl: 0,
-				avg_apy: null
+				avg_apy: null,
+				...getStablecoinRateFields(meta)
 			};
 		}
 	}

--- a/src/routes/trading-view/vaults/stablecoins/+page.svelte
+++ b/src/routes/trading-view/vaults/stablecoins/+page.svelte
@@ -7,7 +7,7 @@
 	import Section from '$lib/components/Section.svelte';
 	import VaultGroupTable from '$lib/top-vaults/VaultGroupTable.svelte';
 	import VaultListingsSelector from '$lib/top-vaults/VaultListingsSelector.svelte';
-	import { getStablecoinLogoUrl } from '$lib/stablecoin-metadata/helpers.js';
+	import { getStablecoinLogoUrl, isStablecoinDepegged } from '$lib/stablecoin-metadata/helpers.js';
 	import { MetaTags, JsonLd } from 'svelte-meta-tags';
 	import MarketSharePieChart from '../MarketSharePieChart.svelte';
 	import MarketShareWidgetBox from '../MarketShareWidgetBox.svelte';
@@ -100,6 +100,8 @@
 			groupLabel="Stablecoin"
 			includeFullName
 			getLogoHref={getStablecoinLogoUrl}
+			getWarningLabel={(row) =>
+				isStablecoinDepegged(row) ? `${row.name} is below 90% of its native peg rate` : undefined}
 			rows={stablecoins}
 			{...options}
 			{onChange}

--- a/src/routes/trading-view/vaults/stablecoins/[denomination=slug]/+page.svelte
+++ b/src/routes/trading-view/vaults/stablecoins/[denomination=slug]/+page.svelte
@@ -1,6 +1,10 @@
 <script lang="ts">
 	import type { TopVaults } from '$lib/top-vaults/schemas';
-	import { formatStablecoinDisplayName, getStablecoinLogoUrl } from '$lib/stablecoin-metadata/helpers';
+	import {
+		formatStablecoinDisplayName,
+		getStablecoinCoingeckoLink,
+		getStablecoinLogoUrl
+	} from '$lib/stablecoin-metadata/helpers';
 	import { fetchAllVaultData, hasVaultCache } from '$lib/top-vaults/client-cache';
 	import { page } from '$app/state';
 	import TopVaultsPage from '$lib/top-vaults/TopVaultsPage.svelte';
@@ -36,6 +40,7 @@
 		return logoPath ? new URL(logoPath, page.url.origin).href : undefined;
 	});
 	let aboutName = $derived(formatStablecoinDisplayName(stablecoinMetadata?.name, stablecoinMetadata?.symbol));
+	let coingeckoHref = $derived(getStablecoinCoingeckoLink(stablecoinMetadata));
 </script>
 
 <MetaTags
@@ -76,7 +81,7 @@
 					image: logoUrl ?? undefined,
 					url: stablecoinMetadata.links.homepage ?? undefined,
 					category: stablecoinMetadata.category,
-					sameAs: [stablecoinMetadata.links.coingecko, stablecoinMetadata.links.defillama].filter(Boolean)
+					sameAs: [coingeckoHref, stablecoinMetadata.links.defillama].filter(Boolean)
 				}
 			: undefined,
 		mainEntity: {
@@ -93,6 +98,7 @@
 	title="{denominationName} stablecoin vaults"
 	showFilters
 	defaultTvlKey="10k"
+	defaultHideUnknown={0}
 >
 	{#snippet detailDescription()}
 		{#if topVaults?.vaults.length}

--- a/tests/integration/trading-view/vaults/stablecoins.test.ts
+++ b/tests/integration/trading-view/vaults/stablecoins.test.ts
@@ -25,6 +25,44 @@ test.describe('stablecoins index page', () => {
 		await expect(page.locator('table')).toContainText('Stablecoin');
 	});
 
+	test('marks depegged stablecoins in the table', async ({ page }) => {
+		await page.goto('/trading-view/vaults/stablecoins');
+
+		const fraxWarning = page.locator('td.full_name .group-name.warning').filter({ hasText: 'Frax' });
+		const fraxRow = page.locator('tbody tr').filter({ has: fraxWarning });
+		await expect(fraxWarning).toBeVisible();
+		await expect(fraxWarning).toHaveAttribute('title', 'FRAX is below 90% of its native peg rate');
+		await expect(fraxRow.locator('td.full_name svg')).toBeVisible();
+		await expect(fraxRow.locator('td.name .group-name.warning')).toHaveCount(0);
+
+		const warningColour = await fraxWarning.evaluate((element) => getComputedStyle(element).color);
+		for (const selector of ['td.name', 'td.full_name', 'td.vault_count', 'td.avg_apy', 'td.tvl', 'td.cta .row-link']) {
+			await expect(fraxRow.locator(selector)).toHaveCSS('color', warningColour);
+		}
+	});
+
+	test('shows stablecoin price and CoinGecko link on stablecoin detail pages', async ({ page }) => {
+		await page.goto('/trading-view/vaults/stablecoins/usdc');
+
+		await expect(page.getByText('Stablecoin price')).toBeVisible();
+		await expect(page.getByText('1 USDC = $1.00')).toBeVisible();
+		await expect(page.getByText(/Fetched 2026.*ago/)).toBeVisible();
+		await expect(page.getByRole('link', { name: 'CoinGecko' })).toHaveAttribute(
+			'href',
+			'https://www.coingecko.com/en/coins/usd-coin'
+		);
+	});
+
+	test('shows USD exchange rate for non-USD stablecoin detail pages', async ({ page }) => {
+		await page.goto('/trading-view/vaults/stablecoins/eura');
+
+		await expect(page.getByText('Stablecoin price')).toBeVisible();
+		await expect(page.getByText('1 EURA = €1.00')).toBeVisible();
+		await expect(page.getByText('USD exchange rate')).toBeVisible();
+		await expect(page.getByText('1 EURA = $1.14')).toBeVisible();
+		await expect(page.getByText(/Fetched 2026.*ago/)).toHaveCount(2);
+	});
+
 	test('uses the updated metadata title and description', async ({ page }) => {
 		await page.goto('/trading-view/vaults/stablecoins');
 

--- a/tests/mocks/stablecoin-metadata/index.mock.ts
+++ b/tests/mocks/stablecoin-metadata/index.mock.ts
@@ -21,7 +21,19 @@ export const mockStablecoins: StablecoinMetadata[] = [
 		},
 		logos: {
 			light: 'http://localhost:4173/api/stablecoin-metadata/usdc/light.png'
-		}
+		},
+		coingecko_id: 'usd-coin',
+		coingecko_link: 'https://www.coingecko.com/en/coins/usd-coin',
+		coingecko_id_source: 'url',
+		coingecko_id_verified_at: '2026-06-26T12:16:16',
+		usd_rate: 0.999667,
+		usd_rate_fetched_at: '2026-06-26T12:16:16',
+		usd_rate_updated_at: '2026-06-26T12:15:26',
+		peg_rate: 0.999667,
+		peg_rate_currency: 'usd',
+		rate_fetch_failed_at: null,
+		rate_fetch_failed_reason: null,
+		depegged_at: null
 	},
 	{
 		symbol: 'USDT',
@@ -40,7 +52,19 @@ export const mockStablecoins: StablecoinMetadata[] = [
 		},
 		logos: {
 			light: 'http://localhost:4173/api/stablecoin-metadata/usdt/light.png'
-		}
+		},
+		coingecko_id: 'tether',
+		coingecko_link: 'https://www.coingecko.com/en/coins/tether',
+		coingecko_id_source: 'url',
+		coingecko_id_verified_at: '2026-06-26T12:16:16',
+		usd_rate: 0.998536,
+		usd_rate_fetched_at: '2026-06-26T12:16:16',
+		usd_rate_updated_at: '2026-06-26T12:15:26',
+		peg_rate: 0.998536,
+		peg_rate_currency: 'usd',
+		rate_fetch_failed_at: null,
+		rate_fetch_failed_reason: null,
+		depegged_at: null
 	},
 	{
 		symbol: 'DAI',
@@ -59,7 +83,48 @@ export const mockStablecoins: StablecoinMetadata[] = [
 		},
 		logos: {
 			light: 'http://localhost:4173/api/stablecoin-metadata/dai/light.png'
-		}
+		},
+		coingecko_id: 'dai',
+		coingecko_link: 'https://www.coingecko.com/en/coins/dai',
+		coingecko_id_source: 'url',
+		coingecko_id_verified_at: '2026-06-26T12:16:16',
+		usd_rate: 0.999703,
+		usd_rate_fetched_at: '2026-06-26T12:16:16',
+		usd_rate_updated_at: '2026-06-26T12:15:26',
+		peg_rate: 0.999703,
+		peg_rate_currency: 'usd',
+		rate_fetch_failed_at: null,
+		rate_fetch_failed_reason: null,
+		depegged_at: null
+	},
+	{
+		symbol: 'EURA',
+		slug: 'eura',
+		name: 'Angle EURA',
+		short_description: 'EURA is a Euro stablecoin issued by Angle.',
+		description: 'EURA is a Euro stablecoin issued by Angle.',
+		category: 'stablecoin',
+		links: {
+			homepage: 'https://www.angle.money/',
+			coingecko: 'https://www.coingecko.com/en/coins/ageur',
+			defillama: null,
+			twitter: 'https://x.com/AngleProtocol'
+		},
+		logos: {
+			light: 'http://localhost:4173/api/stablecoin-metadata/eura/light.png'
+		},
+		coingecko_id: 'ageur',
+		coingecko_link: 'https://www.coingecko.com/en/coins/ageur',
+		coingecko_id_source: 'url',
+		coingecko_id_verified_at: '2026-06-26T12:16:16',
+		usd_rate: 1.14,
+		usd_rate_fetched_at: '2026-06-26T12:16:16',
+		usd_rate_updated_at: '2026-06-26T12:15:11',
+		peg_rate: 0.996731,
+		peg_rate_currency: 'eur',
+		rate_fetch_failed_at: null,
+		rate_fetch_failed_reason: null,
+		depegged_at: null
 	},
 	{
 		symbol: 'FRAX',
@@ -76,7 +141,19 @@ export const mockStablecoins: StablecoinMetadata[] = [
 		},
 		logos: {
 			light: 'http://localhost:4173/api/stablecoin-metadata/frax/light.png'
-		}
+		},
+		coingecko_id: 'frax',
+		coingecko_link: 'https://www.coingecko.com/en/coins/frax',
+		coingecko_id_source: 'url',
+		coingecko_id_verified_at: '2026-06-26T12:16:16',
+		usd_rate: 0.82,
+		usd_rate_fetched_at: '2026-06-26T12:16:16',
+		usd_rate_updated_at: '2026-06-26T12:15:26',
+		peg_rate: 0.82,
+		peg_rate_currency: 'usd',
+		rate_fetch_failed_at: null,
+		rate_fetch_failed_reason: null,
+		depegged_at: '2026-06-26T12:15:26'
 	}
 ];
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -23,6 +23,10 @@ const customLogger = ((logger) => {
 	};
 })(createLogger());
 
+// Allow remote dev-server previews when a coding agent exposes Vite over Tailscale.
+// Vite treats a leading dot as "this hostname and all subdomains".
+const TAILSCALE_ALLOWED_HOST = '.ts.net';
+
 export default defineConfig(({ mode }) => {
 	// Signal test mode to svelte.config.js via env var so it uses a separate
 	// outDir. This env var is inherited by Worker threads (unlike process.argv),
@@ -78,6 +82,8 @@ export default defineConfig(({ mode }) => {
 		resolve: process.env.VITEST ? { conditions: ['browser'] } : undefined,
 
 		server: {
+			// Lets users open an agent-hosted dev server via e.g. brian.tailnet.ts.net.
+			allowedHosts: [TAILSCALE_ALLOWED_HOST],
 			fs: {
 				allow: [process.cwd()]
 			}
@@ -92,7 +98,8 @@ export default defineConfig(({ mode }) => {
 		},
 
 		preview: {
-			allowedHosts: ['.tradingstrategy.ai']
+			// Keep preview consistent with dev for agent-hosted remote checks.
+			allowedHosts: ['.tradingstrategy.ai', TAILSCALE_ALLOWED_HOST]
 		},
 
 		// vitest configuration for unit tests (`pnpm run test:unit`)


### PR DESCRIPTION
## Why
Stablecoin vault pages need to surface native exchange-rate metadata, depeg status, and remote preview/review instructions so users and agents can verify updated vault data correctly.

## Lessons learnt
- Stablecoin metadata and vault entries expose related but differently shaped rate fields: metadata uses `peg_rate`/`peg_rate_currency`, while vault entries use `denomination_token_rate.native_rate`.
- Some stablecoin vaults intentionally use unknown protocol placeholders, so descriptive copy must not render "across 0 protocols" when supported protocol data is absent.
- Vite needs a scoped `.ts.net` allowlist for Tailscale-hosted agent previews.

## Summary
- Added native stablecoin price and USD exchange-rate display, CoinGecko links, and shared native-rate depeg helpers.
- Preserved vault denomination rate metadata and used it in stablecoin listings.
- Highlighted depegged stablecoins in the stablecoin listing.
- Fixed stablecoin detail defaults and description copy for unknown protocol vaults.
- Documented Tailscale preview and local Claude/Codex review workflows.
