### PR TITLE
Fix curator TVL totals for non-USD vaults

### DIFF
--- a/src/lib/curator/CuratorDescription.svelte
+++ b/src/lib/curator/CuratorDescription.svelte
@@ -19,7 +19,12 @@ the vault protocol description widget. Sourced from the top-vaults dataset
 	import { micromark } from 'micromark';
 	import MetricsBox from '$lib/components/MetricsBox.svelte';
 	import Button from '$lib/components/Button.svelte';
-	import { calculateTotalTvl, calculateTvlWeightedApy, isBlacklisted } from '$lib/top-vaults/helpers';
+	import {
+		calculateTotalTvl,
+		calculateTvlWeightedApy,
+		isBlacklisted,
+		withVaultCurrentTvlUsd
+	} from '$lib/top-vaults/helpers';
 	import { VAULT_TVL_OUTLIER_THRESHOLD } from '$lib/echarts/tvl-outliers';
 	import { formatDollar, formatPercent } from '$lib/helpers/formatters';
 	import IconTwitter from '~icons/local/twitter';
@@ -40,8 +45,9 @@ the vault protocol description widget. Sourced from the top-vaults dataset
 	let statsVaults = $derived(
 		vaults.filter((v) => !isBlacklisted(v) && (v.current_nav ?? 0) <= VAULT_TVL_OUTLIER_THRESHOLD)
 	);
-	let totalTvl = $derived(calculateTotalTvl(statsVaults));
-	let averageApy = $derived(calculateTvlWeightedApy(statsVaults));
+	let statsVaultsWithUsdTvl = $derived(statsVaults.map(withVaultCurrentTvlUsd));
+	let totalTvl = $derived(calculateTotalTvl(statsVaultsWithUsdTvl));
+	let averageApy = $derived(calculateTvlWeightedApy(statsVaultsWithUsdTvl));
 	let vaultCountLabel = $derived(`${statsVaults.length} ${statsVaults.length === 1 ? 'vault' : 'vaults'}`);
 	let totalTvlLabel = $derived(`${formatDollar(totalTvl, 1)} TVL`);
 	let averageApyLabel = $derived(averageApy == null ? null : `${formatPercent(averageApy, 1)} APY`);

--- a/src/lib/top-vaults/helpers.test.ts
+++ b/src/lib/top-vaults/helpers.test.ts
@@ -26,6 +26,7 @@ import {
 	isNonUsdDenominatedVault,
 	normaliseKinexysVaultDenomination,
 	normaliseVaultProtocolDisplayName,
+	withVaultCurrentTvlUsd,
 	withVaultDenominationTokenRate,
 	calculateTotalTvl,
 	calculateTvlWeightedApy
@@ -358,6 +359,24 @@ describe('denomination TVL conversion', () => {
 
 		expect(getVaultCurrentTvlUsd(vault)).toBeCloseTo(108_000);
 		expect(getVaultPeakTvlUsd(vault)).toBeCloseTo(129_600);
+	});
+
+	test('uses USD TVL for cross-denomination aggregate inputs', () => {
+		const eurVault = createTestVault('EUR vault', {
+			current_nav: 100_000,
+			one_month_cagr: 0.1,
+			denomination_token_rate: createDenominationTokenRate({ usd_rate: 1.08 })
+		});
+		const usdVault = createTestVault('USD vault', {
+			current_nav: 100_000,
+			one_month_cagr: 0,
+			denomination_token_rate: createDenominationTokenRate({ usd_rate: 1 })
+		});
+
+		const usdVaults = [eurVault, usdVault].map(withVaultCurrentTvlUsd);
+
+		expect(calculateTotalTvl(usdVaults)).toBeCloseTo(208_000);
+		expect(calculateTvlWeightedApy(usdVaults)).toBeCloseTo(108_000 / 208_000 / 10);
 	});
 
 	test('infers EUR denomination when per-vault rate metadata is absent', () => {

--- a/src/lib/top-vaults/helpers.ts
+++ b/src/lib/top-vaults/helpers.ts
@@ -467,6 +467,16 @@ export function getVaultCurrentTvlUsd(vault: VaultWithNavAndRate): number | null
 }
 
 /**
+ * Copy a vault with its current TVL expressed in USD.
+ *
+ * Aggregate helpers use `current_nav` as their TVL input. Call this before
+ * calculating a cross-denomination total or TVL-weighted return.
+ */
+export function withVaultCurrentTvlUsd(vault: VaultInfo): VaultInfo {
+	return { ...vault, current_nav: getVaultCurrentTvlUsd(vault) };
+}
+
+/**
  * Peak vault TVL converted from denomination token units to USD.
  */
 export function getVaultPeakTvlUsd(vault: VaultWithPeakNavAndRate): number | null {

--- a/src/routes/trading-view/vaults/curators/[curator=slug]/+page.server.ts
+++ b/src/routes/trading-view/vaults/curators/[curator=slug]/+page.server.ts
@@ -1,6 +1,12 @@
 import { error } from '@sveltejs/kit';
 import { getCachedTopVaults } from '$lib/top-vaults/cache';
-import { calculateTotalTvl, calculateTvlWeightedApy, isBlacklisted, meetsMinTvl } from '$lib/top-vaults/helpers.js';
+import {
+	calculateTotalTvl,
+	calculateTvlWeightedApy,
+	isBlacklisted,
+	meetsMinTvl,
+	withVaultCurrentTvlUsd
+} from '$lib/top-vaults/helpers.js';
 
 export async function load({ params, fetch }) {
 	const { curator } = params;
@@ -12,8 +18,9 @@ export async function load({ params, fetch }) {
 	// aggregate stats for server-rendered SEO metadata; same eligibility rules
 	// as the curators index listing
 	const eligibleVaults = vaults.filter((v) => v.curator_slug === curator && !isBlacklisted(v) && meetsMinTvl(v));
-	const tvl = calculateTotalTvl(eligibleVaults);
-	const averageApy = calculateTvlWeightedApy(eligibleVaults);
+	const eligibleVaultsWithUsdTvl = eligibleVaults.map(withVaultCurrentTvlUsd);
+	const tvl = calculateTotalTvl(eligibleVaultsWithUsdTvl);
+	const averageApy = calculateTvlWeightedApy(eligibleVaultsWithUsdTvl);
 
 	return {
 		curatorSlug: curator,


### PR DESCRIPTION
## Why

Curator descriptions and SEO metadata summed raw denomination-token balances but labelled the result as USD. Frankencoin's ZCHF vaults therefore reported $13.0M while the individual USD listings totalled $16.1M.

## Lessons learnt

Any aggregate spanning vault denominations must convert `current_nav` to USD before calculating totals or TVL-weighted returns.

## Summary

- Convert curator description and metadata aggregates to USD.
- Add mixed-denomination aggregate regression coverage.