### PR TITLE
docs: mention sharp libvips install workaround

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,13 @@ pnpm --version
 pnpm install --frozen-lockfile
 ```
 
+If `sharp` tries to build from source because Homebrew `libvips` is installed, use the prebuilt
+binary instead:
+
+```shell
+SHARP_IGNORE_GLOBAL_LIBVIPS=1 pnpm install --frozen-lockfile
+```
+
 ## Install and build submodules
 
 `frontend` has one submodule dependency installed under `deps`:


### PR DESCRIPTION
Why

Document the install workaround for local macOS setups where Homebrew libvips makes sharp attempt a source build.

Lessons learnt

sharp may ignore its downloaded prebuilt binary when a compatible global libvips is present, so setting SHARP_IGNORE_GLOBAL_LIBVIPS=1 keeps installs on the simpler prebuilt path.

Summary

- Added a README note showing SHARP_IGNORE_GLOBAL_LIBVIPS=1 pnpm install --frozen-lockfile for the sharp/libvips install failure.