### PR TITLE
Fix vault listing filters

### DIFF
--- a/src/lib/top-vaults/TopVaultsPage.svelte
+++ b/src/lib/top-vaults/TopVaultsPage.svelte
@@ -44,6 +44,8 @@
 		defaultRiskIndex?: number;
 		/** Default value for the "Hide unknown" filter (1 = hide, 0 = show) */
 		defaultHideUnknown?: number;
+		/** Show the "Hide unknown" protocol filter checkbox */
+		showUnknownFilter?: boolean;
 		/** Default monthly return filter key */
 		defaultMonthlyReturnKey?: string;
 		/** Default sort column key */
@@ -87,6 +89,7 @@
 		defaultAgeIndex,
 		defaultRiskIndex,
 		defaultHideUnknown,
+		showUnknownFilter,
 		defaultMonthlyReturnKey,
 		defaultSort,
 		defaultDirection,
@@ -221,6 +224,7 @@
 					{showFilters}
 					{defaultRiskIndex}
 					{defaultHideUnknown}
+					{showUnknownFilter}
 					{defaultMonthlyReturnKey}
 					{defaultSort}
 					{defaultDirection}
@@ -249,6 +253,7 @@
 					{defaultAgeIndex}
 					{defaultRiskIndex}
 					{defaultHideUnknown}
+					{showUnknownFilter}
 					{defaultMonthlyReturnKey}
 					{defaultSort}
 					{defaultDirection}

--- a/src/lib/top-vaults/TopVaultsTable.svelte
+++ b/src/lib/top-vaults/TopVaultsTable.svelte
@@ -107,6 +107,8 @@
 		defaultRiskIndex?: number;
 		/** Default value for the "Hide unknown" filter (1 = hide, 0 = show) */
 		defaultHideUnknown?: number;
+		/** Show the "Hide unknown" protocol filter checkbox */
+		showUnknownFilter?: boolean;
 		/** Default monthly return filter key */
 		defaultMonthlyReturnKey?: string;
 		/** Default sort column key */
@@ -147,6 +149,7 @@
 		defaultAgeIndex = 0,
 		defaultRiskIndex = 1,
 		defaultHideUnknown = 1,
+		showUnknownFilter = true,
 		defaultMonthlyReturnKey = 'any',
 		defaultSort,
 		defaultDirection,
@@ -267,7 +270,7 @@
 	let treasuryRate = $derived((page.data as { treasuryRate?: number | null }).treasuryRate ?? null);
 
 	let hideClosed = $derived(urlState.closed === 1);
-	let hideUnknown = $derived(urlState.unknown === 1);
+	let hideUnknown = $derived(showUnknownFilter && urlState.unknown === 1);
 	let returnsDropdownOpen = $state(false);
 	let selectedReturnColumnIds = $derived(sanitiseReturnColumnSelection(urlState.returns));
 	let selectedReturnColumns = $derived(
@@ -806,21 +809,23 @@
 						</Tooltip>
 					</div>
 
-					<div class="filter-group">
-						<Tooltip>
-							<label class="checkbox-filter" slot="trigger">
-								<span class="filter-label filter-label-hint">Hide unknown</span>
-								<input
-									type="checkbox"
-									checked={hideUnknown}
-									onchange={() => updateSearchParams({ unknown: hideUnknown ? 0 : 1 })}
-								/>
-							</label>
-							<svelte:fragment slot="popup">
-								Don't show vaults whose protocol has not been identified yet
-							</svelte:fragment>
-						</Tooltip>
-					</div>
+					{#if showUnknownFilter}
+						<div class="filter-group">
+							<Tooltip>
+								<label class="checkbox-filter" slot="trigger">
+									<span class="filter-label filter-label-hint">Hide unknown</span>
+									<input
+										type="checkbox"
+										checked={hideUnknown}
+										onchange={() => updateSearchParams({ unknown: hideUnknown ? 0 : 1 })}
+									/>
+								</label>
+								<svelte:fragment slot="popup">
+									Don't show vaults whose protocol has not been identified yet
+								</svelte:fragment>
+							</Tooltip>
+						</div>
+					{/if}
 
 					<div class="filter">
 						<TextInput

--- a/src/lib/trade-executor/helpers/position-chart.test.ts
+++ b/src/lib/trade-executor/helpers/position-chart.test.ts
@@ -151,6 +151,15 @@ describe('buildPositionChartsModel', () => {
 					planned_quantity: '0',
 					executed_quantity: '0',
 					flags: []
+				}),
+				createTrade({
+					trade_id: 4,
+					trade_type: 'repair',
+					planned_quantity: '5',
+					executed_quantity: '0',
+					planned_reserve: '5',
+					executed_reserve: '0',
+					repaired_trade_id: 2
 				})
 			]
 		});
