### PR TITLE
fix: compact mobile vault group listings

### DIFF
--- a/src/lib/top-vaults/VaultGroupTable.svelte
+++ b/src/lib/top-vaults/VaultGroupTable.svelte
@@ -253,6 +253,44 @@
 				}
 			}
 		}
+
+		@media (--viewport-sm-down) {
+			:global(table.datatable.responsive) {
+				--border-spacing: 0;
+				gap: 0;
+			}
+
+			:global(table.datatable.responsive .mobile-sort-select th) {
+				padding: 0;
+			}
+
+			:global(table.datatable.responsive tbody tr) {
+				gap: 0;
+				padding: 0;
+			}
+
+			:global(table.datatable.responsive tbody tr[data-row-index]::before) {
+				display: none;
+			}
+
+			:global(table.datatable.responsive tbody tr td) {
+				padding: 0;
+				font-size: 66%;
+			}
+
+			:global(table.datatable.responsive tbody tr td:not(.cta)::before) {
+				font: inherit;
+			}
+
+			:global(table.datatable.responsive tbody tr td.cta) {
+				padding: 0;
+			}
+
+			:global(table.datatable.responsive tbody tr td .row-link) {
+				padding-right: 0;
+				font: inherit;
+			}
+		}
 	}
 
 	.vault-protocol-table :global(tr.depegged td),

--- a/src/lib/top-vaults/VaultGroupTable.svelte
+++ b/src/lib/top-vaults/VaultGroupTable.svelte
@@ -257,7 +257,7 @@
 		@media (--viewport-sm-down) {
 			:global(table.datatable.responsive) {
 				--border-spacing: 0;
-				gap: 2px;
+				gap: 0.375rem;
 				margin-block: var(--space-xxs);
 			}
 
@@ -266,25 +266,37 @@
 			}
 
 			:global(table.datatable.responsive tbody tr) {
-				grid-template-columns: 1fr 1fr;
-				gap: var(--space-xxs) var(--space-sm);
-				padding: var(--space-sm);
+				grid-template-columns: max-content max-content minmax(0, 1fr);
+				gap: 0 0.5rem;
+				padding: 0.75rem 0.875rem;
+				border-radius: 0.75rem;
+			}
+
+			:global(table.datatable.responsive tbody tr::after) {
+				content: '›';
+				position: absolute;
+				top: 0.75rem;
+				right: 0.875rem;
+				font: var(--f-ui-xl-medium);
+				line-height: 2.5rem;
+				color: var(--c-text-extra-light);
+				pointer-events: none;
 			}
 
 			:global(table.datatable.responsive tbody tr[data-row-index]::before) {
-				top: calc(var(--space-sm) + var(--space-xs));
-				left: calc(var(--space-sm) + 2.25rem + var(--space-sm));
-				font: var(--f-ui-lg-bold);
-				line-height: 2.25rem;
+				top: 0.75rem;
+				left: calc(0.875rem + 2.5rem + 0.5rem);
+				font: var(--f-ui-md-bold);
+				line-height: 2.5rem;
+				color: var(--c-text-light);
 				pointer-events: none;
 			}
 
 			:global(table.datatable.responsive tbody tr td.name) {
 				grid-column: 1 / -1;
 				align-items: center;
-				min-height: 2.25rem;
-				padding-block: var(--space-xs);
-				padding-inline-start: calc(2.25rem + var(--space-sm) + 3rem);
+				min-height: 2.5rem;
+				padding-inline: calc(2.5rem + 0.5rem + 2.75rem) 1.5rem;
 				font: var(--f-ui-lg-bold);
 				line-height: 1.1;
 			}
@@ -295,18 +307,20 @@
 				gap: var(--space-xxs);
 				min-width: 0;
 				padding: 0;
-				font: var(--f-ui-sm-medium);
-				line-height: 1.1;
+				font: var(--f-ui-sm-roman);
+				line-height: 1.2;
+				color: var(--c-text-light);
+				white-space: nowrap;
 				word-break: normal;
 			}
 
 			:global(table.datatable.responsive tbody tr td.name .entity-symbol .logo),
 			:global(table.datatable.responsive tbody tr td.name .entity-symbol .placeholder-logo) {
 				position: absolute;
-				top: calc(var(--space-sm) + var(--space-xs));
-				left: var(--space-sm);
-				width: 2.25rem;
-				height: 2.25rem;
+				top: 0.75rem;
+				left: 0.875rem;
+				width: 2.5rem;
+				height: 2.5rem;
 				object-fit: contain;
 			}
 
@@ -326,21 +340,44 @@
 				display: none;
 			}
 
