### PR TITLE
Update international vault metadata

### DIFF
--- a/src/routes/trading-view/vaults/international/+page.svelte
+++ b/src/routes/trading-view/vaults/international/+page.svelte
@@ -66,9 +66,8 @@ International vault listing for non-USD-denominated vaults.
 			.finally(() => (loading = false));
 	});
 
-	const title = 'International DeFi vaults';
-	const description =
-		'Non-USD-denominated DeFi vaults, with TVL converted to USD using the latest denomination token exchange rates.';
+	const title = 'International stablecoin vaults';
+	const description = 'DeFi vaults nominated in CHF, EUR, GBP, JPY, SGD, and TRY';
 	let pageUrl = $derived(new URL(page.url.pathname, page.url.origin).href);
 	let pageSubtitle = $derived.by(() => {
 		if (!topVaults) return 'Loading non-USD vault TVL and currencies.';

--- a/tests/integration/trading-view/vaults/stablecoins.test.ts
+++ b/tests/integration/trading-view/vaults/stablecoins.test.ts
@@ -78,6 +78,24 @@ test.describe('stablecoins index page', () => {
 		);
 	});
 
+	test('uses the updated international vault metadata title and description', async ({ page }) => {
+		await page.goto('/trading-view/vaults/international');
+
+		await expect(page).toHaveTitle('International stablecoin vaults');
+		await expect(page.locator('meta[name="description"]')).toHaveAttribute(
+			'content',
+			'DeFi vaults nominated in CHF, EUR, GBP, JPY, SGD, and TRY'
+		);
+		await expect(page.locator('meta[property="og:title"]')).toHaveAttribute(
+			'content',
+			'International stablecoin vaults'
+		);
+		await expect(page.locator('meta[property="og:description"]')).toHaveAttribute(
+			'content',
+			'DeFi vaults nominated in CHF, EUR, GBP, JPY, SGD, and TRY'
+		);
+	});
+
 	test('has no JavaScript errors after the chart loads', async ({ page }) => {
 		const errors: string[] = [];
 		page.on('pageerror', (err) => errors.push(err.message));


### PR DESCRIPTION
## Why

The international stablecoin vault listing needs page metadata that matches the requested SEO copy.

## Lessons learnt

The international vault page uses shared `MetaTags` values for the HTML title, meta description, Open Graph, Twitter card, and JSON-LD metadata, so updating the route constants keeps those surfaces aligned.

## Summary

- Updated the `/trading-view/vaults/international` title and meta description.
- Added integration coverage for the international vault metadata values.