@@ -159,6 +168,24 @@ describe('buildPositionChartsModel', () => {
 
 		expect(model.underlyingPrice.markers).toHaveLength(1);
 		expect(model.underlyingPrice.markers[0].tradeId).toBe(1);
+	});
+
+	test('uses planned reserve amount for vault marker USD value when executed quantity is zero', () => {
+		const payload = createPayload({
+			trades: [
+				createTrade({
+					planned_quantity: '123.45',
+					executed_quantity: '0',
+					planned_reserve: '123.45',
+					executed_reserve: '0'
+				})
+			]
+		});
+
+		const model = buildPositionChartsModel(payload);
+
+		expect(model.underlyingPrice.markers).toHaveLength(1);
+		expect(model.underlyingPrice.markers[0].tradeValueUsd).toBe(123.45);
 	});
 
 	test('falls back to underlying_price samples when price_history is missing', () => {

--- a/src/lib/trade-executor/helpers/position-chart.ts
+++ b/src/lib/trade-executor/helpers/position-chart.ts
@@ -96,6 +96,7 @@ function normalisePoints(points: PositionChartPoint[]) {
 function getMarkerTrades(trades: TradeInfo[], tradePathBase: string) {
 	return trades
 		.filter((trade) => !trade.repaired_at)
+		.filter((trade) => !trade.isRepair)
 		.filter((trade) => {
 			const plannedQuantity = trade.planned_quantity;
 			const executedQuantity = trade.executed_quantity ?? 0;
@@ -114,7 +115,7 @@ function getMarkerTrades(trades: TradeInfo[], tradePathBase: string) {
 					directionLabel: trade.direction === TradeDirections.Enter ? 'Increase' : 'Decrease',
 					quantity: trade.executed_quantity ?? trade.planned_quantity ?? null,
 					price: trade.executed_price ?? null,
-					tradeValueUsd: trade.value,
+					tradeValueUsd: getTradeValueUsd(trade),
 					tradeUrl: `${tradePathBase}/trade-${trade.trade_id}`
 				}
 			];
@@ -162,4 +163,9 @@ function getNearestPoint(points: PositionChartPoint[], timestamp: number) {
 
 function getTradeTimestamp(trade: TradeInfo) {
 	return trade.executed_at ?? trade.failed_at ?? trade.started_at ?? trade.opened_at ?? null;
+}
+
+function getTradeValueUsd(trade: TradeInfo) {
+	const reserveValue = Math.abs(trade.executed_reserve || trade.planned_reserve || 0);
+	return reserveValue || trade.value;
 }

--- a/src/routes/trading-view/vaults/chains/[chain=slug]/+page.svelte
+++ b/src/routes/trading-view/vaults/chains/[chain=slug]/+page.svelte
@@ -33,6 +33,7 @@
 	let title = $derived(`${chainName} stablecoin vaults`);
 	let description = $derived(`Top stablecoin vaults on ${chainName} blockchain ranked by performance.`);
 	let pageUrl = $derived(new URL(page.url.pathname, page.url.origin).href);
+	let defaultTvlKey = $derived(chainSlug === 'robinhood' ? 'any' : '10k');
 </script>
 
 <MetaTags
@@ -65,7 +66,7 @@
 	{loading}
 	title="{chainName} stablecoin vaults"
 	showFilters
-	defaultTvlKey="10k"
+	{defaultTvlKey}
 >
 	{#snippet detailDescription()}
 		{#if topVaults?.vaults.length}

--- a/src/routes/trading-view/vaults/protocols/[protocol=slug]/+page.svelte
+++ b/src/routes/trading-view/vaults/protocols/[protocol=slug]/+page.svelte
@@ -94,6 +94,7 @@
 	title={heroTitle}
 	subtitle={isUnknownVaultProtocol ? unknownVaultSubtitle : undefined}
 	showFilters
+	showUnknownFilter={false}
 	defaultTvlKey="10k"
 	defaultHideUnknown={isUnsupportedProtocolSlug(protocolSlug) ? 0 : 1}
 >


### PR DESCRIPTION
## Why

Vault protocol pages already know the protocol from the route, so showing and applying the Hide unknown protocol checkbox is redundant and can hide the page's own rows. Robinhood chain vault listings also need to show vaults below the usual default TVL threshold.

## Lessons learnt

Protocol-specific vault listings should disable protocol-discovery filters at the shared table level so stale URL parameters cannot keep filtering the page after the checkbox is hidden.

## Summary

- Added a `showUnknownFilter` option to the top vaults page and table.
- Disabled the Hide unknown checkbox and filter behaviour on protocol vault listing pages.
- Allowed Robinhood chain vault listings to default to the `any` TVL filter while other chain pages keep `10k`.
