### PR TITLE
fix: support Robinhood Lighter vault IDs

### DIFF
--- a/src/params/vaultId.test.ts
+++ b/src/params/vaultId.test.ts
@@ -14,6 +14,10 @@ describe('vaultId param matcher', () => {
 		expect(match('9998-lighter-pool-281474976625478')).toBe(true);
 	});
 
+	test('matches Lighter Robinhood pool format', () => {
+		expect(match('9998-lighter-pool-robinhood-281474976710654')).toBe(true);
+	});
+
 	test('matches Hibachi vault format', () => {
 		expect(match('9997-hibachi-vault-2')).toBe(true);
 	});

--- a/src/params/vaultId.ts
+++ b/src/params/vaultId.ts
@@ -2,12 +2,15 @@
  * Match chain-specific vault ID formats:
  * - EVM chains (Ethereum, Polygon, Arbitrum, Base, etc.): `${chainId}-0x${address}`
  * - HyperCore / GRVT (chain 325): `${chainId}-vlt:${id}`
- * - Lighter (chain 9998): `${chainId}-lighter-pool-${id}`
+ * - Lighter (chain 9998): `${chainId}-lighter-pool-${id}` or
+ *   `${chainId}-lighter-pool-robinhood-${id}`
  * - Hibachi (chain 9997): `${chainId}-hibachi-vault-${id}`
  * - ApeX (chain 9995): `${chainId}-apex-vault-${id}`
  *
  * To add a new format, append a new alternative to the regex group.
  */
 export function match(param: string) {
-	return /^\d+-(0x[0-9a-f]+|vlt:[0-9a-z]+|lighter-pool-\d+|hibachi-vault-\d+|apex-vault-\d+)$/i.test(param);
+	return /^\d+-(0x[0-9a-f]+|vlt:[0-9a-z]+|lighter-pool-(?:robinhood-)?\d+|hibachi-vault-\d+|apex-vault-\d+)$/i.test(
+		param
+	);
 }


### PR DESCRIPTION
## Why

LLP uses a Robinhood-prefixed Lighter vault ID. The metrics route rejected that valid ID, leaving its share-price chart without data.

## Lessons learnt

Vault-ID route matchers must cover all upstream identifier variants used by the vault dataset.

## Summary

- Accept Robinhood-prefixed Lighter pool IDs.
- Add LLP as a regression case for the vault-ID matcher.