### PR TITLE
Fix vault curator logo and empty rankings

### DIFF
--- a/src/lib/top-vaults/VaultPriceChart.svelte
+++ b/src/lib/top-vaults/VaultPriceChart.svelte
@@ -22,6 +22,7 @@ so relative performance is comparable on a single axis.
 	import SeriesLabel from '$lib/charts/SeriesLabel.svelte';
 	import ChartTooltip from '$lib/charts/ChartTooltip.svelte';
 	import Tooltip from '$lib/components/Tooltip.svelte';
+	import { removeOnError } from '$lib/actions/image';
 	import { getLogoUrl } from '$lib/helpers/assets';
 	import { isPerpetualFuturesVault } from './isPerpetualFuturesVault';
 	import type { PriceScaleCalculator, SimpleDataItem } from '$lib/charts/types';
@@ -49,11 +50,11 @@ so relative performance is comparable on a single axis.
 
 	interface Props {
 		vault: VaultInfo;
-		/** Optional protocol logo URL to use instead of Trading Strategy brand mark */
-		protocolLogoUrl?: string;
+		/** Optional logo URL for the vault legend item, preferring curator over protocol logos. */
+		chartLogoUrl?: string;
 	}
 
-	let { vault, protocolLogoUrl }: Props = $props();
+	let { vault, chartLogoUrl }: Props = $props();
 
 	let showCryptoBenchmarks = $derived(isPerpetualFuturesVault(vault));
 
