### PR TITLE
Fix missing fee data in vault returns

### DIFF
--- a/src/routes/vaults/[vault=slug]/VaultMetrics.svelte
+++ b/src/routes/vaults/[vault=slug]/VaultMetrics.svelte
@@ -25,12 +25,15 @@ Displays supplementary vault information, including transaction status, performa
 	}
 
 	const LIMITED_HISTORY_CHAINS = [9999, 9998, 9997];
+	const NO_DATA_LABEL = 'No data';
+	const MISSING_FEE_TOOLTIP = 'The fee information is not available onchain. Net returns cannot be calculated.';
 
 	let { vault, stablecoinMetadata = null }: Props = $props();
 
 	let chain = $derived(getChain(vault.chain_id));
 	let hasLimitedHistory = $derived(LIMITED_HISTORY_CHAINS.includes(vault.chain_id));
 	let showTransactionStatus = $derived(!isGoodVaultStatus(vault));
+	let hasNetFeeInformation = $derived(vault.net_fees?.fee_mode != null);
 	let denominationSlug = $derived(
 		resolveStablecoinSlug({
 			slug: vault.denomination_slug,
@@ -137,6 +140,14 @@ Displays supplementary vault information, including transaction status, performa
 		if (!period.samplePeriod) return period.label;
 
 		return `${period.label}, ${formatDate(period.samplePeriod.period_start_at)} to ${formatDate(period.samplePeriod.period_end_at)}`;
+	}
+
+	function isMissingFeeValue(value: number | null | undefined): boolean {
+		return value == null;
+	}
+
+	function isNetReturnUnavailable(period: (typeof returnPeriods)[number]): boolean {
+		return !hasNetFeeInformation && period.net.annualised == null;
 	}
 </script>
 
@@ -269,6 +280,14 @@ Displays supplementary vault information, including transaction status, performa
 							</svelte:fragment>
 						</Tooltip>
 					{/snippet}
+					{#snippet noDataCell()}
+						<span class="no-data-tooltip">
+							<Tooltip>
+								<span slot="trigger" class="no-data-cell">{NO_DATA_LABEL}</span>
+								<svelte:fragment slot="popup">{MISSING_FEE_TOOLTIP}</svelte:fragment>
+							</Tooltip>
+						</span>
+					{/snippet}
 					<tr>
 						<td>
 							{@render metricLabel(
@@ -304,7 +323,13 @@ Displays supplementary vault information, including transaction status, performa
 						<tr class="fee-row">
 							<td>{@render metricLabel(fee.tooltip, fee.label, fee.mobileLabel)}</td>
 							{#each returnPeriods as period (period.label)}
-								<td aria-label={`${fee.label} for ${period.label}`}>{formatPercent(fee.value)}</td>
+								<td aria-label={`${fee.label} for ${period.label}`}>
+									{#if isMissingFeeValue(fee.value)}
+										{@render noDataCell()}
+									{:else}
+										{formatPercent(fee.value)}
+									{/if}
+								</td>
 							{/each}
 						</tr>
 					{/each}
@@ -317,25 +342,29 @@ Displays supplementary vault information, including transaction status, performa
 						</td>
 						{#each returnPeriods as period (period.label)}
 							<td>
-								<Tooltip>
-									<span slot="trigger" class="return-cell">{formatPercentProfit(period.net.annualised)}</span>
-									<svelte:fragment slot="popup">
-										<dl class="return-tooltip">
-											<div>
-												<dt>Annualised:</dt>
-												<dd>{formatPercentProfit(period.net.annualised)}</dd>
-											</div>
-											<div>
-												<dt>Raw:</dt>
-												<dd>{formatPercentProfit(period.net.raw)}</dd>
-											</div>
-											<div>
-												<dt>Sampled period:</dt>
-												<dd>{getSamplePeriodLabel(period)}</dd>
-											</div>
-										</dl>
-									</svelte:fragment>
-								</Tooltip>
+								{#if isNetReturnUnavailable(period)}
+									{@render noDataCell()}
+								{:else}
+									<Tooltip>
+										<span slot="trigger" class="return-cell">{formatPercentProfit(period.net.annualised)}</span>
+										<svelte:fragment slot="popup">
+											<dl class="return-tooltip">
+												<div>
+													<dt>Annualised:</dt>
+													<dd>{formatPercentProfit(period.net.annualised)}</dd>
+												</div>
+												<div>
+													<dt>Raw:</dt>
+													<dd>{formatPercentProfit(period.net.raw)}</dd>
+												</div>
+												<div>
+													<dt>Sampled period:</dt>
+													<dd>{getSamplePeriodLabel(period)}</dd>
+												</div>
+											</dl>
+										</svelte:fragment>
+									</Tooltip>
+								{/if}
 							</td>
 						{/each}
 					</tr>
@@ -471,6 +500,14 @@ Displays supplementary vault information, including transaction status, performa
 
 		.return-cell {
 			border-bottom: 1px dotted var(--c-text-light);
+		}
+
+		.no-data-cell {
+			border-bottom: 1px dotted var(--c-text-light);
+		}
+
+		.no-data-tooltip :global(.popup) {
+			max-width: 200px;
 		}
 
 		.return-tooltip {

--- a/src/routes/vaults/[vault=slug]/VaultMetrics.test.ts
+++ b/src/routes/vaults/[vault=slug]/VaultMetrics.test.ts
@@ -1,0 +1,96 @@
+import { cleanup, render, screen } from '@testing-library/svelte';
+import { afterEach, describe, expect, test } from 'vitest';
+import { createTestVault } from '$lib/top-vaults/test-utils';
+import type { PeriodMetrics } from '$lib/top-vaults/schemas';
+import VaultMetrics from './VaultMetrics.svelte';
+
+const MISSING_FEE_TOOLTIP = 'The fee information is not available onchain. Net returns cannot be calculated.';
+
+afterEach(cleanup);
+
+function createPeriodMetrics(
+	period: string,
+	grossReturn: number,
+	grossCagr: number,
+	netReturn: number | null
+): PeriodMetrics {
+	return {
+		period,
+		error_reason: null,
+		period_start_at: '2026-01-01T00:00:00',
+		period_end_at: '2026-02-01T00:00:00',
+		share_price_start: 1,
+		share_price_end: 1 + grossReturn,
+		raw_samples: 31,
+		samples_start_at: '2026-01-01T00:00:00',
+		samples_end_at: '2026-02-01T00:00:00',
+		daily_samples: 31,
+		returns_gross: grossReturn,
+		returns_net: netReturn,
+		cagr_gross: grossCagr,
+		cagr_net: netReturn,
+		volatility: null,
+		sharpe: null,
+		max_drawdown: null,
+		tvl_start: null,
+		tvl_end: null,
+		tvl_low: null,
+		tvl_high: null,
+		ranking_overall: null,
+		ranking_chain: null,
+		ranking_protocol: null
+	};
+}
+
+describe('VaultMetrics', () => {
+	test('shows no data tooltips when fee information and net returns are missing', () => {
+		const vault = createTestVault('No fee data vault', {
+			one_month_cagr: 0.12,
+			one_month_returns: 0.01,
+			three_months_cagr: 0.14,
+			three_months_returns: 0.03,
+			cagr: 0.11,
+			lifetime_return: 0.08,
+			net_fees: null,
+			period_results: [createPeriodMetrics('6m', 0.05, 0.1, null), createPeriodMetrics('1y', 0.08, 0.08, null)]
+		});
+
+		render(VaultMetrics, { props: { vault } });
+
+		expect(screen.getAllByText('No data')).toHaveLength(25);
+		expect(screen.getAllByText(MISSING_FEE_TOOLTIP)).toHaveLength(25);
+		expect(screen.getAllByText('12.0%').length).toBeGreaterThan(0);
+	});
+
+	test('formats known fee and net return values normally', () => {
+		const vault = createTestVault('Known fee vault', {
+			one_month_cagr: 0.12,
+			one_month_returns: 0.01,
+			one_month_cagr_net: 0.1,
+			one_month_returns_net: 0.008,
+			three_months_cagr: 0.14,
+			three_months_returns: 0.03,
+			three_months_cagr_net: 0.11,
+			three_months_returns_net: 0.025,
+			cagr: 0.11,
+			cagr_net: 0.09,
+			lifetime_return: 0.08,
+			lifetime_return_net: 0.07,
+			net_fees: {
+				fee_mode: 'externalised',
+				performance: 0.2,
+				management: 0.01,
+				deposit: 0,
+				withdraw: 0
+			},
+			period_results: [createPeriodMetrics('6m', 0.05, 0.1, 0.04), createPeriodMetrics('1y', 0.08, 0.08, 0.07)]
+		});
+
+		render(VaultMetrics, { props: { vault } });
+
+		expect(screen.queryByText('No data')).not.toBeInTheDocument();
+		expect(screen.getAllByText('20.0%').length).toBeGreaterThan(0);
+		expect(screen.getAllByText('0.0%').length).toBeGreaterThan(0);
+		expect(screen.getAllByText('10.0%').length).toBeGreaterThan(0);
+	});
+});


### PR DESCRIPTION
## Why

Vaults without onchain fee data cannot calculate net returns. The returns and fees table should state that directly rather than render an empty or misleading value.

## Lessons learnt

Fee availability and net-return availability are distinct data states. Keep the unavailable explanation next to the affected cell and constrain the tooltip width for readable scanning.

## Summary

- Render `No data` with an explanatory tooltip for missing fee values and unavailable net returns.
- Limit the unavailable-data tooltip to 200px.
- Add component coverage for unavailable and available fee data.