### PR TITLE
Fix vault returns and grouping UI

### DIFF
--- a/src/lib/echarts/stablecoin-chain-heatmap.ts
+++ b/src/lib/echarts/stablecoin-chain-heatmap.ts
@@ -3,6 +3,7 @@ import { getLogoUrl } from '$lib/helpers/assets';
 import {
 	buildStablecoinMetadataLookup,
 	formatStablecoinDisplayName,
+	getStablecoinDetailsHref,
 	getStablecoinLogoUrl,
 	resolveStablecoinSlug
 } from '$lib/stablecoin-metadata/helpers';
@@ -69,7 +70,7 @@ interface ResolvedStablecoinGroup {
 	label: string;
 	tooltipLabel: string;
 	stablecoinSlug: string;
-	href: string;
+	href?: string;
 	logoUrl?: string;
 }
 
@@ -151,7 +152,7 @@ function resolveStablecoinGroup(
 		label,
 		tooltipLabel,
 		stablecoinSlug,
-		href: `/trading-view/vaults/stablecoins/${stablecoinSlug}`,
+		href: getStablecoinDetailsHref(stablecoinSlug),
 		logoUrl: getStablecoinLogoUrl(stablecoinSlug)
 	};
 }
@@ -179,7 +180,7 @@ export function buildStablecoinChainHeatmapPayload(
 			tooltipLabel: string;
 			totalTvl: number;
 			stablecoinSlug: string;
-			href: string;
+			href?: string;
 			logoUrl?: string;
 		}
 	>();

--- a/src/lib/stablecoin-metadata/helpers.test.ts
+++ b/src/lib/stablecoin-metadata/helpers.test.ts
@@ -4,8 +4,13 @@ import {
 	findStablecoinMetadata,
 	formatStablecoinDisplayName,
 	getStablecoinCoingeckoLink,
+	getStablecoinDetailsHref,
+	getStablecoinLogoUrl,
 	getStablecoinNativeRate,
+	getVaultDenominationLogoUrl,
 	isStablecoinDepegged,
+	isMidasRawUsdVault,
+	OFFCHAIN_USD_SHORT_DESCRIPTION,
 	resolveStablecoinSlug
 } from './helpers';
 import type { StablecoinMetadata } from './schemas';
@@ -68,6 +73,25 @@ describe('stablecoin metadata helpers', () => {
 		});
 
 		expect(slug).toBe('usd-offchain');
