### PR TITLE
Fix hide unknown vault protocol filter

### DIFF
--- a/src/lib/top-vaults/helpers.test.ts
+++ b/src/lib/top-vaults/helpers.test.ts
@@ -213,6 +213,14 @@ describe('hasSupportedProtocol', () => {
 		};
 		expect(hasSupportedProtocol(vault)).toBe(false);
 	});
+
+	test('returns false for manually mapped unknown protocol slugs', () => {
+		const vault = {
+			protocol: 'Unknown vault protocol',
+			protocol_slug: 'erc-4626'
+		};
+		expect(hasSupportedProtocol(vault)).toBe(false);
+	});
 });
 
 describe('isEligibleFrontpageVault', () => {
@@ -272,6 +280,10 @@ describe('isUnsupportedProtocolSlug', () => {
 
 	test('matches the unknown ERC-7450 placeholder slug', () => {
 		expect(isUnsupportedProtocolSlug('unknown-erc-7450')).toBe(true);
+	});
+
+	test('matches manually mapped unknown protocol slugs', () => {
+		expect(isUnsupportedProtocolSlug('erc-4626')).toBe(true);
 	});
 
 	test('ignores supported protocol slugs', () => {

--- a/src/lib/top-vaults/helpers.ts
+++ b/src/lib/top-vaults/helpers.ts
@@ -189,7 +189,10 @@ export function isBlacklisted(vault: Pick<VaultInfo, 'risk_numeric'> & Partial<P
 }
 
 const unsupportedProtocolNames = ['<protocol not yet identified>', '<unknown erc-7450>'] as const;
-const unsupportedProtocolSlugs = new Set(unsupportedProtocolNames.map((protocol) => slugify(protocol)));
+const unsupportedProtocolSlugs = new Set([
+	...unsupportedProtocolNames.map((protocol) => slugify(protocol)),
+	...UNKNOWN_VAULT_PROTOCOL_SLUGS
+]);
 
 export function isUnsupportedProtocolName(protocol: string | null | undefined) {
 	const normalisedProtocol = protocol?.trim();


### PR DESCRIPTION
## Why

The recent unknown vault protocol display mapping made ERC-4626 vaults appear as `Unknown vault protocol`, but the Hide unknown filter still treated the `erc-4626` slug as supported. This left unknown protocol vaults visible on the vault listing even when the checkbox was enabled.

## Lessons learnt

Display-name aliases for unknown protocol buckets need to be reflected in the shared supported-protocol helper, because the listing filter uses that helper rather than display text.

## Summary

- Include manually mapped unknown protocol slugs in the unsupported protocol slug set.
- Add regression coverage for `erc-4626` in `hasSupportedProtocol()` and `isUnsupportedProtocolSlug()`.
