### PR TITLE
Fix Kinexys offchain USD denomination

### DIFF
--- a/src/lib/stablecoin-metadata/helpers.test.ts
+++ b/src/lib/stablecoin-metadata/helpers.test.ts
@@ -62,6 +62,14 @@ describe('stablecoin metadata helpers', () => {
 		expect(slug).toBe('usd-plus');
 	});
 
+	test('uses punctuation as word separators for fallback slugs', () => {
+		const slug = resolveStablecoinSlug({
+			symbol: 'USD (offchain)'
+		});
+
+		expect(slug).toBe('usd-offchain');
+	});
+
 	test('appends symbol to display name when missing', () => {
 		expect(formatStablecoinDisplayName('USD Coin (Circle)', 'USDC')).toBe('USD Coin (Circle) USDC');
 	});

--- a/src/lib/stablecoin-metadata/helpers.ts
+++ b/src/lib/stablecoin-metadata/helpers.ts
@@ -44,7 +44,10 @@ export function formatStablecoinDisplayName(
 }
 
 function normalizeStablecoinText(value: string): string {
-	return value.replaceAll('+', ' plus ').replaceAll('&', ' and ');
+	return value
+		.replaceAll('+', ' plus ')
+		.replaceAll('&', ' and ')
+		.replace(/\s+-\s+/g, ' ');
 }
 
 function getStablecoinLookupKeys(value: string | null | undefined): string[] {

--- a/src/lib/top-vaults/client.ts
+++ b/src/lib/top-vaults/client.ts
@@ -1,7 +1,7 @@
 import { error } from '@sveltejs/kit';
-import { publicApiError } from '$lib/helpers/public-api';
 import { fetchTopVaultsRaw } from './server-config';
 import { type TopVaults, topVaultsSchema } from './schemas';
+import { normaliseKinexysVaultDenomination } from './helpers';
 
 function getSafeErrorSummary(errorValue: unknown): string {
 	if (errorValue instanceof Error) {
@@ -13,7 +13,12 @@ function getSafeErrorSummary(errorValue: unknown): string {
 export async function fetchTopVaults(fetch: Fetch): Promise<TopVaults> {
 	try {
 		const raw = await fetchTopVaultsRaw(fetch);
-		return topVaultsSchema.parse(raw);
+		const data = topVaultsSchema.parse(raw);
+
+		return {
+			...data,
+			vaults: data.vaults.map(normaliseKinexysVaultDenomination)
+		};
 	} catch (e) {
 		if (e && typeof e === 'object' && 'status' in e) throw e;
 		console.error(`Failed to fetch top vaults: ${getSafeErrorSummary(e)}`);

--- a/src/lib/top-vaults/helpers.test.ts
+++ b/src/lib/top-vaults/helpers.test.ts
@@ -24,6 +24,7 @@ import {
 	getVaultPeakTvlUsd,
 	getVaultTvlNative,
 	isNonUsdDenominatedVault,
+	normaliseKinexysVaultDenomination,
 	withVaultDenominationTokenRate,
 	calculateTotalTvl,
 	calculateTvlWeightedApy
@@ -86,6 +87,33 @@ describe('isBlacklisted', () => {
 		const vault = createTestVault('Test vault');
 		expect(vault.risk_numeric).toBeNull();
 		expect(isBlacklisted(vault)).toBe(false);
+	});
+});
+
+describe('normaliseKinexysVaultDenomination', () => {
+	test('uses off-chain USD dollars for Kinexys vault denomination', () => {
+		const vault = createTestVault('JPMorgan OnChain Liquidity-Token Money Market Fund', {
+			protocol: 'Kinexys',
+			denomination: 'USDC',
+			normalised_denomination: 'Circle USDC',
+			denomination_slug: 'usdc',
+			denomination_token_address: '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48',
+			denomination_token_rate: createDenominationTokenRate({ usd_rate: 0.999897 })
+		});
+
+		const normalised = normaliseKinexysVaultDenomination(vault);
+
+		expect(normalised.denomination).toBe('USD (offchain)');
+		expect(normalised.normalised_denomination).toBe('USD (offchain)');
+		expect(normalised.denomination_slug).toBe('usd-offchain');
+		expect(normalised.denomination_token_address).toBeNull();
+		expect(normalised.denomination_token_rate).toBeNull();
+	});
+
+	test('does not change non-Kinexys vaults', () => {
+		const vault = createTestVault('Aave USDC', { protocol: 'Aave V3' });
+
+		expect(normaliseKinexysVaultDenomination(vault)).toBe(vault);
 	});
 });
 

--- a/src/lib/top-vaults/helpers.ts
+++ b/src/lib/top-vaults/helpers.ts
@@ -18,6 +18,26 @@ export function slimVault(vault: Record<string, unknown>): SlimVaultInfo {
 }
 
 const HYPERCORE_CHAIN_ID = 9999;
+const KINEXYS_PROTOCOL_SLUG = 'kinexys';
+const KINEXYS_DENOMINATION = 'USD (offchain)';
+const KINEXYS_DENOMINATION_SLUG = 'usd-offchain';
+
+/**
+ * Kinexys vault balances are denominated in off-chain USD dollars, even when
+ * the scanner reports the settlement token address as USDC.
+ */
+export function normaliseKinexysVaultDenomination(vault: VaultInfo): VaultInfo {
+	if (vault.protocol_slug !== KINEXYS_PROTOCOL_SLUG) return vault;
+
+	return {
+		...vault,
+		denomination: KINEXYS_DENOMINATION,
+		normalised_denomination: KINEXYS_DENOMINATION,
+		denomination_slug: KINEXYS_DENOMINATION_SLUG,
+		denomination_token_address: null,
+		denomination_token_rate: null
+	};
+}
 
 /** Minimum TVL threshold for vault group breakdown pages */
 export const MIN_TVL_THRESHOLD = 10_000;

--- a/src/routes/trading-view/vaults/[vault=slug]/+page.svelte
+++ b/src/routes/trading-view/vaults/[vault=slug]/+page.svelte
@@ -101,7 +101,7 @@
 		<VaultUtilisationChart {vault} />
 		-->
 
-		<VaultMetrics {vault} />
+		<VaultMetrics {vault} {stablecoinMetadata} />
 
 		{#if vault.description}
 			<MetricsBox class="description" title="About the vault">

--- a/src/routes/trading-view/vaults/[vault=slug]/VaultMetrics.svelte
+++ b/src/routes/trading-view/vaults/[vault=slug]/VaultMetrics.svelte
@@ -9,14 +9,16 @@
 	import { formatNumber, formatPercent, formatPercentProfit } from '$lib/helpers/formatters';
 	import { getChain } from '$lib/helpers/chain';
 	import { getStablecoinLogoUrl, resolveStablecoinSlug } from '$lib/stablecoin-metadata/helpers';
+	import type { StablecoinMetadata } from '$lib/stablecoin-metadata/schemas';
 
 	interface Props {
 		vault: VaultInfo;
+		stablecoinMetadata?: StablecoinMetadata | null;
 	}
 
 	const LIMITED_HISTORY_CHAINS = [9999, 9998, 9997];
 
-	let { vault }: Props = $props();
+	let { vault, stablecoinMetadata = null }: Props = $props();
 
 	let chain = $derived(getChain(vault.chain_id));
 	let hasLimitedHistory = $derived(LIMITED_HISTORY_CHAINS.includes(vault.chain_id));
@@ -27,6 +29,12 @@
 			symbol: vault.denomination,
 			name: vault.normalised_denomination
 		})
+	);
+	let denominationLogoUrl = $derived(
+		stablecoinMetadata?.logos.light && denominationSlug ? getStablecoinLogoUrl(denominationSlug) : undefined
+	);
+	let denominationHref = $derived(
+		stablecoinMetadata && denominationSlug ? `/trading-view/vaults/stablecoins/${denominationSlug}` : undefined
 	);
 
 	function getDaysUntil(dateString: string | null): number | null {
@@ -129,16 +137,21 @@
 			</Metric>
 
 			<Metric label="Denomination">
-				{@const denomLogoUrl = denominationSlug ? getStablecoinLogoUrl(denominationSlug) : undefined}
-				<a
-					class="denomination-link"
-					href="/trading-view/vaults/stablecoins/{denominationSlug ?? vault.denomination_slug}"
-				>
-					{#if denomLogoUrl}
-						<img class="denomination-logo" src={denomLogoUrl} alt="" />
-					{/if}
-					{vault.denomination}
-				</a>
+				{#if denominationHref}
+					<a class="denomination-link" href={denominationHref}>
+						{#if denominationLogoUrl}
+							<img class="denomination-logo" src={denominationLogoUrl} alt="" />
+						{/if}
+						{vault.denomination}
+					</a>
+				{:else}
+					<span class="denomination-link">
+						{#if denominationLogoUrl}
+							<img class="denomination-logo" src={denominationLogoUrl} alt="" />
+						{/if}
+						{vault.denomination}
+					</span>
+				{/if}
 			</Metric>
 		</div>
 	</MetricsBox>
@@ -349,7 +362,7 @@
 		}
 
 		.risk-link,
-		.denomination-link,
+		a.denomination-link,
 		.glossary-link {
 			text-decoration: underline;
 			text-decoration-style: dashed;

--- a/src/routes/trading-view/vaults/[vault=slug]/VaultTechnicalDetailsTable.svelte
+++ b/src/routes/trading-view/vaults/[vault=slug]/VaultTechnicalDetailsTable.svelte
@@ -49,6 +49,13 @@
 	let showNativeTvlRows = $derived(denominationCurrency != null && denominationCurrency !== 'usd');
 	let lifetimePeriod = $derived(vault.period_results?.find((p) => p.period.toLowerCase() === 'lifetime') ?? null);
 	let denominationPageSlug = $derived(denominationSlug ?? vault.denomination_slug);
+	let denominationLogoUrl = $derived(
+		stablecoinMetadata?.logos.light && denominationSlug ? getStablecoinLogoUrl(denominationSlug) : undefined
+	);
+	let denominationHref = $derived(
+		stablecoinMetadata && denominationSlug ? `/trading-view/vaults/stablecoins/${denominationSlug}` : undefined
+	);
+	let showExchangeRateRow = $derived(vault.protocol_slug !== 'kinexys');
 	let exchangeRateFetchedAt = $derived(
 		vault.denomination_token_rate?.usd_rate_fetched_at ??
 			vault.denomination_token_rate?.source_currency_usd_rate_fetched_at ??
@@ -70,20 +77,26 @@
 			value: {
 				name: denominationLinkLabel,
 				slug: denominationSlug ?? vault.denomination_slug,
-				address: vault.denomination_token_address
+				address: vault.denomination_token_address,
+				logoUrl: denominationLogoUrl,
+				href: denominationHref
 			},
 			type: 'denomination' as const
 		},
-		{
-			label: 'Exchange rate used',
-			value: {
-				usdRate: getVaultDenominationUsdRate(vault),
-				symbol: vault.denomination,
-				slug: denominationPageSlug,
-				fetchedAt: exchangeRateFetchedAt
-			},
-			type: 'exchangeRate' as const
-		},
+		...(showExchangeRateRow
+			? [
+					{
+						label: 'Exchange rate used',
+						value: {
+							usdRate: getVaultDenominationUsdRate(vault),
+							symbol: vault.denomination,
+							slug: denominationPageSlug,
+							fetchedAt: exchangeRateFetchedAt
+						},
+						type: 'exchangeRate' as const
+					}
+				]
+			: []),
 		{
 			label: 'Share token',
 			value: { name: vault.share_token, address: vault.share_token_address },
@@ -201,19 +214,25 @@
 									{row.value.name} ({row.value.id})
 								</a>
 							{:else if row.type === 'denomination'}
-								{@const denomLogoUrl = getStablecoinLogoUrl(row.value.slug)}
 								{#if row.value.address}
 									<Tooltip>
-										<a
-											slot="trigger"
-											class="denomination-link tooltip-hint"
-											href="/trading-view/vaults/stablecoins/{row.value.slug}"
-										>
-											{#if denomLogoUrl}
-												<img class="denomination-logo" src={denomLogoUrl} alt="" />
+										<span slot="trigger">
+											{#if row.value.href}
+												<a class="denomination-link tooltip-hint" href={row.value.href}>
+													{#if row.value.logoUrl}
+														<img class="denomination-logo" src={row.value.logoUrl} alt="" />
+													{/if}
+													{row.value.name}
+												</a>
+											{:else}
+												<span class="denomination-link tooltip-hint">
+													{#if row.value.logoUrl}
+														<img class="denomination-logo" src={row.value.logoUrl} alt="" />
+													{/if}
+													{row.value.name}
+												</span>
 											{/if}
-											{row.value.name}
-										</a>
+										</span>
 										<svelte:fragment slot="popup">
 											<a
 												class="tooltip-link"
@@ -225,13 +244,20 @@
 											</a>
 										</svelte:fragment>
 									</Tooltip>
-								{:else}
-									<a class="denomination-link" href="/trading-view/vaults/stablecoins/{row.value.slug}">
-										{#if denomLogoUrl}
-											<img class="denomination-logo" src={denomLogoUrl} alt="" />
+								{:else if row.value.href}
+									<a class="denomination-link" href={row.value.href}>
+										{#if row.value.logoUrl}
+											<img class="denomination-logo" src={row.value.logoUrl} alt="" />
 										{/if}
 										{row.value.name}
 									</a>
+								{:else}
+									<span class="denomination-link">
+										{#if row.value.logoUrl}
+											<img class="denomination-logo" src={row.value.logoUrl} alt="" />
+										{/if}
+										{row.value.name}
+									</span>
 								{/if}
 							{:else if row.type === 'exchangeRate'}
 								{#if row.value.usdRate != null}


### PR DESCRIPTION
## Why

Kinexys vaults represent off-chain USD balances, but the vault feed can expose USDC settlement-token metadata. This made the vault page show USDC-specific denomination labels, icons, links and exchange-rate rows that do not apply to the JLTXX/off-chain USD product.

## Lessons learnt

Kinexys denomination handling needs to be normalised at the top-vault data boundary so all vault-detail consumers see the same off-chain USD label. Denomination links and logos should only render when stablecoin metadata exists for the displayed denomination.

## Summary

- Normalised Kinexys vault denomination data to `USD (offchain)` with no denomination token address or rate metadata.
- Rendered Kinexys denomination values as plain text instead of stablecoin links and hid the stablecoin logo fallback.
- Removed the exchange-rate row for Kinexys vault technical details and added focused regression coverage.
