### PR TITLE
feat: add tokenised funds vault listing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Weblog of stuff
 
+- Add tokenised fund listings, NAV market-share chart, and fund-specific vault detail messaging (2026-07-17)
 - Add live TVL and listing-count summaries to chain, protocol, curator and stablecoin vault pages (2026-07-11)
 - Add Robinhood vault-only chain support (2026-07-10)
 - Add curator information boxes to vault detail pages when curator metadata is available (2026-07-05)

--- a/src/lib/top-vaults/VaultListingsSelector.svelte
+++ b/src/lib/top-vaults/VaultListingsSelector.svelte
@@ -5,11 +5,12 @@
 
 	const links = [
 		{ href: '/trading-view/vaults', label: 'Top' },
-		{ href: '/trading-view/vaults/stablecoins', label: 'By stablecoin' },
-		{ href: '/trading-view/vaults/chains', label: 'By chain' },
-		{ href: '/trading-view/vaults/protocols', label: 'By protocol' },
-		{ href: '/trading-view/vaults/curators', label: 'By curator' },
-		{ href: '/trading-view/vaults/international', label: 'International' }
+		{ href: '/trading-view/vaults/stablecoins', label: 'Stablecoins' },
+		{ href: '/trading-view/vaults/chains', label: 'Chains' },
+		{ href: '/trading-view/vaults/protocols', label: 'Protocols' },
+		{ href: '/trading-view/vaults/curators', label: 'Curators' },
+		{ href: '/trading-view/vaults/international', label: 'International' },
+		{ href: '/trading-view/vaults/tokenised-funds', label: 'Tokenised funds' }
 	] as const;
 
 	const otherListLinks = [
@@ -49,14 +50,8 @@
 			{label}
 		</a>
 	{/each}
-	<DropdownMenu
-		label="More rankings"
-		items={otherListLinks}
-		{isActive}
-		resolveHref={resolveDropdownHref}
-		class="nav-dropdown"
-	/>
 	<DropdownMenu label="Charts" items={chartLinks} {isActive} resolveHref={resolveDropdownHref} class="nav-dropdown" />
+	<DropdownMenu label="More" items={otherListLinks} {isActive} resolveHref={resolveDropdownHref} class="nav-dropdown" />
 </nav>
 
 <style>

--- a/src/routes/trading-view/vaults/MarketSharePieChart.svelte
+++ b/src/routes/trading-view/vaults/MarketSharePieChart.svelte
@@ -12,11 +12,26 @@
 		items: MarketShareChartItem[];
 		groupLabel: string;
 		groupLabelPlural: string;
+		/** Group items below this share into an Other slice. Defaults to 2%. */
+		otherThreshold?: number;
+		/** Split long slice names across two lines before the value label. */
+		wrapLabels?: boolean;
+		/** Label for the value shown in chart tooltips. */
+		valueLabel?: string;
 		testId?: string;
 		class?: string;
 	}
 
-	let { items, groupLabel, groupLabelPlural, testId = 'market-share-pie-chart', class: classes = '' }: Props = $props();
+	let {
+		items,
+		groupLabel,
+		groupLabelPlural,
+		otherThreshold,
+		wrapLabels = false,
+		valueLabel = 'TVL',
+		testId = 'market-share-pie-chart',
+		class: classes = ''
+	}: Props = $props();
 
 	const palette = [
 		'#22c55e',
@@ -32,7 +47,7 @@
 		'#64748b'
 	];
 
-	let slices = $derived(buildMarketSharePieSlices(items, { groupLabelPlural }));
+	let slices = $derived(buildMarketSharePieSlices(items, { groupLabelPlural, otherThreshold }));
 	let chartContainer = $state<HTMLDivElement | null>(null);
 	let chartInstance = $state<ReturnType<EChartsStatic['init']> | null>(null);
 	let echartsApi = $state<EChartsStatic | null>(null);
@@ -53,14 +68,58 @@
 		return value >= 10 ? value.toFixed(0) : value.toFixed(1);
 	}
 
