### PR TITLE
fix: include TVL rows without share price in protocol mini charts

### DIFF
--- a/src/lib/echarts/protocol-mini-chart.test.ts
+++ b/src/lib/echarts/protocol-mini-chart.test.ts
@@ -49,6 +49,15 @@ describe('buildProtocolMiniChartPayload', () => {
 		expect(missingDay?.tvl).toBe(400);
 	});
 
+	test('includes TVL rows without a usable share price', () => {
+		const rows = [...createRows('vault-a', 100, 1, 1.01), ...createRows('vault-without-price', 300, 0, 0)];
+		const payload = buildProtocolMiniChartPayload(rows, 2, 3600);
+		const latest = payload.points.at(-1);
+
+		expect(latest?.tvl).toBe(400);
+		expect(latest?.apy).toBeCloseTo(0.129, 2);
+	});
+
 	test('excludes TVL outlier rows using the shared vault outlier threshold', () => {
 		const rows = [
 			...createRows('vault-a', 100, 1, 1.01),

--- a/src/lib/echarts/protocol-mini-chart.ts
+++ b/src/lib/echarts/protocol-mini-chart.ts
@@ -11,7 +11,7 @@ export interface ProtocolMiniChartDailyRow {
 	id: string;
 	day: string | Date;
 	tvl: number;
-	sharePrice: number;
+	sharePrice: number | null;
 }
 
 export interface ProtocolMiniChartLatestApyRow {
@@ -42,14 +42,14 @@ interface NormalisedDailyRow {
 	id: string;
 	day: string;
 	tvl: number;
-	sharePrice: number;
+	sharePrice: number | null;
 }
 
 interface FilledVaultPoint {
 	day: string;
 	dayMs: number;
 	tvl: number;
-	sharePrice: number;
+	sharePrice: number | null;
 }
 
 interface ProtocolMiniChartOptions {
@@ -99,10 +99,12 @@ function buildFilledVaultSeries(rows: NormalisedDailyRow[], allDays: string[]) {
 
 		if (row) {
 			lastTvl = row.tvl;
-			lastSharePrice = row.sharePrice;
+			if (row.sharePrice != null) {
+				lastSharePrice = row.sharePrice;
+			}
 		}
 
-		if (lastTvl == null || lastSharePrice == null) continue;
+		if (lastTvl == null) continue;
 
 		filled.push({
 			day,
@@ -152,7 +154,12 @@ export function buildProtocolMiniChartPayload(
 	const normalisedRows = rows
 		.map((row): NormalisedDailyRow | null => {
 			const day = normaliseDay(row.day);
-			if (!day || !Number.isFinite(row.tvl) || row.tvl < 0 || !Number.isFinite(row.sharePrice) || row.sharePrice <= 0) {
+			if (
+				!day ||
+				!Number.isFinite(row.tvl) ||
+				row.tvl < 0 ||
+				(row.sharePrice != null && !Number.isFinite(row.sharePrice))
+			) {
 				return null;
 			}
 
@@ -165,7 +172,7 @@ export function buildProtocolMiniChartPayload(
 				id: row.id,
 				day,
 				tvl: row.tvl,
-				sharePrice: row.sharePrice
+				sharePrice: row.sharePrice != null && row.sharePrice > 0 ? row.sharePrice : null
 			};
 		})
 		.filter((row): row is NormalisedDailyRow => row !== null)
@@ -196,7 +203,15 @@ export function buildProtocolMiniChartPayload(
 			tvl += current.tvl;
 
 			const lookback = getPointAtOrBefore(vaultPoints, dayMs - LOOKBACK_MS);
-			if (!lookback || lookback.sharePrice <= 0 || current.sharePrice <= 0 || current.dayMs <= lookback.dayMs) continue;
+			if (
+				!lookback ||
+				lookback.sharePrice == null ||
+				current.sharePrice == null ||
+				lookback.sharePrice <= 0 ||
+				current.sharePrice <= 0 ||
+				current.dayMs <= lookback.dayMs
+			)
+				continue;
 
 			const returnRate = current.sharePrice / lookback.sharePrice - 1;
 			if (returnRate <= -1) continue;

--- a/src/lib/echarts/vault-group-mini-chart-server.ts
+++ b/src/lib/echarts/vault-group-mini-chart-server.ts
@@ -54,12 +54,14 @@ export async function getVaultGroupMiniChartRows(vaultIds: string[]): Promise<Pr
 					id,
 					CAST(timestamp AS DATE) AS day,
 					arg_max(total_assets, timestamp) AS tvl,
-					arg_max(share_price, timestamp) AS share_price
+					CASE
+						WHEN arg_max(share_price, timestamp) > 0 THEN arg_max(share_price, timestamp)
+						ELSE NULL
+					END AS share_price
 				FROM parquet_scan($parquetFile)
 				WHERE
 					id IN (${idPlaceholders})
 					AND total_assets >= 0
-					AND share_price > 0
 					AND COALESCE(tvl_filtering_mask, FALSE) = FALSE
 				GROUP BY 1, 2
 				HAVING day <= current_date
@@ -72,7 +74,7 @@ export async function getVaultGroupMiniChartRows(vaultIds: string[]): Promise<Pr
 			id: String(id),
 			day: day as string | Date,
 			tvl: Number(tvl),
-			sharePrice: Number(sharePrice)
+			sharePrice: sharePrice == null ? null : Number(sharePrice)
 		}));
 	} finally {
 		connection.closeSync();

--- a/src/routes/trading-view/vaults/protocols/[protocol=slug]/chart-data/+server.ts
+++ b/src/routes/trading-view/vaults/protocols/[protocol=slug]/chart-data/+server.ts
@@ -9,7 +9,7 @@ import {
 } from '$lib/echarts/vault-group-mini-chart-server';
 import { getCachedTopVaults } from '$lib/top-vaults/cache';
 
-const CACHE_VERSION = 'protocol-mini-chart-v4';
+const CACHE_VERSION = 'protocol-mini-chart-v5';
 const cache = new Map<string, { payload: ProtocolMiniChartPayload; expires: number; version: string }>();
 
 async function getCachedChartData(protocolSlug: string, fetch: Fetch) {


### PR DESCRIPTION
## Why

The T3tris protocol page mini chart was missing the Gami USDC vault TVL because that vault has a positive TVL row in the parquet file but a zero share price. The chart data query filtered out rows with `share_price <= 0`, dropping valid TVL even though share price is only needed for APY calculation.

## Lessons learnt

Protocol mini charts need to treat TVL and share-price availability independently. A missing or zero share price should suppress APY calculation for that vault point, but it should not remove otherwise valid TVL from the chart.

## Summary

- Keep vault group mini chart rows with valid TVL even when share price is missing or zero.
- Allow protocol mini chart aggregation to carry nullable share prices and skip only APY calculation when prices are unavailable.
- Add a regression test for TVL rows without usable share price.
- Bump the protocol mini chart cache version.