### PR TITLE
Add international vault listings

### DIFF
--- a/.claude/docs/worktree.md
+++ b/.claude/docs/worktree.md
@@ -1,0 +1,73 @@
+# Worktrees
+
+Git worktrees share tracked files with the main checkout, but ignored local files are separate per worktree. Before running a dev server, browser preview, or private-data test from a worktree, copy or link the local environment and data cache from the main checkout.
+
+## Required local files
+
+The main checkout normally has local-only files that are intentionally ignored by git:
+
+- `.env.local` - private environment variables loaded by Vite/SvelteKit.
+- `data/` - local cache for large private datasets, including `data/cleaned-vault-prices-1h.parquet`.
+
+Without these files, vault metadata may still load if `TS_PRIVATE_TOP_VAULTS_URL` is set manually, but chart endpoints that need the historical parquet can fail with 500 responses.
+
+## Environment variables
+
+Copy or symlink `.env.local` from the main checkout so the worktree gets the same private server configuration:
+
+```shell
+ln -s /home/mikko/code/frontend/.env.local .env.local
+```
+
+The important vault data variables are:
+
+```env
+TS_PRIVATE_R2_ACCOUNT_ID=
+TS_PRIVATE_R2_ACCESS_KEY_ID=
+TS_PRIVATE_R2_SECRET_ACCESS_KEY=
+TS_PRIVATE_R2_BUCKET_NAME=
+TS_PRIVATE_TOP_VAULTS_URL=
+TS_PRIVATE_VAULT_PRICES_PARQUET_URL=
+```
+
+R2 credentials are the canonical source for both vault metadata and the historical parquet. `TS_PRIVATE_TOP_VAULTS_URL` and `TS_PRIVATE_VAULT_PRICES_PARQUET_URL` are fallback direct URLs when R2 is not configured.
+
+Restart the dev server after changing `.env.local`; Vite reads these values at process start.
+
+## Data symlink
+
+The historical vault parquet is large and is read from a path relative to the current worktree:
+
+```text
+data/cleaned-vault-prices-1h.parquet
+```
+
+Use a symlink instead of duplicating the cache:
+
+```shell
+ln -s /home/mikko/code/frontend/data data
+```
+
+This allows worktree-local endpoints such as `/trading-view/vaults/{id}/metrics` to find the same cached parquet as the main checkout.
+
+## Checks
+
+Confirm ignored local resources are present:
+
+```shell
+ls -l .env.local data/cleaned-vault-prices-1h.parquet
+git check-ignore -v .env.local data/cleaned-vault-prices-1h.parquet
+```
+
+Confirm the running dev server inherited private environment variables:
+
+```shell
+ps -eo pid,cmd | rg 'vite|pnpm run dev'
+tr '\0' '\n' < /proc/<vite-pid>/environ | rg 'TS_PRIVATE_R2_|TS_PRIVATE_TOP_VAULTS_URL|TS_PRIVATE_VAULT_PRICES_PARQUET_URL'
+```
+
+Confirm vault chart data works:
+
+```shell
+curl -s 'http://127.0.0.1:5173/trading-view/vaults/<vault-id>/metrics'
+```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,6 +14,7 @@ working on that area:
 | Doc                                                | Description                                                                                                |
 | -------------------------------------------------- | ---------------------------------------------------------------------------------------------------------- |
 | `.claude/docs/agent-tricks-and-troubleshooting.md` | **MANDATORY read before ANY Claude CLI or Codex CLI invocation** (reviews, sanity checks, or one-off runs) |
+| `.claude/docs/worktree.md`                         | Required local env and data symlinks when running dev servers or private-data checks from git worktrees    |
 
 ## Agent review workflows
 
@@ -68,6 +69,7 @@ pnpm run test:integration # Run integration tests (requires build)
 
 - `TS_PUBLIC_` prefix for client-accessible values
 - `TS_PRIVATE_` prefix for server-only values
+- In git worktrees, copy or symlink ignored local files such as `.env.local` and `data/` from the main checkout before running dev servers; see `.claude/docs/worktree.md`.
 
 **Formatting:**
 
@@ -127,6 +129,8 @@ Use it for:
 - reproducing layout and interaction issues
 
 Always develop and verify against the Vite dev server started with `pnpm run dev` (typical local target `http://127.0.0.1:5173/`). Do **not** use `pnpm run preview` (Vite preview) for development or verification: its preview server runs its own prerender/manifest step that can resolve routes differently from both dev and the production adapter-node server (e.g. newly added routes may 404 under preview while working everywhere else). `pnpm run preview` is only for sanity-checking a production build. Integration tests (`pnpm run test:integration`) intentionally run against a build via the test harness; that is separate from manual development.
+
+When using a git worktree, follow `.claude/docs/worktree.md` before starting the dev server so private env vars and cached vault datasets are available in that worktree.
 
 ```text
 http://127.0.0.1:5173/

--- a/README.md
+++ b/README.md
@@ -53,6 +53,10 @@ Environment variables required by the app are maintained in a checked-in `.env` 
 Put local-only secrets and overrides in `.env.local`, which is gitignored and loaded automatically
 by Vite/SvelteKit. Variables in `.env.local` override `.env`.
 
+When running from a git worktree, ignored local files are not copied from the main checkout. Symlink
+or copy `.env.local` and the `data/` cache before starting the dev server; see
+[worktree setup](./.claude/docs/worktree.md).
+
 Use the existing prefixes when adding variables:
 
 - `TS_PUBLIC_` for values that may be exposed client-side

--- a/docs/chart-pages.md
+++ b/docs/chart-pages.md
@@ -107,6 +107,9 @@ The dropdown and in-page selector can intentionally have different counts. For e
 
 Use Playwright integration tests for chart page navigation and route rendering. The integration test harness uses a test-mode build and Vite preview; for manual development and visual checks, use `pnpm run dev` instead.
 
+If the dev server runs from a git worktree, follow [worktree setup](../.claude/docs/worktree.md)
+first so private env vars and the historical vault parquet cache are available to chart endpoints.
+
 Useful checks:
 
 - Run unit tests for chart payload builders, e.g. `pnpm exec vitest run src/lib/echarts/core3-risk.test.ts`.

--- a/docs/tests.md
+++ b/docs/tests.md
@@ -70,6 +70,9 @@ pnpm run test:integration
 For normal development, keep checked-in defaults in `.env` and place local-only secrets in
 `.env.local`. Vite/SvelteKit loads `.env.local` automatically and it overrides `.env`.
 
+In git worktrees, `.env.local` is not copied from the main checkout. Symlink or copy it before
+running private-data tests or local dev servers; see [worktree setup](../.claude/docs/worktree.md).
+
 The regular integration suite intentionally stays deterministic and uses `.env.test` plus mock
 APIs. This means secret-backed features should not be added to the default `pnpm run test:integration`
 flow unless they can be mocked reliably.
@@ -99,6 +102,9 @@ You can safely run the dev server and test builds concurrently without cache cor
 ### Manual remote previews over Tailscale
 
 For manual browser checks from another machine, use the Vite dev server rather than Vite preview:
+
+If the dev server runs from a git worktree, first make sure `.env.local` and the `data/` cache are
+available in that worktree; see [worktree setup](../.claude/docs/worktree.md).
 
 ```shell
 pnpm run dev --host 0.0.0.0

