### PR TITLE
Fix vault fee display tooltips

### DIFF
--- a/src/lib/top-vaults/AvgApyHeader.svelte
+++ b/src/lib/top-vaults/AvgApyHeader.svelte
@@ -1,0 +1,14 @@
+<!--
+@component
+Column heading for TVL-weighted average APY values in vault group listings.
+-->
+<script lang="ts">
+	import Tooltip from '$lib/components/Tooltip.svelte';
+
+	const avgApyTooltip = 'Total value locked weighted returns, last 30 days';
+</script>
+
+<Tooltip>
+	<span slot="trigger" class="underline">Avg. APY%</span>
+	<svelte:fragment slot="popup">{avgApyTooltip}</svelte:fragment>
+</Tooltip>

--- a/src/lib/top-vaults/VaultGroupTable.svelte
+++ b/src/lib/top-vaults/VaultGroupTable.svelte
@@ -18,6 +18,7 @@
 	import DataTable from '$lib/components/datatable/DataTable.svelte';
 	import TableRowTarget from '$lib/components/datatable/TableRowTarget.svelte';
 	import { UNKNOWN_VAULT_PROTOCOL_SLUG } from '$lib/top-vaults/helpers';
+	import AvgApyHeader from './AvgApyHeader.svelte';
 	import VaultGroupNameCell from './VaultGroupNameCell.svelte';
 	import RiskCell from './RiskCell.svelte';
 	import Core3RiskCell from './Core3RiskCell.svelte';
