### PR TITLE
feat: add vault listing totals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Weblog of stuff
 
+- Add live TVL and listing-count summaries to chain, protocol, curator and stablecoin vault pages (2026-07-11)
 - Add Robinhood vault-only chain support (2026-07-10)
 - Add curator information boxes to vault detail pages when curator metadata is available (2026-07-05)
 - Fix blog sitemap dropping posts beyond the first 100 by paginating through all Ghost Content API pages (2026-07-01)

--- a/src/lib/echarts/core3-risk.ts
+++ b/src/lib/echarts/core3-risk.ts
@@ -1,6 +1,6 @@
 import { getChain } from '$lib/helpers/chain';
 import { getLogoUrl } from '$lib/helpers/assets';
-import { isBlacklisted, getCore3PolForVault, getCore3ReportUrl } from '$lib/top-vaults/helpers';
+import { isBlacklisted, getCore3PolForVault, getCore3ReportUrl, getProtocolDisplayName } from '$lib/top-vaults/helpers';
 import type { Core3Pol, Core3Protocol, VaultInfo } from '$lib/top-vaults/schemas';
 import { getVaultProtocolLogoUrl } from '$lib/vault-protocol/helpers';
 import { VAULT_TVL_OUTLIER_THRESHOLD } from './tvl-outliers';
