### PR TITLE
fix: link HyperEVM vaults from Hyperliquid

### DIFF
--- a/src/lib/top-vaults/TopVaultsPage.svelte
+++ b/src/lib/top-vaults/TopVaultsPage.svelte
@@ -32,6 +32,8 @@
 		filterTvl?: boolean;
 		includeBlacklisted?: boolean;
 		protocolMetadata?: VaultProtocolMetadata;
+		/** Optional context shown beneath the protocol metadata description. */
+		protocolDescriptionExtra?: Snippet;
 		stablecoinMetadata?: StablecoinMetadata;
 		/** Stablecoin slug used for a logo when no metadata record exists. */
 		stablecoinLogoSlug?: string;
@@ -84,6 +86,7 @@
 		filterTvl,
 		includeBlacklisted,
 		protocolMetadata,
+		protocolDescriptionExtra,
 		stablecoinMetadata,
 		stablecoinLogoSlug,
 		curatorMetadata,
@@ -162,13 +165,13 @@
 		<div class="top-vaults-content">
 			{#if protocolMetadata && detailAside}
 				<div class="detail-overview wide-detail-overview">
-					<ProtocolDescription metadata={protocolMetadata} />
+					<ProtocolDescription metadata={protocolMetadata} additionalDescription={protocolDescriptionExtra} />
 					<aside class="detail-aside">
 						{@render detailAside()}
 					</aside>
 				</div>
 			{:else if protocolMetadata}
-				<ProtocolDescription metadata={protocolMetadata} />
+				<ProtocolDescription metadata={protocolMetadata} additionalDescription={protocolDescriptionExtra} />
 			{/if}
 
 			{#if detailDescription && detailAside && !protocolMetadata && !stablecoinMetadata && !curatorMetadata}

--- a/src/lib/vault-protocol/ProtocolDescription.svelte
+++ b/src/lib/vault-protocol/ProtocolDescription.svelte
@@ -3,6 +3,7 @@
   Used on vault protocol detail pages to display protocol metadata.
 -->
 <script lang="ts">
+	import type { Snippet } from 'svelte';
 	import { slide } from 'svelte/transition';
 	import { micromark } from 'micromark';
 	import type { VaultProtocolMetadata } from './schemas';
@@ -17,9 +18,10 @@
 
 	interface Props {
 		metadata: VaultProtocolMetadata;
+		additionalDescription?: Snippet;
 	}
 
-	let { metadata }: Props = $props();
+	let { metadata, additionalDescription }: Props = $props();
 
 	let expanded = $state(false);
 
@@ -47,6 +49,12 @@
 				</Button>
 			{/if}
 		</div>
+
+		{#if additionalDescription}
+			<div class="additional-description">
+				{@render additionalDescription()}
+			</div>
+		{/if}
 
 		{#if expanded}
 			<div transition:slide>
@@ -84,6 +92,14 @@
 			gap: 1rem;
 
 			p {
+				margin: 0;
+			}
+		}
+
+		.additional-description {
+			margin-top: 0.75rem;
+
+			:global(p) {
 				margin: 0;
 			}
 		}

--- a/src/routes/vaults/protocols/[protocol=slug]/+page.svelte
+++ b/src/routes/vaults/protocols/[protocol=slug]/+page.svelte
@@ -13,6 +13,7 @@
 	let { data } = $props();
 	let { protocolSlug, protocolName, protocolMetadata, core3 } = $derived(data);
 	let isUnknownVaultProtocolGroup = $derived(protocolSlug === UNKNOWN_VAULT_PROTOCOL_SLUG);
+	let isHyperliquidProtocolGroup = $derived(protocolSlug === 'hyperliquid');
 
 	let topVaults = $state<TopVaults>();
 	let loading = $state(!hasVaultCache(page.data.generatedAt));
@@ -52,6 +53,13 @@
 {#snippet unknownVaultSubtitle()}
 	These vaults are not yet mapped out. <a class="body-link" href={resolve('/community')}>Contact us</a> to have your vaults
 	listed.
+{/snippet}
+
+{#snippet hyperliquidChainDescription()}
+	<p>
+		If you want to see both Hyperliquid native vaults and HyperEVM vaults, visit
+		<a class="body-link" href={resolve('/vaults/chains/hyperliquid')}>Hyperliquid chain page</a>.
+	</p>
 {/snippet}
 
 <MetaTags
@@ -95,6 +103,7 @@
 	{topVaults}
 	{loading}
 	{protocolMetadata}
+	protocolDescriptionExtra={isHyperliquidProtocolGroup ? hyperliquidChainDescription : undefined}
 	title={heroTitle}
 	subtitle={isUnknownVaultProtocolGroup ? unknownVaultSubtitle : undefined}
 	showFilters


### PR DESCRIPTION
## Why

The Hyperliquid protocol page only contains native HyperCore vaults, while HyperEVM vaults belong to other protocols. Visitors need a direct path to the combined chain listing.

## Lessons learnt

Protocol and chain groupings are intentionally distinct; contextual copy should direct users to the appropriate aggregate view without changing either grouping.

## Summary

- Add a Hyperliquid-specific description sentence linking to the combined chain page.
- Add an optional protocol-description context slot for this targeted guidance.