--- a/docs/vault-data-source.md
+++ b/docs/vault-data-source.md
@@ -148,3 +148,7 @@ For local development, ensure R2 credentials are set in `.env.local`. All data s
 - Top vaults JSON is fetched on first page load and cached in memory for 1 hour
 - Vault prices parquet (~150 MB) is downloaded on first metrics request and cached locally with a 1-hour refresh interval
 - Treasury benchmark data is fetched from FRED on demand (no credentials needed) and cached for 24 hours
+
+When developing from a git worktree, `.env.local` and `data/` are ignored local files and are not
+created automatically. Symlink or copy them from the main checkout before starting the dev server;
+see [worktree setup](../.claude/docs/worktree.md).

--- a/src/lib/top-vaults/TopVaultsTable.svelte
+++ b/src/lib/top-vaults/TopVaultsTable.svelte
@@ -30,9 +30,11 @@
 		formatNumber,
 		formatPercent,
 		formatPercentProfit,
+		formatTokenAmount,
 		formatValue,
 		notFilledMarker
 	} from '$lib/helpers/formatters';
+	import { isStablecoinDepegged } from '$lib/stablecoin-metadata/helpers';
 	import {
 		DEFAULT_TVL_KEY,
 		DEFAULT_TVL_THRESHOLD,
@@ -44,6 +46,11 @@
 		getLockupTooltip,
 		getLifetimeMaxDrawdown,
 		getMonthlyReturn,
+		getVaultCurrentTvlUsd,
+		getVaultDenominationNativeRate,
+		getVaultDenominationCurrency,
+		getVaultPeakTvlUsd,
+		getVaultTvlNative,
 		hasSupportedProtocol,
 		isBlacklisted,
 		isGoodVaultStatus,
@@ -170,7 +177,14 @@
 			}
 		},
 		denomination: { defaultDirection: 'asc', compareFn: stringCompare((v) => v.denomination) },
-		tvl: { defaultDirection: 'desc', compareFn: rankVaultsBy(['current_nav', 'peak_nav']) },
+		tvl: {
+			defaultDirection: 'desc',
+			compareFn: (a: VaultInfo, b: VaultInfo) =>
+				rankVaultsBy(['current_tvl_usd', 'peak_tvl_usd'])(
+					{ current_tvl_usd: getVaultCurrentTvlUsd(a), peak_tvl_usd: getVaultPeakTvlUsd(a) },
+					{ current_tvl_usd: getVaultCurrentTvlUsd(b), peak_tvl_usd: getVaultPeakTvlUsd(b) }
+				)
+		},
 		age: { defaultDirection: 'desc', compareFn: rankVaultsBy(['years']) },
 		fees: { defaultDirection: 'asc', compareFn: rankVaultsBy(['mgmt_fee', 'perf_fee'], Infinity) },
 		lockup: { defaultDirection: 'asc', compareFn: rankVaultsBy(['lockup'], Infinity) },
@@ -316,11 +330,52 @@
 
 	const formatReturn = (v: MaybeNumber) => formatPercentProfit(v, 1);
 	const formatTvl = (v: MaybeNumber) => formatDollar(v, 2);
+	const formatTvlTokenAmount = (v: MaybeNumber, symbol: string) =>
+		v == null ? notFilledMarker : `${formatTokenAmount(v, 2)} ${symbol}`;
 	const formatVolatility = (v: MaybeNumber) => {
 		if (v == null) return notFilledMarker;
 		if (Math.abs(v) > VOLATILITY_CAP) return VOLATILITY_CAP_LABEL;
 		return formatPercent(v, 1);
 	};
+
+	function isFinitePositiveNumber(value: number | null | undefined): value is number {
+		return typeof value === 'number' && Number.isFinite(value) && value > 0;
+	}
+
+	function getVaultUsdRate(vault: VaultInfo): number | null {
+		const rate = vault.denomination_token_rate?.usd_rate;
+		return isFinitePositiveNumber(rate) ? rate : null;
+	}
+
+	function getVaultNativeRate(vault: VaultInfo): number | null {
+		return getVaultDenominationNativeRate(vault);
+	}
+
+	function formatNativeTvl(vault: VaultInfo, nav: number | null): string {
+		const currency = getVaultDenominationCurrency(vault);
+		if (!currency) return notFilledMarker;
+		const nativeTvl = getVaultTvlNative(vault, nav);
+		return nativeTvl == null ? notFilledMarker : `${formatTokenAmount(nativeTvl, 2)} ${currency.toUpperCase()}`;
+	}
+
+	function formatVaultExchangeRate(vault: VaultInfo): string {
+		const usdRate = getVaultUsdRate(vault);
+		if (usdRate == null) return notFilledMarker;
+
+		const currency = getVaultDenominationCurrency(vault);
+		const nativeRate = getVaultNativeRate(vault);
+		const nativeText =
+			currency && currency !== 'usd' && nativeRate != null
+				? ` (${formatTokenAmount(nativeRate, 4, 6)} ${currency.toUpperCase()})`
+				: '';
+
+		return `1 ${vault.denomination} = ${formatDollar(usdRate, 4, 6)}${nativeText}`;
+	}
+
+	function shouldShowTvlBreakdown(vault: VaultInfo): boolean {
+		const currency = getVaultDenominationCurrency(vault);
+		return currency != null && currency !== 'usd' ? true : isStablecoinDepegged(vault);
+	}
 
 	// filter out blacklisted vaults (unless includeBlacklisted, searching "blacklisted",
 	// or the risk dropdown includes blacklisted level)
@@ -339,10 +394,14 @@
 		return tvlThreshold;
 	}
 
+	function getVaultCurrentTvl(vault: VaultInfo): number {
+		return getVaultCurrentTvlUsd(vault) ?? 0;
+	}
+
 	// Get vaults hidden due to TVL threshold (only when filtering is enabled)
 	let hiddenVaults = $derived.by(() => {
 		if (!filterTvl && !showFilters) return [];
-		return baseVaults.filter((v) => (v.current_nav ?? 0) < getVaultTvlThreshold(v));
+		return baseVaults.filter((v) => getVaultCurrentTvl(v) < getVaultTvlThreshold(v));
 	});
 
 	// Count of hidden vaults