@@ -162,7 +162,7 @@ function buildScatterPoint(
 		name: vault.name,
 		vaultSlug: vault.vault_slug,
 		href: `/trading-view/vaults/${vault.vault_slug}`,
-		protocol: vault.protocol,
+		protocol: getProtocolDisplayName(vault.protocol, vault.protocol_slug),
 		protocolSlug: vault.protocol_slug,
 		protocolLogoUrl: getVaultProtocolLogoUrl(vault.protocol_slug),
 		chain: chain?.name ?? vault.chain ?? `Chain ${vault.chain_id}`,

--- a/src/lib/echarts/historical-tvl.ts
+++ b/src/lib/echarts/historical-tvl.ts
@@ -164,7 +164,7 @@ function resolveProtocolGroup(metadata?: HistoricalVaultMetadata) {
 	const protocolSlug = metadata?.protocol_slug?.trim() || slugify(metadata?.protocol ?? 'unknown') || 'unknown';
 	return {
 		key: protocolSlug,
-		label: getProtocolDisplayName(metadata?.protocol) || protocolSlug,
+		label: getProtocolDisplayName(metadata?.protocol, protocolSlug) || protocolSlug,
 		protocolSlug
 	};
 }

--- a/src/lib/echarts/protocol-mini-chart.test.ts
+++ b/src/lib/echarts/protocol-mini-chart.test.ts
@@ -5,11 +5,17 @@ import {
 	type ProtocolMiniChartDailyRow
 } from './protocol-mini-chart';
 
-function createRows(id: string, tvl: number, startPrice: number, endPrice: number): ProtocolMiniChartDailyRow[] {
-	return Array.from({ length: 31 }, (_, index) => {
+function createRows(
+	id: string,
+	tvl: number,
+	startPrice: number,
+	endPrice: number,
+	days = 31
+): ProtocolMiniChartDailyRow[] {
+	return Array.from({ length: days }, (_, index) => {
 		const date = new Date('2026-01-01T00:00:00Z');
 		date.setUTCDate(date.getUTCDate() + index);
-		const progress = index / 30;
+		const progress = index / (days - 1);
 
 		return {
 			id,
@@ -84,5 +90,20 @@ describe('buildProtocolMiniChartPayload', () => {
 		});
 
 		expect(payload.points.at(-1)?.apy).toBeCloseTo(0.045);
+	});
+
+	test('supports TVL-weighted 90 day annualised returns', () => {
+		const rows = [...createRows('vault-a', 100, 1, 1.03, 91), ...createRows('vault-b', 300, 1, 1.06, 91)];
+		const payload = buildProtocolMiniChartPayload(rows, 2, 3600, {
+			generatedAt: new Date('2026-04-02T00:00:00Z'),
+			lookbackDays: 90
+		});
+		const latest = payload.points.at(-1);
+
+		expect(payload.points).toHaveLength(91);
+		expect(payload.meta.pointsWithApy).toBe(1);
+		expect(latest?.date).toBe('2026-04-01');
+		expect(latest?.tvl).toBe(400);
+		expect(latest?.apy).toBeCloseTo(0.232, 2);
 	});
 });

--- a/src/lib/echarts/protocol-mini-chart.ts
+++ b/src/lib/echarts/protocol-mini-chart.ts
@@ -2,8 +2,8 @@ import { parseDate } from '$lib/helpers/date';
 import { annualizedReturn } from '$lib/helpers/financial';
 import { VAULT_TVL_OUTLIER_THRESHOLD } from './tvl-outliers';
 
-const LOOKBACK_DAYS = 30;
-const LOOKBACK_MS = LOOKBACK_DAYS * 24 * 60 * 60 * 1000;
+const DEFAULT_LOOKBACK_DAYS = 30;
+const DAY_MS = 24 * 60 * 60 * 1000;
 const MAX_APY_THRESHOLD = 10;
 export const PROTOCOL_MINI_CHART_TVL_OUTLIER_THRESHOLD = VAULT_TVL_OUTLIER_THRESHOLD;
 
@@ -55,6 +55,7 @@ interface FilledVaultPoint {
 interface ProtocolMiniChartOptions {
 	generatedAt?: Date;
 	latestApyRows?: ProtocolMiniChartLatestApyRow[];
+	lookbackDays?: number;
 }
 
 function normaliseDay(value: string | Date) {
@@ -119,12 +120,13 @@ function buildFilledVaultSeries(rows: NormalisedDailyRow[], allDays: string[]) {
 
 function resolveOptions(optionsOrGeneratedAt?: Date | ProtocolMiniChartOptions): Required<ProtocolMiniChartOptions> {
 	if (optionsOrGeneratedAt instanceof Date) {
-		return { generatedAt: optionsOrGeneratedAt, latestApyRows: [] };
+		return { generatedAt: optionsOrGeneratedAt, latestApyRows: [], lookbackDays: DEFAULT_LOOKBACK_DAYS };
 	}
 
 	return {
 		generatedAt: optionsOrGeneratedAt?.generatedAt ?? new Date(),
-		latestApyRows: optionsOrGeneratedAt?.latestApyRows ?? []
+		latestApyRows: optionsOrGeneratedAt?.latestApyRows ?? [],
+		lookbackDays: optionsOrGeneratedAt?.lookbackDays ?? DEFAULT_LOOKBACK_DAYS
 	};
 }
 
@@ -149,7 +151,8 @@ export function buildProtocolMiniChartPayload(
 	cacheTtlSeconds: number,
 	optionsOrGeneratedAt?: Date | ProtocolMiniChartOptions
 ): ProtocolMiniChartPayload {
-	const { generatedAt, latestApyRows } = resolveOptions(optionsOrGeneratedAt);
+	const { generatedAt, latestApyRows, lookbackDays } = resolveOptions(optionsOrGeneratedAt);
+	const lookbackMs = lookbackDays * DAY_MS;
 	let excludedOutlierPoints = 0;
 	const normalisedRows = rows
 		.map((row): NormalisedDailyRow | null => {
@@ -202,7 +205,7 @@ export function buildProtocolMiniChartPayload(
 
 			tvl += current.tvl;
 
-			const lookback = getPointAtOrBefore(vaultPoints, dayMs - LOOKBACK_MS);
+			const lookback = getPointAtOrBefore(vaultPoints, dayMs - lookbackMs);
 			if (
 				!lookback ||
 				lookback.sharePrice == null ||

--- a/src/lib/echarts/vault-group-mini-chart-server.ts
+++ b/src/lib/echarts/vault-group-mini-chart-server.ts
@@ -6,12 +6,21 @@ import { ensureVaultPricesParquet } from '$lib/top-vaults/vault-prices-parquet';
 export { isEligibleVaultGroupMiniChartVault } from '$lib/top-vaults/helpers';
 
 export const VAULT_GROUP_MINI_CHART_CACHE_TTL_SECONDS = 60 * 60;
+export const VAULT_GROUP_MINI_CHART_THREE_MONTH_LOOKBACK_DAYS = 90;
 
-export function getVaultGroupMiniChartLatestApyRows(vaults: VaultInfo[]): ProtocolMiniChartLatestApyRow[] {
+type VaultGroupMiniChartReturnWindow = 'one-month' | 'three-months';
+
+export function getVaultGroupMiniChartLatestApyRows(
+	vaults: VaultInfo[],
+	returnWindow: VaultGroupMiniChartReturnWindow = 'one-month'
+): ProtocolMiniChartLatestApyRow[] {
 	return vaults.map((vault) => ({
 		id: vault.id,
 		tvl: vault.current_nav ?? 0,
-		apy: vault.one_month_cagr_net ?? vault.one_month_cagr
+		apy:
+			returnWindow === 'three-months'
+				? (vault.three_months_cagr_net ?? vault.three_months_cagr)
+				: (vault.one_month_cagr_net ?? vault.one_month_cagr)
 	}));
 }
 

--- a/src/lib/scatter-plot/helpers.ts
+++ b/src/lib/scatter-plot/helpers.ts
@@ -1,5 +1,5 @@
 import type { VaultInfo } from '$lib/top-vaults/schemas';
-import { resolveVaultDetails } from '$lib/top-vaults/helpers';
+import { getProtocolDisplayName, resolveVaultDetails } from '$lib/top-vaults/helpers';
 import { getChain } from '$lib/helpers/chain';
 
 export const tvlOptions = [
@@ -214,7 +214,7 @@ export function buildBaseHoverLines(v: VaultInfo): string[] {
 	const tvl = `$${v.current_nav!.toLocaleString(undefined, { maximumFractionDigits: 0 })}`;
 	return [
 		`<b>${v.name}</b>`,
-		v.protocol,
+		getProtocolDisplayName(v.protocol, v.protocol_slug),
 		chainName,
 		`TVL: ${tvl}`,
 		`1M return (ann.): ${formatReturn(v.one_month_cagr)}`,

--- a/src/lib/top-vaults/TopVaultsPage.svelte
+++ b/src/lib/top-vaults/TopVaultsPage.svelte
@@ -25,7 +25,7 @@
 		/** Vault dataset to display; may be undefined while loading */
 		topVaults?: TopVaults;
 		title: string;
-		subtitle?: string;
+		subtitle?: string | Snippet;
 		tvlThreshold?: number;
 		tvlTriggerLabel?: string;
 		tvlTooltip?: string;

--- a/src/lib/top-vaults/TopVaultsTable.svelte
+++ b/src/lib/top-vaults/TopVaultsTable.svelte
@@ -46,6 +46,7 @@
 		getLockupTooltip,
 		getLifetimeMaxDrawdown,
 		getMonthlyReturn,
+		getProtocolDisplayName,
 		getVaultCurrentTvlUsd,
 		getVaultDenominationNativeRate,
 		getVaultDenominationCurrency,
@@ -178,7 +179,10 @@
 			defaultDirection: 'asc',
 			compareFn: stringCompare((v) => getChain(v.chain_id)?.name ?? `Chain ${v.chain_id}`)
 		},
-		vault: { defaultDirection: 'asc', compareFn: stringCompare((v) => `${v.name.trim()} ${v.protocol}`) },
+		vault: {
+			defaultDirection: 'asc',
+			compareFn: stringCompare((v) => `${v.name.trim()} ${getProtocolDisplayName(v.protocol, v.protocol_slug)}`)
+		},
 		three_months_sharpe: { defaultDirection: 'desc', compareFn: rankVaultsBy(['three_months_sharpe']) },
 		three_months_volatility: { defaultDirection: 'asc', compareFn: rankVaultsBy(['three_months_volatility']) },
 		max_dd: {
@@ -482,7 +486,7 @@
 				v.chain_id,
 				chain?.name ?? '',
 				v.name,
-				v.protocol,
+				getProtocolDisplayName(v.protocol, v.protocol_slug),
 				v.denomination,
 				v.risk ?? '',
 				v.address
@@ -1045,6 +1049,7 @@
 					{@const chain = getChain(vault.chain_id)}
 					{@const blacklisted = isBlacklisted(vault)}
 					{@const badStatus = !isGoodVaultStatus(vault)}
+					{@const protocolName = getProtocolDisplayName(vault.protocol, vault.protocol_slug)}
 					{@const statusReason = [vault.deposit_closed_reason, vault.redemption_closed_reason]
 						.filter(Boolean)
 						.join('; ')}
@@ -1059,8 +1064,8 @@
 						<td class="vault">
 							<div class="multiline">
 								<strong>{vault.name}</strong>
-								{#if vault.protocol}
-									<span class="secondary">{vault.protocol}</span>
+								{#if protocolName}
+									<span class="secondary">{protocolName}</span>
 								{/if}
 							</div>
 						</td>

--- a/src/lib/top-vaults/client.ts
+++ b/src/lib/top-vaults/client.ts
@@ -1,7 +1,7 @@
 import { error } from '@sveltejs/kit';
 import { fetchTopVaultsRaw } from './server-config';
 import { type TopVaults, topVaultsSchema } from './schemas';
-import { normaliseKinexysVaultDenomination } from './helpers';
+import { normaliseKinexysVaultDenomination, normaliseVaultProtocolDisplayName } from './helpers';
 
 function getSafeErrorSummary(errorValue: unknown): string {
 	if (errorValue instanceof Error) {
@@ -17,7 +17,7 @@ export async function fetchTopVaults(fetch: Fetch): Promise<TopVaults> {
 
 		return {
 			...data,
-			vaults: data.vaults.map(normaliseKinexysVaultDenomination)
+			vaults: data.vaults.map((vault) => normaliseVaultProtocolDisplayName(normaliseKinexysVaultDenomination(vault)))
 		};
 	} catch (e) {
 		if (e && typeof e === 'object' && 'status' in e) throw e;

--- a/src/lib/top-vaults/helpers.test.ts
+++ b/src/lib/top-vaults/helpers.test.ts
@@ -25,6 +25,7 @@ import {
 	getVaultTvlNative,
 	isNonUsdDenominatedVault,
 	normaliseKinexysVaultDenomination,
+	normaliseVaultProtocolDisplayName,
 	withVaultDenominationTokenRate,
 	calculateTotalTvl,
 	calculateTvlWeightedApy
@@ -244,8 +245,23 @@ describe('getProtocolDisplayName', () => {
 		expect(getProtocolDisplayName('<protocol not yet identified>')).toBe('Unknown');
 	});
 
+	test('aliases ERC-4626 slug to unknown vault protocol', () => {
+		expect(getProtocolDisplayName('ERC-4626', 'erc-4626')).toBe('Unknown vault protocol');
+	});
+
 	test('returns the protocol name when it is supported', () => {
 		expect(getProtocolDisplayName('Yearn')).toBe('Yearn');
+	});
+});
+
+describe('normaliseVaultProtocolDisplayName', () => {
+	test('maps ERC-4626 vault protocol display name', () => {
+		const vault = createTestVault('ERC-4626 vault', {
+			protocol: 'ERC-4626',
+			protocol_slug: 'erc-4626'
+		});
+
+		expect(normaliseVaultProtocolDisplayName(vault).protocol).toBe('Unknown vault protocol');
 	});
 });
 

--- a/src/lib/top-vaults/helpers.ts
+++ b/src/lib/top-vaults/helpers.ts
@@ -21,6 +21,8 @@ const HYPERCORE_CHAIN_ID = 9999;
 const KINEXYS_PROTOCOL_SLUG = 'kinexys';
 const KINEXYS_DENOMINATION = 'USD (offchain)';
 const KINEXYS_DENOMINATION_SLUG = 'usd-offchain';
+export const UNKNOWN_VAULT_PROTOCOL_DISPLAY_NAME = 'Unknown vault protocol';
+const UNKNOWN_VAULT_PROTOCOL_SLUGS = new Set(['erc-4626']);
 
 /**
  * Kinexys vault balances are denominated in off-chain USD dollars, even when
@@ -36,6 +38,16 @@ export function normaliseKinexysVaultDenomination(vault: VaultInfo): VaultInfo {
 		denomination_slug: KINEXYS_DENOMINATION_SLUG,
 		denomination_token_address: null,
 		denomination_token_rate: null
+	};
+}
+
+export function normaliseVaultProtocolDisplayName(vault: VaultInfo): VaultInfo {
+	const displayName = getProtocolDisplayName(vault.protocol, vault.protocol_slug);
+	if (displayName === vault.protocol) return vault;
+
+	return {
+		...vault,
+		protocol: displayName
 	};
 }
 
@@ -192,6 +204,10 @@ export function hasSupportedProtocol(vault: Pick<VaultInfo, 'protocol'> & Partia
 	return !isUnsupportedProtocolName(vault.protocol) && !isUnsupportedProtocolSlug(vault.protocol_slug);
 }
 
+export function isManuallyMappedUnknownProtocolSlug(protocolSlug: string | null | undefined) {
+	return protocolSlug != null && UNKNOWN_VAULT_PROTOCOL_SLUGS.has(protocolSlug);
+}
+
 const FRONTPAGE_RISK_FILTER = riskFilterOptions.find((option) => option.label === 'Severe');
 
 /**
@@ -208,7 +224,8 @@ export function isEligibleFrontpageVault(
 	return vault.risk_numeric >= FRONTPAGE_RISK_FILTER.minValue && vault.risk_numeric <= FRONTPAGE_RISK_FILTER.maxValue;
 }
 
-export function getProtocolDisplayName(protocol: string | null | undefined): string {
+export function getProtocolDisplayName(protocol: string | null | undefined, protocolSlug?: string | null): string {
+	if (isManuallyMappedUnknownProtocolSlug(protocolSlug)) return UNKNOWN_VAULT_PROTOCOL_DISPLAY_NAME;
 	if (protocol == null || isUnsupportedProtocolName(protocol)) return 'Unknown';
 	return protocol;
 }
@@ -791,7 +808,7 @@ export function getCore3ProtocolForVault(
 
 	return {
 		slug: '',
-		name: vault.protocol,
+		name: getProtocolDisplayName(vault.protocol, vault.protocol_slug),
 		rank: vault.core3?.core3_ranking ?? null,
 		pol,
 		data_coverage: { percentage: vault.core3?.data_coverage ?? null },

--- a/src/lib/vault-protocol/client.ts
+++ b/src/lib/vault-protocol/client.ts
@@ -1,6 +1,10 @@
 // Client functions for fetching vault protocol metadata
 import { vaultProtocolMetadataUrl } from '$lib/config';
-import { hasSupportedProtocol, isUnsupportedProtocolSlug } from '$lib/top-vaults/helpers';
+import {
+	hasSupportedProtocol,
+	isManuallyMappedUnknownProtocolSlug,
+	isUnsupportedProtocolSlug
+} from '$lib/top-vaults/helpers';
 import { type VaultProtocolMetadata, vaultProtocolMetadataSchema } from './schemas';
 
 const CLIENT_TIMEOUT = 5000;
@@ -23,6 +27,7 @@ export async function fetchVaultProtocolMetadata(
 	}
 
 	if (
+		isManuallyMappedUnknownProtocolSlug(protocolSlug) ||
 		isUnsupportedProtocolSlug(protocolSlug) ||
 		(protocolName != null && !hasSupportedProtocol({ protocol: protocolName, protocol_slug: protocolSlug }))
 	) {

--- a/src/routes/trading-view/vaults/VaultGroupDescription.svelte
+++ b/src/routes/trading-view/vaults/VaultGroupDescription.svelte
@@ -21,6 +21,7 @@ excluded vault count from the loaded vault data.
 		hasSupportedProtocol,
 		isBlacklisted,
 		isEligibleVaultGroupMiniChartVault,
+		getProtocolDisplayName,
 		resolveVaultDetails
 	} from '$lib/top-vaults/helpers';
 	import { formatDollar, formatPercent } from '$lib/helpers/formatters';
@@ -64,7 +65,7 @@ excluded vault count from the loaded vault data.
 			if (!hasSupportedProtocol(vault)) continue;
 			const entry = tvlByProtocol.get(vault.protocol_slug) ?? {
 				slug: vault.protocol_slug,
-				name: vault.protocol,
+				name: getProtocolDisplayName(vault.protocol, vault.protocol_slug),
 				tvl: 0
 			};
 			entry.tvl += vault.current_nav ?? 0;

--- a/src/routes/trading-view/vaults/VaultGroupMiniChart.svelte
+++ b/src/routes/trading-view/vaults/VaultGroupMiniChart.svelte
@@ -2,11 +2,11 @@
 @component
 Compact dual-axis chart for vault group detail pages.
 
-Shows historical protocol TVL as an area series and TVL-weighted one-month
-average return as a line series. The latest return point matches the table's
-net-over-gross metric where available. Only vaults eligible for the group chart
-(not blacklisted, above minimum TVL, within the default risk filter) are included
-— the tooltip states the included vault count.
+Shows historical protocol TVL as an area series and TVL-weighted average return
+as a line series. The latest return point matches the table's net-over-gross
+metric where available. Only vaults eligible for the group chart (not
+blacklisted, above minimum TVL, within the default risk filter) are included —
+the tooltip states the included vault count.
 
 @example
 
@@ -28,6 +28,8 @@ net-over-gross metric where available. Only vaults eligible for the group chart
 		dataUrl: string;
 		compareLabel?: string;
 		compareHref?: string;
+		returnTooltipLabel?: string;
+		returnWindowLabel?: string;
 	}
 
 	interface TooltipParam {
@@ -37,7 +39,14 @@ net-over-gross metric where available. Only vaults eligible for the group chart
 		color?: string;
 	}
 
-	let { title, dataUrl, compareLabel, compareHref }: Props = $props();
+	let {
+		title,
+		dataUrl,
+		compareLabel,
+		compareHref,
+		returnTooltipLabel = 'Average TVL-weighted return',
+		returnWindowLabel = 'trailing 1 month'
+	}: Props = $props();
 
 	let chartContainer = $state<HTMLDivElement | null>(null);
 	let chartInstance = $state<ReturnType<EChartsStatic['init']> | null>(null);
@@ -109,8 +118,8 @@ net-over-gross metric where available. Only vaults eligible for the group chart
 		return [
 			`<div style="margin-bottom: 0.35rem; color: #ffffff; font-family: ${chartFontFamily}; font-weight: 700;">${formatDateLabel(date)}</div>`,
 			`<div style="color: #d5deea; font-family: ${chartFontFamily}; display: flex; justify-content: space-between; gap: 1rem;"><span>${tvlLabel}</span><strong>${typeof tvl === 'number' ? formatUsd(tvl) : 'n/a'}</strong></div>`,
-			`<div style="color: #d5deea; font-family: ${chartFontFamily}; display: flex; justify-content: space-between; gap: 1rem;"><span>Average TVL-weighted return</span><strong>${typeof averageReturn === 'number' ? formatReturn(averageReturn) : 'n/a'}</strong></div>`,
-			`<div style="width: 14rem; max-width: 14rem; white-space: normal; overflow-wrap: anywhere; margin-top: 0.45rem; color: #94a3b8; font-family: ${chartFontFamily}; font-size: 0.78rem; line-height: 1.35;">Return is annualised from each vault's trailing 1 month share-price return, weighted by that vault's TVL. The latest point uses the same net-over-gross return metric as the table where available.</div>`
+			`<div style="color: #d5deea; font-family: ${chartFontFamily}; display: flex; justify-content: space-between; gap: 1rem;"><span>${returnTooltipLabel}</span><strong>${typeof averageReturn === 'number' ? formatReturn(averageReturn) : 'n/a'}</strong></div>`,
+			`<div style="width: 14rem; max-width: 14rem; white-space: normal; overflow-wrap: anywhere; margin-top: 0.45rem; color: #94a3b8; font-family: ${chartFontFamily}; font-size: 0.78rem; line-height: 1.35;">Return is annualised from each vault's ${returnWindowLabel} share-price return, weighted by that vault's TVL. The latest point uses the same net-over-gross return metric as the table where available.</div>`
 		].join('');
 	}
 

--- a/src/routes/trading-view/vaults/chains/+page.svelte
+++ b/src/routes/trading-view/vaults/chains/+page.svelte
@@ -8,12 +8,15 @@
 	import VaultGroupTable from '$lib/top-vaults/VaultGroupTable.svelte';
 	import VaultListingsSelector from '$lib/top-vaults/VaultListingsSelector.svelte';
 	import { getLogoUrl } from '$lib/helpers/assets';
+	import { formatDollar } from '$lib/helpers/formatters';
 	import { MetaTags, JsonLd } from 'svelte-meta-tags';
 	import MarketSharePieChart from '../MarketSharePieChart.svelte';
 	import MarketShareWidgetBox from '../MarketShareWidgetBox.svelte';
 
 	let { data } = $props();
 	let { chains, chartChains, options } = $derived(data);
+	let totalTvl = $derived(chains.reduce((total, chain) => total + chain.tvl, 0));
+	let totalTvlLabel = $derived(`${formatDollar(totalTvl / 1_000_000_000, 1, 1, { notation: 'standard' })} billion`);
 
 	const onChange: ComponentProps<typeof VaultGroupTable>['onChange'] = async (params, scrollToTop) => {
 		// eslint-disable-next-line svelte/no-navigation-without-resolve
@@ -73,14 +76,17 @@
 							<span>DeFi vaults by chain</span>
 						{/snippet}
 						{#snippet subtitle()}
-							<a class="body-link" href={glossaryLinks.defi}>DeFi</a>
-							<a class="body-link" href={glossaryLinks.stablecoin}>stablecoin</a>
-							<a class="body-link" href={glossaryLinks.vault}>vaults</a>
-							on each blockchain.
-							<a class="body-link" href={glossaryLinks.tvl}>TVL</a> represents stablecoin deposits in vaults on a
-							particular chain.
-							<a class="body-link" href={glossaryLinks.apy}>APY</a>
-							represents the yield of last thirty days.
+							<p>
+								<a class="body-link" href={glossaryLinks.defi}>DeFi</a>
+								<a class="body-link" href={glossaryLinks.stablecoin}>stablecoin</a>
+								<a class="body-link" href={glossaryLinks.vault}>vaults</a>
+								on each blockchain.
+								<a class="body-link" href={glossaryLinks.tvl}>TVL</a> represents stablecoin deposits in vaults on a
+								particular chain.
+								<a class="body-link" href={glossaryLinks.apy}>APY</a>
+								represents the yield of last thirty days.
+							</p>
+							<p>{totalTvlLabel} TVL tracked across {chains.length} chains.</p>
 						{/snippet}
 					</HeroBanner>
 				</div>

--- a/src/routes/trading-view/vaults/cumulative-tvl-apy/CumulativeTvlApyChart.svelte
+++ b/src/routes/trading-view/vaults/cumulative-tvl-apy/CumulativeTvlApyChart.svelte
@@ -14,8 +14,7 @@ Standalone cumulative TVL / APY page adapter using the shared ECharts renderer.
 	import { buildCumulativeTvlPoints, formatUsd, getEligibleItems } from '$lib/echarts/cumulative-tvl-apy';
 	import { getLogoUrl } from '$lib/helpers/assets';
 	import { getChain } from '$lib/helpers/chain';
-	import { isBlacklisted } from '$lib/top-vaults/helpers';
-	import { resolveVaultDetails } from '$lib/top-vaults/helpers';
+	import { getProtocolDisplayName, isBlacklisted, resolveVaultDetails } from '$lib/top-vaults/helpers';
 	import { getVaultProtocolLogoUrl } from '$lib/vault-protocol/helpers.js';
 	import { deserialiseSearchParams, serialiseSearchParams } from '$lib/helpers/url-search-state';
 	import { goto } from '$app/navigation';
@@ -121,7 +120,7 @@ Standalone cumulative TVL / APY page adapter using the shared ECharts renderer.
 	let protocolOptions = $derived(() => {
 		const stats: Record<string, { count: number; tvl: number; logoUrl?: string }> = {};
 		for (const v of allEligible) {
-			const name = v.protocol ?? 'Unknown';
+			const name = getProtocolDisplayName(v.protocol, v.protocol_slug);
 			const tvl = v.current_nav ?? 0;
 			stats[name] ??= { count: 0, tvl: 0, logoUrl: getVaultProtocolLogoUrl(v.protocol_slug) };
 			stats[name].count += 1;
@@ -154,7 +153,7 @@ Standalone cumulative TVL / APY page adapter using the shared ECharts renderer.
 	let protocolFiltered = $derived(
 		selectedProtocols.length === 0
 			? allEligible
-			: allEligible.filter((v) => selectedProtocols.includes(v.protocol ?? 'Unknown'))
+			: allEligible.filter((v) => selectedProtocols.includes(getProtocolDisplayName(v.protocol, v.protocol_slug)))
 	);
 
 	let displayedVaults = $derived(protocolFiltered);
@@ -175,7 +174,7 @@ Standalone cumulative TVL / APY page adapter using the shared ECharts renderer.
 				name: vault.name,
 				chain: vault.chain ?? 'Unknown',
 				chainLogoUrl: getLogoUrl('blockchain', getChain(vault.chain_id)?.slug),
-				protocol: vault.protocol ?? 'Unknown',
+				protocol: getProtocolDisplayName(vault.protocol, vault.protocol_slug),
 				protocolLogoUrl: getVaultProtocolLogoUrl(vault.protocol_slug),
 				realApy: (getVaultCagr(vault, selectedWindow) ?? 0) * 100,
 				individualTvl: vault.current_nav ?? 0,

--- a/src/routes/trading-view/vaults/curators/+page.svelte
+++ b/src/routes/trading-view/vaults/curators/+page.svelte
@@ -11,12 +11,15 @@ aggregate TVL, vault count and average APY, plus a market-share pie chart.
 	import Section from '$lib/components/Section.svelte';
 	import VaultGroupTable from '$lib/top-vaults/VaultGroupTable.svelte';
 	import VaultListingsSelector from '$lib/top-vaults/VaultListingsSelector.svelte';
+	import { formatDollar } from '$lib/helpers/formatters';
 	import { MetaTags, JsonLd } from 'svelte-meta-tags';
 	import MarketSharePieChart from '../MarketSharePieChart.svelte';
 	import MarketShareWidgetBox from '../MarketShareWidgetBox.svelte';
 
 	let { data } = $props();
 	let { curators, curatorLogos, chartCurators, options } = $derived(data);
+	let totalTvl = $derived(curators.reduce((total, curator) => total + curator.tvl, 0));
+	let totalTvlLabel = $derived(`${formatDollar(totalTvl / 1_000_000_000, 1, 1, { notation: 'standard' })} billion`);
 
 	const onChange: ComponentProps<typeof VaultGroupTable>['onChange'] = async (params, scrollToTop) => {
 		// eslint-disable-next-line svelte/no-navigation-without-resolve
@@ -76,14 +79,17 @@ aggregate TVL, vault count and average APY, plus a market-share pie chart.
 							<span>Stablecoin vault curators</span>
 						{/snippet}
 						{#snippet subtitle()}
-							Curator rankings for
-							<a class="body-link" href={glossaryLinks.defi}>DeFi</a>
-							<a class="body-link" href={glossaryLinks.stablecoin}>stablecoin</a>
-							<a class="body-link" href={glossaryLinks.vault}>vaults</a>. Curators select and manage vault strategies.
-							<a class="body-link" href={glossaryLinks.tvl}>TVL</a> represents stablecoin deposits across a curator’s
-							vaults.
-							<a class="body-link" href={glossaryLinks.apy}>APY</a>
-							represents the yield of last thirty days.
+							<p>
+								Curator rankings for
+								<a class="body-link" href={glossaryLinks.defi}>DeFi</a>
+								<a class="body-link" href={glossaryLinks.stablecoin}>stablecoin</a>
+								<a class="body-link" href={glossaryLinks.vault}>vaults</a>. Curators select and manage vault strategies.
+								<a class="body-link" href={glossaryLinks.tvl}>TVL</a> represents stablecoin deposits across a curator’s
+								vaults.
+								<a class="body-link" href={glossaryLinks.apy}>APY</a>
+								represents the yield of last thirty days.
+							</p>
+							<p>{totalTvlLabel} TVL tracked across {curators.length} curators.</p>
 						{/snippet}
 					</HeroBanner>
 				</div>

--- a/src/routes/trading-view/vaults/current-peak-tvl/TvlScatterPlot.svelte
+++ b/src/routes/trading-view/vaults/current-peak-tvl/TvlScatterPlot.svelte
@@ -16,8 +16,12 @@ Plotly.js is loaded dynamically from CDN.
 -->
 <script lang="ts">
 	import type { VaultInfo } from '$lib/top-vaults/schemas';
-	import { isBlacklisted, hasSupportedProtocol } from '$lib/top-vaults/helpers';
-	import { resolveVaultDetails } from '$lib/top-vaults/helpers';
+	import {
+		getProtocolDisplayName,
+		isBlacklisted,
+		hasSupportedProtocol,
+		resolveVaultDetails
+	} from '$lib/top-vaults/helpers';
 	import { getChain, getChainsBySlug } from '$lib/helpers/chain';
 	import {
 		loadPlotly,
@@ -73,10 +77,11 @@ Plotly.js is loaded dynamically from CDN.
 
 	function formatHoverText(v: VaultInfo): string {
 		const chainName = getChain(v.chain_id)?.name ?? `Chain ${v.chain_id}`;
+		const protocolName = getProtocolDisplayName(v.protocol, v.protocol_slug);
 		const retention = v.current_nav! / v.peak_nav!;
 		return [
 			`<b>${v.name}</b>`,
-			v.protocol,
+			protocolName,
 			`Chain: ${chainName}`,
 			`Current TVL: ${formatTvl(v.current_nav!)}`,
 			`Peak TVL: ${formatTvl(v.peak_nav!)}`,
@@ -149,7 +154,8 @@ Plotly.js is loaded dynamically from CDN.
 		const supported = currentVaults.filter((v) => hasSupportedProtocol(v));
 		const protocolCounts = new Map<string, number>();
 		for (const v of supported) {
-			protocolCounts.set(v.protocol, (protocolCounts.get(v.protocol) ?? 0) + 1);
+			const protocol = getProtocolDisplayName(v.protocol, v.protocol_slug);
+			protocolCounts.set(protocol, (protocolCounts.get(protocol) ?? 0) + 1);
 		}
 
 		const sortedProtocols = [...protocolCounts.entries()].sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]));
@@ -159,7 +165,7 @@ Plotly.js is loaded dynamically from CDN.
 		for (let i = 0; i < sortedProtocols.length; i++) {
 			const [protocol] = sortedProtocols[i];
 			const color = protocolPalette[i % protocolPalette.length];
-			const group = supported.filter((v) => v.protocol === protocol);
+			const group = supported.filter((v) => getProtocolDisplayName(v.protocol, v.protocol_slug) === protocol);
 			traces.push(buildTvlTrace(group, protocol, color));
 		}
 

--- a/src/routes/trading-view/vaults/protocols/+page.server.ts
+++ b/src/routes/trading-view/vaults/protocols/+page.server.ts
@@ -23,7 +23,7 @@ export async function load({ fetch, url: { searchParams } }) {
 
 		acc[slug] ??= {
 			slug,
-			name: getProtocolDisplayName(vault.protocol),
+			name: getProtocolDisplayName(vault.protocol, vault.protocol_slug),
 			vault_count: 0,
 			tvl: 0,
 			avg_apy: null,

--- a/src/routes/trading-view/vaults/protocols/+page.svelte
+++ b/src/routes/trading-view/vaults/protocols/+page.svelte
@@ -7,6 +7,7 @@
 	import Section from '$lib/components/Section.svelte';
 	import VaultGroupTable from '$lib/top-vaults/VaultGroupTable.svelte';
 	import VaultListingsSelector from '$lib/top-vaults/VaultListingsSelector.svelte';
+	import { formatDollar } from '$lib/helpers/formatters';
 	import { getVaultProtocolLogoUrl } from '$lib/vault-protocol/helpers.js';
 	import { MetaTags, JsonLd } from 'svelte-meta-tags';
 	import MarketSharePieChart from '../MarketSharePieChart.svelte';
@@ -14,6 +15,8 @@
 
 	let { data } = $props();
 	let { protocols, chartProtocols, options } = $derived(data);
+	let totalTvl = $derived(protocols.reduce((total, protocol) => total + protocol.tvl, 0));
+	let totalTvlLabel = $derived(`${formatDollar(totalTvl / 1_000_000_000, 1, 1, { notation: 'standard' })} billion`);
 
 	const onChange: ComponentProps<typeof VaultGroupTable>['onChange'] = async (params, scrollToTop) => {
 		// eslint-disable-next-line svelte/no-navigation-without-resolve
@@ -69,16 +72,19 @@
 							<span>Vault protocols</span>
 						{/snippet}
 						{#snippet subtitle()}
-							<a class="body-link" href={glossaryLinks.vault}>Vaults</a>
-							grouped by
-							<a class="body-link" href={glossaryLinks.protocol}>protocol</a>. Vaults are built on different digital
-							asset management protocols, and this listing shows the relative popularity of each.
-							<a class="body-link" href={glossaryLinks.tvl}>TVL</a>
-							represents
-							<a class="body-link" href={glossaryLinks.stablecoin}>stablecoin</a>
-							deposits in a protocol’s vaults.
-							<a class="body-link" href={glossaryLinks.apy}>APY</a>
-							represents the yield of the last thirty days.
+							<p>
+								<a class="body-link" href={glossaryLinks.vault}>Vaults</a>
+								grouped by
+								<a class="body-link" href={glossaryLinks.protocol}>protocol</a>. Vaults are built on different digital
+								asset management protocols, and this listing shows the relative popularity of each.
+								<a class="body-link" href={glossaryLinks.tvl}>TVL</a>
+								represents
+								<a class="body-link" href={glossaryLinks.stablecoin}>stablecoin</a>
+								deposits in a protocol’s vaults.
+								<a class="body-link" href={glossaryLinks.apy}>APY</a>
+								represents the yield of the last thirty days.
+							</p>
+							<p>{totalTvlLabel} TVL tracked across {protocols.length} protocols.</p>
 						{/snippet}
 					</HeroBanner>
 				</div>

--- a/src/routes/trading-view/vaults/protocols/[protocol=slug]/+page.server.ts
+++ b/src/routes/trading-view/vaults/protocols/[protocol=slug]/+page.server.ts
@@ -19,7 +19,7 @@ export async function load({ params, fetch }) {
 
 	return {
 		protocolSlug: protocol,
-		protocolName: getProtocolDisplayName(protocolVault.protocol),
+		protocolName: getProtocolDisplayName(protocolVault.protocol, protocolVault.protocol_slug),
 		protocolMetadata,
 		core3
 	};

--- a/src/routes/trading-view/vaults/protocols/[protocol=slug]/+page.svelte
+++ b/src/routes/trading-view/vaults/protocols/[protocol=slug]/+page.svelte
@@ -1,8 +1,9 @@
 <script lang="ts">
 	import type { TopVaults } from '$lib/top-vaults/schemas';
 	import { fetchAllVaultData, hasVaultCache } from '$lib/top-vaults/client-cache';
-	import { isUnsupportedProtocolSlug } from '$lib/top-vaults/helpers';
+	import { isManuallyMappedUnknownProtocolSlug, isUnsupportedProtocolSlug } from '$lib/top-vaults/helpers';
 	import { getVaultProtocolLogoUrl } from '$lib/vault-protocol/helpers.js';
+	import { resolve } from '$app/paths';
 	import { page } from '$app/state';
 	import TopVaultsPage from '$lib/top-vaults/TopVaultsPage.svelte';
 	import Core3Ratings from '$lib/top-vaults/Core3Ratings.svelte';
@@ -11,6 +12,7 @@
 
 	let { data } = $props();
 	let { protocolSlug, protocolName, protocolMetadata, core3 } = $derived(data);
+	let isUnknownVaultProtocol = $derived(isManuallyMappedUnknownProtocolSlug(protocolSlug));
 
 	let topVaults = $state<TopVaults>();
 	let loading = $state(!hasVaultCache(page.data.generatedAt));
@@ -27,14 +29,26 @@
 			.finally(() => (loading = false));
 	});
 
-	let title = $derived(`${protocolName} vaults and yields`);
-	let description = $derived(protocolMetadata?.short_description ?? `Top stablecoin vaults on ${protocolName}`);
+	const unknownVaultDescription = 'These vaults are not yet mapped out. Contact us to have your vaults listed.';
+
+	let title = $derived(isUnknownVaultProtocol ? 'Unknown vaults' : `${protocolName} vaults and yields`);
+	let heroTitle = $derived(isUnknownVaultProtocol ? 'Unknown vaults' : `${protocolName} powered stablecoin vaults`);
+	let description = $derived(
+		isUnknownVaultProtocol
+			? unknownVaultDescription
+			: (protocolMetadata?.short_description ?? `Top stablecoin vaults on ${protocolName}`)
+	);
 	let pageUrl = $derived(new URL(page.url.pathname, page.url.origin).href);
 	let logoUrl = $derived.by(() => {
 		const logoPath = protocolMetadata?.logos.light ? getVaultProtocolLogoUrl(protocolMetadata.slug) : undefined;
 		return logoPath ? new URL(logoPath, page.url.origin).href : undefined;
 	});
 </script>
+
+{#snippet unknownVaultSubtitle()}
+	These vaults are not yet mapped out. <a class="body-link" href={resolve('/community')}>Contact us</a> to have your vaults
+	listed.
+{/snippet}
 
 <MetaTags
 	{title}
@@ -77,17 +91,20 @@
 	{topVaults}
 	{loading}
 	{protocolMetadata}
-	title="{protocolName} powered stablecoin vaults"
+	title={heroTitle}
+	subtitle={isUnknownVaultProtocol ? unknownVaultSubtitle : undefined}
 	showFilters
 	defaultTvlKey="10k"
 	defaultHideUnknown={isUnsupportedProtocolSlug(protocolSlug) ? 0 : 1}
 >
 	{#snippet detailAside()}
 		<VaultGroupMiniChart
-			title="All {protocolName} vaults: TVL and returns"
+			title="All {protocolName} vaults: TVL and TVL-weighted 3-month ann. return"
 			dataUrl="/trading-view/vaults/protocols/{protocolSlug}/chart-data"
 			compareLabel="Compare all protocols"
 			compareHref="/trading-view/vaults/historical-tvl-protocol"
+			returnTooltipLabel="TVL-weighted 3-month ann. return"
+			returnWindowLabel="trailing 3-month"
 		/>
 	{/snippet}
 

--- a/src/routes/trading-view/vaults/protocols/[protocol=slug]/chart-data/+server.ts
+++ b/src/routes/trading-view/vaults/protocols/[protocol=slug]/chart-data/+server.ts
@@ -5,11 +5,12 @@ import {
 	getVaultGroupMiniChartLatestApyRows,
 	isEligibleVaultGroupMiniChartVault,
 	getVaultGroupMiniChartRows,
-	VAULT_GROUP_MINI_CHART_CACHE_TTL_SECONDS
+	VAULT_GROUP_MINI_CHART_CACHE_TTL_SECONDS,
+	VAULT_GROUP_MINI_CHART_THREE_MONTH_LOOKBACK_DAYS
 } from '$lib/echarts/vault-group-mini-chart-server';
 import { getCachedTopVaults } from '$lib/top-vaults/cache';
 
-const CACHE_VERSION = 'protocol-mini-chart-v5';
+const CACHE_VERSION = 'protocol-mini-chart-v6';
 const cache = new Map<string, { payload: ProtocolMiniChartPayload; expires: number; version: string }>();
 
 async function getCachedChartData(protocolSlug: string, fetch: Fetch) {
@@ -28,7 +29,8 @@ async function getCachedChartData(protocolSlug: string, fetch: Fetch) {
 			? getMockVaultGroupMiniChartRows(eligibleVaults)
 			: await getVaultGroupMiniChartRows(eligibleVaults.map((vault) => vault.id));
 	const payload = buildProtocolMiniChartPayload(rows, eligibleVaults.length, VAULT_GROUP_MINI_CHART_CACHE_TTL_SECONDS, {
-		latestApyRows: getVaultGroupMiniChartLatestApyRows(eligibleVaults)
+		latestApyRows: getVaultGroupMiniChartLatestApyRows(eligibleVaults, 'three-months'),
+		lookbackDays: VAULT_GROUP_MINI_CHART_THREE_MONTH_LOOKBACK_DAYS
 	});
 
 	cache.set(cacheKey, {

--- a/src/routes/trading-view/vaults/stablecoins/+page.svelte
+++ b/src/routes/trading-view/vaults/stablecoins/+page.svelte
@@ -7,6 +7,7 @@
 	import Section from '$lib/components/Section.svelte';
 	import VaultGroupTable from '$lib/top-vaults/VaultGroupTable.svelte';
 	import VaultListingsSelector from '$lib/top-vaults/VaultListingsSelector.svelte';
+	import { formatDollar } from '$lib/helpers/formatters';
 	import { getStablecoinLogoUrl, isStablecoinDepegged } from '$lib/stablecoin-metadata/helpers.js';
 	import { MetaTags, JsonLd } from 'svelte-meta-tags';
 	import MarketSharePieChart from '../MarketSharePieChart.svelte';
@@ -14,6 +15,8 @@
 
 	let { data } = $props();
 	let { stablecoins, chartStablecoins, options } = $derived(data);
+	let totalTvl = $derived(stablecoins.reduce((total, stablecoin) => total + stablecoin.tvl, 0));
+	let totalTvlLabel = $derived(`${formatDollar(totalTvl / 1_000_000_000, 1, 1, { notation: 'standard' })} billion`);
 
 	const onChange: ComponentProps<typeof VaultGroupTable>['onChange'] = async (params, scrollToTop) => {
 		// eslint-disable-next-line svelte/no-navigation-without-resolve
@@ -69,14 +72,17 @@
 							<span>{pageTitle}</span>
 						{/snippet}
 						{#snippet subtitle()}
-							<a class="body-link" href={glossaryLinks.defi}>DeFi</a>
-							<a class="body-link" href={glossaryLinks.vault}>vaults</a>
-							for different
-							<a class="body-link" href={glossaryLinks.stablecoin}>stablecoins</a>.
-							<a class="body-link" href={glossaryLinks.tvl}>TVL</a>
-							represents deposits of a stablecoin in vaults.
-							<a class="body-link" href={glossaryLinks.apy}>APY</a>
-							represents the yield of last thirty days.
+							<p>
+								<a class="body-link" href={glossaryLinks.defi}>DeFi</a>
+								<a class="body-link" href={glossaryLinks.vault}>vaults</a>
+								for different
+								<a class="body-link" href={glossaryLinks.stablecoin}>stablecoins</a>.
+								<a class="body-link" href={glossaryLinks.tvl}>TVL</a>
+								represents deposits of a stablecoin in vaults.
+								<a class="body-link" href={glossaryLinks.apy}>APY</a>
+								represents the yield of last thirty days.
+							</p>
+							<p>{totalTvlLabel} TVL tracked across {stablecoins.length} stablecoins.</p>
 						{/snippet}
 					</HeroBanner>
 				</div>

--- a/src/routes/trading-view/vaults/yield-protocol/ProtocolScatterPlot.svelte
+++ b/src/routes/trading-view/vaults/yield-protocol/ProtocolScatterPlot.svelte
@@ -14,7 +14,7 @@ coloured by protocol. Plotly.js is loaded dynamically from CDN.
 -->
 <script lang="ts">
 	import type { VaultInfo } from '$lib/top-vaults/schemas';
-	import { isBlacklisted, hasSupportedProtocol } from '$lib/top-vaults/helpers';
+	import { getProtocolDisplayName, isBlacklisted, hasSupportedProtocol } from '$lib/top-vaults/helpers';
 	import {
 		loadPlotly,
 		computeScatterRanges,
@@ -57,8 +57,12 @@ coloured by protocol. Plotly.js is loaded dynamically from CDN.
 
 	function formatHoverText(v: VaultInfo): string {
 		const lines = buildBaseHoverLines(v);
-		lines.splice(3, 0, `Protocol: ${v.protocol}`);
+		lines.splice(3, 0, `Protocol: ${getProtocolDisplayName(v.protocol, v.protocol_slug)}`);
 		return lines.join('<br>');
+	}
+
+	function getProtocolName(vault: VaultInfo) {
+		return getProtocolDisplayName(vault.protocol, vault.protocol_slug);
 	}
 
 	/**
@@ -68,7 +72,8 @@ coloured by protocol. Plotly.js is loaded dynamically from CDN.
 	function buildProtocolTraces(currentVaults: VaultInfo[], minX?: number): any[] {
 		const protocolCounts = new Map<string, number>();
 		for (const v of currentVaults) {
-			protocolCounts.set(v.protocol, (protocolCounts.get(v.protocol) ?? 0) + 1);
+			const protocol = getProtocolName(v);
+			protocolCounts.set(protocol, (protocolCounts.get(protocol) ?? 0) + 1);
 		}
 
 		const sortedProtocols = [...protocolCounts.entries()].sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]));
@@ -81,11 +86,11 @@ coloured by protocol. Plotly.js is loaded dynamically from CDN.
 		for (let i = 0; i < majorProtocols.length; i++) {
 			const [protocol] = majorProtocols[i];
 			const color = protocolPalette[i % protocolPalette.length];
-			const group = currentVaults.filter((v) => v.protocol === protocol);
+			const group = currentVaults.filter((v) => getProtocolName(v) === protocol);
 			traces.push(buildTrace(group, protocol, color, formatHoverText, minX));
 		}
 
-		const otherVaults = currentVaults.filter((v) => otherProtocols.has(v.protocol));
+		const otherVaults = currentVaults.filter((v) => otherProtocols.has(getProtocolName(v)));
 		if (otherVaults.length > 0) {
 			traces.push(buildTrace(otherVaults, 'Other', greyColor, formatHoverText, minX));
 		}


### PR DESCRIPTION
## Why

Give vault-listing visitors an at-a-glance view of the TVL and breadth represented by each grouping.

## Lessons learnt

The existing group rows already contain the filtered aggregate TVL and count, so header summaries can stay current without a separate data request.

## Summary

- Add live TVL and group-count descriptions to chain, protocol, curator and stablecoin listings.
- Add the feature to the changelog.