### PR TITLE
fix: inline small vault listings

### DIFF
--- a/src/lib/top-vaults/inline-data.test.ts
+++ b/src/lib/top-vaults/inline-data.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest';
+import { INLINE_VAULT_COUNT_LIMIT, getInlineVaultListing } from './inline-data';
+import { createTestVault } from './test-utils';
+
+describe('getInlineVaultListing', () => {
+	const topVaults = {
+		generated_at: '2026-07-24T00:00:00.000Z',
+		vaults: [createTestVault('Vault')],
+		core3_protocols: {},
+		curators: {}
+	};
+
+	it('includes listings with fewer than 100 vaults', () => {
+		const listing = getInlineVaultListing(topVaults, topVaults.vaults);
+
+		expect(listing).toEqual(topVaults);
+	});
+
+	it('keeps listings with 100 vaults out of the initial page data', () => {
+		const vaults = Array.from({ length: INLINE_VAULT_COUNT_LIMIT }, (_, index) => createTestVault(`Vault ${index}`));
+
+		expect(getInlineVaultListing({ ...topVaults, vaults }, vaults)).toBeUndefined();
+	});
+});

--- a/src/lib/top-vaults/inline-data.ts
+++ b/src/lib/top-vaults/inline-data.ts
@@ -1,0 +1,22 @@
+import type { TopVaults, VaultInfo } from './schemas';
+
+/**
+ * Maximum number of vault records included in a listing route's initial HTML.
+ *
+ * Small, pre-filtered groups render immediately with their server data. Larger
+ * listings keep using the shared client-side export to avoid inflating the page
+ * response with hundreds or thousands of full vault records.
+ */
+export const INLINE_VAULT_COUNT_LIMIT = 100;
+
+/**
+ * Create an initial payload for a small, pre-filtered vault listing.
+ *
+ * @param topVaults - Complete, server-cached vault dataset
+ * @param vaults - Records belonging to the current listing
+ */
+export function getInlineVaultListing(topVaults: TopVaults, vaults: VaultInfo[]): TopVaults | undefined {
+	if (vaults.length >= INLINE_VAULT_COUNT_LIMIT) return undefined;
+
+	return { ...topVaults, vaults };
+}

--- a/src/routes/vaults/chains/[chain=slug]/+page.server.ts
+++ b/src/routes/vaults/chains/[chain=slug]/+page.server.ts
@@ -1,15 +1,23 @@
 import { error } from '@sveltejs/kit';
-import { getChain } from '$lib/helpers/chain';
+import { getChain, getChainsBySlug } from '$lib/helpers/chain';
+import { getCachedTopVaults } from '$lib/top-vaults/cache';
+import { getInlineVaultListing } from '$lib/top-vaults/inline-data';
 