+			:global(table.datatable.responsive tbody tr td.core3_risk) {
+				display: none;
+			}
+
 			:global(table.datatable.responsive tbody tr td:not(.cta)::before) {
 				flex: none;
-				font: var(--f-ui-xs-roman);
-				line-height: 1.1;
+				font: inherit;
+				line-height: inherit;
+			}
+
+			:global(table.datatable.responsive tbody tr td.vault_count) {
+				margin-inline-start: calc(2.5rem + 0.5rem + 2.75rem);
+			}
+
+			:global(table.datatable.responsive tbody tr td.vault_count::before) {
+				content: 'vaults';
+				order: 2;
+			}
+
+			:global(table.datatable.responsive tbody tr td.avg_apy::before),
+			:global(table.datatable.responsive tbody tr td.tvl::before) {
+				content: '·';
+			}
+
+			:global(table.datatable.responsive tbody tr td.avg_apy::after) {
+				content: 'APY';
+			}
+
+			:global(table.datatable.responsive tbody tr td.tvl::after) {
+				content: 'TVL';
 			}
 
 			:global(table.datatable.responsive tbody tr td.cta) {
-				grid-column: 1 / -1;
-				padding: 0;
+				display: contents;
 			}
 
 			:global(table.datatable.responsive tbody tr td .row-link) {
-				padding-right: 0;
-				font: var(--f-ui-sm-medium);
-				line-height: 1.1;
+				display: none;
 			}
 		}
 	}

--- a/src/lib/top-vaults/VaultGroupTable.svelte
+++ b/src/lib/top-vaults/VaultGroupTable.svelte
@@ -257,55 +257,89 @@
 		@media (--viewport-sm-down) {
 			:global(table.datatable.responsive) {
 				--border-spacing: 0;
-				gap: 0;
+				gap: 2px;
 				margin-block: var(--space-xxs);
 			}
 
 			:global(table.datatable.responsive .mobile-sort-select th) {
-				padding: 0;
+				padding: var(--space-xxs) 0;
 			}
 
 			:global(table.datatable.responsive tbody tr) {
-				gap: 0;
-				padding: var(--space-xxs);
+				grid-template-columns: 1fr 1fr;
+				gap: var(--space-xxs) var(--space-sm);
+				padding: var(--space-xs);
 			}
 
 			:global(table.datatable.responsive tbody tr[data-row-index]::before) {
-				top: var(--space-xxs);
-				left: calc(1.5rem + var(--space-xxs));
-				font-size: 66%;
+				top: var(--space-xs);
+				left: calc(var(--space-xs) + 2rem + var(--space-xs));
+				font: var(--f-ui-md-bold);
+				line-height: 2rem;
 				pointer-events: none;
 			}
 
 			:global(table.datatable.responsive tbody tr td.name) {
-				padding-inline-start: calc(1.5rem + var(--space-xxs) + 1.75em);
+				grid-column: 1 / -1;
+				align-items: center;
+				min-height: 2rem;
+				padding-inline-start: calc(2rem + var(--space-xs) + 2.5rem);
+				font: var(--f-ui-md-bold);
+				line-height: 1.1;
 			}
 
 			:global(table.datatable.responsive tbody tr td) {
+				display: flex;
+				align-items: baseline;
+				gap: var(--space-xxs);
+				min-width: 0;
 				padding: 0;
-				font-size: 66%;
+				font: var(--f-ui-sm-medium);
+				line-height: 1.1;
+				word-break: normal;
 			}
 
 			:global(table.datatable.responsive tbody tr td.name .entity-symbol .logo),
 			:global(table.datatable.responsive tbody tr td.name .entity-symbol .placeholder-logo) {
 				position: absolute;
-				top: var(--space-xxs);
-				left: var(--space-xxs);
-				width: 1.5rem;
-				height: 1.5rem;
+				top: var(--space-xs);
+				left: var(--space-xs);
+				width: 2rem;
+				height: 2rem;
+				object-fit: contain;
+			}
+
+			:global(table.datatable.responsive tbody tr td.name .entity-symbol),
+			:global(table.datatable.responsive tbody tr td.name .entity-symbol .label),
+			:global(table.datatable.responsive tbody tr td.name .group-name) {
+				min-width: 0;
+			}
+
+			:global(table.datatable.responsive tbody tr td.name .group-name > span:last-child) {
+				overflow: hidden;
+				text-overflow: ellipsis;
+				white-space: nowrap;
+			}
+
+			:global(table.datatable.responsive tbody tr td.name::before) {
+				display: none;
 			}
 
 			:global(table.datatable.responsive tbody tr td:not(.cta)::before) {
-				font: inherit;
+				flex: none;
+				font: var(--f-ui-xs-roman);
+				line-height: 1.1;
 			}
 
 			:global(table.datatable.responsive tbody tr td.cta) {
+				grid-column: 1 / -1;
 				padding: 0;
 			}
 
 			:global(table.datatable.responsive tbody tr td .row-link) {
 				padding-right: 0;
-				font: inherit;
+				font: var(--f-ui-sm-medium);
+				line-height: 1.1;
 			}
 		}
 	}

