### PR TITLE
Improve tokenised funds chart labels

### DIFF
--- a/src/lib/top-vaults/AvgApyHeader.svelte
+++ b/src/lib/top-vaults/AvgApyHeader.svelte
@@ -1,0 +1,14 @@
+<!--
+@component
+Column heading for TVL-weighted average APY values in vault group listings.
+-->
+<script lang="ts">
+	import Tooltip from '$lib/components/Tooltip.svelte';
+
+	const avgApyTooltip = 'Total value locked weighted returns, last 30 days';
+</script>
+
+<Tooltip>
+	<span slot="trigger" class="underline">Avg. APY%</span>
+	<svelte:fragment slot="popup">{avgApyTooltip}</svelte:fragment>
+</Tooltip>

--- a/src/lib/top-vaults/VaultGroupTable.svelte
+++ b/src/lib/top-vaults/VaultGroupTable.svelte
@@ -18,6 +18,7 @@
 	import DataTable from '$lib/components/datatable/DataTable.svelte';
 	import TableRowTarget from '$lib/components/datatable/TableRowTarget.svelte';
 	import { UNKNOWN_VAULT_PROTOCOL_SLUG } from '$lib/top-vaults/helpers';
+	import AvgApyHeader from './AvgApyHeader.svelte';
 	import VaultGroupNameCell from './VaultGroupNameCell.svelte';
 	import RiskCell from './RiskCell.svelte';
 	import Core3RiskCell from './Core3RiskCell.svelte';
