### PR TITLE
fix: distinguish multichain vault labels

### DIFF
--- a/src/lib/echarts/core3-risk.ts
+++ b/src/lib/echarts/core3-risk.ts
@@ -1,6 +1,11 @@
-import { getChain } from '$lib/helpers/chain';
+import { getChain, getChainDisplayName } from '$lib/helpers/chain';
 import { getLogoUrl } from '$lib/helpers/assets';
-import { isBlacklisted, getCore3PolForVault, getCore3ReportUrl, getProtocolDisplayName } from '$lib/top-vaults/helpers';
+import {
+	isBlacklisted,
+	getCore3PolForVault,
+	getCore3ReportUrl,
+	getVaultProtocolDisplayName
+} from '$lib/top-vaults/helpers';
 import type { Core3Pol, Core3Protocol, VaultInfo } from '$lib/top-vaults/schemas';
 import { getVaultProtocolLogoUrl } from '$lib/vault-protocol/helpers';
 import { VAULT_TVL_OUTLIER_THRESHOLD } from './tvl-outliers';
@@ -162,10 +167,10 @@ function buildScatterPoint(
 		name: vault.name,
 		vaultSlug: vault.vault_slug,
 		href: `/vaults/${vault.vault_slug}`,
-		protocol: getProtocolDisplayName(vault.protocol, vault.protocol_slug),
+		protocol: getVaultProtocolDisplayName(vault),
 		protocolSlug: vault.protocol_slug,
 		protocolLogoUrl: getVaultProtocolLogoUrl(vault.protocol_slug),
-		chain: chain?.name ?? vault.chain ?? `Chain ${vault.chain_id}`,
+		chain: chain ? getChainDisplayName(vault.chain_id) : (vault.chain ?? `Chain ${vault.chain_id}`),
 		chainId: vault.chain_id,
 		chainLogoUrl: chain ? getLogoUrl('blockchain', chain.slug) : undefined,
 		denomination: vault.denomination ?? vault.normalised_denomination ?? 'Stablecoin',

--- a/src/lib/helpers/chain.test.ts
+++ b/src/lib/helpers/chain.test.ts
@@ -1,0 +1,10 @@
+import { describe, expect, test } from 'vitest';
+import { getChainDisplayName, getChain } from './chain';
+
+describe('getChainDisplayName', () => {
+	test('distinguishes HyperEVM from the Hyperliquid grouping', () => {
+		expect(getChainDisplayName(999)).toBe('HyperEVM');
+		expect(getChainDisplayName(9999)).toBe('Hyperliquid');
+		expect(getChain('hyperliquid')?.name).toBe('Hyperliquid');
+	});
+});

--- a/src/lib/helpers/chain.ts
+++ b/src/lib/helpers/chain.ts
@@ -322,11 +322,25 @@ export const chains = (() => {
 
 export type Chain = (typeof chains)[number];
 
+const HYPEREVM_CHAIN_ID = 999;
+
 /**
  * Get a chain by id or slug
  */
 export function getChain(identifier: Maybe<number | string>) {
 	return chains.find(({ id, slug }) => id === identifier || slug === identifier);
+}
+
+/**
+ * Return the human-readable name for an individual chain.
+ *
+ * HyperEVM and HyperCore intentionally share the `hyperliquid` slug for
+ * grouping, but an individual HyperEVM vault must still identify its chain.
+ */
+export function getChainDisplayName(identifier: Maybe<number | string>): string {
+	const chain = getChain(identifier);
+	if (!chain) return typeof identifier === 'number' ? `Chain ${identifier}` : 'Unknown chain';
+	return chain.id === HYPEREVM_CHAIN_ID ? 'HyperEVM' : chain.name;
 }
 
 /**

--- a/src/lib/scatter-plot/helpers.ts
+++ b/src/lib/scatter-plot/helpers.ts
@@ -1,6 +1,6 @@
 import type { VaultInfo } from '$lib/top-vaults/schemas';
-import { getProtocolDisplayName, resolveVaultDetails } from '$lib/top-vaults/helpers';
-import { getChain } from '$lib/helpers/chain';
+import { getVaultProtocolDisplayName, resolveVaultDetails } from '$lib/top-vaults/helpers';
+import { getChainDisplayName } from '$lib/helpers/chain';
 
 export const tvlOptions = [
 	{ value: 50_000, label: '$50k' },
@@ -210,11 +210,11 @@ export function buildChartConfig() {
  * Returns an array of HTML strings; callers insert view-specific lines.
  */
 export function buildBaseHoverLines(v: VaultInfo): string[] {
-	const chainName = getChain(v.chain_id)?.name ?? `Chain ${v.chain_id}`;
+	const chainName = getChainDisplayName(v.chain_id);
 	const tvl = `$${v.current_nav!.toLocaleString(undefined, { maximumFractionDigits: 0 })}`;
 	return [
 		`<b>${v.name}</b>`,
-		getProtocolDisplayName(v.protocol, v.protocol_slug),
+		getVaultProtocolDisplayName(v),
 		chainName,
 		`TVL: ${tvl}`,
 		`1M return (ann.): ${formatReturn(v.one_month_cagr)}`,

--- a/src/lib/top-vaults/ChainCell.svelte
+++ b/src/lib/top-vaults/ChainCell.svelte
@@ -16,7 +16,7 @@
 		<svelte:fragment slot="trigger">
 			{#if chain}
 				<a href="/vaults/chains/{chain.slug}">
-					<img src={getLogoUrl('blockchain', chain.slug)} alt={chain.name} />
+					<img src={getLogoUrl('blockchain', chain.slug)} alt={label} />
 				</a>
 			{:else}
 				<div class="no-logo">?</div>

--- a/src/lib/top-vaults/TopVaultsTable.svelte
+++ b/src/lib/top-vaults/TopVaultsTable.svelte
@@ -24,7 +24,7 @@
 	import IconChevronUp from '~icons/local/chevron-up';
 	import IconChevronDown from '~icons/local/chevron-down';
 	import IconLock from '~icons/local/lock';
-	import { getChain } from '$lib/helpers/chain';
+	import { getChain, getChainDisplayName } from '$lib/helpers/chain';
 	import {
 		formatDollar,
 		formatNumber,
@@ -46,7 +46,7 @@
 		getLockupTooltip,
 		getLifetimeMaxDrawdown,
 		getMonthlyReturn,
-		getProtocolDisplayName,
+		getVaultProtocolDisplayName,
 		getVaultCurrentTvlUsd,
 		getVaultDenominationNativeRate,
 		getVaultDenominationCurrency,
@@ -180,11 +180,11 @@
 		...returnSortColumnMap,
 		chain: {
 			defaultDirection: 'asc',
-			compareFn: stringCompare((v) => getChain(v.chain_id)?.name ?? `Chain ${v.chain_id}`)
+			compareFn: stringCompare((v) => getChainDisplayName(v.chain_id))
 		},
 		vault: {
 			defaultDirection: 'asc',
-			compareFn: stringCompare((v) => `${v.name.trim()} ${getProtocolDisplayName(v.protocol, v.protocol_slug)}`)
+			compareFn: stringCompare((v) => `${v.name.trim()} ${getVaultProtocolDisplayName(v)}`)
 		},
 		three_months_sharpe: { defaultDirection: 'desc', compareFn: rankVaultsBy(['three_months_sharpe']) },
 		three_months_volatility: { defaultDirection: 'asc', compareFn: rankVaultsBy(['three_months_volatility']) },
@@ -488,9 +488,9 @@
 
 			const vaultCompareStr = [
 				v.chain_id,
-				chain?.name ?? '',
+				getChainDisplayName(v.chain_id),
 				v.name,
-				getProtocolDisplayName(v.protocol, v.protocol_slug),
+				getVaultProtocolDisplayName(v),
 				v.denomination,
 				v.risk ?? '',
 				v.address
@@ -1065,7 +1065,7 @@
 					{@const chain = getChain(vault.chain_id)}
 					{@const blacklisted = isBlacklisted(vault)}
 					{@const badStatus = !isGoodVaultStatus(vault)}
-					{@const protocolName = getProtocolDisplayName(vault.protocol, vault.protocol_slug)}
+					{@const protocolName = getVaultProtocolDisplayName(vault)}
 					{@const statusReason = [vault.deposit_closed_reason, vault.redemption_closed_reason]
 						.filter(Boolean)
 						.join('; ')}
@@ -1074,7 +1074,7 @@
 						<td class="index"></td>
 						{#if showChainCol}
 							<td class="chain">
-								<ChainCell {chain} label={chain?.name ?? `Chain ${vault.chain_id}`} />
+								<ChainCell {chain} label={getChainDisplayName(vault.chain_id)} />
 							</td>
 						{/if}
 						<td class="vault">

--- a/src/lib/top-vaults/helpers.test.ts
+++ b/src/lib/top-vaults/helpers.test.ts
@@ -5,6 +5,7 @@ import {
 	isEligibleFrontpageVault,
 	hasSupportedProtocol,
 	getProtocolDisplayName,
+	getVaultProtocolDisplayName,
 	isUnknownVaultProtocol,
 	isUnsupportedProtocolSlug,
 	meetsMinTvl,
@@ -261,6 +262,25 @@ describe('getProtocolDisplayName', () => {
 
 	test('returns the protocol name when it is supported', () => {
 		expect(getProtocolDisplayName('Yearn')).toBe('Yearn');
+	});
+});
+
+describe('getVaultProtocolDisplayName', () => {
+	test('labels Lighter vaults on Robinhood without changing their protocol slug', () => {
+		const vault = createTestVault('Lighter Robinhood vault', {
+			protocol: 'Lighter',
+			chain: 'robinhood'
+		});
+
+		expect(getVaultProtocolDisplayName(vault)).toBe('Lighter Robinhood');
+		expect(vault.protocol_slug).toBe('lighter');
+		expect(getProtocolDisplayName(vault.protocol, vault.protocol_slug)).toBe('Lighter');
+	});
+
+	test('keeps the standard Lighter display name on the Lighter chain', () => {
+		const vault = createTestVault('Lighter vault', { protocol: 'Lighter', chain: 'lighter' });
+
+		expect(getVaultProtocolDisplayName(vault)).toBe('Lighter');
 	});
 });
 

--- a/src/lib/top-vaults/helpers.ts
+++ b/src/lib/top-vaults/helpers.ts
@@ -4,6 +4,7 @@ import { slimVaultKeys } from './schemas';
 import { resolve } from '$app/paths';
 import { vaultSparklinesUrl } from '$lib/config';
 import { capitalize, isNumber } from '$lib/helpers/formatters';
+import { getChain } from '$lib/helpers/chain';
 import { slugify } from '$lib/helpers/slugify';
 
 /**
@@ -245,6 +246,18 @@ export function getProtocolDisplayName(protocol: string | null | undefined, prot
 	if (isManuallyMappedUnknownProtocolSlug(protocolSlug)) return UNKNOWN_VAULT_PROTOCOL_DISPLAY_NAME;
 	if (protocol == null || isUnsupportedProtocolName(protocol)) return 'Unknown';
 	return protocol;
+}
+
+/**
+ * Return the protocol name for an individual vault without changing the
+ * protocol slug used for grouping.
+ */
+export function getVaultProtocolDisplayName(vault: Pick<VaultInfo, 'protocol' | 'protocol_slug' | 'chain_id'>): string {
+	const displayName = getProtocolDisplayName(vault.protocol, vault.protocol_slug);
+	if (vault.protocol_slug === 'lighter' && getChain(vault.chain_id)?.slug === 'robinhood') {
+		return 'Lighter Robinhood';
+	}
+	return displayName;
 }
 
 /**

--- a/src/routes/_components/VaultEcosystemChart.svelte
+++ b/src/routes/_components/VaultEcosystemChart.svelte
@@ -6,7 +6,8 @@ loaded dynamically from CDN.
 -->
 <script lang="ts">
 	import type { SlimVaultInfo } from '$lib/top-vaults/schemas';
-	import { isBlacklisted } from '$lib/top-vaults/helpers';
+	import { getChainDisplayName } from '$lib/helpers/chain';
+	import { getVaultProtocolDisplayName, isBlacklisted } from '$lib/top-vaults/helpers';
 	import {
 		loadPlotly,
 		buildPlotlyChrome,
@@ -95,8 +96,8 @@ loaded dynamically from CDN.
 					labels.push(v.name);
 					individualTvl.push(tvl);
 					vaultSlugs.push(v.vault_slug);
-					chains.push(v.chain ?? 'Unknown');
-					protocols.push(v.protocol ?? 'Unknown');
+					chains.push(getChainDisplayName(v.chain_id));
+					protocols.push(getVaultProtocolDisplayName(v));
 				}
 
 				const totalTvl = runningTvl;

--- a/src/routes/_components/VaultEcosystemChartECharts.svelte
+++ b/src/routes/_components/VaultEcosystemChartECharts.svelte
@@ -7,8 +7,8 @@ Homepage adapter around the shared ECharts cumulative TVL / APY renderer.
 	import CumulativeTvlApyChart from '$lib/echarts/CumulativeTvlApyChart.svelte';
 	import { buildCumulativeTvlPoints, getEligibleItems } from '$lib/echarts/cumulative-tvl-apy';
 	import { getLogoUrl } from '$lib/helpers/assets';
-	import { getChain } from '$lib/helpers/chain';
-	import { isBlacklisted, resolveVaultDetails } from '$lib/top-vaults/helpers';
+	import { getChain, getChainDisplayName } from '$lib/helpers/chain';
+	import { getVaultProtocolDisplayName, isBlacklisted, resolveVaultDetails } from '$lib/top-vaults/helpers';
 	import type { SlimVaultInfo } from '$lib/top-vaults/schemas';
 	import { getVaultProtocolLogoUrl } from '$lib/vault-protocol/helpers.js';
 
@@ -46,9 +46,9 @@ Homepage adapter around the shared ECharts cumulative TVL / APY renderer.
 		buildCumulativeTvlPoints(
 			eligibleVaults.map((vault) => ({
 				name: vault.name,
-				chain: vault.chain ?? 'Unknown',
+				chain: getChainDisplayName(vault.chain_id),
 				chainLogoUrl: getLogoUrl('blockchain', getChain(vault.chain_id)?.slug),
-				protocol: vault.protocol ?? 'Unknown',
+				protocol: getVaultProtocolDisplayName(vault),
 				protocolLogoUrl: getVaultProtocolLogoUrl(vault.protocol_slug),
 				realApy: (getCagr(vault) ?? 0) * 100,
 				individualTvl: vault.current_nav ?? 0,

--- a/src/routes/_components/VaultItem.svelte
+++ b/src/routes/_components/VaultItem.svelte
@@ -2,8 +2,8 @@
 	import type { SlimVaultInfo } from '$lib/top-vaults/schemas';
 	import { formatPercentProfit } from '$lib/helpers/formatters';
 	import { getLogoUrl } from '$lib/helpers/assets';
-	import { getChain } from '$lib/helpers/chain';
-	import { resolveVaultDetails } from '$lib/top-vaults/helpers';
+	import { getChain, getChainDisplayName } from '$lib/helpers/chain';
+	import { getVaultProtocolDisplayName, resolveVaultDetails } from '$lib/top-vaults/helpers';
 	import VaultSparkline from '$lib/top-vaults/VaultSparkline.svelte';
 
 	interface Props {
@@ -20,14 +20,18 @@
 <li class="vault-item">
 	<!-- eslint-disable-next-line svelte/no-navigation-without-resolve -->
 	<a href={resolveVaultDetails(vault)}>
-		<img class="chain-logo" src={getLogoUrl('blockchain', getChain(vault.chain_id)?.slug)} alt={chain.name} />
+		<img
+			class="chain-logo"
+			src={getLogoUrl('blockchain', getChain(vault.chain_id)?.slug)}
+			alt={getChainDisplayName(vault.chain_id)}
+		/>
 
 		<div class="name">
 			<div class="vault-name truncate lines-2">
 				{vault.name}
 			</div>
 			<div class="protocol-name">
-				{vault.protocol}
+				{getVaultProtocolDisplayName(vault)}
 			</div>
 		</div>
 

--- a/src/routes/vaults/[vault=slug]/+page.svelte
+++ b/src/routes/vaults/[vault=slug]/+page.svelte
@@ -21,7 +21,12 @@
 	import VaultRankings from './VaultRankings.svelte';
 	import Core3Ratings from '$lib/top-vaults/Core3Ratings.svelte';
 	import IconDiscord from '~icons/local/discord';
-	import { getMorphoFlags, hasSupportedProtocol, isBlacklisted } from '$lib/top-vaults/helpers';
+	import {
+		getMorphoFlags,
+		getVaultProtocolDisplayName,
+		hasSupportedProtocol,
+		isBlacklisted
+	} from '$lib/top-vaults/helpers';
 	import { getVaultProtocolLogoUrl } from '$lib/vault-protocol/helpers.js';
 
 	let { data } = $props();
@@ -137,7 +142,12 @@
 		<VaultPeriodicMetrics {vault} {chain} />
 
 		{#if core3}
-			<Core3Ratings {core3} protocolName={vault.protocol} protocolSlug={vault.protocol_slug} context="vault" />
+			<Core3Ratings
+				{core3}
+				protocolName={getVaultProtocolDisplayName(vault)}
+				protocolSlug={vault.protocol_slug}
+				context="vault"
+			/>
 		{/if}
 
 		<VaultTechnicalDetailsTable {vault} {chain} {stablecoinMetadata} {generated_at} />

--- a/src/routes/vaults/[vault=slug]/SocialMetaTags.svelte
+++ b/src/routes/vaults/[vault=slug]/SocialMetaTags.svelte
@@ -2,7 +2,8 @@
 	import { page } from '$app/state';
 	import type { Chain } from '$lib/helpers/chain';
 	import { formatDollar, formatPercent } from '$lib/helpers/formatters';
-	import { getVaultSparklineUrl } from '$lib/top-vaults/helpers';
+	import { getVaultProtocolDisplayName, getVaultSparklineUrl } from '$lib/top-vaults/helpers';
+	import { getChainDisplayName } from '$lib/helpers/chain';
 	import type { VaultInfo } from '$lib/top-vaults/schemas';
 	import { getVaultProtocolLogoUrl } from '$lib/vault-protocol/helpers.js';
 	import type { VaultProtocolMetadata } from '$lib/vault-protocol/schemas';
@@ -17,7 +18,7 @@
 	let { vault, chain, protocolMetadata }: Props = $props();
 
 	let generatedDescription = $derived.by(() => {
-		const parts = [`${vault.name} on ${vault.protocol} on ${chain.name}`];
+		const parts = [`${vault.name} on ${getVaultProtocolDisplayName(vault)} on ${getChainDisplayName(vault.chain_id)}`];
 		if (vault.current_nav != null) {
 			parts.push(`TVL: ${formatDollar(vault.current_nav, 0)}`);
 		}
@@ -54,7 +55,7 @@
 		if (vault.risk_numeric != null) {
 			props.push({ '@type': 'PropertyValue', name: 'riskScore', value: vault.risk_numeric });
 		}
-		props.push({ '@type': 'PropertyValue', name: 'blockchain', value: chain.name });
+		props.push({ '@type': 'PropertyValue', name: 'blockchain', value: getChainDisplayName(vault.chain_id) });
 		if (vault.denomination) {
 			props.push({ '@type': 'PropertyValue', name: 'denomination', value: vault.denomination });
 		}
@@ -100,7 +101,7 @@
 	let provider = $derived.by(() => {
 		const org: Record<string, unknown> = {
 			'@type': 'Organization',
-			name: vault.protocol
+			name: getVaultProtocolDisplayName(vault)
 		};
 		if (protocolMetadata?.links.homepage) {
 			org.url = protocolMetadata.links.homepage;

--- a/src/routes/vaults/[vault=slug]/VaultMetrics.svelte
+++ b/src/routes/vaults/[vault=slug]/VaultMetrics.svelte
@@ -11,7 +11,7 @@ Displays supplementary vault information, including transaction status, performa
 	import { resolve } from '$app/paths';
 	import { getFormattedLockup, isGoodVaultStatus } from '$lib/top-vaults/helpers';
 	import { formatNumber, formatPercent, formatPercentProfit } from '$lib/helpers/formatters';
-	import { getChain } from '$lib/helpers/chain';
+	import { getChain, getChainDisplayName } from '$lib/helpers/chain';
 	import {
 		getStablecoinDetailsHref,
 		getVaultDenominationLogoUrl,
@@ -213,8 +213,8 @@ Displays supplementary vault information, including transaction status, performa
 						<span class="underline">Age*</span>
 					</span>
 					<svelte:fragment slot="popup">
-						Due to {chain?.name} architecture, we currently have limited history of data on this vault and it might not reach
-						all the way back to the launch of the vault.
+						Due to {getChainDisplayName(vault.chain_id)} architecture, we currently have limited history of data on this vault
+						and it might not reach all the way back to the launch of the vault.
 					</svelte:fragment>
 				</Tooltip>
 			{/snippet}

--- a/src/routes/vaults/[vault=slug]/VaultPageHeader.svelte
+++ b/src/routes/vaults/[vault=slug]/VaultPageHeader.svelte
@@ -3,7 +3,7 @@
 	import Button from '$lib/components/Button.svelte';
 	import PageHeader from '$lib/components/PageHeader.svelte';
 	import UpdateInfoButton from '$lib/top-vaults/UpdateInfoButton.svelte';
-	import { hasSupportedProtocol } from '$lib/top-vaults/helpers';
+	import { getVaultProtocolDisplayName, hasSupportedProtocol } from '$lib/top-vaults/helpers';
 
 	interface Props {
 		vault: VaultInfo;
@@ -12,7 +12,7 @@
 	let { vault }: Props = $props();
 
 	let externalSiteName = $derived.by(() => {
-		if (hasSupportedProtocol(vault)) return vault.protocol;
+		if (hasSupportedProtocol(vault)) return getVaultProtocolDisplayName(vault);
 		if (vault.link) return new URL(vault.link).host;
 	});
 </script>

--- a/src/routes/vaults/[vault=slug]/VaultTechnicalDetailsTable.svelte
+++ b/src/routes/vaults/[vault=slug]/VaultTechnicalDetailsTable.svelte
@@ -11,6 +11,7 @@
 		getFeeModeDescription,
 		getVaultDenominationUsdRate,
 		getVaultDenominationCurrency,
+		getVaultProtocolDisplayName,
 		getVaultTvlNative
 	} from '$lib/top-vaults/helpers';
 	import {
@@ -105,7 +106,7 @@
 		},
 		{
 			label: 'Protocol',
-			value: { name: vault.protocol, slug: vault.protocol_slug },
+			value: { name: getVaultProtocolDisplayName(vault), slug: vault.protocol_slug },
 			type: 'protocol' as const
 		},
 		{

--- a/src/routes/vaults/cumulative-tvl-apy/CumulativeTvlApyChart.svelte
+++ b/src/routes/vaults/cumulative-tvl-apy/CumulativeTvlApyChart.svelte
@@ -13,8 +13,13 @@ Standalone cumulative TVL / APY page adapter using the shared ECharts renderer.
 	import CumulativeTvlApyECharts from '$lib/echarts/CumulativeTvlApyChart.svelte';
 	import { buildCumulativeTvlPoints, formatUsd, getEligibleItems } from '$lib/echarts/cumulative-tvl-apy';
 	import { getLogoUrl } from '$lib/helpers/assets';
-	import { getChain } from '$lib/helpers/chain';
-	import { getProtocolDisplayName, isBlacklisted, resolveVaultDetails } from '$lib/top-vaults/helpers';
+	import { getChain, getChainDisplayName } from '$lib/helpers/chain';
+	import {
+		getProtocolDisplayName,
+		getVaultProtocolDisplayName,
+		isBlacklisted,
+		resolveVaultDetails
+	} from '$lib/top-vaults/helpers';
 	import { getVaultProtocolLogoUrl } from '$lib/vault-protocol/helpers.js';
 	import { deserialiseSearchParams, serialiseSearchParams } from '$lib/helpers/url-search-state';
 	import { goto } from '$app/navigation';
@@ -172,9 +177,9 @@ Standalone cumulative TVL / APY page adapter using the shared ECharts renderer.
 		buildCumulativeTvlPoints(
 			displayedVaults.map((vault) => ({
 				name: vault.name,
-				chain: vault.chain ?? 'Unknown',
+				chain: getChainDisplayName(vault.chain_id),
 				chainLogoUrl: getLogoUrl('blockchain', getChain(vault.chain_id)?.slug),
-				protocol: getProtocolDisplayName(vault.protocol, vault.protocol_slug),
+				protocol: getVaultProtocolDisplayName(vault),
 				protocolLogoUrl: getVaultProtocolLogoUrl(vault.protocol_slug),
 				realApy: (getVaultCagr(vault, selectedWindow) ?? 0) * 100,
 				individualTvl: vault.current_nav ?? 0,

--- a/src/routes/vaults/current-peak-tvl/TvlScatterPlot.svelte
+++ b/src/routes/vaults/current-peak-tvl/TvlScatterPlot.svelte
@@ -18,11 +18,12 @@ Plotly.js is loaded dynamically from CDN.
 	import type { VaultInfo } from '$lib/top-vaults/schemas';
 	import {
 		getProtocolDisplayName,
+		getVaultProtocolDisplayName,
 		isBlacklisted,
 		hasSupportedProtocol,
 		resolveVaultDetails
 	} from '$lib/top-vaults/helpers';
-	import { getChain, getChainsBySlug } from '$lib/helpers/chain';
+	import { getChain, getChainDisplayName, getChainsBySlug } from '$lib/helpers/chain';
 	import {
 		loadPlotly,
 		buildMarker,
@@ -76,8 +77,8 @@ Plotly.js is loaded dynamically from CDN.
 	}
 
 	function formatHoverText(v: VaultInfo): string {
-		const chainName = getChain(v.chain_id)?.name ?? `Chain ${v.chain_id}`;
-		const protocolName = getProtocolDisplayName(v.protocol, v.protocol_slug);
+		const chainName = getChainDisplayName(v.chain_id);
+		const protocolName = getVaultProtocolDisplayName(v);
 		const retention = v.current_nav! / v.peak_nav!;
 		return [
 			`<b>${v.name}</b>`,

--- a/src/routes/vaults/yield-chain/ChainScatterPlot.svelte
+++ b/src/routes/vaults/yield-chain/ChainScatterPlot.svelte
@@ -15,7 +15,7 @@ coloured by blockchain. Plotly.js is loaded dynamically from CDN.
 <script lang="ts">
 	import type { VaultInfo } from '$lib/top-vaults/schemas';
 	import { isBlacklisted } from '$lib/top-vaults/helpers';
-	import { getChain, getChainsBySlug } from '$lib/helpers/chain';
+	import { getChain, getChainDisplayName, getChainsBySlug } from '$lib/helpers/chain';
 	import {
 		loadPlotly,
 		computeScatterRanges,
@@ -58,7 +58,7 @@ coloured by blockchain. Plotly.js is loaded dynamically from CDN.
 
 	function formatHoverText(v: VaultInfo): string {
 		const lines = buildBaseHoverLines(v);
-		const chainName = getChain(v.chain_id)?.name ?? `Chain ${v.chain_id}`;
+		const chainName = getChainDisplayName(v.chain_id);
 		lines.splice(3, 0, `Chain: ${chainName}`);
 		return lines.join('<br>');
 	}

--- a/src/routes/vaults/yield-protocol/ProtocolScatterPlot.svelte
+++ b/src/routes/vaults/yield-protocol/ProtocolScatterPlot.svelte
@@ -14,7 +14,12 @@ coloured by protocol. Plotly.js is loaded dynamically from CDN.
 -->
 <script lang="ts">
 	import type { VaultInfo } from '$lib/top-vaults/schemas';
-	import { getProtocolDisplayName, isBlacklisted, hasSupportedProtocol } from '$lib/top-vaults/helpers';
+	import {
+		getProtocolDisplayName,
+		getVaultProtocolDisplayName,
+		isBlacklisted,
+		hasSupportedProtocol
+	} from '$lib/top-vaults/helpers';
 	import {
 		loadPlotly,
 		computeScatterRanges,
@@ -57,7 +62,7 @@ coloured by protocol. Plotly.js is loaded dynamically from CDN.
 
 	function formatHoverText(v: VaultInfo): string {
 		const lines = buildBaseHoverLines(v);
-		lines.splice(3, 0, `Protocol: ${getProtocolDisplayName(v.protocol, v.protocol_slug)}`);
+		lines.splice(3, 0, `Protocol: ${getVaultProtocolDisplayName(v)}`);
 		return lines.join('<br>');
 	}
 


### PR DESCRIPTION
## Why

Vault labels need to distinguish HyperEVM from Hyperliquid and Robinhood-hosted Lighter vaults without splitting their existing chain or protocol groups.

## Lessons learnt

Keep vault-specific display labels separate from slug-based grouping keys so charts, filters, routes, and aggregate totals remain stable.

## Summary

- Display HyperEVM for vaults on chain 999 while retaining the Hyperliquid group.
- Display Lighter Robinhood for Lighter vaults on the Robinhood chain while retaining the Lighter protocol group.
- Apply the labels across vault listings, detail views, charts, metadata, and homepage surfaces.