+	});
+
+	test('uses the US flag and hides off-chain USD from stablecoin navigation', () => {
+		expect(getStablecoinLogoUrl('usd-offchain')).toBe('/flags/us.svg');
+		expect(getStablecoinDetailsHref('usd-offchain')).toBeUndefined();
+		expect(getStablecoinDetailsHref('usdc')).toBe('/trading-view/vaults/stablecoins/usdc');
+		expect(OFFCHAIN_USD_SHORT_DESCRIPTION).toBe('U.S. Dollars in the banking system without onchain transparency');
+	});
+
+	test('uses the US flag only for Midas vaults denominated in raw USD', () => {
+		expect(isMidasRawUsdVault({ protocol_slug: 'midas', denomination: 'USD' })).toBe(true);
+		expect(isMidasRawUsdVault({ protocol_slug: 'midas', denomination: 'USDT' })).toBe(false);
+		expect(getVaultDenominationLogoUrl({ protocol_slug: 'midas', denomination: 'USD' }, 'usd')).toBe('/flags/us.svg');
+		expect(getVaultDenominationLogoUrl({ protocol_slug: 'midas', denomination: 'USDT' }, 'usdt')).not.toBe(
+			'/flags/us.svg'
+		);
+		expect(getVaultDenominationLogoUrl({ protocol_slug: 'morpho', denomination: 'USD' }, 'usd')).not.toBe(
+			'/flags/us.svg'
+		);
 	});
 
 	test('appends symbol to display name when missing', () => {

--- a/src/lib/stablecoin-metadata/helpers.ts
+++ b/src/lib/stablecoin-metadata/helpers.ts
@@ -4,6 +4,9 @@ import { slugify } from '$lib/helpers/slugify';
 import type { StablecoinMetadata } from './schemas';
 
 export const STABLECOIN_DEPEG_RATE_THRESHOLD = 0.9;
+export const OFFCHAIN_USD_STABLECOIN_SLUG = 'usd-offchain';
+export const OFFCHAIN_USD_SHORT_DESCRIPTION = 'U.S. Dollars in the banking system without onchain transparency';
+const OFFCHAIN_USD_LOGO_URL = '/flags/us.svg';
 
 interface StablecoinLookupInput {
 	slug?: string | null;
@@ -128,6 +131,54 @@ export function resolveStablecoinSlug(
 }
 
 /**
+ * Return the stablecoin details page URL when the denomination is navigable.
+ *
+ * Off-chain USD has a standalone page, but is intentionally not linked from
+ * stablecoin listings because it is a vault accounting denomination rather
+ * than an on-chain stablecoin product.
+ *
+ * @param slug stablecoin denomination slug
+ */
+export function getStablecoinDetailsHref(slug: string | null | undefined): string | undefined {
+	const trimmedSlug = slug?.trim().toLowerCase();
+	if (!trimmedSlug || trimmedSlug === OFFCHAIN_USD_STABLECOIN_SLUG) return undefined;
+
+	return `/trading-view/vaults/stablecoins/${trimmedSlug}`;
+}
+
+/**
+ * Whether a vault is denominated in Midas' raw USD accounting currency.
+ *
+ * This is distinct from tokenised stablecoins such as USDT, even though their
+ * metadata can expose a USD symbol alias.
+ *
+ * @param vault vault denomination fields
+ */
+export function isMidasRawUsdVault(vault: { protocol_slug?: string | null; denomination?: string | null }): boolean {
+	return vault.protocol_slug === 'midas' && vault.denomination?.trim().toLowerCase() === 'usd';
+}
+
+/**
+ * Return the denomination logo for a vault.
+ *
+ * Midas reports certain vaults as raw USD rather than an on-chain token. These
+ * use the US flag; tokenised denominations such as USDT retain their own logos.
+ *
+ * @param vault vault denomination fields
+ * @param slug resolved stablecoin denomination slug
+ */
+export function getVaultDenominationLogoUrl(
+	vault: { protocol_slug?: string | null; denomination?: string | null },
+	slug: string | null | undefined
+): string | undefined {
+	if (isMidasRawUsdVault(vault)) {
+		return OFFCHAIN_USD_LOGO_URL;
+	}
+
+	return slug ? getStablecoinLogoUrl(slug) : undefined;
+}
+
+/**
  * Return the CoinGecko URL for a stablecoin metadata record.
  *
  * @param metadata stablecoin metadata from the external metadata index
@@ -193,6 +244,10 @@ export function isStablecoinDepegged(metadata: StablecoinRateInput | null | unde
  * Returns undefined if the stablecoin metadata URL is not configured.
  */
 export function getStablecoinLogoUrl(slug: string, options: MetadataLogoOptions = {}): string | undefined {
+	const normalisedSlug = slug.trim().toLowerCase();
+	if (normalisedSlug === OFFCHAIN_USD_STABLECOIN_SLUG) {
+		return OFFCHAIN_USD_LOGO_URL;
+	}
 	if (!stablecoinMetadataUrl) return undefined;
 	return buildMetadataLogoProxyPath('stablecoin', slug, {
 		format: 'webp',

--- a/src/lib/top-vaults/TopVaultsPage.svelte
+++ b/src/lib/top-vaults/TopVaultsPage.svelte
@@ -33,6 +33,8 @@
 		includeBlacklisted?: boolean;
 		protocolMetadata?: VaultProtocolMetadata;
 		stablecoinMetadata?: StablecoinMetadata;
+		/** Stablecoin slug used for a logo when no metadata record exists. */
+		stablecoinLogoSlug?: string;
 		curatorMetadata?: CuratorInfo;
 		/** Show interactive filter dropdowns (Min TVL, Min age, Max risk) */
 		showFilters?: boolean;
@@ -83,6 +85,7 @@
 		includeBlacklisted,
 		protocolMetadata,
 		stablecoinMetadata,
+		stablecoinLogoSlug,
 		curatorMetadata,
 		showFilters,
 		defaultTvlKey,
@@ -132,10 +135,10 @@
 									<img src={protocolLogoUrl} alt={protocolMetadata.name} />
 								{/if}
 							{/if}
-							{#if stablecoinMetadata?.logos.light}
-								{@const stablecoinLogoUrl = getStablecoinLogoUrl(stablecoinMetadata.slug)}
+							{#if stablecoinMetadata?.logos.light || stablecoinLogoSlug}
+								{@const stablecoinLogoUrl = getStablecoinLogoUrl(stablecoinMetadata?.slug ?? stablecoinLogoSlug ?? '')}
 								{#if stablecoinLogoUrl}
-									<img src={stablecoinLogoUrl} alt={stablecoinMetadata.name} />
+									<img src={stablecoinLogoUrl} alt={stablecoinMetadata?.name ?? pageTitle} />
 								{/if}
 							{/if}
 							{#if curatorMetadata?.logos.generic}

--- a/src/lib/top-vaults/VaultGroupTable.svelte
+++ b/src/lib/top-vaults/VaultGroupTable.svelte
@@ -37,7 +37,7 @@
 		page?: number;
 		sort?: SortOptions['keys'][number];
 		direction?: SortOptions['directions'][number];
-		getHref?: (slug: string) => string;
+		getHref?: (slug: string) => string | undefined;
 		getWarningLabel?: (row: VaultGroup) => string | undefined;
 	}
 
@@ -161,7 +161,8 @@
 			id: 'cta',
 			header: '',
 			accessor: (row) => getHref(row.slug),
-			cell: ({ value }) => createRender(TableRowTarget, { size: 'sm', label: 'View vaults', href: value }),
+			cell: ({ value }) =>
+				value ? createRender(TableRowTarget, { size: 'sm', label: 'View vaults', href: value }) : '',
 			plugins: { sort: { disable: true } }
 		})
 	]);

--- a/src/routes/trading-view/vaults/MarketSharePieChart.svelte
+++ b/src/routes/trading-view/vaults/MarketSharePieChart.svelte
@@ -90,9 +90,10 @@
 			: `<span>${titleLabel}</span>`;
 		const showNameRow = slice.name !== slice.label;
 		const groupedLabel = `${toTitleCase(groupLabelPlural)} grouped`;
-		const hint = slice.isOther
-			? ''
-			: `<div class="tooltip-hint" style="margin-top: 0.75rem; display: inline-flex; align-items: center; border: 1px solid rgba(191, 219, 254, 0.16); border-radius: 999px; padding: 0.38rem 0.72rem; color: #f8fafc; font-family: ${chartFontFamily}; background: rgba(125, 211, 252, 0.08); box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.06);"><span style="text-decoration: underline;">Click to view more</span></div>`;
+		const hint =
+			slice.isOther || !slice.url
+				? ''
+				: `<div class="tooltip-hint" style="margin-top: 0.75rem; display: inline-flex; align-items: center; border: 1px solid rgba(191, 219, 254, 0.16); border-radius: 999px; padding: 0.38rem 0.72rem; color: #f8fafc; font-family: ${chartFontFamily}; background: rgba(125, 211, 252, 0.08); box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.06);"><span style="text-decoration: underline;">Click to view more</span></div>`;
 
 		return [
 			`<div style="margin-bottom: 0.7rem; padding-bottom: 0.65rem; border-bottom: 1px solid rgba(191, 219, 254, 0.12);"><div class="tooltip-title" style="${TOOLTIP_TITLE_STYLE}">${title}</div>${showNameRow ? `<div style="margin-top: 0.18rem; color: rgba(226, 232, 240, 0.76); font-family: ${chartFontFamily}; line-height: 1.35;">${escapeHtml(slice.name)}</div>` : ''}</div>`,

--- a/src/routes/trading-view/vaults/VaultGroupDescription.svelte
+++ b/src/routes/trading-view/vaults/VaultGroupDescription.svelte
@@ -30,6 +30,8 @@ excluded vault count from the loaded vault data.
 	interface Props {
 		/** MetricsBox heading, e.g. "About Base vaults" */
 		title: string;
+		/** Optional introductory sentence shown before the generated vault summary. */
+		description?: string;
 		/** Sentence opener naming the group, e.g. "Base blockchain" or "Circle USDC" */
 		subject: string;
 		/** Verb phrase linking the subject to the vault count, e.g. "has" or "is used in" */
@@ -37,7 +39,7 @@ excluded vault count from the loaded vault data.
 		vaults: VaultInfo[];
 	}
 
-	let { title, subject, verbPhrase = 'has', vaults }: Props = $props();
+	let { title, description, subject, verbPhrase = 'has', vaults }: Props = $props();
 
 	// all headline stats derive from this set: exclude blacklisted vaults and broken
 	// TVL outliers so a single bad data point doesn't inflate the figures
@@ -89,6 +91,9 @@ excluded vault count from the loaded vault data.
 
 <div class="vault-group-description">
 	<MetricsBox {title}>
+		{#if description}
+			<p>{description}</p>
+		{/if}
 		<p>
 			{subject}
 			{verbPhrase}

--- a/src/routes/trading-view/vaults/[vault=slug]/+page.server.ts
+++ b/src/routes/trading-view/vaults/[vault=slug]/+page.server.ts
@@ -1,6 +1,10 @@
 import { getChain } from '$lib/helpers/chain';
 import { fetchStablecoinMetadataIndex } from '$lib/stablecoin-metadata/client';
-import { buildStablecoinMetadataLookup, findStablecoinMetadata } from '$lib/stablecoin-metadata/helpers';
+import {
+	buildStablecoinMetadataLookup,
+	findStablecoinMetadata,
+	isMidasRawUsdVault
+} from '$lib/stablecoin-metadata/helpers';
 import { getCachedTopVaults } from '$lib/top-vaults/cache';
 import {
 	getCore3ProtocolForVault,
@@ -35,12 +39,14 @@ export async function load({ params, fetch }) {
 		fetchStablecoinMetadataIndex(fetch)
 	]);
 	const stablecoinMetadataLookup = buildStablecoinMetadataLookup(stablecoinMetadataIndex);
-	const stablecoinMetadata = findStablecoinMetadata(
-		stablecoinMetadataLookup,
-		vault.denomination_slug,
-		vault.denomination,
-		vault.normalised_denomination
-	);
+	const stablecoinMetadata = isMidasRawUsdVault(vault)
+		? undefined
+		: findStablecoinMetadata(
+				stablecoinMetadataLookup,
+				vault.denomination_slug,
+				vault.denomination,
+				vault.normalised_denomination
+			);
 	const vaultWithRates = withVaultDenominationTokenRate(
 		vault,
 		stablecoinMetadata,

--- a/src/routes/trading-view/vaults/[vault=slug]/VaultMetrics.svelte
+++ b/src/routes/trading-view/vaults/[vault=slug]/VaultMetrics.svelte
@@ -8,10 +8,15 @@ Displays supplementary vault information, including transaction status, performa
 	import Tooltip from '$lib/components/Tooltip.svelte';
 	import Risk from '$lib/top-vaults/Risk.svelte';
 	import Metric from './Metric.svelte';
+	import { resolve } from '$app/paths';
 	import { getFormattedLockup, isGoodVaultStatus } from '$lib/top-vaults/helpers';
 	import { formatNumber, formatPercent, formatPercentProfit } from '$lib/helpers/formatters';
 	import { getChain } from '$lib/helpers/chain';
-	import { getStablecoinLogoUrl, resolveStablecoinSlug } from '$lib/stablecoin-metadata/helpers';
+	import {
+		getStablecoinDetailsHref,
+		getVaultDenominationLogoUrl,
+		resolveStablecoinSlug
+	} from '$lib/stablecoin-metadata/helpers';
 	import type { StablecoinMetadata } from '$lib/stablecoin-metadata/schemas';
 
 	interface Props {
@@ -33,12 +38,8 @@ Displays supplementary vault information, including transaction status, performa
 			name: vault.normalised_denomination
 		})
 	);
-	let denominationLogoUrl = $derived(
-		stablecoinMetadata?.logos.light && denominationSlug ? getStablecoinLogoUrl(denominationSlug) : undefined
-	);
-	let denominationHref = $derived(
-		stablecoinMetadata && denominationSlug ? `/trading-view/vaults/stablecoins/${denominationSlug}` : undefined
-	);
+	let denominationLogoUrl = $derived(getVaultDenominationLogoUrl(vault, denominationSlug));
+	let denominationHref = $derived(stablecoinMetadata ? getStablecoinDetailsHref(denominationSlug) : undefined);
 
 	function getDaysUntil(dateString: string | null): number | null {
 		if (!dateString) return null;
@@ -57,19 +58,48 @@ Displays supplementary vault information, including transaction status, performa
 	);
 	let periodResults = $derived(new Map(vault.period_results.map((metrics) => [metrics.period.toLowerCase(), metrics])));
 	let returnPeriods = $derived([
-		{ label: '1M', gross: vault.one_month_returns, net: vault.one_month_returns_net },
-		{ label: '3M', gross: vault.three_months_returns, net: vault.three_months_returns_net },
+		{
+			label: '1M',
+			samplePeriod: periodResults.get('1m'),
+			gross: { annualised: vault.one_month_cagr, raw: vault.one_month_returns },
+			net: { annualised: vault.one_month_cagr_net, raw: vault.one_month_returns_net }
+		},
+		{
+			label: '3M',
+			samplePeriod: periodResults.get('3m'),
+			gross: { annualised: vault.three_months_cagr, raw: vault.three_months_returns },
+			net: { annualised: vault.three_months_cagr_net, raw: vault.three_months_returns_net }
+		},
 		{
 			label: '6M',
-			gross: periodResults.get('6m')?.returns_gross ?? null,
-			net: periodResults.get('6m')?.returns_net ?? null
+			samplePeriod: periodResults.get('6m'),
+			gross: {
+				annualised: periodResults.get('6m')?.cagr_gross ?? null,
+				raw: periodResults.get('6m')?.returns_gross ?? null
+			},
+			net: {
+				annualised: periodResults.get('6m')?.cagr_net ?? null,
+				raw: periodResults.get('6m')?.returns_net ?? null
+			}
 		},
 		{
 			label: '1Y',
-			gross: periodResults.get('1y')?.returns_gross ?? null,
-			net: periodResults.get('1y')?.returns_net ?? null
+			samplePeriod: periodResults.get('1y'),
+			gross: {
+				annualised: periodResults.get('1y')?.cagr_gross ?? null,
+				raw: periodResults.get('1y')?.returns_gross ?? null
+			},
+			net: {
+				annualised: periodResults.get('1y')?.cagr_net ?? null,
+				raw: periodResults.get('1y')?.returns_net ?? null
+			}
 		},
-		{ label: 'Lifetime', gross: vault.lifetime_return, net: vault.lifetime_return_net }
+		{
+			label: 'Lifetime',
+			samplePeriod: periodResults.get('lifetime'),
+			gross: { annualised: vault.cagr, raw: vault.lifetime_return },
+			net: { annualised: vault.cagr_net, raw: vault.lifetime_return_net }
+		}
 	]);
 	let feeRows = $derived([
 		{
@@ -97,6 +127,17 @@ Displays supplementary vault information, including transaction status, performa
 			tooltip: '<strong>Withdrawal fee</strong> is a one-time fee applied when exiting the vault.'
 		}
 	]);
+
+	function formatDate(value: string | null | undefined): string {
+		if (value == null) return 'unknown';
+		return value.split('T')[0] ?? 'unknown';
+	}
+
+	function getSamplePeriodLabel(period: (typeof returnPeriods)[number]): string {
+		if (!period.samplePeriod) return period.label;
+
+		return `${period.label}, ${formatDate(period.samplePeriod.period_start_at)} to ${formatDate(period.samplePeriod.period_end_at)}`;
+	}
 </script>
 
 <div class="additional-metrics">
@@ -161,7 +202,7 @@ Displays supplementary vault information, including transaction status, performa
 			{#snippet maxDrawdownLabel()}
 				<Tooltip>
 					<span slot="trigger">
-						<a class="glossary-link" href="/glossary/maximum-drawdown">Maximum drawdown</a>
+						<a class="glossary-link" href={resolve('/glossary/maximum-drawdown')}>Maximum drawdown</a>
 					</span>
 					<svelte:fragment slot="popup">Maximum drawdown over the vault lifetime.</svelte:fragment>
 				</Tooltip>
@@ -172,7 +213,7 @@ Displays supplementary vault information, including transaction status, performa
 			</Metric>
 
 			<Metric label="Protocol Technical Risk">
-				<a class="risk-link" href="/blog/announcing-vault-technical-risk-framework-beta">
+				<a class="risk-link" href={resolve('/blog/announcing-vault-technical-risk-framework-beta')}>
 					<Risk risk={vault.risk} />
 				</a>
 			</Metric>
@@ -183,6 +224,7 @@ Displays supplementary vault information, including transaction status, performa
 
 			<Metric label="Denomination">
 				{#if denominationHref}
+					<!-- eslint-disable-next-line svelte/no-navigation-without-resolve -->
 					<a class="denomination-link" href={denominationHref}>
 						{#if denominationLogoUrl}
 							<img class="denomination-logo" src={denominationLogoUrl} alt="" />
@@ -207,7 +249,7 @@ Displays supplementary vault information, including transaction status, performa
 				<thead>
 					<tr>
 						<th></th>
-						{#each returnPeriods as period}
+						{#each returnPeriods as period (period.label)}
 							<th scope="col">{period.label}</th>
 						{/each}
 					</tr>
@@ -230,31 +272,71 @@ Displays supplementary vault information, including transaction status, performa
 					<tr>
 						<td>
 							{@render metricLabel(
-								'<strong>Gross returns</strong> reflect the change in the vault share price before investor-facing fees are deducted.',
+								'<strong>Gross returns</strong> are annualised. They reflect the change in the vault share price before investor-facing fees are deducted.',
 								'Gross'
 							)}
 						</td>
-						{#each returnPeriods as period}
-							<td>{formatPercentProfit(period.gross)}</td>
+						{#each returnPeriods as period (period.label)}
+							<td>
+								<Tooltip>
+									<span slot="trigger" class="return-cell">{formatPercentProfit(period.gross.annualised)}</span>
+									<svelte:fragment slot="popup">
+										<dl class="return-tooltip">
+											<div>
+												<dt>Annualised:</dt>
+												<dd>{formatPercentProfit(period.gross.annualised)}</dd>
+											</div>
+											<div>
+												<dt>Raw:</dt>
+												<dd>{formatPercentProfit(period.gross.raw)}</dd>
+											</div>
+											<div>
+												<dt>Sampled period:</dt>
+												<dd>{getSamplePeriodLabel(period)}</dd>
+											</div>
+										</dl>
+									</svelte:fragment>
+								</Tooltip>
+							</td>
 						{/each}
 					</tr>
-					{#each feeRows as fee}
+					{#each feeRows as fee (fee.label)}
 						<tr class="fee-row">
 							<td>{@render metricLabel(fee.tooltip, fee.label, fee.mobileLabel)}</td>
-							{#each returnPeriods as _}
-								<td>{formatPercent(fee.value)}</td>
+							{#each returnPeriods as period (period.label)}
+								<td aria-label={`${fee.label} for ${period.label}`}>{formatPercent(fee.value)}</td>
 							{/each}
 						</tr>
 					{/each}
 					<tr>
 						<td>
 							{@render metricLabel(
-								'<strong>Net returns</strong> are the gross returns after all investor-facing fees have been deducted.',
+								'<strong>Net returns</strong> are annualised. They are the gross returns after all investor-facing fees have been deducted.',
 								'Net'
 							)}
 						</td>
-						{#each returnPeriods as period}
-							<td>{formatPercentProfit(period.net)}</td>
+						{#each returnPeriods as period (period.label)}
+							<td>
+								<Tooltip>
+									<span slot="trigger" class="return-cell">{formatPercentProfit(period.net.annualised)}</span>
+									<svelte:fragment slot="popup">
+										<dl class="return-tooltip">
+											<div>
+												<dt>Annualised:</dt>
+												<dd>{formatPercentProfit(period.net.annualised)}</dd>
+											</div>
+											<div>
+												<dt>Raw:</dt>
+												<dd>{formatPercentProfit(period.net.raw)}</dd>
+											</div>
+											<div>
+												<dt>Sampled period:</dt>
+												<dd>{getSamplePeriodLabel(period)}</dd>
+											</div>
+										</dl>
+									</svelte:fragment>
+								</Tooltip>
+							</td>
 						{/each}
 					</tr>
 				</tbody>
@@ -385,6 +467,32 @@ Displays supplementary vault information, including transaction status, performa
 			display: inline-flex;
 			align-items: center;
 			gap: 0.75ex;
+		}
+
+		.return-cell {
+			border-bottom: 1px dotted var(--c-text-light);
+		}
+
+		.return-tooltip {
+			display: grid;
+			gap: 0.35rem;
+			margin: 0;
+
+			div {
+				display: grid;
+				grid-template-columns: max-content 1fr;
+				gap: 0.75rem;
+			}
+
+			dt {
+				color: var(--c-text-light);
+			}
+
+			dd {
+				margin: 0;
+				text-align: right;
+				font-weight: 500;
+			}
 		}
 
 		.label-mobile {

--- a/src/routes/trading-view/vaults/[vault=slug]/VaultTechnicalDetailsTable.svelte
+++ b/src/routes/trading-view/vaults/[vault=slug]/VaultTechnicalDetailsTable.svelte
@@ -13,7 +13,11 @@
 		getVaultDenominationCurrency,
 		getVaultTvlNative
 	} from '$lib/top-vaults/helpers';
-	import { getStablecoinLogoUrl, resolveStablecoinSlug } from '$lib/stablecoin-metadata/helpers';
+	import {
+		getStablecoinDetailsHref,
+		getVaultDenominationLogoUrl,
+		resolveStablecoinSlug
+	} from '$lib/stablecoin-metadata/helpers';
 	import type { StablecoinMetadata } from '$lib/stablecoin-metadata/schemas';
 	import { getLogoUrl } from '$lib/helpers/assets';
 
@@ -49,12 +53,8 @@
 	let showNativeTvlRows = $derived(denominationCurrency != null && denominationCurrency !== 'usd');
 	let lifetimePeriod = $derived(vault.period_results?.find((p) => p.period.toLowerCase() === 'lifetime') ?? null);
 	let denominationPageSlug = $derived(denominationSlug ?? vault.denomination_slug);
-	let denominationLogoUrl = $derived(
-		stablecoinMetadata?.logos.light && denominationSlug ? getStablecoinLogoUrl(denominationSlug) : undefined
-	);
-	let denominationHref = $derived(
-		stablecoinMetadata && denominationSlug ? `/trading-view/vaults/stablecoins/${denominationSlug}` : undefined
-	);
+	let denominationLogoUrl = $derived(getVaultDenominationLogoUrl(vault, denominationSlug));
+	let denominationHref = $derived(stablecoinMetadata ? getStablecoinDetailsHref(denominationSlug) : undefined);
 	let showExchangeRateRow = $derived(vault.protocol_slug !== 'kinexys');
 	let exchangeRateFetchedAt = $derived(
 		vault.denomination_token_rate?.usd_rate_fetched_at ??
@@ -91,7 +91,8 @@
 							usdRate: getVaultDenominationUsdRate(vault),
 							symbol: vault.denomination,
 							slug: denominationPageSlug,
-							fetchedAt: exchangeRateFetchedAt
+							fetchedAt: exchangeRateFetchedAt,
+							href: getStablecoinDetailsHref(denominationPageSlug)
 						},
 						type: 'exchangeRate' as const
 					}
@@ -262,9 +263,11 @@
 							{:else if row.type === 'exchangeRate'}
 								{#if row.value.usdRate != null}
 									<span class="exchange-rate-cell">
-										<a href="/trading-view/vaults/stablecoins/{row.value.slug}">
+										{#if row.value.href}
+											<a href={row.value.href}>{formatExchangeRate(row.value.usdRate, row.value.symbol)}</a>
+										{:else}
 											{formatExchangeRate(row.value.usdRate, row.value.symbol)}
-										</a>
+										{/if}
 										{#if row.value.fetchedAt}
 											<span class="secondary">
 												fetched <Timestamp date={row.value.fetchedAt} relative />

--- a/src/routes/trading-view/vaults/market-share-pie.ts
+++ b/src/routes/trading-view/vaults/market-share-pie.ts
@@ -9,7 +9,7 @@ export interface MarketShareChartItem {
 	tvl: number;
 	avgApy: number | null;
 	logoUrl?: string;
-	href: string;
+	href?: string;
 }
 
 export interface MarketSharePieSlice {

--- a/src/routes/trading-view/vaults/stablecoin-chain-heatmap/StablecoinChainHeatmapChart.svelte
+++ b/src/routes/trading-view/vaults/stablecoin-chain-heatmap/StablecoinChainHeatmapChart.svelte
@@ -353,33 +353,63 @@ Client-side ECharts heatmap for current vault TVL by stablecoin and chain.
 				<div class="stablecoin-axis" aria-label="Stablecoins">
 					{#each data?.stablecoins ?? [] as stablecoin (stablecoin.key)}
 						{@const tooltipId = getAxisTooltipId('stablecoin', stablecoin.key)}
-						<a
-							class="axis-label stablecoin-label"
-							href={stablecoin.href}
-							aria-describedby={tooltipId}
-							data-tooltip-active={activeAxisTooltipId === tooltipId ? 'true' : 'false'}
-							onmouseenter={() => showAxisTooltip(tooltipId)}
-							onmouseleave={() => hideAxisTooltip(tooltipId)}
-							onfocus={() => showAxisTooltip(tooltipId)}
-							onblur={() => hideAxisTooltip(tooltipId)}
-						>
-							{#if stablecoin.logoUrl}
-								<img class="axis-logo" src={stablecoin.logoUrl} alt="" loading="lazy" />
-							{/if}
-							<span>{stablecoin.label}</span>
-							<span
-								id={tooltipId}
-								class="axis-tooltip"
-								role="tooltip"
-								style={getAxisTooltipStyle('stablecoin', tooltipId)}
+						{#if stablecoin.href}
+							<a
+								class="axis-label stablecoin-label"
+								href={stablecoin.href}
+								aria-describedby={tooltipId}
+								data-tooltip-active={activeAxisTooltipId === tooltipId ? 'true' : 'false'}
+								onmouseenter={() => showAxisTooltip(tooltipId)}
+								onmouseleave={() => hideAxisTooltip(tooltipId)}
+								onfocus={() => showAxisTooltip(tooltipId)}
+								onblur={() => hideAxisTooltip(tooltipId)}
 							>
-								<span class="axis-tooltip-title">{stablecoin.tooltipLabel}</span>
-								<span class="axis-tooltip-metric-line">
-									TVL:&nbsp;<span class="axis-tooltip-metric-value">{buildAxisTooltipValue(stablecoin.totalTvl)}</span>
+								{#if stablecoin.logoUrl}
+									<img class="axis-logo" src={stablecoin.logoUrl} alt="" loading="lazy" />
+								{/if}
+								<span>{stablecoin.label}</span>
+								<span
+									id={tooltipId}
+									class="axis-tooltip"
+									role="tooltip"
+									style={getAxisTooltipStyle('stablecoin', tooltipId)}
+								>
+									<span class="axis-tooltip-title">{stablecoin.tooltipLabel}</span>
+									<span class="axis-tooltip-metric-line">
+										TVL:&nbsp;<span class="axis-tooltip-metric-value">{buildAxisTooltipValue(stablecoin.totalTvl)}</span
+										>
+									</span>
+									<span class="axis-tooltip-cta">Click here to view more.</span>
 								</span>
-								<span class="axis-tooltip-cta">Click here to view more.</span>
-							</span>
-						</a>
+							</a>
+						{:else}
+							<a
+								class="axis-label stablecoin-label"
+								aria-describedby={tooltipId}
+								data-tooltip-active={activeAxisTooltipId === tooltipId ? 'true' : 'false'}
+								onmouseenter={() => showAxisTooltip(tooltipId)}
+								onmouseleave={() => hideAxisTooltip(tooltipId)}
+								onfocus={() => showAxisTooltip(tooltipId)}
+								onblur={() => hideAxisTooltip(tooltipId)}
+							>
+								{#if stablecoin.logoUrl}
+									<img class="axis-logo" src={stablecoin.logoUrl} alt="" loading="lazy" />
+								{/if}
+								<span>{stablecoin.label}</span>
+								<span
+									id={tooltipId}
+									class="axis-tooltip"
+									role="tooltip"
+									style={getAxisTooltipStyle('stablecoin', tooltipId)}
+								>
+									<span class="axis-tooltip-title">{stablecoin.tooltipLabel}</span>
+									<span class="axis-tooltip-metric-line">
+										TVL:&nbsp;<span class="axis-tooltip-metric-value">{buildAxisTooltipValue(stablecoin.totalTvl)}</span
+										>
+									</span>
+								</span>
+							</a>
+						{/if}
 					{/each}
 				</div>
 

--- a/src/routes/trading-view/vaults/stablecoins/+page.server.ts
+++ b/src/routes/trading-view/vaults/stablecoins/+page.server.ts
@@ -7,6 +7,7 @@ import { fetchStablecoinMetadataIndex } from '$lib/stablecoin-metadata/client';
 import {
 	buildStablecoinMetadataLookup,
 	getStablecoinCoingeckoLink,
+	getStablecoinDetailsHref,
 	getStablecoinLogoUrl,
 	resolveStablecoinSlug
 } from '$lib/stablecoin-metadata/helpers.js';
@@ -106,7 +107,7 @@ export async function load({ fetch, url: { searchParams } }) {
 		tvl: group.tvl,
 		avgApy: group.avg_apy ?? null,
 		logoUrl: getStablecoinLogoUrl(group.slug),
-		href: `/trading-view/vaults/stablecoins/${group.slug}`
+		href: getStablecoinDetailsHref(group.slug)
 	}));
 
 	const options = {

--- a/src/routes/trading-view/vaults/stablecoins/+page.svelte
+++ b/src/routes/trading-view/vaults/stablecoins/+page.svelte
@@ -8,7 +8,11 @@
 	import VaultGroupTable from '$lib/top-vaults/VaultGroupTable.svelte';
 	import VaultListingsSelector from '$lib/top-vaults/VaultListingsSelector.svelte';
 	import { formatDollar } from '$lib/helpers/formatters';
-	import { getStablecoinLogoUrl, isStablecoinDepegged } from '$lib/stablecoin-metadata/helpers.js';
+	import {
+		getStablecoinDetailsHref,
+		getStablecoinLogoUrl,
+		isStablecoinDepegged
+	} from '$lib/stablecoin-metadata/helpers.js';
 	import { MetaTags, JsonLd } from 'svelte-meta-tags';
 	import MarketSharePieChart from '../MarketSharePieChart.svelte';
 	import MarketShareWidgetBox from '../MarketShareWidgetBox.svelte';
@@ -27,13 +31,6 @@
 	const pageTitle = 'Vaults by stablecoin';
 	const description =
 		'DeFi vaults for different stablecoins. TVL represents deposits of a stablecoin in vaults. APY represents the yield of last thirty days.';
-	const glossaryLinks = {
-		defi: resolve('/glossary/defi'),
-		vault: resolve('/glossary/vault'),
-		stablecoin: resolve('/glossary/stablecoin'),
-		tvl: resolve('/glossary/total-value-locked-tvl'),
-		apy: resolve('/glossary/apy')
-	};
 	let pageUrl = $derived(new URL(page.url.pathname, page.url.origin).href);
 </script>
 
@@ -73,13 +70,13 @@
 						{/snippet}
 						{#snippet subtitle()}
 							<p>
-								<a class="body-link" href={glossaryLinks.defi}>DeFi</a>
-								<a class="body-link" href={glossaryLinks.vault}>vaults</a>
+								<a class="body-link" href={resolve('/glossary/defi')}>DeFi</a>
+								<a class="body-link" href={resolve('/glossary/vault')}>vaults</a>
 								for different
-								<a class="body-link" href={glossaryLinks.stablecoin}>stablecoins</a>.
-								<a class="body-link" href={glossaryLinks.tvl}>TVL</a>
+								<a class="body-link" href={resolve('/glossary/stablecoin')}>stablecoins</a>.
+								<a class="body-link" href={resolve('/glossary/total-value-locked-tvl')}>TVL</a>
 								represents deposits of a stablecoin in vaults.
-								<a class="body-link" href={glossaryLinks.apy}>APY</a>
+								<a class="body-link" href={resolve('/glossary/apy')}>APY</a>
 								represents the yield of last thirty days.
 							</p>
 							<p>{totalTvlLabel} TVL tracked across {stablecoins.length} stablecoins.</p>
@@ -106,6 +103,7 @@
 			groupLabel="Stablecoin"
 			includeFullName
 			getLogoHref={getStablecoinLogoUrl}
+			getHref={getStablecoinDetailsHref}
 			getWarningLabel={(row) =>
 				isStablecoinDepegged(row) ? `${row.name} is below 90% of its native peg rate` : undefined}
 			rows={stablecoins}

--- a/src/routes/trading-view/vaults/stablecoins/[denomination=slug]/+page.server.ts
+++ b/src/routes/trading-view/vaults/stablecoins/[denomination=slug]/+page.server.ts
@@ -5,6 +5,8 @@ import {
 	buildStablecoinMetadataLookup,
 	formatStablecoinDisplayName,
 	findStablecoinMetadata,
+	OFFCHAIN_USD_STABLECOIN_SLUG,
+	OFFCHAIN_USD_SHORT_DESCRIPTION,
 	resolveStablecoinSlug
 } from '$lib/stablecoin-metadata/helpers';
 
@@ -31,8 +33,11 @@ export async function load({ params, fetch }) {
 		return slug === denomination;
 	});
 
-	// 404 only if neither vault data nor metadata exists
-	if (!match && !stablecoinMetadata) error(404, 'Vault stablecoin not found');
+	// Off-chain USD is a recognised accounting denomination even if no vault is
+	// currently present in the dataset, so retain its standalone information page.
+	if (!match && !stablecoinMetadata && denomination !== OFFCHAIN_USD_STABLECOIN_SLUG) {
+		error(404, 'Vault stablecoin not found');
+	}
 
 	const denominationSymbol = stablecoinMetadata?.symbol ?? match?.denomination ?? denomination.toUpperCase();
 	const denominationName =
@@ -45,6 +50,10 @@ export async function load({ params, fetch }) {
 		denominationSlug: denomination,
 		denominationSymbol,
 		denominationName,
+		shortDescription:
+			denomination === OFFCHAIN_USD_STABLECOIN_SLUG
+				? OFFCHAIN_USD_SHORT_DESCRIPTION
+				: (stablecoinMetadata?.short_description ?? null),
 		stablecoinMetadata
 	};
 }

--- a/src/routes/trading-view/vaults/stablecoins/[denomination=slug]/+page.svelte
+++ b/src/routes/trading-view/vaults/stablecoins/[denomination=slug]/+page.svelte
@@ -13,7 +13,7 @@
 	import VaultGroupDescription from '../../VaultGroupDescription.svelte';
 
 	let { data } = $props();
-	let { denominationSlug, denominationSymbol, denominationName, stablecoinMetadata } = $derived(data);
+	let { denominationSlug, denominationSymbol, denominationName, shortDescription, stablecoinMetadata } = $derived(data);
 
 	let topVaults = $state<TopVaults>();
 	let loading = $state(!hasVaultCache(page.data.generatedAt));
@@ -31,12 +31,10 @@
 	});
 
 	let title = $derived(`${denominationName} stablecoin vaults | Trading Strategy`);
-	let description = $derived(
-		stablecoinMetadata?.short_description ?? `Top ${denominationName} DeFi vaults ranked by performance.`
-	);
+	let description = $derived(shortDescription ?? `Top ${denominationName} DeFi vaults ranked by performance.`);
 	let pageUrl = $derived(new URL(page.url.pathname, page.url.origin).href);
 	let logoUrl = $derived.by(() => {
-		const logoPath = stablecoinMetadata?.logos.light ? getStablecoinLogoUrl(stablecoinMetadata.slug) : undefined;
+		const logoPath = denominationSlug ? getStablecoinLogoUrl(denominationSlug) : undefined;
 		return logoPath ? new URL(logoPath, page.url.origin).href : undefined;
 	});
 	let aboutName = $derived(formatStablecoinDisplayName(stablecoinMetadata?.name, stablecoinMetadata?.symbol));
@@ -95,6 +93,7 @@
 	{topVaults}
 	{loading}
 	{stablecoinMetadata}
+	stablecoinLogoSlug={denominationSlug}
 	title="{denominationName} stablecoin vaults"
 	showFilters
 	defaultTvlKey="10k"

--- a/src/routes/trading-view/vaults/stablecoins/[denomination=slug]/chart-data/+server.ts
+++ b/src/routes/trading-view/vaults/stablecoins/[denomination=slug]/chart-data/+server.ts
@@ -8,7 +8,11 @@ import {
 	VAULT_GROUP_MINI_CHART_CACHE_TTL_SECONDS
 } from '$lib/echarts/vault-group-mini-chart-server';
 import { fetchStablecoinMetadataIndex } from '$lib/stablecoin-metadata/client';
-import { buildStablecoinMetadataLookup, resolveStablecoinSlug } from '$lib/stablecoin-metadata/helpers';
+import {
+	buildStablecoinMetadataLookup,
+	OFFCHAIN_USD_STABLECOIN_SLUG,
+	resolveStablecoinSlug
+} from '$lib/stablecoin-metadata/helpers';
 import { getCachedTopVaults } from '$lib/top-vaults/cache';
 
 const CACHE_VERSION = 'stablecoin-mini-chart-v4';
@@ -36,7 +40,14 @@ async function getCachedChartData(denominationSlug: string, fetch: Fetch) {
 		);
 		return slug === denominationSlug;
 	});
-	if (stablecoinVaults.length === 0) error(404, 'Vault stablecoin not found');
+	if (stablecoinVaults.length === 0) {
+		if (denominationSlug === OFFCHAIN_USD_STABLECOIN_SLUG) {
+			return buildProtocolMiniChartPayload([], 0, VAULT_GROUP_MINI_CHART_CACHE_TTL_SECONDS, {
+				latestApyRows: []
+			});
+		}
+		error(404, 'Vault stablecoin not found');
+	}
 
 	const eligibleVaults = stablecoinVaults.filter(isEligibleVaultGroupMiniChartVault);
 	const rows =

--- a/static/flags/us.svg
+++ b/static/flags/us.svg
@@ -1,0 +1,19 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" role="img" aria-label="United States flag">
+	<defs>
+		<clipPath id="circle"><circle cx="12" cy="12" r="11" /></clipPath>
+	</defs>
+	<g clip-path="url(#circle)">
+		<rect width="24" height="24" fill="#fff" />
+		<path fill="#b22234" d="M0 0h24v1.85H0zm0 3.69h24v1.85H0zm0 3.69h24v1.85H0zm0 3.69h24v1.85H0zm0 3.69h24v1.85H0zm0 3.69h24v1.85H0zm0 3.69h24v1.85H0z" />
+		<rect width="10.5" height="12.92" fill="#3c3b6e" />
+		<g fill="#fff">
+			<circle cx="1.6" cy="1.7" r=".45" /><circle cx="4" cy="1.7" r=".45" /><circle cx="6.4" cy="1.7" r=".45" /><circle cx="8.8" cy="1.7" r=".45" />
+			<circle cx="2.8" cy="3.4" r=".45" /><circle cx="5.2" cy="3.4" r=".45" /><circle cx="7.6" cy="3.4" r=".45" />
+			<circle cx="1.6" cy="5.1" r=".45" /><circle cx="4" cy="5.1" r=".45" /><circle cx="6.4" cy="5.1" r=".45" /><circle cx="8.8" cy="5.1" r=".45" />
+			<circle cx="2.8" cy="6.8" r=".45" /><circle cx="5.2" cy="6.8" r=".45" /><circle cx="7.6" cy="6.8" r=".45" />
+			<circle cx="1.6" cy="8.5" r=".45" /><circle cx="4" cy="8.5" r=".45" /><circle cx="6.4" cy="8.5" r=".45" /><circle cx="8.8" cy="8.5" r=".45" />
+			<circle cx="2.8" cy="10.2" r=".45" /><circle cx="5.2" cy="10.2" r=".45" /><circle cx="7.6" cy="10.2" r=".45" />
+		</g>
+	</g>
+	<circle cx="12" cy="12" r="11" fill="none" stroke="rgba(15, 23, 42, .18)" />
+</svg>


### PR DESCRIPTION
## Why

The vault pages need clearer returns and grouping behaviour: gross/net return cells should show annualised headline metrics while still exposing raw sampled-period returns, and vault grouping pages need more robust stablecoin, protocol, and market-share metadata handling.

## Lessons learnt

- Short-period returns are easy to misread when raw and annualised values are mixed in the same table, so the UI needs explicit tooltip labelling for both values and the sampled date range.
- Stablecoin and protocol metadata helpers need to gracefully handle unknown or off-chain denominations so grouped vault pages do not produce broken links or misleading labels.

## Summary

- Annualise the gross/net values in the vault returns and fees table, with per-cell tooltips for annualised value, raw value, and sampled period.
- Improve fee-adjusted vault metric messaging, stablecoin denomination links/logos, and grouped vault table/filter behaviour.
- Add supporting helper coverage and static flag/logo assets used by the updated vault grouping UI.