-export async function load({ params }) {
+export async function load({ params, fetch }) {
 	const chainSlug = params.chain;
 	const chain = getChain(chainSlug);
 
 	if (!chain) error(404, 'Chain not found');
 
+	const topVaults = await getCachedTopVaults(fetch);
+	const chainIds = new Set(getChainsBySlug(chainSlug).map((item) => item.id));
+	const chainVaults = topVaults.vaults.filter((vault) => chainIds.has(vault.chain_id));
+
 	return {
 		chain,
 		chainSlug,
-		chainName: chain.name
+		chainName: chain.name,
+		totalVaultCount: topVaults.vaults.length,
+		initialTopVaults: getInlineVaultListing(topVaults, chainVaults)
 	};
 }

--- a/src/routes/vaults/chains/[chain=slug]/+page.svelte
+++ b/src/routes/vaults/chains/[chain=slug]/+page.svelte
@@ -9,25 +9,33 @@
 	import VaultGroupDescription from '../../VaultGroupDescription.svelte';
 
 	let { data } = $props();
-	let { chain, chainSlug, chainName } = $derived(data);
+	let { chain, chainSlug, chainName, initialTopVaults } = $derived(data);
 
-	let topVaults = $state<TopVaults>();
-	let totalVaultCount = $state<number>();
-	let loading = $state(!hasVaultCache(page.data.generatedAt));
+	let fetchedTopVaults = $state<TopVaults>();
+	let fetchedTotalVaultCount = $state<number>();
+	let fetchSettled = $state(false);
+	let topVaults = $derived(initialTopVaults ?? fetchedTopVaults);
+	let totalVaultCount = $derived(initialTopVaults ? data.totalVaultCount : fetchedTotalVaultCount);
+	let loading = $derived(!initialTopVaults && !fetchSettled && !hasVaultCache(page.data.generatedAt));
 
 	$effect(() => {
+		if (initialTopVaults) {
+			return;
+		}
+
+		fetchSettled = false;
 		fetchAllVaultData(page.data.generatedAt)
 			.then((allData) => {
-				totalVaultCount = allData.vaults.length;
+				fetchedTotalVaultCount = allData.vaults.length;
 				// Include vaults from all chains sharing this slug (e.g. HyperEVM + HyperCore)
 				const chainIds = new Set(getChainsBySlug(chainSlug).map((c) => c.id));
-				topVaults = {
+				fetchedTopVaults = {
 					...allData,
 					vaults: allData.vaults.filter((v) => chainIds.has(v.chain_id))
 				};
 			})
 			.catch((e) => console.error('Failed to load vault data:', e))
-			.finally(() => (loading = false));
+			.finally(() => (fetchSettled = true));
 	});
 
 	let title = $derived(`${chainName} stablecoin vaults`);

--- a/src/routes/vaults/curators/[curator=slug]/+page.server.ts
+++ b/src/routes/vaults/curators/[curator=slug]/+page.server.ts
@@ -1,5 +1,6 @@
 import { error } from '@sveltejs/kit';
 import { getCachedTopVaults } from '$lib/top-vaults/cache';
+import { getInlineVaultListing } from '$lib/top-vaults/inline-data';
 import {
 	calculateTotalTvl,
 	calculateTvlWeightedApy,
@@ -10,7 +11,8 @@ import {
 
 export async function load({ params, fetch }) {
 	const { curator } = params;
-	const { vaults, curators } = await getCachedTopVaults(fetch);
+	const topVaults = await getCachedTopVaults(fetch);
+	const { vaults, curators } = topVaults;
 
 	const curatorInfo = curators[curator];
 	if (!curatorInfo) error(404, 'Curator not found');
@@ -28,6 +30,11 @@ export async function load({ params, fetch }) {
 		curator: curatorInfo,
 		vaultCount: eligibleVaults.length,
 		tvl,
-		averageApy
+		averageApy,
+		totalVaultCount: vaults.length,
+		initialTopVaults: getInlineVaultListing(
+			topVaults,
+			vaults.filter((vault) => vault.curator_slug === curator)
+		)
 	};
 }

--- a/src/routes/vaults/curators/[curator=slug]/+page.svelte
+++ b/src/routes/vaults/curators/[curator=slug]/+page.svelte
@@ -12,23 +12,31 @@ with an "about" panel and a TVL/return mini chart.
 	import { formatDollar, formatPercent } from '$lib/helpers/formatters';
 
 	let { data } = $props();
-	let { curatorSlug, curatorName, curator, vaultCount, tvl, averageApy } = $derived(data);
+	let { curatorSlug, curatorName, curator, vaultCount, tvl, averageApy, initialTopVaults } = $derived(data);
 
-	let topVaults = $state<TopVaults>();
-	let totalVaultCount = $state<number>();
-	let loading = $state(!hasVaultCache(page.data.generatedAt));
+	let fetchedTopVaults = $state<TopVaults>();
+	let fetchedTotalVaultCount = $state<number>();
+	let fetchSettled = $state(false);
+	let topVaults = $derived(initialTopVaults ?? fetchedTopVaults);
+	let totalVaultCount = $derived(initialTopVaults ? data.totalVaultCount : fetchedTotalVaultCount);
+	let loading = $derived(!initialTopVaults && !fetchSettled && !hasVaultCache(page.data.generatedAt));
 
 	$effect(() => {
+		if (initialTopVaults) {
+			return;
+		}
+
+		fetchSettled = false;
 		fetchAllVaultData(page.data.generatedAt)
 			.then((allData) => {
-				totalVaultCount = allData.vaults.length;
-				topVaults = {
+				fetchedTotalVaultCount = allData.vaults.length;
+				fetchedTopVaults = {
 					...allData,
 					vaults: allData.vaults.filter((v) => v.curator_slug === curatorSlug)
 				};
 			})
 			.catch((e) => console.error('Failed to load vault data:', e))
-			.finally(() => (loading = false));
+			.finally(() => (fetchSettled = true));
 	});
 
 	/** Google truncates search snippets around this length; keep the meta description within it */

--- a/src/routes/vaults/protocols/[protocol=slug]/+page.server.ts
+++ b/src/routes/vaults/protocols/[protocol=slug]/+page.server.ts
@@ -1,5 +1,6 @@
 import { error } from '@sveltejs/kit';
 import { getCachedTopVaults } from '$lib/top-vaults/cache';
+import { getInlineVaultListing } from '$lib/top-vaults/inline-data';
 import { fetchVaultProtocolMetadata } from '$lib/vault-protocol/client';
 import {
 	getCore3ProtocolForVault,
@@ -11,20 +12,22 @@ import {
 
 export async function load({ params, fetch }) {
 	const { protocol } = params;
-	const { vaults, core3_protocols } = await getCachedTopVaults(fetch);
+	const topVaults = await getCachedTopVaults(fetch);
+	const { vaults, core3_protocols } = topVaults;
 
 	const isUnknownGroup = protocol === UNKNOWN_VAULT_PROTOCOL_SLUG;
-	const protocolVault = vaults.find((v) => (isUnknownGroup ? isUnknownVaultProtocol(v) : v.protocol_slug === protocol));
+	const protocolVaults = vaults.filter((v) =>
+		isUnknownGroup ? isUnknownVaultProtocol(v) : v.protocol_slug === protocol
+	);
+	const protocolVault = protocolVaults[0];
 	if (!protocolVault) error(404, 'Vault protocol not found');
 
 	const protocolMetadata = isUnknownGroup
 		? undefined
 		: await fetchVaultProtocolMetadata(fetch, protocol, protocolVault.protocol);
 	const core3 =
-		vaults
-			.filter((v) => (isUnknownGroup ? isUnknownVaultProtocol(v) : v.protocol_slug === protocol))
-			.map((vault) => getCore3ProtocolForVault(vault, core3_protocols))
-			.find((rating) => rating !== null) ?? null;
+		protocolVaults.map((vault) => getCore3ProtocolForVault(vault, core3_protocols)).find((rating) => rating !== null) ??
+		null;
 
 	return {
 		protocolSlug: protocol,
@@ -32,6 +35,7 @@ export async function load({ params, fetch }) {
 			? UNKNOWN_VAULT_PROTOCOL_DISPLAY_NAME
 			: getProtocolDisplayName(protocolVault.protocol, protocolVault.protocol_slug),
 		protocolMetadata,
-		core3
+		core3,
+		initialTopVaults: getInlineVaultListing(topVaults, protocolVaults)
 	};
 }

--- a/src/routes/vaults/protocols/[protocol=slug]/+page.svelte
+++ b/src/routes/vaults/protocols/[protocol=slug]/+page.svelte
@@ -11,17 +11,24 @@
 	import VaultGroupMiniChart from '../../VaultGroupMiniChart.svelte';
 
 	let { data } = $props();
-	let { protocolSlug, protocolName, protocolMetadata, core3 } = $derived(data);
+	let { protocolSlug, protocolName, protocolMetadata, core3, initialTopVaults } = $derived(data);
 	let isUnknownVaultProtocolGroup = $derived(protocolSlug === UNKNOWN_VAULT_PROTOCOL_SLUG);
 	let isHyperliquidProtocolGroup = $derived(protocolSlug === 'hyperliquid');
 
-	let topVaults = $state<TopVaults>();
-	let loading = $state(!hasVaultCache(page.data.generatedAt));
+	let fetchedTopVaults = $state<TopVaults>();
+	let fetchSettled = $state(false);
+	let topVaults = $derived(initialTopVaults ?? fetchedTopVaults);
+	let loading = $derived(!initialTopVaults && !fetchSettled && !hasVaultCache(page.data.generatedAt));
 
 	$effect(() => {
+		if (initialTopVaults) {
+			return;
+		}
+
+		fetchSettled = false;
 		fetchAllVaultData(page.data.generatedAt)
 			.then((allData) => {
-				topVaults = {
+				fetchedTopVaults = {
 					...allData,
 					vaults: allData.vaults.filter((vault) =>
 						isUnknownVaultProtocolGroup ? isUnknownVaultProtocol(vault) : vault.protocol_slug === protocolSlug
@@ -29,7 +36,7 @@
 				};
 			})
 			.catch((e) => console.error('Failed to load vault data:', e))
-			.finally(() => (loading = false));
+			.finally(() => (fetchSettled = true));
 	});
 
 	const unknownVaultDescription = 'These vaults are not yet mapped out. Contact us to have your vaults listed.';

--- a/src/routes/vaults/stablecoins/[denomination=slug]/+page.server.ts
+++ b/src/routes/vaults/stablecoins/[denomination=slug]/+page.server.ts
@@ -1,5 +1,6 @@
 import { error } from '@sveltejs/kit';
 import { getCachedTopVaults } from '$lib/top-vaults/cache';
+import { getInlineVaultListing } from '$lib/top-vaults/inline-data';
 import { fetchStablecoinMetadataIndex } from '$lib/stablecoin-metadata/client';
 import {
 	buildStablecoinMetadataLookup,
@@ -13,10 +14,11 @@ import {
 export async function load({ params, fetch }) {
 	const { denomination } = params;
 
-	const [{ vaults }, metadataIndex] = await Promise.all([
+	const [topVaults, metadataIndex] = await Promise.all([
 		getCachedTopVaults(fetch),
 		fetchStablecoinMetadataIndex(fetch)
 	]);
+	const { vaults } = topVaults;
 
 	const metadataLookup = buildStablecoinMetadataLookup(metadataIndex);
 	const stablecoinMetadata = findStablecoinMetadata(metadataLookup, denomination);
@@ -54,6 +56,10 @@ export async function load({ params, fetch }) {
 			denomination === OFFCHAIN_USD_STABLECOIN_SLUG
 				? OFFCHAIN_USD_SHORT_DESCRIPTION
 				: (stablecoinMetadata?.short_description ?? null),
-		stablecoinMetadata
+		stablecoinMetadata,
+		initialTopVaults: getInlineVaultListing(
+			topVaults,
+			vaults.filter((vault) => vault.denomination_slug === denomination)
+		)
 	};
 }

--- a/src/routes/vaults/stablecoins/[denomination=slug]/+page.svelte
+++ b/src/routes/vaults/stablecoins/[denomination=slug]/+page.svelte
@@ -13,21 +13,35 @@
 	import VaultGroupDescription from '../../VaultGroupDescription.svelte';
 
 	let { data } = $props();
-	let { denominationSlug, denominationSymbol, denominationName, shortDescription, stablecoinMetadata } = $derived(data);
+	let {
+		denominationSlug,
+		denominationSymbol,
+		denominationName,
+		shortDescription,
+		stablecoinMetadata,
+		initialTopVaults
+	} = $derived(data);
 
-	let topVaults = $state<TopVaults>();
-	let loading = $state(!hasVaultCache(page.data.generatedAt));
+	let fetchedTopVaults = $state<TopVaults>();
+	let fetchSettled = $state(false);
+	let topVaults = $derived(initialTopVaults ?? fetchedTopVaults);
+	let loading = $derived(!initialTopVaults && !fetchSettled && !hasVaultCache(page.data.generatedAt));
 
 	$effect(() => {
+		if (initialTopVaults) {
+			return;
+		}
+
+		fetchSettled = false;
 		fetchAllVaultData(page.data.generatedAt)
 			.then((allData) => {
-				topVaults = {
+				fetchedTopVaults = {
 					...allData,
 					vaults: allData.vaults.filter((v) => v.denomination_slug === denominationSlug)
 				};
 			})
 			.catch((e) => console.error('Failed to load vault data:', e))
-			.finally(() => (loading = false));
+			.finally(() => (fetchSettled = true));
 	});
 
 	let title = $derived(`${denominationName} stablecoin vaults | Trading Strategy`);

--- a/src/routes/vaults/tokenised-funds/+page.server.ts
+++ b/src/routes/vaults/tokenised-funds/+page.server.ts
@@ -1,12 +1,15 @@
 import { getCachedTopVaults } from '$lib/top-vaults/cache';
 import { getVaultCurrentTvlUsd } from '$lib/top-vaults/helpers.js';
+import { getInlineVaultListing } from '$lib/top-vaults/inline-data';
 
 export async function load({ fetch }) {
-	const { vaults } = await getCachedTopVaults(fetch);
+	const topVaults = await getCachedTopVaults(fetch);
+	const { vaults } = topVaults;
 	const tokenisedFunds = vaults.filter((vault) => vault.flags.includes('tokenised_fund'));
 
 	return {
 		fundCount: tokenisedFunds.length,
-		totalNavUsd: tokenisedFunds.reduce((total, vault) => total + (getVaultCurrentTvlUsd(vault) ?? 0), 0)
+		totalNavUsd: tokenisedFunds.reduce((total, vault) => total + (getVaultCurrentTvlUsd(vault) ?? 0), 0),
+		initialTopVaults: getInlineVaultListing(topVaults, tokenisedFunds)
 	};
 }

--- a/src/routes/vaults/tokenised-funds/+page.svelte
+++ b/src/routes/vaults/tokenised-funds/+page.svelte
@@ -21,19 +21,24 @@ Tokenised fund listing for vaults with a regulated fund structure.
 	import type { MarketShareChartItem } from '../market-share-pie';
 
 	let { data } = $props();
-	let topVaults = $state<TopVaults>();
+	let fetchedTopVaults = $state<TopVaults>();
+	let topVaults = $derived(data.initialTopVaults ?? fetchedTopVaults);
 	let fetchSettled = $state(false);
-	let loading = $derived(!fetchSettled && !hasVaultCache(data.generatedAt));
+	let loading = $derived(!data.initialTopVaults && !fetchSettled && !hasVaultCache(data.generatedAt));
 
 	function isTokenisedFund(vault: VaultInfo): boolean {
 		return vault.flags.includes('tokenised_fund');
 	}
 
 	$effect(() => {
+		if (data.initialTopVaults) {
+			return;
+		}
+
 		fetchSettled = false;
 		fetchAllVaultData(data.generatedAt)
 			.then((allData) => {
-				topVaults = {
+				fetchedTopVaults = {
 					...allData,
 					vaults: allData.vaults.filter(isTokenisedFund)
 				};
@@ -53,15 +58,16 @@ Tokenised fund listing for vaults with a regulated fund structure.
 	);
 	let chartTitle = $derived(`Total ${formatDollar(totalNavUsd, 2, 3)} tokenised fund NAV`);
 	let chartFunds = $derived.by((): MarketShareChartItem[] => {
-		if (!topVaults) return [];
+		const vaultData = topVaults;
+		if (!vaultData) return [];
 
-		return topVaults.vaults.filter(isTokenisedFund).map((vault) => ({
+		return vaultData.vaults.filter(isTokenisedFund).map((vault) => ({
 			slug: vault.id,
 			label: vault.name,
 			name: vault.name,
 			tvl: getVaultCurrentTvlUsd(vault) ?? 0,
 			avgApy: vault.cagr_net ?? vault.three_months_cagr ?? null,
-			logoUrl: vault.curator_slug ? (topVaults.curators[vault.curator_slug]?.logos.generic ?? undefined) : undefined,
+			logoUrl: vault.curator_slug ? (vaultData.curators[vault.curator_slug]?.logos.generic ?? undefined) : undefined,
 			href: resolveVaultDetails(vault)
 		}));
 	});


### PR DESCRIPTION
## Why

Small vault group pages can render their complete listing immediately, avoiding an unnecessary skeleton while the full export downloads. Large pages must continue to defer that export to keep initial responses small.

## Lessons learnt

A strict record-count threshold keeps the behaviour predictable across all group-specific listing routes.

## Summary

- Inline pre-filtered vault data for protocol, chain, stablecoin, curator, and tokenised-fund listings below 100 records.
- Keep the existing client-side fetch path for listings with 100 or more records.
- Add coverage for the threshold behaviour.