### PR TITLE
fix: group unknown vault protocols

### DIFF
--- a/src/lib/top-vaults/VaultGroupTable.svelte
+++ b/src/lib/top-vaults/VaultGroupTable.svelte
@@ -17,6 +17,7 @@
 	import { createRender } from '$lib/components/datatable/utils';
 	import DataTable from '$lib/components/datatable/DataTable.svelte';
 	import TableRowTarget from '$lib/components/datatable/TableRowTarget.svelte';
+	import { UNKNOWN_VAULT_PROTOCOL_SLUG } from '$lib/top-vaults/helpers';
 	import VaultGroupNameCell from './VaultGroupNameCell.svelte';
 	import RiskCell from './RiskCell.svelte';
 	import Core3RiskCell from './Core3RiskCell.svelte';
@@ -99,7 +100,7 @@
 				createRender(VaultGroupNameCell, {
 					label: value.name,
 					logoUrl: getLogoHref?.(value.slug),
-					showPlaceholder: value.name === 'Unknown' && !getLogoHref?.(value.slug)
+					showPlaceholder: value.slug === UNKNOWN_VAULT_PROTOCOL_SLUG && !getLogoHref?.(value.slug)
 				}),
 			plugins: { sort: { getSortValue: (v) => v.name, invert: true } }
 		}),