@@ -149,7 +150,7 @@
 		}),
 		table.column({
 			accessor: 'avg_apy',
-			header: 'Avg. APY%',
+			header: createRender(AvgApyHeader, {}),
 			cell: ({ value }) => formatPercent(value)
 		}),
 		table.column({

--- a/src/routes/vaults/MarketSharePieChart.svelte
+++ b/src/routes/vaults/MarketSharePieChart.svelte
@@ -14,6 +14,10 @@
 		groupLabelPlural: string;
 		/** Group items below this share into an Other slice. Defaults to 2%. */
 		otherThreshold?: number;
+		/** Maximum number of standalone slices before grouping the rest as Other. */
+		maxIndividualSlices?: number;
+		/** Show slice logos inside chart labels when `logoUrl` is available. */
+		showLabelLogos?: boolean;
 		/** Split long slice names across two lines before the value label. */
 		wrapLabels?: boolean;
 		/** Label for the value shown in chart tooltips. */
@@ -27,6 +31,8 @@
 		groupLabel,
 		groupLabelPlural,
 		otherThreshold,
+		maxIndividualSlices,
+		showLabelLogos = false,
 		wrapLabels = false,
 		valueLabel = 'TVL',
 		testId = 'market-share-pie-chart',
@@ -47,7 +53,7 @@
 		'#64748b'
 	];
 
-	let slices = $derived(buildMarketSharePieSlices(items, { groupLabelPlural, otherThreshold }));
+	let slices = $derived(buildMarketSharePieSlices(items, { groupLabelPlural, otherThreshold, maxIndividualSlices }));
 	let chartContainer = $state<HTMLDivElement | null>(null);
 	let chartInstance = $state<ReturnType<EChartsStatic['init']> | null>(null);
 	let echartsApi = $state<EChartsStatic | null>(null);
@@ -66,6 +72,10 @@
 
 	function formatLabelPercentage(value: number): string {
 		return value >= 10 ? value.toFixed(0) : value.toFixed(1);
+	}
+
+	function getLogoRichKey(slice: MarketSharePieSlice): string {
+		return `logo_${(slice.slug ?? slice.label).replace(/\W+/g, '_')}`;
 	}
 
 	function splitLabelIntoTwoLines(label: string): string[] {
@@ -89,21 +99,34 @@
 		return [words.slice(0, bestIndex).join(' '), words.slice(bestIndex).join(' ')];
 	}
 
-	function formatSliceLabel(label: string): string {
+	function formatSliceLabel(slice: MarketSharePieSlice, includeLogo: boolean): string {
+		const { label } = slice;
 		const lines = wrapLabels ? splitLabelIntoTwoLines(label) : [label];
 		const style = wrapLabels && label.length > 45 ? 'labelCompact' : 'label';
-		return lines.map((line) => `{${style}|${line}}`).join('\n');
+		const labelText = lines.map((line) => `{${style}|${line}}`).join('\n');
+
+		if (includeLogo && slice.logoUrl && !slice.isOther) {
+			return `{${getLogoRichKey(slice)}|}\n${labelText}`;
+		}
+
+		return labelText;
 	}
 
 	function getValueLabelStyle(label: string): string {
 		return wrapLabels && label.length > 45 ? 'valueCompact' : 'value';
 	}
 
-	function buildLabelRichStyles(isMobile: boolean) {
+	function trackChartInputs(...inputs: unknown[]): void {
+		// Svelte tracks effect dependencies when arguments are evaluated.
+		inputs.forEach(Boolean);
+	}
+
+	function buildLabelRichStyles(isMobile: boolean, currentSlices: MarketSharePieSlice[]) {
 		const labelFontSize = wrapLabels ? (isMobile ? 9 : 9.5) : 11;
 		const valueFontSize = wrapLabels ? (isMobile ? 9 : 9.5) : 10.5;
 		const compactLabelFontSize = wrapLabels ? (isMobile ? 7.5 : 8) : labelFontSize;
 		const compactValueFontSize = wrapLabels ? (isMobile ? 8 : 8.5) : valueFontSize;
+		const logoSize = isMobile ? 14 : 16;
 		const rich: Record<string, Record<string, unknown>> = {
 			label: {
 				color: '#f8fbff',
@@ -142,6 +165,21 @@
 				verticalAlign: 'middle'
 			}
 		};
+
+		for (const slice of currentSlices) {
+			if (!showLabelLogos || isMobile || !slice.logoUrl || slice.isOther) continue;
+			rich[getLogoRichKey(slice)] = {
+				width: logoSize,
+				height: logoSize,
+				lineHeight: logoSize + 2,
+				align: 'center',
+				verticalAlign: 'middle',
+				borderRadius: logoSize / 2,
+				backgroundColor: {
+					image: slice.logoUrl
+				}
+			};
+		}
 
 		return rich;
 	}
@@ -205,7 +243,9 @@
 		destroyChart();
 
 		const isMobile = window.innerWidth <= 768;
-		const labelRichStyles = buildLabelRichStyles(isMobile);
+		const includeLabelLogos = showLabelLogos && !isMobile;
+		const currentSlices = slices;
+		const labelRichStyles = buildLabelRichStyles(isMobile, currentSlices);
 		chartInstance = echartsApi.init(chartContainer);
 		chartInstance.setOption({
 			animationDuration: 450,
@@ -241,7 +281,7 @@
 				{
 					name: `${groupLabel} ${valueLabel}`,
 					type: 'pie',
-					radius: isMobile ? ['24%', '49%'] : ['35%', '70%'],
+					radius: isMobile ? ['24%', '48%'] : ['35%', '70%'],
 					center: ['50%', '53%'],
 					avoidLabelOverlap: true,
 					minAngle: 2,
@@ -257,15 +297,15 @@
 						fontFamily: chartFontFamily,
 						fontSize: isMobile ? 12 : 12,
 						lineHeight: isMobile ? 18 : 18,
-						padding: wrapLabels ? (isMobile ? [4, 6, 4, 6] : [4, 8, 4, 8]) : isMobile ? [5, 8, 5, 8] : [6, 11, 6, 11],
-						borderRadius: 999,
+						padding: wrapLabels ? (isMobile ? [4, 5, 4, 5] : [4, 8, 4, 8]) : isMobile ? [4, 6, 4, 6] : [6, 11, 6, 11],
+						borderRadius: isMobile ? 0 : 999,
 						backgroundColor: 'rgba(255, 255, 255, 0.14)',
 						shadowBlur: 10,
 						shadowColor: 'rgba(15, 23, 42, 0.16)',
 						formatter: (params: { data?: MarketSharePieSlice }) => {
 							const slice = params.data;
 							if (!slice) return '';
-							return `${formatSliceLabel(slice.label)}\n{${getValueLabelStyle(slice.label)}|${formatLabelPercentage(slice.percentage)}%}`;
+							return `${formatSliceLabel(slice, includeLabelLogos)}\n{${getValueLabelStyle(slice.label)}|${formatLabelPercentage(slice.percentage)}%}`;
 						},
 						rich: labelRichStyles
 					},
@@ -289,13 +329,14 @@
 							shadowColor: 'rgba(56, 189, 248, 0.22)'
 						}
 					},
-					data: slices
+					data: currentSlices
 				}
 			]
 		});
 
 		chartInstance.on('click', (params) => {
 			const targetUrl = params.data?.url;
+			// eslint-disable-next-line svelte/no-navigation-without-resolve -- Chart items already provide resolved hrefs.
 			if (targetUrl) goto(targetUrl);
 		});
 
