### PR TITLE
fix: improve mobile protocol vault listings

### DIFF
--- a/src/lib/top-vaults/TopVaultsPage.svelte
+++ b/src/lib/top-vaults/TopVaultsPage.svelte
@@ -386,6 +386,10 @@
 		}
 
 		@media (--viewport-sm-down) {
+			.update-info {
+				display: none;
+			}
+
 			.top-vaults-header :global(.hero-banner) {
 				min-height: 0;
 				padding-block: var(--space-xs);
@@ -394,6 +398,20 @@
 			.hero-layout {
 				grid-template-columns: 1fr;
 				align-items: stretch;
+			}
+
+			.page-title {
+				display: flex;
+				flex-wrap: nowrap;
+
+				img {
+					flex: none;
+				}
+
+				span {
+					flex: 1;
+					min-width: 0;
+				}
 			}
 		}
 	}

--- a/src/lib/top-vaults/TopVaultsTable.svelte
+++ b/src/lib/top-vaults/TopVaultsTable.svelte
@@ -1873,7 +1873,12 @@
 				width: 9%;
 
 				@media (--viewport-sm-down) {
-					display: none;
+					width: 4.5rem;
+					padding-inline: 0.125rem;
+
+					:global(.vault-sparkline) {
+						--sparkline-width: 4rem;
+					}
 				}
 
 				&:is(td) {

--- a/src/routes/vaults/protocols/[protocol=slug]/+page.server.ts
+++ b/src/routes/vaults/protocols/[protocol=slug]/+page.server.ts
@@ -36,6 +36,7 @@ export async function load({ params, fetch }) {
 			: getProtocolDisplayName(protocolVault.protocol, protocolVault.protocol_slug),
 		protocolMetadata,
 		core3,
+		totalVaultCount: vaults.length,
 		initialTopVaults: getInlineVaultListing(topVaults, protocolVaults)
 	};
 }

--- a/src/routes/vaults/protocols/[protocol=slug]/+page.svelte
+++ b/src/routes/vaults/protocols/[protocol=slug]/+page.svelte
@@ -21,8 +21,10 @@
 	let defaultTvlKey = $derived(isApexProtocolGroup ? 'any' : '10k');
 
 	let fetchedTopVaults = $state<TopVaults>();
+	let fetchedTotalVaultCount = $state<number>();
 	let fetchSettled = $state(false);
 	let topVaults = $derived(initialTopVaults ?? fetchedTopVaults);
+	let totalVaultCount = $derived(initialTopVaults ? data.totalVaultCount : fetchedTotalVaultCount);
 	let loading = $derived(!initialTopVaults && !fetchSettled && !hasVaultCache(page.data.generatedAt));
 
 	$effect(() => {
@@ -33,6 +35,7 @@
 		fetchSettled = false;
 		fetchAllVaultData(page.data.generatedAt)
 			.then((allData) => {
+				fetchedTotalVaultCount = allData.vaults.length;
 				fetchedTopVaults = {
 					...allData,
 					vaults: allData.vaults.filter((vault) =>
@@ -113,6 +116,7 @@
 
 <TopVaultsPage
 	{topVaults}
+	{totalVaultCount}
 	{loading}
 	{protocolMetadata}
 	protocolDescriptionExtra={isHyperliquidProtocolGroup ? hyperliquidChainDescription : undefined}


### PR DESCRIPTION
## Why

Mobile protocol vault listings should retain essential context and trends on small screens, while clearly showing each protocol listing’s share of the complete vault database.

## Lessons learnt

Scoped listing pages need to supply the complete database total separately, because their table data only contains the currently scoped vaults.

## Summary

- Hide the Update info control on mobile and keep page icons aligned with their headings.
- Show protocol listing counts out of all indexed vaults.
- Restore a compact 3M price sparkline column in the mobile vault table.