### PR TITLE
Add protocol vault summary

### DIFF
--- a/src/lib/vault-protocol/ProtocolDescription.svelte
+++ b/src/lib/vault-protocol/ProtocolDescription.svelte
@@ -41,18 +41,28 @@
 
 <div class="protocol-description">
 	<MetricsBox title="About {metadata.name}">
-		<div class="description-text">
-			<p>{metadata.short_description}</p>
+		{#if additionalDescription}
+			<div class="description-text">
+				<p>{metadata.short_description}</p>
+			</div>
+
+			<div class="additional-description">
+				{@render additionalDescription()}
+			</div>
+
 			{#if hasExpandableContent}
 				<Button ghost class="toggle-btn" on:click={() => (expanded = !expanded)}>
 					{expanded ? 'View less' : 'View more'}
 				</Button>
 			{/if}
-		</div>
-
-		{#if additionalDescription}
-			<div class="additional-description">
-				{@render additionalDescription()}
+		{:else}
+			<div class="description-text">
+				<p>{metadata.short_description}</p>
+				{#if hasExpandableContent}
+					<Button ghost class="toggle-btn" on:click={() => (expanded = !expanded)}>
+						{expanded ? 'View less' : 'View more'}
+					</Button>
+				{/if}
 			</div>
 		{/if}
 
@@ -102,9 +112,16 @@
 			:global(p) {
 				margin: 0;
 			}
+
+			:global(strong) {
+				color: var(--c-text);
+				font-weight: 600;
+			}
 		}
 
 		:global(.toggle-btn) {
+			justify-self: start;
+			margin-top: 0.75rem;
 			color: var(--c-text-extra-light);
 
 			&:hover {

--- a/src/routes/vaults/chains/[chain=slug]/+page.server.ts
+++ b/src/routes/vaults/chains/[chain=slug]/+page.server.ts
@@ -1,10 +1,13 @@
-import { error } from '@sveltejs/kit';
+import { error, redirect } from '@sveltejs/kit';
 import { getChain, getChainsBySlug } from '$lib/helpers/chain';
 import { getCachedTopVaults } from '$lib/top-vaults/cache';
 import { getInlineVaultListing } from '$lib/top-vaults/inline-data';
 
 export async function load({ params, fetch }) {
 	const chainSlug = params.chain;
+	// ApeX's chain and protocol are one and the same, so this special rule avoids maintaining two copies of the page.
+	if (chainSlug === 'apex') redirect(301, '/vaults/protocols/apex');
+
 	const chain = getChain(chainSlug);
 
 	if (!chain) error(404, 'Chain not found');

--- a/src/routes/vaults/protocols/[protocol=slug]/+page.svelte
+++ b/src/routes/vaults/protocols/[protocol=slug]/+page.svelte
@@ -1,8 +1,17 @@
 <script lang="ts">
 	import type { TopVaults } from '$lib/top-vaults/schemas';
 	import { fetchAllVaultData, hasVaultCache } from '$lib/top-vaults/client-cache';
-	import { isUnknownVaultProtocol, UNKNOWN_VAULT_PROTOCOL_SLUG } from '$lib/top-vaults/helpers';
+	import {
+		calculateTotalTvl,
+		calculateTvlWeightedApy,
+		isBlacklisted,
+		isEligibleVaultGroupMiniChartVault,
+		isUnknownVaultProtocol,
+		UNKNOWN_VAULT_PROTOCOL_SLUG
+	} from '$lib/top-vaults/helpers';
 	import { getVaultProtocolLogoUrl } from '$lib/vault-protocol/helpers.js';
+	import { VAULT_TVL_OUTLIER_THRESHOLD } from '$lib/echarts/tvl-outliers';
+	import { formatDollar, formatPercent } from '$lib/helpers/formatters';
 	import { resolve } from '$app/paths';
 	import { page } from '$app/state';
 	import TopVaultsPage from '$lib/top-vaults/TopVaultsPage.svelte';
@@ -63,6 +72,13 @@
 		const logoPath = protocolMetadata?.logos.light ? getVaultProtocolLogoUrl(protocolMetadata.slug) : undefined;
 		return logoPath ? new URL(logoPath, page.url.origin).href : undefined;
 	});
+	let statsVaults = $derived(
+		(topVaults?.vaults ?? []).filter(
+			(vault) => !isBlacklisted(vault) && (vault.current_nav ?? 0) <= VAULT_TVL_OUTLIER_THRESHOLD
+		)
+	);
+	let totalTvl = $derived(calculateTotalTvl(statsVaults));
+	let averageMonthlyReturn = $derived(calculateTvlWeightedApy(statsVaults.filter(isEligibleVaultGroupMiniChartVault)));
 </script>
 
 {#snippet unknownVaultSubtitle()}
@@ -75,6 +91,19 @@
 		If you want to see both Hyperliquid native vaults and HyperEVM vaults, visit
 		<a class="body-link" href={resolve('/vaults/chains/hyperliquid')}>Hyperliquid chain page</a>.
 	</p>
+{/snippet}
+
+{#snippet protocolDescriptionExtra()}
+	{#if averageMonthlyReturn != null}
+		<p>
+			{protocolName} has <strong>{formatDollar(totalTvl, 1)}</strong> TVL in
+			<strong>{statsVaults.length} {statsVaults.length === 1 ? 'vault' : 'vaults'}</strong> with the TVL-weighted
+			average monthly returns of <strong>{formatPercent(averageMonthlyReturn, 1)}</strong>.
+		</p>
+	{/if}
+	{#if isHyperliquidProtocolGroup}
+		{@render hyperliquidChainDescription()}
+	{/if}
 {/snippet}
 
 <MetaTags
@@ -119,7 +148,9 @@
 	{totalVaultCount}
 	{loading}
 	{protocolMetadata}
-	protocolDescriptionExtra={isHyperliquidProtocolGroup ? hyperliquidChainDescription : undefined}
+	protocolDescriptionExtra={averageMonthlyReturn != null || isHyperliquidProtocolGroup
+		? protocolDescriptionExtra
+		: undefined}
 	title={heroTitle}
 	subtitle={isUnknownVaultProtocolGroup ? unknownVaultSubtitle : undefined}
 	showFilters


### PR DESCRIPTION
## Why

Protocol detail pages should surface their key vault metrics without duplicating ApeX content across its synthetic chain and protocol pages.

## Lessons learnt

Synthetic perp DEX chain routes can represent the same product as a protocol route and should redirect when one page is canonical.

## Summary

- Add a TVL, vault-count, and TVL-weighted monthly-return summary to protocol descriptions.
- Place the summary before the expandable description control and emphasise its metrics.
- Redirect the ApeX chain page to the canonical ApeX protocol page.