@@ -337,12 +378,16 @@
 	});
 
 	$effect(() => {
-		slices;
-		groupLabel;
-		groupLabelPlural;
-		otherThreshold;
-		wrapLabels;
-		valueLabel;
+		trackChartInputs(
+			slices,
+			groupLabel,
+			groupLabelPlural,
+			otherThreshold,
+			maxIndividualSlices,
+			showLabelLogos,
+			wrapLabels,
+			valueLabel
+		);
 		if (!runtimeReady || !echartsApi || !chartContainer) return;
 
 		let cancelled = false;

--- a/src/routes/vaults/[vault=slug]/VaultMetrics.svelte
+++ b/src/routes/vaults/[vault=slug]/VaultMetrics.svelte
@@ -27,6 +27,9 @@ Displays supplementary vault information, including transaction status, performa
 	const LIMITED_HISTORY_CHAINS = [9999, 9998, 9997];
 	const NO_DATA_LABEL = 'No data';
 	const MISSING_FEE_TOOLTIP = 'The fee information is not available onchain. Net returns cannot be calculated.';
+	const INTERNALISED_FEE_TOOLTIP =
+		'Fees are internalised and already reduced from the gross profit and thus reflected in the share price.';
+	const INTERNALISED_FEE_DISCLAIMER = 'Fees are internalised for this vault and already removed from the gross profit.';
 
 	let { vault, stablecoinMetadata = null }: Props = $props();
 
@@ -34,6 +37,11 @@ Displays supplementary vault information, including transaction status, performa
 	let hasLimitedHistory = $derived(LIMITED_HISTORY_CHAINS.includes(vault.chain_id));
 	let showTransactionStatus = $derived(!isGoodVaultStatus(vault));
 	let hasNetFeeInformation = $derived(vault.net_fees?.fee_mode != null);
+	let hasInternalisedFees = $derived(
+		vault.fee_internalised === true ||
+			vault.gross_fees?.fee_mode?.startsWith('internalised') ||
+			vault.net_fees?.fee_mode?.startsWith('internalised')
+	);
 	let denominationSlug = $derived(
 		resolveStablecoinSlug({
 			slug: vault.denomination_slug,
@@ -108,25 +116,25 @@ Displays supplementary vault information, including transaction status, performa
 		{
 			label: 'Performance fee',
 			mobileLabel: 'Performance',
-			value: vault.net_fees?.performance,
+			value: vault.gross_fees?.performance,
 			tooltip: '<strong>Performance fee</strong> is charged against investment profits.'
 		},
 		{
 			label: 'Management fee',
 			mobileLabel: 'Management',
-			value: vault.net_fees?.management,
+			value: vault.gross_fees?.management,
 			tooltip: '<strong>Management fee</strong> is charged annually for managing the vault.'
 		},
 		{
 			label: 'Deposit fee',
 			mobileLabel: 'Deposit',
-			value: vault.net_fees?.deposit,
+			value: vault.gross_fees?.deposit,
 			tooltip: '<strong>Deposit fee</strong> is a one-time fee applied when entering the vault.'
 		},
 		{
 			label: 'Withdrawal fee',
 			mobileLabel: 'Withdrawal',
-			value: vault.net_fees?.withdraw,
+			value: vault.gross_fees?.withdraw,
 			tooltip: '<strong>Withdrawal fee</strong> is a one-time fee applied when exiting the vault.'
 		}
 	]);
@@ -148,6 +156,11 @@ Displays supplementary vault information, including transaction status, performa
 
 	function isNetReturnUnavailable(period: (typeof returnPeriods)[number]): boolean {
 		return !hasNetFeeInformation && period.net.annualised == null;
+	}
+
+	function withInternalisedFeeTooltip(tooltip: string): string {
+		if (!hasInternalisedFees) return tooltip;
+		return `${tooltip}<p>${INTERNALISED_FEE_TOOLTIP}</p>`;
 	}
 </script>
 
@@ -321,7 +334,7 @@ Displays supplementary vault information, including transaction status, performa
 					</tr>
 					{#each feeRows as fee (fee.label)}
 						<tr class="fee-row">
-							<td>{@render metricLabel(fee.tooltip, fee.label, fee.mobileLabel)}</td>
+							<td>{@render metricLabel(withInternalisedFeeTooltip(fee.tooltip), fee.label, fee.mobileLabel)}</td>
 							{#each returnPeriods as period (period.label)}
 								<td aria-label={`${fee.label} for ${period.label}`}>
 									{#if isMissingFeeValue(fee.value)}
@@ -336,7 +349,9 @@ Displays supplementary vault information, including transaction status, performa
 					<tr>
 						<td>
 							{@render metricLabel(
-								'<strong>Net returns</strong> are annualised. They are the gross returns after all investor-facing fees have been deducted.',
+								withInternalisedFeeTooltip(
+									'<strong>Net returns</strong> are annualised. They are the gross returns after all investor-facing fees have been deducted.'
+								),
 								'Net'
 							)}
 						</td>
@@ -371,6 +386,9 @@ Displays supplementary vault information, including transaction status, performa
 				</tbody>
 			</table>
 		</div>
+		{#if hasInternalisedFees}
+			<p class="fee-disclaimer">{INTERNALISED_FEE_DISCLAIMER}</p>
+		{/if}
 	</MetricsBox>
 </div>
 
@@ -484,6 +502,12 @@ Displays supplementary vault information, including transaction status, performa
 
 		.table-scroll {
 			overflow-x: auto;
+		}
+
+		.fee-disclaimer {
+			margin: 0.75rem 0 0;
+			font: var(--f-ui-sm-roman);
+			color: var(--c-text-light);
 		}
 
 		@media (--viewport-md-up) {

--- a/src/routes/vaults/[vault=slug]/VaultMetrics.test.ts
+++ b/src/routes/vaults/[vault=slug]/VaultMetrics.test.ts
@@ -5,6 +5,9 @@ import type { PeriodMetrics } from '$lib/top-vaults/schemas';
 import VaultMetrics from './VaultMetrics.svelte';
 
 const MISSING_FEE_TOOLTIP = 'The fee information is not available onchain. Net returns cannot be calculated.';
+const INTERNALISED_FEE_TOOLTIP =
+	'Fees are internalised and already reduced from the gross profit and thus reflected in the share price.';
+const INTERNALISED_FEE_DISCLAIMER = 'Fees are internalised for this vault and already removed from the gross profit.';
 
 afterEach(cleanup);
 
@@ -76,6 +79,13 @@ describe('VaultMetrics', () => {
 			cagr_net: 0.09,
 			lifetime_return: 0.08,
 			lifetime_return_net: 0.07,
+			gross_fees: {
+				fee_mode: 'externalised',
+				performance: 0.3,
+				management: 0.02,
+				deposit: 0,
+				withdraw: 0
+			},
 			net_fees: {
 				fee_mode: 'externalised',
 				performance: 0.2,
@@ -89,8 +99,48 @@ describe('VaultMetrics', () => {
 		render(VaultMetrics, { props: { vault } });
 
 		expect(screen.queryByText('No data')).not.toBeInTheDocument();
-		expect(screen.getAllByText('20.0%').length).toBeGreaterThan(0);
+		expect(screen.queryByText('20.0%')).not.toBeInTheDocument();
+		expect(screen.getAllByText('30.0%').length).toBeGreaterThan(0);
+		expect(screen.getAllByText('2.0%').length).toBeGreaterThan(0);
 		expect(screen.getAllByText('0.0%').length).toBeGreaterThan(0);
 		expect(screen.getAllByText('10.0%').length).toBeGreaterThan(0);
+	});
+
+	test('explains internalised fees in fee and net return tooltips', () => {
+		const vault = createTestVault('Internalised fee vault', {
+			one_month_cagr: 0.12,
+			one_month_returns: 0.01,
+			one_month_cagr_net: 0.12,
+			one_month_returns_net: 0.01,
+			three_months_cagr: 0.14,
+			three_months_returns: 0.03,
+			three_months_cagr_net: 0.14,
+			three_months_returns_net: 0.03,
+			cagr: 0.11,
+			cagr_net: 0.11,
+			lifetime_return: 0.08,
+			lifetime_return_net: 0.08,
+			fee_internalised: true,
+			gross_fees: {
+				fee_mode: 'internalised_skimming',
+				performance: 0.1,
+				management: 0,
+				deposit: 0,
+				withdraw: 0
+			},
+			net_fees: {
+				fee_mode: 'internalised_skimming',
+				performance: 0,
+				management: 0,
+				deposit: 0,
+				withdraw: 0
+			},
+			period_results: [createPeriodMetrics('6m', 0.05, 0.1, 0.05), createPeriodMetrics('1y', 0.08, 0.08, 0.08)]
+		});
+
+		render(VaultMetrics, { props: { vault } });
+
+		expect(screen.getAllByText(INTERNALISED_FEE_TOOLTIP)).toHaveLength(5);
+		expect(screen.getByText(INTERNALISED_FEE_DISCLAIMER)).toBeInTheDocument();
 	});
 });

--- a/src/routes/vaults/curators/+page.svelte
+++ b/src/routes/vaults/curators/+page.svelte
@@ -34,13 +34,6 @@ aggregate TVL, vault count and average APY, plus a market-share pie chart.
 	const title = 'Stablecoin vault curators';
 	const description =
 		'Curator rankings for DeFi stablecoin vaults. Curators select and manage vault strategies. TVL represents stablecoin deposits across a curator’s vaults. APY represents the yield of last thirty days.';
-	const glossaryLinks = {
-		defi: resolve('/glossary/defi'),
-		vault: resolve('/glossary/vault'),
-		stablecoin: resolve('/glossary/stablecoin'),
-		tvl: resolve('/glossary/total-value-locked-tvl'),
-		apy: resolve('/glossary/apy')
-	};
 	let pageUrl = $derived(new URL(page.url.pathname, page.url.origin).href);
 </script>
 
@@ -81,12 +74,13 @@ aggregate TVL, vault count and average APY, plus a market-share pie chart.
 						{#snippet subtitle()}
 							<p>
 								Curator rankings for
-								<a class="body-link" href={glossaryLinks.defi}>DeFi</a>
-								<a class="body-link" href={glossaryLinks.stablecoin}>stablecoin</a>
-								<a class="body-link" href={glossaryLinks.vault}>vaults</a>. Curators select and manage vault strategies.
-								<a class="body-link" href={glossaryLinks.tvl}>TVL</a> represents stablecoin deposits across a curator’s
-								vaults.
-								<a class="body-link" href={glossaryLinks.apy}>APY</a>
+								<a class="body-link" href={resolve('/glossary/defi')}>DeFi</a>
+								<a class="body-link" href={resolve('/glossary/stablecoin')}>stablecoin</a>
+								<a class="body-link" href={resolve('/glossary/vault')}>vaults</a>. Curators select and manage vault
+								strategies.
+								<a class="body-link" href={resolve('/glossary/total-value-locked-tvl')}>TVL</a> represents stablecoin
+								deposits across a curator’s vaults.
+								<a class="body-link" href={resolve('/glossary/apy')}>APY</a>
 								represents the yield of last thirty days.
 							</p>
 							<p>{totalTvlLabel} TVL tracked across {curators.length} curators.</p>
@@ -100,6 +94,7 @@ aggregate TVL, vault count and average APY, plus a market-share pie chart.
 							items={chartCurators}
 							groupLabel="Curator"
 							groupLabelPlural="curators"
+							showLabelLogos
 							testId="curator-tvl-pie-chart"
 						/>
 					</MarketShareWidgetBox>

--- a/src/routes/vaults/market-share-pie.ts
+++ b/src/routes/vaults/market-share-pie.ts
@@ -40,6 +40,7 @@ export interface MarketSharePieSlice {
 interface BuildMarketSharePieOptions {
 	otherThreshold?: number;
 	groupLabelPlural?: string;
+	maxIndividualSlices?: number;
 }
 
 function calculateWeightedApy(items: MarketShareChartItem[]): number | null {
@@ -63,7 +64,13 @@ export function buildMarketSharePieSlices(
 	items: MarketShareChartItem[],
 	options: BuildMarketSharePieOptions = {}
 ): MarketSharePieSlice[] {
-	const { otherThreshold = MARKET_SHARE_OTHER_THRESHOLD, groupLabelPlural = 'items' } = options;
+	const {
+		otherThreshold = MARKET_SHARE_OTHER_THRESHOLD,
+		groupLabelPlural = 'items',
+		maxIndividualSlices: rawMaxIndividualSlices
+	} = options;
+	const maxIndividualSlices =
+		rawMaxIndividualSlices == null ? undefined : Math.max(0, Math.floor(rawMaxIndividualSlices));
 	const chartableItems = items.filter((item) => item.tvl > 0).toSorted((a, b) => b.tvl - a.tvl);
 	const totalTvl = chartableItems.reduce((sum, item) => sum + item.tvl, 0);
 
@@ -74,7 +81,8 @@ export function buildMarketSharePieSlices(
 
 	for (const item of chartableItems) {
 		const percentage = item.tvl / totalTvl;
-		if (percentage < otherThreshold) {
+		const reachedIndividualSliceLimit = maxIndividualSlices != null && visibleSlices.length >= maxIndividualSlices;
+		if (reachedIndividualSliceLimit || percentage < otherThreshold) {
 			otherMembers.push(item);
 			continue;
 		}
@@ -118,5 +126,5 @@ export function buildMarketSharePieSlices(
 		});
 	}
 
-	return visibleSlices.toSorted((a, b) => b.tvl - a.tvl);
+	return maxIndividualSlices == null ? visibleSlices.toSorted((a, b) => b.tvl - a.tvl) : visibleSlices;
 }

--- a/src/routes/vaults/stablecoins/stablecoin-pie.test.ts
+++ b/src/routes/vaults/stablecoins/stablecoin-pie.test.ts
@@ -57,4 +57,38 @@ describe('buildMarketSharePieSlices', () => {
 		expect(slices.map((slice) => slice.label)).toEqual(['USDC', 'DAI']);
 		expect(slices.some((slice) => slice.isOther)).toBe(false);
 	});
+
+	test('groups entries after the standalone slice limit into Other', () => {
+		const slices = buildMarketSharePieSlices(
+			[
+				{ slug: 'fund-1', label: 'Fund 1', name: 'Fund 1', tvl: 100, avgApy: 0.01, href: '/fund-1' },
+				{ slug: 'fund-2', label: 'Fund 2', name: 'Fund 2', tvl: 90, avgApy: 0.02, href: '/fund-2' },
+				{ slug: 'fund-3', label: 'Fund 3', name: 'Fund 3', tvl: 80, avgApy: 0.03, href: '/fund-3' },
+				{ slug: 'fund-4', label: 'Fund 4', name: 'Fund 4', tvl: 70, avgApy: 0.04, href: '/fund-4' },
+				{ slug: 'fund-5', label: 'Fund 5', name: 'Fund 5', tvl: 60, avgApy: 0.05, href: '/fund-5' },
+				{ slug: 'fund-6', label: 'Fund 6', name: 'Fund 6', tvl: 50, avgApy: 0.06, href: '/fund-6' },
+				{ slug: 'fund-7', label: 'Fund 7', name: 'Fund 7', tvl: 40, avgApy: 0.07, href: '/fund-7' },
+				{ slug: 'fund-8', label: 'Fund 8', name: 'Fund 8', tvl: 30, avgApy: 0.08, href: '/fund-8' },
+				{ slug: 'fund-9', label: 'Fund 9', name: 'Fund 9', tvl: 20, avgApy: 0.09, href: '/fund-9' }
+			],
+			{ groupLabelPlural: 'funds', otherThreshold: 0, maxIndividualSlices: 7 }
+		);
+
+		expect(slices.map((slice) => slice.label)).toEqual([
+			'Fund 1',
+			'Fund 2',
+			'Fund 3',
+			'Fund 4',
+			'Fund 5',
+			'Fund 6',
+			'Fund 7',
+			'Other'
+		]);
+		expect(slices.at(-1)).toMatchObject({
+			label: 'Other',
+			name: 'Other funds',
+			memberCount: 2,
+			tvl: 50
+		});
+	});
 });

--- a/src/routes/vaults/tokenised-funds/+page.svelte
+++ b/src/routes/vaults/tokenised-funds/+page.svelte
@@ -61,6 +61,7 @@ Tokenised fund listing for vaults with a regulated fund structure.
 			name: vault.name,
 			tvl: getVaultCurrentTvlUsd(vault) ?? 0,
 			avgApy: vault.cagr_net ?? vault.three_months_cagr ?? null,
+			logoUrl: vault.curator_slug ? (topVaults.curators[vault.curator_slug]?.logos.generic ?? undefined) : undefined,
 			href: resolveVaultDetails(vault)
 		}));
 	});
@@ -100,7 +101,7 @@ Tokenised fund listing for vaults with a regulated fund structure.
 						{#snippet subtitle()}
 							<p>
 								{#if topVaults}
-									Tracking {formatDollar(totalNavUsd, 2, 3)} net asset value across {topVaults.vaults.length}{' '}
+									Tracking {formatDollar(totalNavUsd, 2, 3)} net asset value across {topVaults.vaults.length}
 									{topVaults.vaults.length === 1 ? 'fund' : 'funds'}.
 								{:else}
 									Loading tokenised fund net asset value.
@@ -124,7 +125,9 @@ Tokenised fund listing for vaults with a regulated fund structure.
 								items={chartFunds}
 								groupLabel="Fund"
 								groupLabelPlural="funds"
-								otherThreshold={0.1}
+								otherThreshold={0}
+								maxIndividualSlices={7}
+								showLabelLogos
 								wrapLabels
 								valueLabel="Net asset value"
 								testId="tokenised-fund-nav-pie-chart"


### PR DESCRIPTION
## Why

The tokenised funds chart became hard to scan as more funds were added. It needed a predictable seven-entry breakdown plus an Other slice, curator logos on desktop labels, and a cleaner mobile layout without rounded label boxes or logos.

## Lessons learnt

ECharts rich label images work well for desktop curator branding, but mobile labels need to stay text-only to fit all chart slices cleanly. The shared market-share helper also needs an explicit standalone slice limit instead of relying only on percentage thresholds.

## Summary

- Added a reusable standalone slice limit to the market-share pie helper and covered it with a unit test.
- Added optional chart label logos for curator-branded charts, while suppressing those logos on mobile.
- Updated tokenised funds to show seven named fund slices plus Other and tuned mobile labels to use square boxes.