### PR TITLE
Fix mobile vault protocol table labels

### DIFF
--- a/src/lib/components/datatable/MobileSortSelect.svelte
+++ b/src/lib/components/datatable/MobileSortSelect.svelte
@@ -3,6 +3,7 @@
 	import type { SortKey } from 'svelte-headless-table/plugins';
 	import { Subscribe, type HeaderRow } from 'svelte-headless-table';
 	import Select from '$lib/components/Select.svelte';
+	import { getColumnLabel } from './utils';
 
 	interface Props {
 		// eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -38,7 +39,7 @@
 							{#each [['desc', '▼'], ['asc', '▲']] as [order, indicator] (order)}
 								<option value={sortValue({ ...cell, order })} selected={sort.order === order}>
 									<!-- eslint-disable-next-line svelte/require-store-reactive-access -->
-									{cell.label}
+									{getColumnLabel(cell.label)}
 									{indicator}
 								</option>
 							{/each}

--- a/src/lib/components/datatable/TableRow.svelte
+++ b/src/lib/components/datatable/TableRow.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import type { HTMLAttributes } from 'svelte/elements';
 	import { type BodyCell, Subscribe, Render } from 'svelte-headless-table';
+	import { getColumnLabel } from './utils';
 
 	interface Props {
 		index: number | undefined;
@@ -18,7 +19,7 @@
 	{#each cells as cell (cell.id)}
 		<Subscribe cellAttrs={cell.attrs()} let:cellAttrs>
 			<!-- eslint-disable-next-line svelte/require-store-reactive-access -->
-			<td class={cell.id} {...cellAttrs} data-label={cell.column.header}>
+			<td class={cell.id} {...cellAttrs} data-label={getColumnLabel(cell.column.header)}>
 				<Render of={cell.render()} />
 			</td>
 		</Subscribe>

--- a/src/lib/components/datatable/utils.ts
+++ b/src/lib/components/datatable/utils.ts
@@ -11,3 +11,32 @@ export function createRender<TProps extends Record<string, any> = Record<string,
 ) {
 	return originalCreateRender(component as unknown as CreateRenderParams[0], props);
 }
+
+/**
+ * Resolve a plain-text label for a table column header.
+ *
+ * Column headers may be plain strings or `ComponentRenderConfig` objects (e.g. a
+ * header rendered through a Svelte component to add a tooltip). Contexts that can
+ * only display text — the mobile card `data-label` and the mobile sort `<select>`
+ * — cannot render a component and would otherwise stringify the config to
+ * "[object Object]". Component-based headers should carry a `label` prop holding
+ * their plain-text equivalent so those contexts can fall back to it.
+ *
+ * @param header - The column `header` (or header cell `label`) value.
+ * @returns Plain-text label, or an empty string when none can be resolved.
+ */
+export function getColumnLabel(header: unknown): string {
+	if (typeof header === 'string' || typeof header === 'number') {
+		return String(header);
+	}
+	if (header && typeof header === 'object' && 'props' in header) {
+		const props = (header as { props?: unknown }).props;
+		if (props && typeof props === 'object' && 'label' in props) {
+			const label = (props as { label?: unknown }).label;
+			if (typeof label === 'string' || typeof label === 'number') {
+				return String(label);
+			}
+		}
+	}
+	return '';
+}

--- a/src/lib/top-vaults/AvgApyHeader.svelte
+++ b/src/lib/top-vaults/AvgApyHeader.svelte
@@ -5,10 +5,21 @@ Column heading for TVL-weighted average APY values in vault group listings.
 <script lang="ts">
 	import Tooltip from '$lib/components/Tooltip.svelte';
 
+	interface Props {
+		/**
+		 * Plain-text column label. Rendered on desktop as the tooltip trigger, and
+		 * read back via `getColumnLabel()` for the mobile card label and sort select,
+		 * which cannot render this component.
+		 */
+		label?: string;
+	}
+
+	let { label = 'Avg. APY%' }: Props = $props();
+
 	const avgApyTooltip = 'Total value locked weighted returns, last 30 days';
 </script>
 
 <Tooltip>
-	<span slot="trigger" class="underline">Avg. APY%</span>
+	<span slot="trigger" class="underline">{label}</span>
 	<svelte:fragment slot="popup">{avgApyTooltip}</svelte:fragment>
 </Tooltip>

--- a/src/lib/top-vaults/VaultGroupTable.svelte
+++ b/src/lib/top-vaults/VaultGroupTable.svelte
@@ -150,7 +150,7 @@
 		}),
 		table.column({
 			accessor: 'avg_apy',
-			header: createRender(AvgApyHeader, {}),
+			header: createRender(AvgApyHeader, { label: 'Avg. APY%' }),
 			cell: ({ value }) => formatPercent(value)
 		}),
 		table.column({
@@ -192,6 +192,14 @@
 
 		/* hide full_name column on mobile */
 		:global(:is(th.full_name, td.full_name)) {
+			@media (--viewport-sm-down) {
+				display: none;
+			}
+		}
+
+		/* hide the CORE3 cell in the mobile card view when a protocol has no rating,
+		   so an empty "CORE3 –" row is not shown */
+		:global(td.core3_risk:has(.empty)) {
 			@media (--viewport-sm-down) {
 				display: none;
 			}


### PR DESCRIPTION
## Why

On the mobile view of `/vaults/protocols` (and the curator group listings), the responsive card layout renders each cell's label from the `data-label` attribute. `TableRow` set `data-label` directly from the column `header`, but the "Avg. APY%" column's header is a Svelte component render config (used to attach a desktop tooltip), so it stringified to **`[object Object]`** as the mobile label.

Additionally, protocols with no CORE3 rating still rendered a `CORE3 –` row in the mobile card, adding empty visual noise.

## Lessons learnt

- `svelte-headless-table` column `header` values can be either a plain string or a `ComponentRenderConfig` object. Any text-only context (mobile `data-label`, mobile sort `<select>`) must resolve a plain-text label instead of stringifying the config — use the shared `getColumnLabel()` helper and give component-based headers a `label` prop carrying their plain-text equivalent.
- The responsive card view is pure CSS (`content: attr(data-label)` per `td`), so per-cell mobile visibility is best handled with a scoped `:has()` rule keyed off the cell's rendered content (e.g. `td.core3_risk:has(.empty)`), not by changing the data.

## Summary

- Added `getColumnLabel()` in `datatable/utils.ts` to resolve a plain-text label from a string or component header config.
- `TableRow.svelte` and `MobileSortSelect.svelte` now route header/label values through `getColumnLabel()`.
- `AvgApyHeader.svelte` accepts a `label` prop; `VaultGroupTable` passes `label: 'Avg. APY%'` so the text-only mobile contexts have a fallback.
- Hide the CORE3 cell in the mobile card view when a protocol has no rating (`td.core3_risk:has(.empty)`), verified at a 375px viewport.

🤖 Generated with [Claude Code](https://claude.com/claude-code)