--- a/src/lib/top-vaults/VaultGroupTable.svelte
+++ b/src/lib/top-vaults/VaultGroupTable.svelte
@@ -258,6 +258,7 @@
 			:global(table.datatable.responsive) {
 				--border-spacing: 0;
 				gap: 0;
+				margin-block: var(--space-xxs);
 			}
 
 			:global(table.datatable.responsive .mobile-sort-select th) {
@@ -266,23 +267,32 @@
 
 			:global(table.datatable.responsive tbody tr) {
 				gap: 0;
-				padding: 0;
+				padding: var(--space-xxs);
 			}
 
 			:global(table.datatable.responsive tbody tr[data-row-index]::before) {
-				top: 0;
-				left: 0;
+				top: var(--space-xxs);
+				left: calc(1.5rem + var(--space-xxs));
 				font-size: 66%;
 				pointer-events: none;
 			}
 
 			:global(table.datatable.responsive tbody tr td.name) {
-				padding-inline-start: 1.75em;
+				padding-inline-start: calc(1.5rem + var(--space-xxs) + 1.75em);
 			}
 
 			:global(table.datatable.responsive tbody tr td) {
 				padding: 0;
 				font-size: 66%;
+			}
+
+			:global(table.datatable.responsive tbody tr td.name .entity-symbol .logo),
+			:global(table.datatable.responsive tbody tr td.name .entity-symbol .placeholder-logo) {
+				position: absolute;
+				top: var(--space-xxs);
+				left: var(--space-xxs);
+				width: 1.5rem;
+				height: 1.5rem;
 			}
 
 			:global(table.datatable.responsive tbody tr td:not(.cta)::before) {

--- a/src/lib/top-vaults/VaultGroupTable.svelte
+++ b/src/lib/top-vaults/VaultGroupTable.svelte
@@ -268,23 +268,24 @@
 			:global(table.datatable.responsive tbody tr) {
 				grid-template-columns: 1fr 1fr;
 				gap: var(--space-xxs) var(--space-sm);
-				padding: var(--space-xs);
+				padding: var(--space-sm);
 			}
 
 			:global(table.datatable.responsive tbody tr[data-row-index]::before) {
-				top: var(--space-xs);
-				left: calc(var(--space-xs) + 2rem + var(--space-xs));
-				font: var(--f-ui-md-bold);
-				line-height: 2rem;
+				top: calc(var(--space-sm) + var(--space-xs));
+				left: calc(var(--space-sm) + 2.25rem + var(--space-sm));
+				font: var(--f-ui-lg-bold);
+				line-height: 2.25rem;
 				pointer-events: none;
 			}
 
 			:global(table.datatable.responsive tbody tr td.name) {
 				grid-column: 1 / -1;
 				align-items: center;
-				min-height: 2rem;
-				padding-inline-start: calc(2rem + var(--space-xs) + 2.5rem);
-				font: var(--f-ui-md-bold);
+				min-height: 2.25rem;
+				padding-block: var(--space-xs);
+				padding-inline-start: calc(2.25rem + var(--space-sm) + 3rem);
+				font: var(--f-ui-lg-bold);
 				line-height: 1.1;
 			}
 
@@ -302,10 +303,10 @@
 			:global(table.datatable.responsive tbody tr td.name .entity-symbol .logo),
 			:global(table.datatable.responsive tbody tr td.name .entity-symbol .placeholder-logo) {
 				position: absolute;
-				top: var(--space-xs);
-				left: var(--space-xs);
-				width: 2rem;
-				height: 2rem;
+				top: calc(var(--space-sm) + var(--space-xs));
+				left: var(--space-sm);
+				width: 2.25rem;
+				height: 2.25rem;
 				object-fit: contain;
 			}
 

--- a/src/lib/top-vaults/VaultGroupTable.svelte
+++ b/src/lib/top-vaults/VaultGroupTable.svelte
@@ -270,7 +270,14 @@
 			}
 
 			:global(table.datatable.responsive tbody tr[data-row-index]::before) {
-				display: none;
+				top: 0;
+				left: 0;
+				font-size: 66%;
+				pointer-events: none;
+			}
+
+			:global(table.datatable.responsive tbody tr td.name) {
+				padding-inline-start: 1.75em;
 			}
 
 			:global(table.datatable.responsive tbody tr td) {

--- a/src/routes/vaults/protocols/+page.svelte
+++ b/src/routes/vaults/protocols/+page.svelte
@@ -95,6 +95,7 @@
 							items={chartProtocols}
 							groupLabel="Protocol"
 							groupLabelPlural="protocols"
+							showLabelLogos
 							testId="protocol-tvl-pie-chart"
 						/>
 					</MarketShareWidgetBox>


### PR DESCRIPTION
## Why

Vault group listings need a clear, compact mobile hierarchy without sacrificing readability, while desktop market-share charts benefit from stronger visual identification.

## Lessons learnt

Responsive data tables apply their mobile card styling in shared CSS, so listing-specific overrides belong in the group table component. ECharts rich-label images can be enabled per chart while retaining its existing mobile exclusion.

## Summary

- Redesign mobile vault group cards around a logo, rank, and name header with one compact statistics line.
- Hide CORE3 and the visible CTA on mobile while keeping each card fully clickable.
- Add readable spacing, typography, card separation, and a navigation chevron.
- Show protocol logos in market-share pie labels on desktop only.