@@ -150,12 +151,12 @@ so relative performance is comparable on a single axis.
 	const benchmarkLegend: LegendItem[] = $derived(
 		showCryptoBenchmarks
 			? [
-					{ label: vault.name, color: getVaultColor(vaultDirection), logoUrl: protocolLogoUrl },
+					{ label: vault.name, color: getVaultColor(vaultDirection), logoUrl: chartLogoUrl },
 					{ label: 'BTC', color: '#f7931a80', logoUrl: getLogoUrl('token', 'btc') },
 					{ label: 'ETH', color: '#627eea80', logoUrl: getLogoUrl('token', 'eth') }
 				]
 			: [
-					{ label: vault.name, color: getVaultColor(vaultDirection), logoUrl: protocolLogoUrl },
+					{ label: vault.name, color: getVaultColor(vaultDirection), logoUrl: chartLogoUrl },
 					{
 						label: 'US 3M T-bill',
 						color: '#4a90d9a0',
@@ -344,7 +345,7 @@ so relative performance is comparable on a single axis.
 							>
 								<span class="legend-swatch" aria-hidden="true"></span>
 								{#if benchmark.logoUrl}
-									<img class="legend-logo" src={benchmark.logoUrl} alt="" aria-hidden="true" />
+									<img class="legend-logo" src={benchmark.logoUrl} alt="" aria-hidden="true" use:removeOnError />
 								{/if}
 								<span>{benchmark.label}</span>
 							</a>
@@ -359,7 +360,7 @@ so relative performance is comparable on a single axis.
 						<div class="legend-item" style:--legend-color={benchmark.color}>
 							<span class="legend-swatch" aria-hidden="true"></span>
 							{#if benchmark.logoUrl}
-								<img class="legend-logo" src={benchmark.logoUrl} alt="" aria-hidden="true" />
+								<img class="legend-logo" src={benchmark.logoUrl} alt="" aria-hidden="true" use:removeOnError />
 							{/if}
 							<span>{benchmark.label}</span>
 						</div>

--- a/src/routes/trading-view/vaults/[vault=slug]/+page.svelte
+++ b/src/routes/trading-view/vaults/[vault=slug]/+page.svelte
@@ -44,6 +44,12 @@
 					? 'Withdrawals may be disabled for this vault'
 					: undefined
 	);
+	let chartLogoUrl = $derived(
+		curatorMetadata?.logos.generic ??
+			curatorMetadata?.logos.light ??
+			curatorMetadata?.logos.dark ??
+			(protocolMetadata ? getVaultProtocolLogoUrl(protocolMetadata.slug) : undefined)
+	);
 </script>
 
 <SocialMediaTags {vault} {chain} {protocolMetadata} />
@@ -89,10 +95,7 @@
 
 		<VaultRankings {vault} {chain} {protocolMetadata} />
 
-		<ChartWithFeaturedMetrics
-			{vault}
-			protocolLogoUrl={protocolMetadata ? getVaultProtocolLogoUrl(protocolMetadata.slug) : undefined}
-		/>
+		<ChartWithFeaturedMetrics {vault} {chartLogoUrl} />
 
 		<!-- Vault protocols do not report useful utilisation data.
 		<VaultUtilisationChart {vault} />

--- a/src/routes/trading-view/vaults/[vault=slug]/ChartWithFeaturedMetrics.svelte
+++ b/src/routes/trading-view/vaults/[vault=slug]/ChartWithFeaturedMetrics.svelte
@@ -15,10 +15,10 @@
 
 	interface Props {
 		vault: VaultInfo;
-		protocolLogoUrl?: string;
+		chartLogoUrl?: string;
 	}
 
-	let { vault, protocolLogoUrl }: Props = $props();
+	let { vault, chartLogoUrl }: Props = $props();
 
 	let denominationCurrency = $derived(getVaultDenominationCurrency(vault));
 	let showNativeTvl = $derived(denominationCurrency != null && denominationCurrency !== 'usd');
@@ -38,7 +38,7 @@
 
 <MetricsBox>
 	<div class="chart-area">
-		<VaultPriceChart {vault} {protocolLogoUrl} />
+		<VaultPriceChart {vault} {chartLogoUrl} />
 
 		<div class="divider"></div>
 

--- a/src/routes/trading-view/vaults/[vault=slug]/VaultRankings.svelte
+++ b/src/routes/trading-view/vaults/[vault=slug]/VaultRankings.svelte
@@ -15,40 +15,51 @@
 
 	let { vault, chain, protocolMetadata }: Props = $props();
 
-	let period1m = $derived(vault.period_results.find((p) => p.period === '1M'))!;
+	let period1m = $derived(vault.period_results.find((p) => p.period === '1M'));
+	let hasRankings = $derived(
+		period1m?.ranking_overall != null || period1m?.ranking_chain != null || period1m?.ranking_protocol != null
+	);
 </script>
 
-<div class="vault-rankings">
-	<span>🏆</span>
+{#if hasRankings}
+	<div class="vault-rankings">
+		<span>🏆</span>
 
-	<ul>
-		<li>
-			<span class="rank">#{period1m.ranking_overall}</span>
-			<a href={resolve('/trading-view/vaults')}>overall</a>
-		</li>
-		<li>
-			<span class="rank">#{period1m.ranking_chain}</span>
-			on
-			<EntitySymbol size="0.875em" logoUrl={getLogoUrl('blockchain', chain?.slug)}>
-				<a href={resolve(`/trading-view/vaults/chains/${chain?.slug}`)}>
-					{chain?.name}
-				</a>
-			</EntitySymbol>
-		</li>
-		<li>
-			<span class="rank">#{period1m.ranking_protocol}</span>
-			on
-			<EntitySymbol
-				size="0.875em"
-				logoUrl={protocolMetadata ? getVaultProtocolLogoUrl(protocolMetadata.slug) : undefined}
-			>
-				<a href={resolve(`/trading-view/vaults/protocols/${vault.protocol_slug}`)}>
-					{vault.protocol}
-				</a>
-			</EntitySymbol>
-		</li>
-	</ul>
-</div>
+		<ul>
+			{#if period1m?.ranking_overall != null}
+				<li>
+					<span class="rank">#{period1m.ranking_overall}</span>
+					<a href={resolve('/trading-view/vaults')}>overall</a>
+				</li>
+			{/if}
+			{#if period1m?.ranking_chain != null && chain}
+				<li>
+					<span class="rank">#{period1m.ranking_chain}</span>
+					on
+					<EntitySymbol size="0.875em" logoUrl={getLogoUrl('blockchain', chain.slug)}>
+						<a href={`/trading-view/vaults/chains/${chain.slug}`}>
+							{chain.name}
+						</a>
+					</EntitySymbol>
+				</li>
+			{/if}
+			{#if period1m?.ranking_protocol != null}
+				<li>
+					<span class="rank">#{period1m.ranking_protocol}</span>
+					on
+					<EntitySymbol
+						size="0.875em"
+						logoUrl={protocolMetadata ? getVaultProtocolLogoUrl(protocolMetadata.slug) : undefined}
+					>
+						<a href={`/trading-view/vaults/protocols/${vault.protocol_slug}`}>
+							{vault.protocol}
+						</a>
+					</EntitySymbol>
+				</li>
+			{/if}
+		</ul>
+	</div>
+{/if}
 
 <style>
 	.vault-rankings {


### PR DESCRIPTION
## Why

Vault detail pages should show curator branding when curator metadata is available, and should not render empty ranking placeholders when ranking data has not been calculated yet.

## Lessons learnt

Vault detail pages now receive curator information from master, so chart branding should prefer curator logos before falling back to protocol logos. Ranking fields can be null for fresh or externally sourced vaults and need to be treated as absent UI state.

## Summary

- Prefer curator logos in the top vault chart legend, with protocol logos as fallback.
- Hide missing ranking chips and suppress the whole rankings row when no 1M rankings exist.
- Keep image error handling on chart legend logos so unavailable logo assets do not show broken image UI.