@@ -360,7 +419,7 @@
 
 			// TVL filter (prop-driven or dropdown-driven)
 			if (filterTvl || showFilters) {
-				if ((v.current_nav ?? 0) < getVaultTvlThreshold(v)) {
+				if (getVaultCurrentTvl(v) < getVaultTvlThreshold(v)) {
 					return false;
 				}
 			}
@@ -424,10 +483,12 @@
 	let statsVaults = $derived(filteredVaults.filter((v) => !isBlacklisted(v)));
 
 	// Calculate total TVL from non-blacklisted, fully-filtered vaults
-	let totalTvl = $derived(calculateTotalTvl(statsVaults));
+	let totalTvl = $derived(calculateTotalTvl(statsVaults.map((v) => ({ current_nav: getVaultCurrentTvlUsd(v) }))));
 
 	// Calculate TVL-weighted average 1M APY from non-blacklisted, fully-filtered vaults
-	let avgTvlWeightedApy1M = $derived(calculateTvlWeightedApy(statsVaults));
+	let avgTvlWeightedApy1M = $derived(
+		calculateTvlWeightedApy(statsVaults.map((v) => ({ ...v, current_nav: getVaultCurrentTvlUsd(v) })))
+	);
 
 	// sort vaults
 	let sortedVaults = $derived.by(() => {
@@ -582,6 +643,33 @@
 			lifetimeData
 		)}
 	</td>
+{/snippet}
+
+{#snippet tvlValues(vault: VaultInfo)}
+	<div class="multiline multival">
+		<span class="primary">{formatTvl(getVaultCurrentTvlUsd(vault))}</span>
+		<span class="secondary">{formatTvl(getVaultPeakTvlUsd(vault))}</span>
+	</div>
+{/snippet}
+
+{#snippet tvlBreakdown(label: string, nav: number | null, vault: VaultInfo)}
+	<section class="tvl-breakdown-section">
+		<h4>{label}</h4>
+		<dl>
+			<div>
+				<dt>{vault.denomination}</dt>
+				<dd>{formatTvlTokenAmount(nav, vault.denomination)}</dd>
+			</div>
+			<div>
+				<dt>USD</dt>
+				<dd>{formatTvl(nav == null ? null : getVaultCurrentTvlUsd({ ...vault, current_nav: nav }))}</dd>
+			</div>
+			<div>
+				<dt>{getVaultDenominationCurrency(vault)?.toUpperCase() ?? 'Native currency'}</dt>
+				<dd>{formatNativeTvl(vault, nav)}</dd>
+			</div>
+		</dl>
+	</section>
 {/snippet}
 
 <div class="top-vaults-table">
@@ -934,7 +1022,7 @@
 						'TVL USD<br/>(current/&ZeroWidthSpace;peak)',
 						'tvl',
 						'desc',
-						rankVaultsBy(['current_nav', 'peak_nav'])
+						sortColumnMap['tvl'].compareFn
 					)}
 					{@render sortColHeader('Age (y)', 'age', 'desc', rankVaultsBy(['years']))}
 					{@render sortColHeader(
@@ -1010,10 +1098,24 @@
 							{formatValue(vault.denomination)}
 						</td>
 						<td class="tvl right">
-							<div class="multiline multival">
-								<span class="primary">{formatTvl(vault.current_nav)}</span>
-								<span class="secondary">{formatTvl(vault.peak_nav)}</span>
-							</div>
+							{#if shouldShowTvlBreakdown(vault)}
+								<Tooltip>
+									<svelte:fragment slot="trigger">
+										<div class="tvl-tooltip-trigger">
+											{@render tvlValues(vault)}
+										</div>
+									</svelte:fragment>
+									<svelte:fragment slot="popup">
+										<div class="tvl-breakdown">
+											{@render tvlBreakdown('Current TVL', vault.current_nav, vault)}
+											{@render tvlBreakdown('Peak TVL', vault.peak_nav, vault)}
+											<p class="exchange-rate">Exchange rate: {formatVaultExchangeRate(vault)}</p>
+										</div>
+									</svelte:fragment>
+								</Tooltip>
+							{:else}
+								{@render tvlValues(vault)}
+							{/if}
 						</td>
 						<td class="age right">
 							{formatNumber(vault.years, 1)}
@@ -1523,6 +1625,61 @@
 
 			.tvl {
 				width: 6.25%;
+
+				.tvl-tooltip-trigger {
+					display: inline-grid;
+					justify-items: end;
+					cursor: help;
+				}
+
+				:global(.popup) {
+					right: 0;
+					width: min(90vw, 28rem);
+				}
+
+				.tvl-breakdown {
+					display: grid;
+					gap: 0.85rem;
+					min-width: min(22rem, 80vw);
+				}
+
+				.tvl-breakdown-section {
+					display: grid;
+					gap: 0.35rem;
+
+					h4 {
+						margin: 0;
+						font: var(--f-ui-sm-bold);
+					}
+
+					dl {
+						display: grid;
+						gap: 0.25rem;
+						margin: 0;
+					}
+
+					div {
+						display: grid;
+						grid-template-columns: minmax(7rem, 1fr) auto;
+						gap: 1rem;
+					}
+
+					dt {
+						color: var(--c-text-light);
+					}
+
+					dd {
+						margin: 0;
+						text-align: right;
+						font-weight: 600;
+					}
+				}
+
+				.exchange-rate {
+					margin: 0;
+					padding-top: 0.5rem;
+					border-top: 1px solid var(--c-text-ultra-light);
+				}
 			}
 
 			.age {

--- a/src/lib/top-vaults/VaultListingsSelector.svelte
+++ b/src/lib/top-vaults/VaultListingsSelector.svelte
@@ -8,7 +8,8 @@
 		{ href: '/trading-view/vaults/stablecoins', label: 'By stablecoin' },
 		{ href: '/trading-view/vaults/chains', label: 'By chain' },
 		{ href: '/trading-view/vaults/protocols', label: 'By protocol' },
-		{ href: '/trading-view/vaults/curators', label: 'By curator' }
+		{ href: '/trading-view/vaults/curators', label: 'By curator' },
+		{ href: '/trading-view/vaults/international', label: 'International' }
 	] as const;
 
 	const otherListLinks = [

--- a/src/lib/top-vaults/helpers.test.ts
+++ b/src/lib/top-vaults/helpers.test.ts
@@ -16,10 +16,51 @@ import {
 	getCore3RankingUrl,
 	getCore3ScoreTone,
 	getCore3CategoryScores,
+	getCurrencyUsdRates,
+	getVaultCurrentTvlUsd,
+	getVaultDenominationCurrency,
+	getVaultDenominationUsdRate,
+	getVaultPeakTvlUsd,
+	getVaultTvlNative,
+	isNonUsdDenominatedVault,
+	withVaultDenominationTokenRate,
 	calculateTvlWeightedApy
 } from './helpers';
-import type { Core3Protocol } from './schemas';
+import type { StablecoinMetadata } from '$lib/stablecoin-metadata/schemas';
+import type { Core3Protocol, DenominationTokenRate } from './schemas';
 import { createTestVault } from './test-utils';
+
+function createDenominationTokenRate(overrides: Partial<DenominationTokenRate> = {}): DenominationTokenRate {
+	return {
+		coingecko_id: null,
+		source_currency: null,
+		usd_rate: null,
+		usd_rate_fetched_at: null,
+		usd_rate_source: null,
+		native_rate: null,
+		native_rate_currency: null,
+		native_rate_fetched_at: null,
+		native_rate_source: null,
+		source_currency_usd_rate: null,
+		source_currency_usd_rate_fetched_at: null,
+		source_currency_usd_rate_source: null,
+		...overrides
+	};
+}
+
+function createStablecoinMetadata(overrides: Partial<StablecoinMetadata> = {}): StablecoinMetadata {
+	return {
+		symbol: 'EURA',
+		slug: 'eura',
+		name: 'Angle EURA',
+		short_description: 'Euro stablecoin',
+		description: 'Euro stablecoin',
+		category: 'stablecoin',
+		links: { homepage: null, coingecko: null, defillama: null, twitter: null },
+		logos: { light: null },
+		...overrides
+	};
+}
 
 describe('isBlacklisted', () => {
 	test('returns true for blacklisted vaults', () => {
@@ -150,6 +191,143 @@ describe('meetsMinTvl', () => {
 		const vaultAbove = createTestVault('Vault below', { current_nav: 10_000 });
 		expect(meetsMinTvl(vaultBelow)).toBe(false);
 		expect(meetsMinTvl(vaultAbove)).toBe(true);
+	});
+});
+
+describe('denomination TVL conversion', () => {
+	test('detects non-USD denomination from token rate metadata', () => {
+		const vault = createTestVault('EUR vault', {
+			denomination: 'EURS',
+			denomination_token_rate: createDenominationTokenRate({
+				native_rate_currency: 'eur',
+				usd_rate: 1.08
+			})
+		});
+
+		expect(getVaultDenominationCurrency(vault)).toBe('eur');
+		expect(isNonUsdDenominatedVault(vault)).toBe(true);
+	});
+
+	test('does not treat USD denomination as international', () => {
+		const vault = createTestVault('USDC vault', {
+			denomination_token_rate: createDenominationTokenRate({
+				native_rate_currency: 'usd',
+				usd_rate: 1
+			})
+		});
+
+		expect(getVaultDenominationCurrency(vault)).toBe('usd');
+		expect(isNonUsdDenominatedVault(vault)).toBe(false);
+	});
+
+	test('converts current and peak TVL to USD using the denomination token rate', () => {
+		const vault = createTestVault('EUR vault', {
+			current_nav: 100_000,
+			peak_nav: 120_000,
+			denomination_token_rate: createDenominationTokenRate({
+				native_rate_currency: 'eur',
+				usd_rate: 1.08
+			})
+		});
+
+		expect(getVaultCurrentTvlUsd(vault)).toBeCloseTo(108_000);
+		expect(getVaultPeakTvlUsd(vault)).toBeCloseTo(129_600);
+	});
+
+	test('infers EUR denomination when per-vault rate metadata is absent', () => {
+		const vault = createTestVault('EURCV vault', {
+			denomination: 'EURCV',
+			normalised_denomination: 'EURCV',
+			denomination_slug: 'eurcv'
+		});
+
+		expect(getVaultDenominationCurrency(vault)).toBe('eur');
+		expect(isNonUsdDenominatedVault(vault)).toBe(true);
+	});
+
+	test('keeps USD-branded denominations out of international listings', () => {
+		const vault = createTestVault('USDG vault', {
+			denomination: 'USDG',
+			normalised_denomination: 'USDG',
+			denomination_slug: 'usdg'
+		});
+
+		expect(getVaultDenominationCurrency(vault)).toBe('usd');
+		expect(isNonUsdDenominatedVault(vault)).toBe(false);
+	});
+
+	test('does not treat a missing non-USD exchange rate as one dollar', () => {
+		const vault = createTestVault('tGBP vault', {
+			current_nav: 100_000,
+			denomination: 'tGBP',
+			normalised_denomination: 'tGBP',
+			denomination_slug: 'tgbp'
+		});
+
+		expect(getVaultDenominationCurrency(vault)).toBe('gbp');
+		expect(getVaultDenominationUsdRate(vault)).toBeNull();
+		expect(getVaultCurrentTvlUsd(vault)).toBeNull();
+	});
+
+	test('enriches EUR vaults with currency fallback rates when token metadata has no USD rate', () => {
+		const vault = createTestVault('EURCV vault', {
+			current_nav: 100_000,
+			denomination: 'EURCV',
+			normalised_denomination: 'EURCV',
+			denomination_slug: 'eurcv'
+		});
+		const currencyUsdRates = getCurrencyUsdRates([
+			createStablecoinMetadata({
+				slug: 'eura',
+				symbol: 'EURA',
+				usd_rate: 1.14,
+				usd_rate_fetched_at: '2026-06-26T12:16:16Z',
+				peg_rate: 1,
+				peg_rate_currency: 'eur'
+			})
+		]);
+		const eurcvMetadata = createStablecoinMetadata({
+			slug: 'eurcv',
+			symbol: 'EURCV',
+			name: 'SG-FORGE EUR CoinVertible',
+			peg_rate_currency: null,
+			usd_rate: null,
+			peg_rate: null
+		});
+
+		const enrichedVault = withVaultDenominationTokenRate(vault, eurcvMetadata, currencyUsdRates);
+
+		expect(getVaultCurrentTvlUsd(enrichedVault)).toBeCloseTo(114_000);
+		expect(getVaultTvlNative(enrichedVault, enrichedVault.current_nav)).toBeCloseTo(100_000);
+		expect(enrichedVault.denomination_token_rate?.usd_rate_fetched_at).toBe('2026-06-26T12:16:16Z');
+		expect(enrichedVault.denomination_token_rate?.source_currency_usd_rate_fetched_at).toBe('2026-06-26T12:16:16Z');
+	});
+
+	test('replaces empty denomination token rate objects with inferred fallback rates', () => {
+		const vault = createTestVault('EURCV vault', {
+			current_nav: 100_000,
+			peak_nav: 120_000,
+			denomination: 'EURCV',
+			normalised_denomination: 'EURCV',
+			denomination_slug: 'eurcv',
+			denomination_token_rate: createDenominationTokenRate()
+		});
+		const currencyUsdRates = getCurrencyUsdRates([
+			createStablecoinMetadata({
+				slug: 'eura',
+				symbol: 'EURA',
+				usd_rate: 1.14,
+				usd_rate_fetched_at: '2026-06-26T12:16:16Z',
+				peg_rate: 1,
+				peg_rate_currency: 'eur'
+			})
+		]);
+
+		const enrichedVault = withVaultDenominationTokenRate(vault, undefined, currencyUsdRates);
+
+		expect(enrichedVault.denomination_token_rate?.usd_rate).toBe(1.14);
+		expect(getVaultCurrentTvlUsd(enrichedVault)).toBeCloseTo(114_000);
+		expect(getVaultPeakTvlUsd(enrichedVault)).toBeCloseTo(136_800);
 	});
 });
 

--- a/src/lib/top-vaults/helpers.ts
+++ b/src/lib/top-vaults/helpers.ts
@@ -1,4 +1,5 @@
-import type { Core3Pol, Core3Protocol, FeeMode, SlimVaultInfo, VaultInfo } from './schemas';
+import type { StablecoinMetadata } from '$lib/stablecoin-metadata/schemas';
+import type { Core3Pol, Core3Protocol, DenominationTokenRate, FeeMode, SlimVaultInfo, VaultInfo } from './schemas';
 import { slimVaultKeys } from './schemas';
 import { resolve } from '$app/paths';
 import { vaultSparklinesUrl } from '$lib/config';
@@ -203,6 +204,217 @@ export function meetsDefaultTvl(vault: Pick<VaultInfo, 'current_nav' | 'chain_id
 	return (vault.current_nav ?? 0) >= threshold;
 }
 
+type VaultDenominationFields = Pick<
+	VaultInfo,
+	'denomination' | 'normalised_denomination' | 'denomination_slug' | 'denomination_token_rate'
+>;
+type VaultWithRate = Pick<VaultInfo, 'denomination_token_rate'> & Partial<VaultDenominationFields>;
+type VaultWithNavAndRate = Pick<VaultInfo, 'current_nav' | 'denomination_token_rate'>;
+type VaultWithPeakNavAndRate = Pick<VaultInfo, 'peak_nav' | 'denomination_token_rate'>;
+
+export interface CurrencyUsdRate {
+	rate: number;
+	fetchedAt: string | null;
+}
+
+const nonUsdCurrencyCodes = ['eur', 'gbp', 'jpy', 'cad', 'chf', 'aud', 'try', 'sgd', 'brl', 'mxn', 'zar'] as const;
+
+function inferVaultDenominationCurrency(vault: Partial<VaultDenominationFields>): string | null {
+	const candidates = [vault.denomination_slug, vault.denomination, vault.normalised_denomination]
+		.map((value) => value?.trim().toLowerCase())
+		.filter((value): value is string => Boolean(value));
+
+	if (candidates.some((value) => value.includes('usd'))) return 'usd';
+
+	for (const currency of nonUsdCurrencyCodes) {
+		if (
+			candidates.some(
+				(value) =>
+					value === currency ||
+					value.startsWith(currency) ||
+					value.endsWith(currency) ||
+					value.includes(`${currency}-`) ||
+					value.includes(`-${currency}`)
+			)
+		) {
+			return currency;
+		}
+	}
+
+	return null;
+}
+
+/**
+ * Return the detected denomination currency for a vault, when rate metadata
+ * provides one. USD-denominated vaults resolve to `usd`; non-USD pegs resolve
+ * to currencies like `eur`, `gbp`, or `jpy`.
+ */
+export function getVaultDenominationCurrency(vault: VaultWithRate): string | null {
+	return (
+		vault.denomination_token_rate?.native_rate_currency?.toLowerCase() ??
+		vault.denomination_token_rate?.source_currency?.toLowerCase() ??
+		inferVaultDenominationCurrency(vault) ??
+		null
+	);
+}
+
+export function getStablecoinMetadataCurrency(metadata: StablecoinMetadata | undefined): string | null {
+	const currency = metadata?.peg_rate_currency?.toLowerCase();
+	if (!currency || currency === 'usd') return null;
+	return currency;
+}
+
+function isFinitePositiveNumber(value: number | null | undefined): value is number {
+	return typeof value === 'number' && Number.isFinite(value) && value > 0;
+}
+
+export function getCurrencyUsdRates(metadataIndex: StablecoinMetadata[]): Map<string, CurrencyUsdRate> {
+	const rates = new Map<string, CurrencyUsdRate[]>();
+
+	for (const metadata of metadataIndex) {
+		const currency = getStablecoinMetadataCurrency(metadata);
+		if (!currency || !isFinitePositiveNumber(metadata.usd_rate) || !isFinitePositiveNumber(metadata.peg_rate)) {
+			continue;
+		}
+
+		rates.set(currency, [
+			...(rates.get(currency) ?? []),
+			{
+				rate: metadata.usd_rate / metadata.peg_rate,
+				fetchedAt: metadata.usd_rate_fetched_at ?? metadata.usd_rate_updated_at ?? null
+			}
+		]);
+	}
+
+	return new Map(
+		[...rates.entries()].map(([currency, values]) => {
+			const sorted = values.toSorted((a, b) => a.rate - b.rate);
+			return [currency, sorted[Math.floor(sorted.length / 2)]];
+		})
+	);
+}
+
+export function buildVaultDenominationTokenRate(
+	metadata: StablecoinMetadata | undefined,
+	currency: string,
+	currencyUsdRates: Map<string, CurrencyUsdRate>
+): DenominationTokenRate | null {
+	const currencyUsdRate = currencyUsdRates.get(currency);
+	const usdRate = metadata?.usd_rate ?? currencyUsdRate?.rate ?? null;
+	if (!isFinitePositiveNumber(usdRate)) return null;
+	const usdRateFetchedAt =
+		metadata?.usd_rate_fetched_at ?? metadata?.usd_rate_updated_at ?? currencyUsdRate?.fetchedAt ?? null;
+
+	return {
+		coingecko_id: metadata?.coingecko_id ?? null,
+		source_currency: currency,
+		usd_rate: usdRate,
+		usd_rate_fetched_at: usdRateFetchedAt,
+		usd_rate_source: metadata?.usd_rate ? 'stablecoin-metadata' : 'stablecoin-metadata-currency-fallback',
+		native_rate: metadata?.peg_rate ?? null,
+		native_rate_currency: currency,
+		native_rate_fetched_at: metadata?.usd_rate_fetched_at ?? metadata?.usd_rate_updated_at ?? null,
+		native_rate_source: metadata?.peg_rate ? 'stablecoin-metadata' : null,
+		source_currency_usd_rate: currencyUsdRate?.rate ?? null,
+		source_currency_usd_rate_fetched_at: currencyUsdRate?.fetchedAt ?? null,
+		source_currency_usd_rate_source: currencyUsdRate ? 'stablecoin-metadata' : null
+	};
+}
+
+export function withVaultDenominationTokenRate(
+	vault: VaultInfo,
+	metadata: StablecoinMetadata | undefined,
+	currencyUsdRates: Map<string, CurrencyUsdRate>
+): VaultInfo {
+	if (isFinitePositiveNumber(vault.denomination_token_rate?.usd_rate)) return vault;
+
+	const vaultCurrency = getVaultDenominationCurrency(vault);
+	const metadataCurrency = getStablecoinMetadataCurrency(metadata);
+	const currency = vaultCurrency ?? metadataCurrency;
+	if (!currency || currency === 'usd') return vault;
+
+	const denominationTokenRate = buildVaultDenominationTokenRate(metadata, currency, currencyUsdRates);
+	if (!denominationTokenRate) return vault;
+
+	return {
+		...vault,
+		denomination_token_rate: denominationTokenRate
+	};
+}
+
+/**
+ * Whether the vault denomination is explicitly known to be non-USD.
+ *
+ * Backend rate metadata is preferred. When the vault feed has no rate metadata,
+ * common fiat denomination symbols are inferred conservatively so USD-branded
+ * symbols such as USDC, USDT, USDe, FDUSD and USDG stay classified as USD.
+ */
+export function isNonUsdDenominatedVault(vault: VaultWithRate): boolean {
+	const currency = getVaultDenominationCurrency(vault);
+	return currency != null && currency !== 'usd';
+}
+
+/**
+ * Return the vault denomination token USD conversion rate.
+ *
+ * Missing USD rates default to 1 only for USD-denominated or unknown-currency
+ * vaults, because existing vault pages already treat their NAV as USD. Known
+ * non-USD vaults return `null` when no exchange rate is available, avoiding an
+ * unconverted denomination-token NAV being displayed as dollars.
+ */
+export function getVaultDenominationUsdRate(vault: VaultWithRate): number | null {
+	const rate = vault.denomination_token_rate?.usd_rate;
+	if (rate != null && Number.isFinite(rate) && rate > 0) return rate;
+
+	const currency = getVaultDenominationCurrency(vault);
+	return currency == null || currency === 'usd' ? 1 : null;
+}
+
+export function getVaultDenominationNativeRate(vault: VaultWithRate): number | null {
+	const rate = vault.denomination_token_rate;
+	if (rate?.native_rate != null && Number.isFinite(rate.native_rate) && rate.native_rate > 0) return rate.native_rate;
+
+	const currency = getVaultDenominationCurrency(vault);
+	if (currency === 'usd') return getVaultDenominationUsdRate(vault);
+
+	if (
+		rate?.usd_rate != null &&
+		Number.isFinite(rate.usd_rate) &&
+		rate.usd_rate > 0 &&
+		rate.source_currency_usd_rate != null &&
+		Number.isFinite(rate.source_currency_usd_rate) &&
+		rate.source_currency_usd_rate > 0
+	) {
+		return rate.usd_rate / rate.source_currency_usd_rate;
+	}
+
+	return null;
+}
+
+export function getVaultTvlNative(vault: VaultWithRate, nav: number | null): number | null {
+	if (nav == null) return null;
+	const nativeRate = getVaultDenominationNativeRate(vault);
+	return nativeRate == null ? null : nav * nativeRate;
+}
+
+/**
+ * Current vault TVL converted from denomination token units to USD.
+ */
+export function getVaultCurrentTvlUsd(vault: VaultWithNavAndRate): number | null {
+	if (vault.current_nav == null) return null;
+	const usdRate = getVaultDenominationUsdRate(vault);
+	return usdRate == null ? null : vault.current_nav * usdRate;
+}
+
+/**
+ * Peak vault TVL converted from denomination token units to USD.
+ */
+export function getVaultPeakTvlUsd(vault: VaultWithPeakNavAndRate): number | null {
+	if (vault.peak_nav == null) return null;
+	const usdRate = getVaultDenominationUsdRate(vault);
+	return usdRate == null ? null : vault.peak_nav * usdRate;
+}
+
 const DEFAULT_DETAIL_RISK_FILTER = riskFilterOptions[1];
 
 /**
@@ -321,12 +533,15 @@ export function getFeeModeDescription(mode: string | null | undefined): string {
  */
 const MAX_APY_THRESHOLD = 10;
 
+type TvlWeightedApyVault = Pick<VaultInfo, 'current_nav' | 'one_month_cagr_net' | 'one_month_cagr' | 'risk_numeric'> &
+	Partial<Pick<VaultInfo, 'risk'>>;
+
 /**
  * Calculate TVL-weighted average APY for an array of vaults.
  * Uses net returns when available, falls back to gross returns.
  * Excludes blacklisted vaults and vaults with APY > 1000%.
  */
-export function calculateTvlWeightedApy(vaults: SlimVaultInfo[]): number | null {
+export function calculateTvlWeightedApy(vaults: TvlWeightedApyVault[]): number | null {
 	let weightedSum = 0;
 	let tvlSum = 0;
 

--- a/src/routes/trading-view/vaults/[vault=slug]/+page.server.ts
+++ b/src/routes/trading-view/vaults/[vault=slug]/+page.server.ts
@@ -2,7 +2,12 @@ import { getChain } from '$lib/helpers/chain';
 import { fetchStablecoinMetadataIndex } from '$lib/stablecoin-metadata/client';
 import { buildStablecoinMetadataLookup, findStablecoinMetadata } from '$lib/stablecoin-metadata/helpers';
 import { getCachedTopVaults } from '$lib/top-vaults/cache';
-import { getCore3ProtocolForVault, resolveVaultDetails } from '$lib/top-vaults/helpers.js';
+import {
+	getCore3ProtocolForVault,
+	getCurrencyUsdRates,
+	resolveVaultDetails,
+	withVaultDenominationTokenRate
+} from '$lib/top-vaults/helpers.js';
 import { fetchVaultProtocolMetadata } from '$lib/vault-protocol/client';
 import { error, redirect } from '@sveltejs/kit';
 
@@ -36,6 +41,11 @@ export async function load({ params, fetch }) {
 		vault.denomination,
 		vault.normalised_denomination
 	);
+	const vaultWithRates = withVaultDenominationTokenRate(
+		vault,
+		stablecoinMetadata,
+		getCurrencyUsdRates(stablecoinMetadataIndex)
+	);
 
-	return { vault, chain, protocolMetadata, stablecoinMetadata, generated_at, core3 };
+	return { vault: vaultWithRates, chain, protocolMetadata, stablecoinMetadata, generated_at, core3 };
 }

--- a/src/routes/trading-view/vaults/[vault=slug]/+page.svelte
+++ b/src/routes/trading-view/vaults/[vault=slug]/+page.svelte
@@ -10,7 +10,8 @@
 	import SocialMediaTags from './SocialMetaTags.svelte';
 	import VaultPageHeader from './VaultPageHeader.svelte';
 	import ChartWithFeaturedMetrics from './ChartWithFeaturedMetrics.svelte';
-	import VaultUtilisationChart from '$lib/top-vaults/VaultUtilisationChart.svelte';
+	// Vault protocols do not report useful utilisation data.
+	// import VaultUtilisationChart from '$lib/top-vaults/VaultUtilisationChart.svelte';
 	import VaultMetrics from './VaultMetrics.svelte';
 	import VaultTechnicalDetailsTable from './VaultTechnicalDetailsTable.svelte';
 	import VaultPeriodicMetrics from './VaultPeriodicMetrics.svelte';
@@ -92,7 +93,9 @@
 			protocolLogoUrl={protocolMetadata ? getVaultProtocolLogoUrl(protocolMetadata.slug) : undefined}
 		/>
 
+		<!-- Vault protocols do not report useful utilisation data.
 		<VaultUtilisationChart {vault} />
+		-->
 
 		<VaultMetrics {vault} />
 

--- a/src/routes/trading-view/vaults/[vault=slug]/ChartWithFeaturedMetrics.svelte
+++ b/src/routes/trading-view/vaults/[vault=slug]/ChartWithFeaturedMetrics.svelte
@@ -5,7 +5,13 @@
 	import Profitability from '$lib/components/Profitability.svelte';
 	import Tooltip from '$lib/components/Tooltip.svelte';
 	import Metric from './Metric.svelte';
-	import { formatDollar, formatNumber, formatPercent } from '$lib/helpers/formatters';
+	import { formatDollar, formatNumber, formatPercent, formatTokenAmount } from '$lib/helpers/formatters';
+	import {
+		getVaultCurrentTvlUsd,
+		getVaultDenominationCurrency,
+		getVaultPeakTvlUsd,
+		getVaultTvlNative
+	} from '$lib/top-vaults/helpers';
 
 	interface Props {
 		vault: VaultInfo;
@@ -13,6 +19,21 @@
 	}
 
 	let { vault, protocolLogoUrl }: Props = $props();
+
+	let denominationCurrency = $derived(getVaultDenominationCurrency(vault));
+	let showNativeTvl = $derived(denominationCurrency != null && denominationCurrency !== 'usd');
+	let currentNativeTvl = $derived(getVaultTvlNative(vault, vault.current_nav));
+	let peakNativeTvl = $derived(getVaultTvlNative(vault, vault.peak_nav));
+	let nativeTvlLabel = $derived.by(() => {
+		if (!showNativeTvl || currentNativeTvl == null || !denominationCurrency) return null;
+
+		const peak = peakNativeTvl == null ? '' : ` / ${formatNativeTvlAmount(peakNativeTvl)}`;
+		return `(${formatNativeTvlAmount(currentNativeTvl)}${peak}) ${denominationCurrency.toUpperCase()}`;
+	});
+
+	function formatNativeTvlAmount(value: number | null): string {
+		return value == null ? '' : formatTokenAmount(value, 2);
+	}
 </script>
 
 <MetricsBox>
@@ -38,8 +59,11 @@
 				{/if}
 			</Metric>
 			<Metric size="xl" label="Total value locked">
-				{formatDollar(vault.current_nav, 1)}
-				<div class="sm">peak {formatDollar(vault.peak_nav, 1)}</div>
+				{formatDollar(getVaultCurrentTvlUsd(vault), 1)}
+				<div class="sm">peak {formatDollar(getVaultPeakTvlUsd(vault), 1)}</div>
+				{#if nativeTvlLabel}
+					<div class="sm">{nativeTvlLabel}</div>
+				{/if}
 			</Metric>
 			<div class="desktop">
 				<Metric size="lg" label="3M Sharpe">

--- a/src/routes/trading-view/vaults/[vault=slug]/VaultTechnicalDetailsTable.svelte
+++ b/src/routes/trading-view/vaults/[vault=slug]/VaultTechnicalDetailsTable.svelte
@@ -4,9 +4,15 @@
 	import { getExplorerUrl } from '$lib/helpers/chain';
 	import MetricsBox from '$lib/components/MetricsBox.svelte';
 	import { CopyWidget, HashAddress, Timestamp, Tooltip } from '$lib/components';
-	import { formatAmount, notFilledMarker } from '$lib/helpers/formatters';
+	import { formatAmount, formatDollar, notFilledMarker } from '$lib/helpers/formatters';
 	import { parseDate } from '$lib/helpers/date';
-	import { getFeeModeLabel, getFeeModeDescription } from '$lib/top-vaults/helpers';
+	import {
+		getFeeModeLabel,
+		getFeeModeDescription,
+		getVaultDenominationUsdRate,
+		getVaultDenominationCurrency,
+		getVaultTvlNative
+	} from '$lib/top-vaults/helpers';
 	import { getStablecoinLogoUrl, resolveStablecoinSlug } from '$lib/stablecoin-metadata/helpers';
 	import type { StablecoinMetadata } from '$lib/stablecoin-metadata/schemas';
 	import { getLogoUrl } from '$lib/helpers/assets';
@@ -38,6 +44,16 @@
 
 		return `${fullName} (${symbol})`;
 	});
+	let denominationCurrency = $derived(getVaultDenominationCurrency(vault));
+	let nativeCurrencySymbol = $derived(denominationCurrency?.toUpperCase());
+	let showNativeTvlRows = $derived(denominationCurrency != null && denominationCurrency !== 'usd');
+	let lifetimePeriod = $derived(vault.period_results?.find((p) => p.period.toLowerCase() === 'lifetime') ?? null);
+	let denominationPageSlug = $derived(denominationSlug ?? vault.denomination_slug);
+	let exchangeRateFetchedAt = $derived(
+		vault.denomination_token_rate?.usd_rate_fetched_at ??
+			vault.denomination_token_rate?.source_currency_usd_rate_fetched_at ??
+			null
+	);
 
 	let lastUpdatedStale = $derived.by(() => {
 		const lastUpdated = parseDate(vault.last_updated_at);
@@ -57,6 +73,16 @@
 				address: vault.denomination_token_address
 			},
 			type: 'denomination' as const
+		},
+		{
+			label: 'Exchange rate used',
+			value: {
+				usdRate: getVaultDenominationUsdRate(vault),
+				symbol: vault.denomination,
+				slug: denominationPageSlug,
+				fetchedAt: exchangeRateFetchedAt
+			},
+			type: 'exchangeRate' as const
 		},
 		{
 			label: 'Share token',
@@ -83,6 +109,26 @@
 			value: { amount: vault.peak_nav, symbol: vault.denomination },
 			type: 'currency' as const
 		},
+		...(showNativeTvlRows && nativeCurrencySymbol
+			? [
+					{
+						label: `TVL low (${nativeCurrencySymbol})`,
+						value: {
+							amount: getVaultTvlNative(vault, lifetimePeriod?.tvl_low ?? null),
+							symbol: nativeCurrencySymbol
+						},
+						type: 'currency' as const
+					},
+					{
+						label: `TVL high (${nativeCurrencySymbol})`,
+						value: {
+							amount: getVaultTvlNative(vault, lifetimePeriod?.tvl_high ?? null),
+							symbol: nativeCurrencySymbol
+						},
+						type: 'currency' as const
+					}
+				]
+			: []),
 		{
 			label: 'Last share price',
 			value: { amount: vault.last_share_price, symbol: vault.denomination },
@@ -124,6 +170,11 @@
 			default:
 				return String(value);
 		}
+	}
+
+	function formatExchangeRate(usdRate: number | null | undefined, symbol: string): string {
+		if (usdRate == null) return notFilledMarker;
+		return `1 ${symbol} = ${formatDollar(usdRate, 4, 6)}`;
 	}
 </script>
 
@@ -181,6 +232,21 @@
 										{/if}
 										{row.value.name}
 									</a>
+								{/if}
+							{:else if row.type === 'exchangeRate'}
+								{#if row.value.usdRate != null}
+									<span class="exchange-rate-cell">
+										<a href="/trading-view/vaults/stablecoins/{row.value.slug}">
+											{formatExchangeRate(row.value.usdRate, row.value.symbol)}
+										</a>
+										{#if row.value.fetchedAt}
+											<span class="secondary">
+												fetched <Timestamp date={row.value.fetchedAt} relative />
+											</span>
+										{/if}
+									</span>
+								{:else}
+									{notFilledMarker}
 								{/if}
 							{:else if row.type === 'token'}
 								{#if row.value.address}
@@ -357,6 +423,18 @@
 		display: inline-flex;
 		align-items: center;
 		gap: 0.4em;
+	}
+
+	.exchange-rate-cell {
+		display: inline-flex;
+		flex-wrap: wrap;
+		align-items: baseline;
+		gap: 0.4rem;
+	}
+
+	.secondary {
+		color: var(--c-text-extra-light);
+		font: var(--f-ui-sm-roman);
 	}
 
 	.denomination-logo,

--- a/src/routes/trading-view/vaults/international/+page.svelte
+++ b/src/routes/trading-view/vaults/international/+page.svelte
@@ -1,0 +1,121 @@
+<!--
+International vault listing for non-USD-denominated vaults.
+-->
+<script lang="ts">
+	import { page } from '$app/state';
+	import { MetaTags, JsonLd } from 'svelte-meta-tags';
+	import TopVaultsPage from '$lib/top-vaults/TopVaultsPage.svelte';
+	import { fetchStablecoinMetadataIndex } from '$lib/stablecoin-metadata/client';
+	import { buildStablecoinMetadataLookup, findStablecoinMetadata } from '$lib/stablecoin-metadata/helpers';
+	import type { StablecoinMetadata } from '$lib/stablecoin-metadata/schemas';
+	import { fetchAllVaultData, hasVaultCache } from '$lib/top-vaults/client-cache';
+	import {
+		type CurrencyUsdRate,
+		getCurrencyUsdRates,
+		getVaultCurrentTvlUsd,
+		getVaultDenominationCurrency,
+		isNonUsdDenominatedVault,
+		withVaultDenominationTokenRate
+	} from '$lib/top-vaults/helpers';
+	import type { TopVaults, VaultInfo } from '$lib/top-vaults/schemas';
+	import { formatDollar } from '$lib/helpers/formatters';
+
+	let topVaults = $state<TopVaults>();
+	let loading = $state(!hasVaultCache());
+
+	function formatCurrencyList(currencies: string[]): string {
+		if (currencies.length === 0) return 'unknown currencies';
+		if (currencies.length === 1) return currencies[0];
+		if (currencies.length === 2) return `${currencies[0]} and ${currencies[1]}`;
+
+		return `${currencies.slice(0, -1).join(', ')}, and ${currencies[currencies.length - 1]}`;
+	}
+
+	function getVaultMetadata(vault: VaultInfo, lookup: Map<string, StablecoinMetadata>): StablecoinMetadata | undefined {
+		return findStablecoinMetadata(lookup, vault.denomination_slug, vault.denomination, vault.normalised_denomination);
+	}
+
+	function toInternationalVault(
+		vault: VaultInfo,
+		lookup: Map<string, StablecoinMetadata>,
+		currencyUsdRates: Map<string, CurrencyUsdRate>
+	): VaultInfo | null {
+		const metadata = getVaultMetadata(vault, lookup);
+		const enrichedVault = withVaultDenominationTokenRate(vault, metadata, currencyUsdRates);
+
+		return isNonUsdDenominatedVault(enrichedVault) && getVaultCurrentTvlUsd(enrichedVault) != null
+			? enrichedVault
+			: null;
+	}
+
+	$effect(() => {
+		Promise.all([fetchAllVaultData(), fetchStablecoinMetadataIndex(fetch)])
+			.then(([allData, metadataIndex]) => {
+				const lookup = buildStablecoinMetadataLookup(metadataIndex);
+				const currencyUsdRates = getCurrencyUsdRates(metadataIndex);
+				const internationalVaults = allData.vaults
+					.map((vault) => toInternationalVault(vault, lookup, currencyUsdRates))
+					.filter((vault): vault is VaultInfo => vault != null && isNonUsdDenominatedVault(vault));
+
+				topVaults = {
+					...allData,
+					vaults: internationalVaults
+				};
+			})
+			.catch((e) => console.error('Failed to load vault data:', e))
+			.finally(() => (loading = false));
+	});
+
+	const title = 'International DeFi vaults';
+	const description =
+		'Non-USD-denominated DeFi vaults, with TVL converted to USD using the latest denomination token exchange rates.';
+	let pageUrl = $derived(new URL(page.url.pathname, page.url.origin).href);
+	let pageSubtitle = $derived.by(() => {
+		if (!topVaults) return 'Loading non-USD vault TVL and currencies.';
+
+		const vaults = topVaults.vaults;
+		const totalTvlUsd = vaults.reduce((sum, vault) => sum + (getVaultCurrentTvlUsd(vault) ?? 0), 0);
+		const currencies = [
+			...new Set(
+				vaults
+					.map((vault) => getVaultDenominationCurrency(vault)?.toUpperCase())
+					.filter((currency): currency is string => Boolean(currency))
+			)
+		].toSorted((a, b) => a.localeCompare(b));
+
+		return `Total ${vaults.length} non-USD vaults with ${formatDollar(totalTvlUsd, 0)} USD TVL with currencies of ${formatCurrencyList(currencies)}.`;
+	});
+</script>
+
+<MetaTags
+	{title}
+	{description}
+	canonical={pageUrl}
+	openGraph={{ siteName: 'Trading Strategy', url: pageUrl, title, description, type: 'website' }}
+	twitter={{ site: '@TradingProtocol', cardType: 'summary', title, description }}
+/>
+
+<JsonLd
+	schema={{
+		'@context': 'http://schema.org',
+		'@type': 'CollectionPage',
+		name: title,
+		description,
+		url: pageUrl,
+		provider: { '@type': 'Organization', name: 'Trading Strategy' },
+		mainEntity: {
+			'@type': 'ItemList',
+			numberOfItems: topVaults?.vaults.length ?? 0
+		}
+	}}
+/>
+
+<TopVaultsPage
+	{topVaults}
+	{loading}
+	title="International stablecoin vaults"
+	subtitle={pageSubtitle}
+	showFilters
+	defaultTvlKey="10k"
+	defaultHideUnknown={0}
+/>

--- a/src/routes/trading-view/vaults/sitemap.xml/+server.ts
+++ b/src/routes/trading-view/vaults/sitemap.xml/+server.ts
@@ -15,6 +15,7 @@ const priority = 0.8;
 const staticSubPages = [
 	'all',
 	'high-tvl',
+	'international',
 	'new-vaults',
 	'current-peak-tvl',
 	'cumulative-tvl-apy',


### PR DESCRIPTION
## Why

Non-USD vaults need a dedicated listing and detail-page handling so their TVL is shown consistently in USD while still exposing the denomination and native currency context. The existing pages treated some non-USD vault NAV values as already-dollar-denominated or skipped conversion when the backend supplied an empty denomination rate object.

## Lessons learnt

Git worktrees do not copy ignored local files such as `.env.local` and `data/`, so private vault chart data can fail locally even when the main checkout works. The new worktree documentation records the required env and data symlink setup.

EURCV metadata may not have its own USD rate, so the frontend needs to infer the native currency and use stablecoin metadata fallback rates. Empty `denomination_token_rate` objects should not block that enrichment.

## Summary

- Add an International vault listing page for non-USD vaults and include it in vault listing navigation and the sitemap.
- Convert current and peak TVL through denomination exchange rates in listings and vault detail metrics, including native-currency context and tooltips for non-USD/depegged vaults.
- Enrich vault detail loads with stablecoin metadata fallback rates, including fetched timestamps and empty-rate-object handling.
- Hide the utilisation chart on vault detail pages because vault protocols do not report useful utilisation data.
- Add worktree documentation and cross-links for local env/data setup.