--- a/src/lib/top-vaults/helpers.test.ts
+++ b/src/lib/top-vaults/helpers.test.ts
@@ -5,6 +5,7 @@ import {
 	isEligibleFrontpageVault,
 	hasSupportedProtocol,
 	getProtocolDisplayName,
+	isUnknownVaultProtocol,
 	isUnsupportedProtocolSlug,
 	meetsMinTvl,
 	getFormattedLockup,
@@ -289,6 +290,20 @@ describe('isUnsupportedProtocolSlug', () => {
 
 	test('ignores supported protocol slugs', () => {
 		expect(isUnsupportedProtocolSlug('yearn')).toBe(false);
+	});
+});
+
+describe('isUnknownVaultProtocol', () => {
+	test.each([
+		{ protocol: 'ERC-4626', protocol_slug: 'erc-4626' },
+		{ protocol: '<protocol not yet identified>', protocol_slug: 'protocol-not-yet-identified' },
+		{ protocol: 'Unknown', protocol_slug: 'unknown' }
+	])('groups $protocol as unknown', (vault) => {
+		expect(isUnknownVaultProtocol(vault)).toBe(true);
+	});
+
+	test('does not group a recognised protocol as unknown', () => {
+		expect(isUnknownVaultProtocol({ protocol: 'Yearn', protocol_slug: 'yearn' })).toBe(false);
 	});
 });
 

--- a/src/lib/top-vaults/helpers.ts
+++ b/src/lib/top-vaults/helpers.ts
@@ -22,6 +22,8 @@ const KINEXYS_PROTOCOL_SLUG = 'kinexys';
 const KINEXYS_DENOMINATION = 'USD (offchain)';
 const KINEXYS_DENOMINATION_SLUG = 'usd-offchain';
 export const UNKNOWN_VAULT_PROTOCOL_DISPLAY_NAME = 'Unknown vault protocol';
+/** Canonical group used for vaults whose underlying protocol is unidentified or unsupported. */
+export const UNKNOWN_VAULT_PROTOCOL_SLUG = 'unknown';
 const UNKNOWN_VAULT_PROTOCOL_SLUGS = new Set(['erc-4626']);
 
 /**
@@ -209,6 +211,18 @@ export function hasSupportedProtocol(vault: Pick<VaultInfo, 'protocol'> & Partia
 
 export function isManuallyMappedUnknownProtocolSlug(protocolSlug: string | null | undefined) {
 	return protocolSlug != null && UNKNOWN_VAULT_PROTOCOL_SLUGS.has(protocolSlug);
+}
+
+/**
+ * Whether a vault belongs in the combined unknown-protocol group.
+ *
+ * This includes protocol placeholders from the data source, the generic ERC-4626
+ * classification, and records explicitly labelled "Unknown".
+ */
+export function isUnknownVaultProtocol(vault: Pick<VaultInfo, 'protocol'> & Partial<Pick<VaultInfo, 'protocol_slug'>>) {
+	if (isManuallyMappedUnknownProtocolSlug(vault.protocol_slug)) return true;
+	if (isUnsupportedProtocolName(vault.protocol) || isUnsupportedProtocolSlug(vault.protocol_slug)) return true;
+	return vault.protocol?.trim().toLowerCase() === 'unknown';
 }
 
 const FRONTPAGE_RISK_FILTER = riskFilterOptions.find((option) => option.label === 'Severe');

--- a/src/lib/vault-protocol/helpers.ts
+++ b/src/lib/vault-protocol/helpers.ts
@@ -1,6 +1,6 @@
 import { vaultProtocolMetadataUrl } from '$lib/config';
 import { buildMetadataLogoProxyPath, type MetadataLogoOptions } from '$lib/metadata-logo/proxy';
-import { isUnsupportedProtocolSlug } from '$lib/top-vaults/helpers';
+import { isUnsupportedProtocolSlug, UNKNOWN_VAULT_PROTOCOL_SLUG } from '$lib/top-vaults/helpers';
 
 /**
  * Return the "light" version of the vault protocol logo URL for a given
@@ -14,7 +14,7 @@ import { isUnsupportedProtocolSlug } from '$lib/top-vaults/helpers';
  */
 export function getVaultProtocolLogoUrl(slug: string, options: MetadataLogoOptions = {}): string | undefined {
 	if (!vaultProtocolMetadataUrl) return undefined;
-	if (isUnsupportedProtocolSlug(slug)) return undefined;
+	if (slug === UNKNOWN_VAULT_PROTOCOL_SLUG || isUnsupportedProtocolSlug(slug)) return undefined;
 	return buildMetadataLogoProxyPath('protocol', slug, {
 		format: 'webp',
 		...options

--- a/src/routes/trading-view/vaults/protocols/+page.server.ts
+++ b/src/routes/trading-view/vaults/protocols/+page.server.ts
@@ -5,7 +5,10 @@ import {
 	getCore3PolForVault,
 	getProtocolDisplayName,
 	isBlacklisted,
-	meetsMinTvl
+	isUnknownVaultProtocol,
+	meetsMinTvl,
+	UNKNOWN_VAULT_PROTOCOL_DISPLAY_NAME,
+	UNKNOWN_VAULT_PROTOCOL_SLUG
 } from '$lib/top-vaults/helpers.js';
 import { sortOptions } from '$lib/top-vaults/VaultGroupTable.svelte';
 import { getNumberParam, getStringParam } from '$lib/helpers/url-params';
@@ -18,12 +21,15 @@ export async function load({ fetch, url: { searchParams } }) {
 	const eligibleVaults = vaults.filter((v) => !isBlacklisted(v) && meetsMinTvl(v));
 
 	const protocols = eligibleVaults.reduce<Record<string, VaultGroup>>((acc, vault) => {
-		const slug = vault.protocol_slug;
+		const isUnknown = isUnknownVaultProtocol(vault);
+		const slug = isUnknown ? UNKNOWN_VAULT_PROTOCOL_SLUG : vault.protocol_slug;
 		const core3Pol = getCore3PolForVault(vault, core3_protocols);
 
 		acc[slug] ??= {
 			slug,
-			name: getProtocolDisplayName(vault.protocol, vault.protocol_slug),
+			name: isUnknown
+				? UNKNOWN_VAULT_PROTOCOL_DISPLAY_NAME
+				: getProtocolDisplayName(vault.protocol, vault.protocol_slug),
 			vault_count: 0,
 			tvl: 0,
 			avg_apy: null,
@@ -43,7 +49,11 @@ export async function load({ fetch, url: { searchParams } }) {
 	// Calculate TVL-weighted average APY for each protocol
 	const protocolGroups: VaultGroup[] = Object.values(protocols).map((group) => ({
 		...group,
-		avg_apy: calculateTvlWeightedApy(eligibleVaults.filter((v) => v.protocol_slug === group.slug))
+		avg_apy: calculateTvlWeightedApy(
+			eligibleVaults.filter((vault) =>
+				group.slug === UNKNOWN_VAULT_PROTOCOL_SLUG ? isUnknownVaultProtocol(vault) : vault.protocol_slug === group.slug
+			)
+		)
 	}));
 
 	const chartProtocols: MarketShareChartItem[] = protocolGroups.map((group) => ({

--- a/src/routes/trading-view/vaults/protocols/[protocol=slug]/+page.server.ts
+++ b/src/routes/trading-view/vaults/protocols/[protocol=slug]/+page.server.ts
@@ -1,25 +1,36 @@
 import { error } from '@sveltejs/kit';
 import { getCachedTopVaults } from '$lib/top-vaults/cache';
 import { fetchVaultProtocolMetadata } from '$lib/vault-protocol/client';
-import { getCore3ProtocolForVault, getProtocolDisplayName } from '$lib/top-vaults/helpers.js';
+import {
+	getCore3ProtocolForVault,
+	getProtocolDisplayName,
+	isUnknownVaultProtocol,
+	UNKNOWN_VAULT_PROTOCOL_DISPLAY_NAME,
+	UNKNOWN_VAULT_PROTOCOL_SLUG
+} from '$lib/top-vaults/helpers.js';
 
 export async function load({ params, fetch }) {
 	const { protocol } = params;
 	const { vaults, core3_protocols } = await getCachedTopVaults(fetch);
 
-	const protocolVault = vaults.find((v) => v.protocol_slug === protocol);
+	const isUnknownGroup = protocol === UNKNOWN_VAULT_PROTOCOL_SLUG;
+	const protocolVault = vaults.find((v) => (isUnknownGroup ? isUnknownVaultProtocol(v) : v.protocol_slug === protocol));
 	if (!protocolVault) error(404, 'Vault protocol not found');
 
-	const protocolMetadata = await fetchVaultProtocolMetadata(fetch, protocol, protocolVault.protocol);
+	const protocolMetadata = isUnknownGroup
+		? undefined
+		: await fetchVaultProtocolMetadata(fetch, protocol, protocolVault.protocol);
 	const core3 =
 		vaults
-			.filter((v) => v.protocol_slug === protocol)
+			.filter((v) => (isUnknownGroup ? isUnknownVaultProtocol(v) : v.protocol_slug === protocol))
 			.map((vault) => getCore3ProtocolForVault(vault, core3_protocols))
 			.find((rating) => rating !== null) ?? null;
 
 	return {
 		protocolSlug: protocol,
-		protocolName: getProtocolDisplayName(protocolVault.protocol, protocolVault.protocol_slug),
+		protocolName: isUnknownGroup
+			? UNKNOWN_VAULT_PROTOCOL_DISPLAY_NAME
+			: getProtocolDisplayName(protocolVault.protocol, protocolVault.protocol_slug),
 		protocolMetadata,
 		core3
 	};

--- a/src/routes/trading-view/vaults/protocols/[protocol=slug]/+page.svelte
+++ b/src/routes/trading-view/vaults/protocols/[protocol=slug]/+page.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import type { TopVaults } from '$lib/top-vaults/schemas';
 	import { fetchAllVaultData, hasVaultCache } from '$lib/top-vaults/client-cache';
-	import { isManuallyMappedUnknownProtocolSlug, isUnsupportedProtocolSlug } from '$lib/top-vaults/helpers';
+	import { isUnknownVaultProtocol, UNKNOWN_VAULT_PROTOCOL_SLUG } from '$lib/top-vaults/helpers';
 	import { getVaultProtocolLogoUrl } from '$lib/vault-protocol/helpers.js';
 	import { resolve } from '$app/paths';
 	import { page } from '$app/state';
@@ -12,7 +12,7 @@
 
 	let { data } = $props();
 	let { protocolSlug, protocolName, protocolMetadata, core3 } = $derived(data);
-	let isUnknownVaultProtocol = $derived(isManuallyMappedUnknownProtocolSlug(protocolSlug));
+	let isUnknownVaultProtocolGroup = $derived(protocolSlug === UNKNOWN_VAULT_PROTOCOL_SLUG);
 
 	let topVaults = $state<TopVaults>();
 	let loading = $state(!hasVaultCache(page.data.generatedAt));
@@ -22,7 +22,9 @@
 			.then((allData) => {
 				topVaults = {
 					...allData,
-					vaults: allData.vaults.filter((v) => v.protocol_slug === protocolSlug)
+					vaults: allData.vaults.filter((vault) =>
+						isUnknownVaultProtocolGroup ? isUnknownVaultProtocol(vault) : vault.protocol_slug === protocolSlug
+					)
 				};
 			})
 			.catch((e) => console.error('Failed to load vault data:', e))
@@ -31,10 +33,12 @@
 
 	const unknownVaultDescription = 'These vaults are not yet mapped out. Contact us to have your vaults listed.';
 
-	let title = $derived(isUnknownVaultProtocol ? 'Unknown vaults' : `${protocolName} vaults and yields`);
-	let heroTitle = $derived(isUnknownVaultProtocol ? 'Unknown vaults' : `${protocolName} powered stablecoin vaults`);
+	let title = $derived(isUnknownVaultProtocolGroup ? 'Unknown vaults' : `${protocolName} vaults and yields`);
+	let heroTitle = $derived(
+		isUnknownVaultProtocolGroup ? 'Unknown vaults' : `${protocolName} powered stablecoin vaults`
+	);
 	let description = $derived(
-		isUnknownVaultProtocol
+		isUnknownVaultProtocolGroup
 			? unknownVaultDescription
 			: (protocolMetadata?.short_description ?? `Top stablecoin vaults on ${protocolName}`)
 	);
@@ -92,11 +96,11 @@
 	{loading}
 	{protocolMetadata}
 	title={heroTitle}
-	subtitle={isUnknownVaultProtocol ? unknownVaultSubtitle : undefined}
+	subtitle={isUnknownVaultProtocolGroup ? unknownVaultSubtitle : undefined}
 	showFilters
 	showUnknownFilter={false}
 	defaultTvlKey="10k"
-	defaultHideUnknown={isUnsupportedProtocolSlug(protocolSlug) ? 0 : 1}
+	defaultHideUnknown={isUnknownVaultProtocolGroup ? 0 : 1}
 >
 	{#snippet detailAside()}
 		<VaultGroupMiniChart

--- a/src/routes/trading-view/vaults/protocols/[protocol=slug]/chart-data/+server.ts
+++ b/src/routes/trading-view/vaults/protocols/[protocol=slug]/chart-data/+server.ts
@@ -9,8 +9,9 @@ import {
 	VAULT_GROUP_MINI_CHART_THREE_MONTH_LOOKBACK_DAYS
 } from '$lib/echarts/vault-group-mini-chart-server';
 import { getCachedTopVaults } from '$lib/top-vaults/cache';
+import { isUnknownVaultProtocol, UNKNOWN_VAULT_PROTOCOL_SLUG } from '$lib/top-vaults/helpers';
 
-const CACHE_VERSION = 'protocol-mini-chart-v6';
+const CACHE_VERSION = 'protocol-mini-chart-v7';
 const cache = new Map<string, { payload: ProtocolMiniChartPayload; expires: number; version: string }>();
 
 async function getCachedChartData(protocolSlug: string, fetch: Fetch) {
@@ -20,7 +21,9 @@ async function getCachedChartData(protocolSlug: string, fetch: Fetch) {
 	if (cached && cached.version === CACHE_VERSION && now < cached.expires) return cached.payload;
 
 	const { vaults } = await getCachedTopVaults(fetch);
-	const protocolVaults = vaults.filter((vault) => vault.protocol_slug === protocolSlug);
+	const protocolVaults = vaults.filter((vault) =>
+		protocolSlug === UNKNOWN_VAULT_PROTOCOL_SLUG ? isUnknownVaultProtocol(vault) : vault.protocol_slug === protocolSlug
+	);
 	if (protocolVaults.length === 0) error(404, 'Vault protocol not found');
 
 	const eligibleVaults = protocolVaults.filter(isEligibleVaultGroupMiniChartVault);


### PR DESCRIPTION
## Why

Unidentified, placeholder, and ERC-4626 vaults appeared as separate protocol entries even though they do not identify a concrete vault protocol.

## Lessons learnt

Protocol grouping needs a canonical unknown slug shared by the list, its detail page, and chart data. The combined unknown group must use the existing blank placeholder icon instead of attempting metadata-logo lookups.

## Summary

- Group unsupported and unidentified vault protocols into one Unknown vault protocol entry.
- Serve the combined vault list and mini chart from the canonical unknown route.
- Retain the existing Unknown placeholder icon.