### PR TITLE
fix: hide repair trades from position chart markers

### DIFF
--- a/src/lib/trade-executor/helpers/position-chart.test.ts
+++ b/src/lib/trade-executor/helpers/position-chart.test.ts
@@ -151,6 +151,15 @@ describe('buildPositionChartsModel', () => {
 					planned_quantity: '0',
 					executed_quantity: '0',
 					flags: []
+				}),
+				createTrade({
+					trade_id: 4,
+					trade_type: 'repair',
+					planned_quantity: '5',
+					executed_quantity: '0',
+					planned_reserve: '5',
+					executed_reserve: '0',
+					repaired_trade_id: 2
 				})
 			]
 		});
@@ -159,6 +168,24 @@ describe('buildPositionChartsModel', () => {
 
 		expect(model.underlyingPrice.markers).toHaveLength(1);
 		expect(model.underlyingPrice.markers[0].tradeId).toBe(1);
+	});
+
+	test('uses planned reserve amount for vault marker USD value when executed quantity is zero', () => {
+		const payload = createPayload({
+			trades: [
+				createTrade({
+					planned_quantity: '123.45',
+					executed_quantity: '0',
+					planned_reserve: '123.45',
+					executed_reserve: '0'
+				})
+			]
+		});
+
+		const model = buildPositionChartsModel(payload);
+
+		expect(model.underlyingPrice.markers).toHaveLength(1);
+		expect(model.underlyingPrice.markers[0].tradeValueUsd).toBe(123.45);
 	});
 
 	test('falls back to underlying_price samples when price_history is missing', () => {

--- a/src/lib/trade-executor/helpers/position-chart.ts
+++ b/src/lib/trade-executor/helpers/position-chart.ts
@@ -96,6 +96,7 @@ function normalisePoints(points: PositionChartPoint[]) {
 function getMarkerTrades(trades: TradeInfo[], tradePathBase: string) {
 	return trades
 		.filter((trade) => !trade.repaired_at)
+		.filter((trade) => !trade.isRepair)
 		.filter((trade) => {
 			const plannedQuantity = trade.planned_quantity;
 			const executedQuantity = trade.executed_quantity ?? 0;
@@ -114,7 +115,7 @@ function getMarkerTrades(trades: TradeInfo[], tradePathBase: string) {
 					directionLabel: trade.direction === TradeDirections.Enter ? 'Increase' : 'Decrease',
 					quantity: trade.executed_quantity ?? trade.planned_quantity ?? null,
 					price: trade.executed_price ?? null,
-					tradeValueUsd: trade.value,
+					tradeValueUsd: getTradeValueUsd(trade),
 					tradeUrl: `${tradePathBase}/trade-${trade.trade_id}`
 				}
 			];
@@ -162,4 +163,9 @@ function getNearestPoint(points: PositionChartPoint[], timestamp: number) {
 
 function getTradeTimestamp(trade: TradeInfo) {
 	return trade.executed_at ?? trade.failed_at ?? trade.started_at ?? trade.opened_at ?? null;
+}
+
+function getTradeValueUsd(trade: TradeInfo) {
+	const reserveValue = Math.abs(trade.executed_reserve || trade.planned_reserve || 0);
+	return reserveValue || trade.value;
 }


### PR DESCRIPTION
## Why

Position charts could show repair counter-trades as normal increase/decrease markers. In Hyper AI this surfaced as a tooltip for trade #849 showing an Increase position marker with `$0.00` trade value, even though the live payload identifies the trade as `trade_type: repair` for repairing another trade.

## Lessons learnt

Filtering only trades with `repaired_at` removes original repaired trades, but it does not remove repair counter-trades. Chart marker generation needs to exclude `trade_type === repair` as well. Vault-style trades may also need reserve fields for a meaningful USD display value.

## Summary

- Exclude repair trades from position chart marker generation.
- Use reserve notional as the marker USD value fallback for vault-style trades.
- Add regression coverage for both repair markers and vault reserve-value display.