+	function splitLabelIntoTwoLines(label: string): string[] {
+		const words = label.trim().split(/\s+/);
+		if (label.length <= 24 || words.length < 2) return [label];
+
+		const targetLength = label.length / 2;
+		let bestIndex = 1;
+		let bestDistance = Infinity;
+		let currentLength = 0;
+
+		for (let index = 1; index < words.length; index++) {
+			currentLength += words[index - 1].length + (index > 1 ? 1 : 0);
+			const distance = Math.abs(currentLength - targetLength);
+			if (distance < bestDistance) {
+				bestIndex = index;
+				bestDistance = distance;
+			}
+		}
+
+		return [words.slice(0, bestIndex).join(' '), words.slice(bestIndex).join(' ')];
+	}
+
+	function formatSliceLabel(label: string): string {
+		const lines = wrapLabels ? splitLabelIntoTwoLines(label) : [label];
+		const style = wrapLabels && label.length > 45 ? 'labelCompact' : 'label';
+		return lines.map((line) => `{${style}|${line}}`).join('\n');
+	}
+
+	function getValueLabelStyle(label: string): string {
+		return wrapLabels && label.length > 45 ? 'valueCompact' : 'value';
+	}
+
 	function buildLabelRichStyles(isMobile: boolean) {
+		const labelFontSize = wrapLabels ? (isMobile ? 9 : 9.5) : 11;
+		const valueFontSize = wrapLabels ? (isMobile ? 9 : 9.5) : 10.5;
+		const compactLabelFontSize = wrapLabels ? (isMobile ? 7.5 : 8) : labelFontSize;
+		const compactValueFontSize = wrapLabels ? (isMobile ? 8 : 8.5) : valueFontSize;
 		const rich: Record<string, Record<string, unknown>> = {
 			label: {
 				color: '#f8fbff',
 				fontFamily: chartFontFamily,
 				fontWeight: 700,
-				fontSize: isMobile ? 11 : 11,
+				fontSize: labelFontSize,
 				lineHeight: isMobile ? 15 : 15,
+				align: 'center',
+				verticalAlign: 'middle'
+			},
+			labelCompact: {
+				color: '#f8fbff',
+				fontFamily: chartFontFamily,
+				fontWeight: 700,
+				fontSize: compactLabelFontSize,
+				lineHeight: isMobile ? 12 : 13,
 				align: 'center',
 				verticalAlign: 'middle'
 			},
@@ -68,8 +127,17 @@
 				color: '#dbeafe',
 				fontFamily: chartFontFamily,
 				fontWeight: 600,
-				fontSize: isMobile ? 10.5 : 10.5,
+				fontSize: valueFontSize,
 				lineHeight: isMobile ? 14 : 14,
+				align: 'center',
+				verticalAlign: 'middle'
+			},
+			valueCompact: {
+				color: '#dbeafe',
+				fontFamily: chartFontFamily,
+				fontWeight: 600,
+				fontSize: compactValueFontSize,
+				lineHeight: isMobile ? 12 : 13,
 				align: 'center',
 				verticalAlign: 'middle'
 			}
@@ -97,7 +165,7 @@
 
 		return [
 			`<div style="margin-bottom: 0.7rem; padding-bottom: 0.65rem; border-bottom: 1px solid rgba(191, 219, 254, 0.12);"><div class="tooltip-title" style="${TOOLTIP_TITLE_STYLE}">${title}</div>${showNameRow ? `<div style="margin-top: 0.18rem; color: rgba(226, 232, 240, 0.76); font-family: ${chartFontFamily}; line-height: 1.35;">${escapeHtml(slice.name)}</div>` : ''}</div>`,
-			buildTooltipRow('TVL', formatDollar(slice.tvl, 2)),
+			buildTooltipRow(valueLabel, formatDollar(slice.tvl, 2)),
 			buildTooltipRow('APY', formatPercent(slice.avgApy)),
 			buildTooltipRow('Share', `${slice.percentage.toFixed(1)}%`),
 			slice.isOther && slice.memberCount ? buildTooltipRow(groupedLabel, String(slice.memberCount)) : '',
@@ -171,7 +239,7 @@
 			},
 			series: [
 				{
-					name: `${groupLabel} TVL`,
+					name: `${groupLabel} ${valueLabel}`,
 					type: 'pie',
 					radius: isMobile ? ['24%', '49%'] : ['35%', '70%'],
 					center: ['50%', '53%'],
@@ -189,7 +257,7 @@
 						fontFamily: chartFontFamily,
 						fontSize: isMobile ? 12 : 12,
 						lineHeight: isMobile ? 18 : 18,
-						padding: isMobile ? [5, 8, 5, 8] : [6, 11, 6, 11],
+						padding: wrapLabels ? (isMobile ? [4, 6, 4, 6] : [4, 8, 4, 8]) : isMobile ? [5, 8, 5, 8] : [6, 11, 6, 11],
 						borderRadius: 999,
 						backgroundColor: 'rgba(255, 255, 255, 0.14)',
 						shadowBlur: 10,
@@ -197,7 +265,7 @@
 						formatter: (params: { data?: MarketSharePieSlice }) => {
 							const slice = params.data;
 							if (!slice) return '';
-							return `{label|${slice.label}}\n{value|${formatLabelPercentage(slice.percentage)}%}`;
+							return `${formatSliceLabel(slice.label)}\n{${getValueLabelStyle(slice.label)}|${formatLabelPercentage(slice.percentage)}%}`;
 						},
 						rich: labelRichStyles
 					},
@@ -272,6 +340,9 @@
 		slices;
 		groupLabel;
 		groupLabelPlural;
+		otherThreshold;
+		wrapLabels;
+		valueLabel;
 		if (!runtimeReady || !echartsApi || !chartContainer) return;
 
 		let cancelled = false;

--- a/src/routes/trading-view/vaults/[vault=slug]/+page.svelte
+++ b/src/routes/trading-view/vaults/[vault=slug]/+page.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { resolve } from '$app/paths';
 	import { discordUrl } from '$lib/config';
 	import VaultListingsSelector from '$lib/top-vaults/VaultListingsSelector.svelte';
 	import Alert from '$lib/components/Alert.svelte';
@@ -33,6 +34,7 @@
 	let morphoAlertStatus = $derived(blacklisted ? ('error' as const) : ('warning' as const));
 	let showBlacklistedAlert = $derived(blacklisted && !notesDuplicateMorphoFlags);
 	let showNotes = $derived(vault.notes != null && !notesDuplicateMorphoFlags);
+	let isTokenisedFund = $derived(vault.flags.includes('tokenised_fund'));
 	let depositMayBeDisabled = $derived(vault.deposit_closed_reason != null);
 	let redemptionMayBeDisabled = $derived(vault.redemption_closed_reason != null);
 	let operationWarning = $derived(
@@ -61,7 +63,16 @@
 
 	{#if operationWarning}
 		<Section padding="md">
-			<Alert size="md" status="warning">{operationWarning}</Alert>
+			{#if isTokenisedFund}
+				<Alert size="md" status="info">
+					{vault.name} is a tokenised fund. It is smart contract-based, but may not offer all features of vaults.
+					<a href={resolve('/glossary/tokenised-fund')}
+						>Read more about the differences between vaults and tokenised funds here.</a
+					>
+				</Alert>
+			{:else}
+				<Alert size="md" status="warning">{operationWarning}</Alert>
+			{/if}
 		</Section>
 	{/if}
 
@@ -116,7 +127,7 @@
 		{/if}
 
 		{#if curatorMetadata}
-			<VaultCuratorInfo curator={curatorMetadata} />
+			<VaultCuratorInfo {vault} curator={curatorMetadata} />
 		{/if}
 
 		{#if protocolMetadata}

--- a/src/routes/trading-view/vaults/[vault=slug]/VaultCuratorInfo.svelte
+++ b/src/routes/trading-view/vaults/[vault=slug]/VaultCuratorInfo.svelte
@@ -15,16 +15,18 @@ curator.
 	import { resolve } from '$app/paths';
 	import Button from '$lib/components/Button.svelte';
 	import MetricsBox from '$lib/components/MetricsBox.svelte';
-	import type { CuratorInfo } from '$lib/top-vaults/schemas';
+	import type { CuratorInfo, VaultInfo } from '$lib/top-vaults/schemas';
 
 	interface Props {
 		curator: CuratorInfo;
+		vault: VaultInfo;
 	}
 
-	let { curator }: Props = $props();
+	let { curator, vault }: Props = $props();
 
 	let curatorPageUrl = $derived(resolve(`/trading-view/vaults/curators/${curator.slug}`));
 	let curatorLogoUrl = $derived(curator.logos.generic ?? curator.logos.light ?? curator.logos.dark);
+	let assetType = $derived(vault.flags.includes('tokenised_fund') ? 'tokenised fund' : 'vault');
 </script>
 
 <MetricsBox>
@@ -35,7 +37,7 @@ curator.
 		<div class="content">
 			<h2>About {curator.name}</h2>
 			<p class="description">
-				This vault is curated by <a href={curatorPageUrl}>{curator.name}</a>.
+				This {assetType} is curated by <a href={curatorPageUrl}>{curator.name}</a>.
 			</p>
 			{#if curator.short_description}
 				<p class="description">{curator.short_description}</p>

--- a/src/routes/trading-view/vaults/[vault=slug]/VaultProtocolInfo.svelte
+++ b/src/routes/trading-view/vaults/[vault=slug]/VaultProtocolInfo.svelte
@@ -18,6 +18,7 @@
 	let { vault, protocolMetadata }: Props = $props();
 
 	let protocolPageUrl = $derived(resolve(`/trading-view/vaults/protocols/${vault.protocol_slug}`));
+	let assetType = $derived(vault.flags.includes('tokenised_fund') ? 'tokenised fund' : 'vault');
 </script>
 
 <MetricsBox>
@@ -31,7 +32,7 @@
 		<div class="content">
 			<h2>About {protocolMetadata.name}</h2>
 			<p class="description">
-				This vault is running on <a href={protocolPageUrl}>{protocolMetadata.name}</a>:
+				This {assetType} is running on <a href={protocolPageUrl}>{protocolMetadata.name}</a>:
 			</p>
 			<p class="description">{protocolMetadata.short_description}</p>
 		</div>

--- a/src/routes/trading-view/vaults/sitemap.xml/+server.ts
+++ b/src/routes/trading-view/vaults/sitemap.xml/+server.ts
@@ -18,6 +18,7 @@ const staticSubPages = [
 	'high-tvl',
 	'international',
 	'new-vaults',
+	'tokenised-funds',
 	'current-peak-tvl',
 	'cumulative-tvl-apy',
 	'yield-chain',

--- a/src/routes/trading-view/vaults/tokenised-funds/+page.svelte
+++ b/src/routes/trading-view/vaults/tokenised-funds/+page.svelte
@@ -1,0 +1,199 @@
+<!--
+Tokenised fund listing for vaults with a regulated fund structure.
+-->
+<script lang="ts">
+	import { resolve } from '$app/paths';
+	import { page } from '$app/state';
+	import Alert from '$lib/components/Alert.svelte';
+	import HeroBanner from '$lib/components/HeroBanner.svelte';
+	import Section from '$lib/components/Section.svelte';
+	import Spinner from '$lib/components/Spinner.svelte';
+	import { formatDollar } from '$lib/helpers/formatters';
+	import { fetchAllVaultData, hasVaultCache } from '$lib/top-vaults/client-cache';
+	import { getVaultCurrentTvlUsd, resolveVaultDetails } from '$lib/top-vaults/helpers';
+	import TopVaultsOptIn from '$lib/top-vaults/TopVaultsOptIn.svelte';
+	import TopVaultsTable from '$lib/top-vaults/TopVaultsTable.svelte';
+	import VaultListingsSelector from '$lib/top-vaults/VaultListingsSelector.svelte';
+	import type { TopVaults, VaultInfo } from '$lib/top-vaults/schemas';
+	import { JsonLd, MetaTags } from 'svelte-meta-tags';
+	import MarketSharePieChart from '../MarketSharePieChart.svelte';
+	import MarketShareWidgetBox from '../MarketShareWidgetBox.svelte';
+	import type { MarketShareChartItem } from '../market-share-pie';
+
+	let topVaults = $state<TopVaults>();
+	let loading = $state(!hasVaultCache(page.data.generatedAt));
+
+	function isTokenisedFund(vault: VaultInfo): boolean {
+		return vault.flags.includes('tokenised_fund');
+	}
+
+	$effect(() => {
+		fetchAllVaultData(page.data.generatedAt)
+			.then((allData) => {
+				topVaults = {
+					...allData,
+					vaults: allData.vaults.filter(isTokenisedFund)
+				};
+			})
+			.catch((e) => console.error('Failed to load vault data:', e))
+			.finally(() => (loading = false));
+	});
+
+	const title = 'Tokenised funds';
+	const description =
+		'Tokenised funds are regulated investment funds with on-chain shares and varying levels of data transparency.';
+	let pageUrl = $derived(new URL(page.url.pathname, page.url.origin).href);
+	let totalNavUsd = $derived(
+		topVaults?.vaults.reduce((total, vault) => total + (getVaultCurrentTvlUsd(vault) ?? 0), 0) ?? 0
+	);
+	let chartTitle = $derived(`Total ${formatDollar(totalNavUsd, 2, 3)} tokenised fund NAV`);
+	let chartFunds = $derived.by((): MarketShareChartItem[] => {
+		if (!topVaults) return [];
+
+		return topVaults.vaults.filter(isTokenisedFund).map((vault) => ({
+			slug: vault.id,
+			label: vault.name,
+			name: vault.name,
+			tvl: getVaultCurrentTvlUsd(vault) ?? 0,
+			avgApy: vault.cagr_net ?? vault.three_months_cagr ?? null,
+			href: resolveVaultDetails(vault)
+		}));
+	});
+</script>
+
+<MetaTags
+	{title}
+	{description}
+	canonical={pageUrl}
+	openGraph={{ siteName: 'Trading Strategy', url: pageUrl, title, description, type: 'website' }}
+	twitter={{ site: '@TradingProtocol', cardType: 'summary', title, description }}
+/>
+
+<JsonLd
+	schema={{
+		'@context': 'http://schema.org',
+		'@type': 'CollectionPage',
+		name: title,
+		description,
+		url: pageUrl,
+		provider: { '@type': 'Organization', name: 'Trading Strategy' },
+		mainEntity: {
+			'@type': 'ItemList',
+			numberOfItems: topVaults?.vaults.length ?? 0
+		}
+	}}
+/>
+
+<main class="tokenised-fund-index-page ds-3">
+	<Section tag="header">
+		<div class="header-stack">
+			<VaultListingsSelector />
+
+			<div class="tokenised-fund-index-header">
+				<div class="intro-column">
+					<HeroBanner {title}>
+						{#snippet subtitle()}
+							<p>
+								{#if topVaults}
+									Tracking {formatDollar(totalNavUsd, 2, 3)} net asset value across {topVaults.vaults.length}{' '}
+									{topVaults.vaults.length === 1 ? 'fund' : 'funds'}.
+								{:else}
+									Loading tokenised fund net asset value.
+								{/if}
+							</p>
+							<p>
+								Tokenised funds are often similar to vaults, but with a different compliance structure. Tokenised funds
+								offer varying levels of transparency, and all data may not be available.
+								<a href={resolve('/glossary/tokenised-fund')}
+									>Read more about the differences between vaults and tokenised funds here.</a
+								>
+							</p>
+						{/snippet}
+					</HeroBanner>
+				</div>
+
+				<div class="chart-column">
+					<MarketShareWidgetBox title={chartTitle}>
+						{#if topVaults}
+							<MarketSharePieChart
+								items={chartFunds}
+								groupLabel="Fund"
+								groupLabelPlural="funds"
+								otherThreshold={0.1}
+								wrapLabels
+								valueLabel="Net asset value"
+								testId="tokenised-fund-nav-pie-chart"
+							/>
+						{:else}
+							<div class="chart-loading"><Spinner size="48" /></div>
+						{/if}
+					</MarketShareWidgetBox>
+				</div>
+			</div>
+		</div>
+	</Section>
+
+	<Section padding="sm">
+		{#if loading}
+			<TopVaultsTable loading showFilters defaultTvlKey="10k" defaultHideUnknown={0} />
+		{:else if !topVaults?.vaults.length}
+			<Alert title="Error">No tokenised fund data available.</Alert>
+		{:else}
+			<TopVaultsTable {topVaults} showFilters defaultTvlKey="10k" defaultHideUnknown={0} />
+		{/if}
+	</Section>
+
+	<Section>
+		<TopVaultsOptIn />
+	</Section>
+</main>
+
+<style>
+	.tokenised-fund-index-page {
+		.header-stack {
+			display: grid;
+			gap: 1rem;
+		}
+
+		.tokenised-fund-index-header {
+			display: grid;
+			grid-template-columns: minmax(0, 1fr) minmax(25rem, 40rem);
+			gap: 1.5rem;
+			align-items: stretch;
+		}
+
+		.intro-column,
+		.chart-column {
+			display: grid;
+		}
+
+		.intro-column {
+			align-content: start;
+		}
+
+		.intro-column :global(.subtitle a) {
+			text-decoration: underline;
+			text-underline-offset: 0.15em;
+		}
+
+		.chart-column :global(.metrics-box) {
+			height: 100%;
+		}
+
+		.chart-column :global(.market-share-pie-chart) {
+			align-self: stretch;
+		}
+
+		.chart-loading {
+			display: grid;
+			min-height: 19rem;
+			place-items: center;
+		}
+
+		@media (--viewport-sm-down) {
+			.tokenised-fund-index-header {
+				grid-template-columns: 1fr;
+			}
+		}
+	}
+</style>

--- a/tests/integration/trading-view/vaults/charts-dropdown.test.ts
+++ b/tests/integration/trading-view/vaults/charts-dropdown.test.ts
@@ -29,6 +29,21 @@ test.describe('charts dropdown in vault listings navigation', () => {
 			await page.goto('/trading-view/vaults');
 		});
 
+		test('shows the requested navigation order', async ({ page }) => {
+			const nav = page.locator('.vault-listings-selector');
+			await expect(nav.locator('a, button')).toHaveText([
+				'Top',
+				'Stablecoins',
+				'Chains',
+				'Protocols',
+				'Curators',
+				'International',
+				'Tokenised funds',
+				'Charts',
+				'More'
+			]);
+		});
+
 		test('Charts trigger is visible in the nav', async ({ page }) => {
 			const nav = page.locator('.vault-listings-selector');
 			const trigger = nav.locator('button', { hasText: 'Charts' });

--- a/tests/integration/trading-view/vaults/index.test.ts
+++ b/tests/integration/trading-view/vaults/index.test.ts
@@ -351,12 +351,14 @@ test.describe('vault index page', () => {
 		);
 	});
 
-	test('warns when deposits may be disabled on a vault detail page', async ({ page }) => {
+	test('explains the tokenised fund structure when deposits may be disabled on a vault detail page', async ({
+		page
+	}) => {
 		await page.goto('/trading-view/vaults/deposit-disabled-vault');
 
-		const alert = page.locator('.alert-list.warning').first();
+		const alert = page.locator('.alert-list.info').first();
 		await expect(alert).toBeVisible();
-		await expect(alert).toContainText('Deposits may be disabled for this vault');
+		await expect(alert).toContainText('Deposit disabled vault is a tokenised fund');
 	});
 
 	test('warns when withdrawals may be disabled on a vault detail page', async ({ page }) => {

--- a/tests/integration/trading-view/vaults/tokenised-funds.test.ts
+++ b/tests/integration/trading-view/vaults/tokenised-funds.test.ts
@@ -1,0 +1,38 @@
+import { expect, test } from '@playwright/test';
+
+test.describe('tokenised funds page', () => {
+	test('lists tokenised funds and links to the glossary explanation', async ({ page }) => {
+		await page.goto('/trading-view/vaults/tokenised-funds');
+
+		await expect(page).toHaveTitle('Tokenised funds');
+		await expect(page.locator('h1')).toHaveText('Tokenised funds');
+		await expect(page.locator('.vault-listings-selector a', { hasText: 'Tokenised funds' })).toHaveAttribute(
+			'href',
+			'/trading-view/vaults/tokenised-funds'
+		);
+		await expect(
+			page.getByRole('link', { name: 'Read more about the differences between vaults and tokenised funds here.' })
+		).toHaveAttribute('href', '/glossary/tokenised-fund');
+		await expect(page.getByText('Tracking $20.00K net asset value across 1 fund.')).toBeVisible();
+		await expect(page.getByText('Total $20.00K tokenised fund NAV')).toBeVisible();
+		await expect(page.getByTestId('tokenised-fund-nav-pie-chart').locator('canvas')).toBeVisible({
+			timeout: 15000
+		});
+		await expect(page.locator('tbody tr.targetable')).toHaveCount(1);
+		await expect(page.locator('tbody tr.targetable')).toContainText('Deposit disabled vault');
+	});
+
+	test('explains the tokenised fund structure instead of the deposit warning', async ({ page }) => {
+		await page.goto('/trading-view/vaults/deposit-disabled-vault');
+
+		const alert = page.locator('.alert-list.info').first();
+		await expect(alert).toBeVisible();
+		await expect(alert).toContainText(
+			'Deposit disabled vault is a tokenised fund. It is smart contract-based, but may not offer all features of vaults.'
+		);
+		await expect(
+			alert.getByRole('link', { name: 'Read more about the differences between vaults and tokenised funds here.' })
+		).toHaveAttribute('href', '/glossary/tokenised-fund');
+		await expect(alert).not.toContainText('Deposits may be disabled for this vault');
+	});
+});

--- a/tests/mocks/top-vaults/list.mock.ts
+++ b/tests/mocks/top-vaults/list.mock.ts
@@ -395,6 +395,7 @@ const closedVaultPeriodResult = {
 const depositDisabledVault = createTestVault('Deposit disabled vault', {
 	chain: 'base',
 	current_nav: 20_000,
+	flags: ['tokenised_fund'],
 	deposit_closed_reason: 'Deposits paused',
 	period_results: [closedVaultPeriodResult]
 });

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -2,6 +2,7 @@
  * Vite configuration file; see: https://vite.dev/config/
  */
 import { defineConfig } from 'vitest/config';
+import { realpathSync } from 'node:fs';
 import { sveltekit } from '@sveltejs/kit/vite';
 import { type LogOptions, createLogger } from 'vite';
 import Icons from 'unplugin-icons/vite';
@@ -85,7 +86,9 @@ export default defineConfig(({ mode }) => {
 			// Lets users open an agent-hosted dev server via e.g. brian.tailnet.ts.net.
 			allowedHosts: [TAILSCALE_ALLOWED_HOST],
 			fs: {
-				allow: [process.cwd()]
+				// Worktrees can symlink node_modules from their main checkout. Vite serves
+				// client modules through /@fs, so permit the resolved dependency directory too.
+				allow: [process.cwd(), realpathSync('node_modules')]
 			}
 		},
 


### PR DESCRIPTION
## Why
Tokenised funds need a dedicated listing and detail treatment because their smart-contract structure and disclosure model differ from standard vaults.

## Lessons learnt
The vault dataset already exposes extensible flags, so `tokenised_fund` can drive the listing, chart, and detail-page messaging without a separate data contract.

## Summary
- Add the Tokenised funds listing, navigation entry, sitemap route, NAV-by-fund chart, and glossary links.
- Add tokenised-fund-specific detail messaging and terminology.
- Update chart label wrapping, navigation labels, Vite worktree access, fixtures, and integration coverage.