@@ -149,7 +150,7 @@
 		}),
 		table.column({
 			accessor: 'avg_apy',
-			header: 'Avg. APY%',
+			header: createRender(AvgApyHeader, {}),
 			cell: ({ value }) => formatPercent(value)
 		}),
 		table.column({

--- a/src/routes/vaults/[vault=slug]/VaultMetrics.svelte
+++ b/src/routes/vaults/[vault=slug]/VaultMetrics.svelte
@@ -27,6 +27,9 @@ Displays supplementary vault information, including transaction status, performa
 	const LIMITED_HISTORY_CHAINS = [9999, 9998, 9997];
 	const NO_DATA_LABEL = 'No data';
 	const MISSING_FEE_TOOLTIP = 'The fee information is not available onchain. Net returns cannot be calculated.';
+	const INTERNALISED_FEE_TOOLTIP =
+		'Fees are internalised and already reduced from the gross profit and thus reflected in the share price.';
+	const INTERNALISED_FEE_DISCLAIMER = 'Fees are internalised for this vault and already removed from the gross profit.';
 
 	let { vault, stablecoinMetadata = null }: Props = $props();
 
@@ -34,6 +37,11 @@ Displays supplementary vault information, including transaction status, performa
 	let hasLimitedHistory = $derived(LIMITED_HISTORY_CHAINS.includes(vault.chain_id));
 	let showTransactionStatus = $derived(!isGoodVaultStatus(vault));
 	let hasNetFeeInformation = $derived(vault.net_fees?.fee_mode != null);
+	let hasInternalisedFees = $derived(
+		vault.fee_internalised === true ||
+			vault.gross_fees?.fee_mode?.startsWith('internalised') ||
+			vault.net_fees?.fee_mode?.startsWith('internalised')
+	);
 	let denominationSlug = $derived(
 		resolveStablecoinSlug({
 			slug: vault.denomination_slug,
@@ -108,25 +116,25 @@ Displays supplementary vault information, including transaction status, performa
 		{
 			label: 'Performance fee',
 			mobileLabel: 'Performance',
-			value: vault.net_fees?.performance,
+			value: vault.gross_fees?.performance,
 			tooltip: '<strong>Performance fee</strong> is charged against investment profits.'
 		},
 		{
 			label: 'Management fee',
 			mobileLabel: 'Management',
-			value: vault.net_fees?.management,
+			value: vault.gross_fees?.management,
 			tooltip: '<strong>Management fee</strong> is charged annually for managing the vault.'
 		},
 		{
 			label: 'Deposit fee',
 			mobileLabel: 'Deposit',
-			value: vault.net_fees?.deposit,
+			value: vault.gross_fees?.deposit,
 			tooltip: '<strong>Deposit fee</strong> is a one-time fee applied when entering the vault.'
 		},
 		{
 			label: 'Withdrawal fee',
 			mobileLabel: 'Withdrawal',
-			value: vault.net_fees?.withdraw,
+			value: vault.gross_fees?.withdraw,
 			tooltip: '<strong>Withdrawal fee</strong> is a one-time fee applied when exiting the vault.'
 		}
 	]);
@@ -148,6 +156,11 @@ Displays supplementary vault information, including transaction status, performa
 
 	function isNetReturnUnavailable(period: (typeof returnPeriods)[number]): boolean {
 		return !hasNetFeeInformation && period.net.annualised == null;
+	}
+
+	function withInternalisedFeeTooltip(tooltip: string): string {
+		if (!hasInternalisedFees) return tooltip;
+		return `${tooltip}<p>${INTERNALISED_FEE_TOOLTIP}</p>`;
 	}
 </script>
 
@@ -321,7 +334,7 @@ Displays supplementary vault information, including transaction status, performa
 					</tr>
 					{#each feeRows as fee (fee.label)}
 						<tr class="fee-row">
-							<td>{@render metricLabel(fee.tooltip, fee.label, fee.mobileLabel)}</td>
+							<td>{@render metricLabel(withInternalisedFeeTooltip(fee.tooltip), fee.label, fee.mobileLabel)}</td>
 							{#each returnPeriods as period (period.label)}
 								<td aria-label={`${fee.label} for ${period.label}`}>
 									{#if isMissingFeeValue(fee.value)}
@@ -336,7 +349,9 @@ Displays supplementary vault information, including transaction status, performa
 					<tr>
 						<td>
 							{@render metricLabel(
-								'<strong>Net returns</strong> are annualised. They are the gross returns after all investor-facing fees have been deducted.',
+								withInternalisedFeeTooltip(
+									'<strong>Net returns</strong> are annualised. They are the gross returns after all investor-facing fees have been deducted.'
+								),
 								'Net'
 							)}
 						</td>
@@ -371,6 +386,9 @@ Displays supplementary vault information, including transaction status, performa
 				</tbody>
 			</table>
 		</div>
+		{#if hasInternalisedFees}
+			<p class="fee-disclaimer">{INTERNALISED_FEE_DISCLAIMER}</p>
+		{/if}
 	</MetricsBox>
 </div>
 
@@ -484,6 +502,12 @@ Displays supplementary vault information, including transaction status, performa
 
 		.table-scroll {
 			overflow-x: auto;
+		}
+
+		.fee-disclaimer {
+			margin: 0.75rem 0 0;
+			font: var(--f-ui-sm-roman);
+			color: var(--c-text-light);
 		}
 
 		@media (--viewport-md-up) {

--- a/src/routes/vaults/[vault=slug]/VaultMetrics.test.ts
+++ b/src/routes/vaults/[vault=slug]/VaultMetrics.test.ts
@@ -5,6 +5,9 @@ import type { PeriodMetrics } from '$lib/top-vaults/schemas';
 import VaultMetrics from './VaultMetrics.svelte';
 
 const MISSING_FEE_TOOLTIP = 'The fee information is not available onchain. Net returns cannot be calculated.';
+const INTERNALISED_FEE_TOOLTIP =
+	'Fees are internalised and already reduced from the gross profit and thus reflected in the share price.';
+const INTERNALISED_FEE_DISCLAIMER = 'Fees are internalised for this vault and already removed from the gross profit.';
 
 afterEach(cleanup);
 
@@ -76,6 +79,13 @@ describe('VaultMetrics', () => {
 			cagr_net: 0.09,
 			lifetime_return: 0.08,
 			lifetime_return_net: 0.07,
+			gross_fees: {
+				fee_mode: 'externalised',
+				performance: 0.3,
+				management: 0.02,
+				deposit: 0,
+				withdraw: 0
+			},
 			net_fees: {
 				fee_mode: 'externalised',
 				performance: 0.2,
@@ -89,8 +99,48 @@ describe('VaultMetrics', () => {
 		render(VaultMetrics, { props: { vault } });
 
 		expect(screen.queryByText('No data')).not.toBeInTheDocument();
-		expect(screen.getAllByText('20.0%').length).toBeGreaterThan(0);
+		expect(screen.queryByText('20.0%')).not.toBeInTheDocument();
+		expect(screen.getAllByText('30.0%').length).toBeGreaterThan(0);
+		expect(screen.getAllByText('2.0%').length).toBeGreaterThan(0);
 		expect(screen.getAllByText('0.0%').length).toBeGreaterThan(0);
 		expect(screen.getAllByText('10.0%').length).toBeGreaterThan(0);
+	});
+
+	test('explains internalised fees in fee and net return tooltips', () => {
+		const vault = createTestVault('Internalised fee vault', {
+			one_month_cagr: 0.12,
+			one_month_returns: 0.01,
+			one_month_cagr_net: 0.12,
+			one_month_returns_net: 0.01,
+			three_months_cagr: 0.14,
+			three_months_returns: 0.03,
+			three_months_cagr_net: 0.14,
+			three_months_returns_net: 0.03,
+			cagr: 0.11,
+			cagr_net: 0.11,
+			lifetime_return: 0.08,
+			lifetime_return_net: 0.08,
+			fee_internalised: true,
+			gross_fees: {
+				fee_mode: 'internalised_skimming',
+				performance: 0.1,
+				management: 0,
+				deposit: 0,
+				withdraw: 0
+			},
+			net_fees: {
+				fee_mode: 'internalised_skimming',
+				performance: 0,
+				management: 0,
+				deposit: 0,
+				withdraw: 0
+			},
+			period_results: [createPeriodMetrics('6m', 0.05, 0.1, 0.05), createPeriodMetrics('1y', 0.08, 0.08, 0.08)]
+		});
+
+		render(VaultMetrics, { props: { vault } });
+
+		expect(screen.getAllByText(INTERNALISED_FEE_TOOLTIP)).toHaveLength(5);
+		expect(screen.getByText(INTERNALISED_FEE_DISCLAIMER)).toBeInTheDocument();
 	});
 });


### PR DESCRIPTION
## Why

Vault listing and detail pages needed clearer fee metadata. Group listings with an Avg. APY column now explain that the value is TVL-weighted over the last 30 days. Vault detail fee tables need to display contractual gross fees while keeping net return values sourced from the existing net return data, and internalised-fee vaults need explicit copy explaining why gross and net returns may match.

## Lessons learnt

Internalised vault fees can already be reflected in the share price data, so the frontend should not infer a fee adjustment from the displayed contractual fee. The UI needs to distinguish display-only gross fee schedules from net return fields supplied by the vault dataset.

## Summary

- Added a tooltip-backed Avg. APY header to the shared vault group table.
- Switched vault detail fee rows to display gross fee values while leaving net return rows on net return fields.
- Added internalised-fee explanatory tooltip copy and a table disclaimer for internalised-fee vaults.
- Added focused regression coverage for fee display and internalised-fee messaging.