### PR TITLE
feat: add Xerberus vault risk ratings

### DIFF
--- a/src/lib/top-vaults/TopVaultsTable.svelte
+++ b/src/lib/top-vaults/TopVaultsTable.svelte
@@ -131,6 +131,8 @@
 		generated_at: new Date().toISOString(),
 		vaults: [],
 		core3_protocols: {},
+		xerberus_protocols: {},
+		xerberus_stats: null,
 		curators: {}
 	};
 	const SKELETON_ROW_COUNT = 10;

--- a/src/lib/top-vaults/XerberusRisk.svelte
+++ b/src/lib/top-vaults/XerberusRisk.svelte
@@ -1,0 +1,192 @@
+<!--
+@component
+Displays the third-party Xerberus risk assessment for an individual vault.
+
+Xerberus may rate a vault pool directly or fall back to an assessment of its
+underlying protocol. This distinction is stated in the card so users do not
+mistake protocol coverage for a vault-specific assessment.
+
+@example
+
+```svelte
+  <XerberusRisk xerberus={vault.xerberus} />
+```
+-->
+<script lang="ts">
+	import MetricsBox from '$lib/components/MetricsBox.svelte';
+	import Tooltip from '$lib/components/Tooltip.svelte';
+	import { formatNumber } from '$lib/helpers/formatters';
+	import type { XerberusVault } from './schemas';
+	import IconQuestionCircle from '~icons/local/question-circle';
+
+	const XERBERUS_ICON_URL = 'https://app.xerberus.io/favicon.ico';
+
+	interface Props {
+		xerberus: XerberusVault;
+	}
+
+	let { xerberus }: Props = $props();
+	let isPoolAssessment = $derived(xerberus.entity_type === 'pool');
+	let assessmentLabel = $derived(isPoolAssessment ? 'Pool-level' : 'Protocol-level');
+</script>
+
+<MetricsBox class="xerberus-risk">
+	<div class="content">
+		<header class="box-header">
+			<img class="xerberus-icon" src={XERBERUS_ICON_URL} alt="Xerberus" />
+			<div class="score">{formatNumber(xerberus.score, 0, 0)}</div>
+			<h2>Xerberus risk rating</h2>
+		</header>
+
+		<table class="data">
+			<tbody>
+				<tr>
+					<th>
+						<Tooltip>
+							<span slot="trigger" class="metric-label">
+								Xerberus score
+								<IconQuestionCircle />
+							</span>
+							<svelte:fragment slot="popup">
+								The Xerberus assessment uses a 0–100 scale. Higher scores represent a stronger rating.
+							</svelte:fragment>
+						</Tooltip>
+					</th>
+					<td>{formatNumber(xerberus.score, 0, 0)} / 100</td>
+				</tr>
+				<tr>
+					<th>Assessment level</th>
+					<td>{assessmentLabel}</td>
+				</tr>
+				<tr>
+					<th>Rated entity</th>
+					<td>{xerberus.name}</td>
+				</tr>
+			</tbody>
+		</table>
+
+		<footer class="footer">
+			<p>This is Xerberus risk rating for the vault. Higher is better.</p>
+			{#if xerberus.report_url}
+				<!-- eslint-disable-next-line svelte/no-navigation-without-resolve -->
+				<a href={xerberus.report_url} target="_blank" rel="noreferrer">View full rating on the Xerberus website</a>
+			{/if}
+		</footer>
+	</div>
+</MetricsBox>
+
+<style>
+	.content {
+		display: grid;
+		gap: 1.25rem;
+	}
+
+	.box-header {
+		display: flex;
+		align-items: center;
+		gap: 0.875rem;
+
+		h2 {
+			margin: 0;
+			font: var(--f-ui-sm-bold);
+			font-size: 1rem;
+			letter-spacing: 0.06em;
+			text-transform: uppercase;
+			color: var(--c-text-light);
+
+			@media (--viewport-sm-down) {
+				font-size: 0.875rem;
+			}
+		}
+	}
+
+	.xerberus-icon {
+		width: 2.5rem;
+		height: 2.5rem;
+		border-radius: var(--radius-sm);
+		object-fit: contain;
+	}
+
+	.score {
+		display: grid;
+		place-items: center;
+		min-width: 3.25rem;
+		padding: 0.25rem 0.75rem;
+		border: 2px solid color-mix(in srgb, var(--c-link), transparent 55%);
+		border-radius: var(--radius-md);
+		background: color-mix(in srgb, var(--c-link), transparent 88%);
+		font: var(--f-heading-md-medium);
+		color: color-mix(in srgb, var(--c-text), var(--c-link) 80%);
+	}
+
+	.footer {
+		border-top: 1px solid var(--c-box-3);
+		padding-top: 1.25rem;
+		display: grid;
+		gap: 0.5rem;
+
+		p {
+			margin: 0;
+		}
+
+		a {
+			justify-self: start;
+		}
+	}
+
+	.footer p,
+	.footer a {
+		font: var(--f-ui-md-roman);
+		color: var(--c-text-extra-light);
+	}
+
+	.footer a {
+		text-decoration: underline;
+		font-weight: 500;
+		color: var(--c-text-light);
+	}
+
+	table.data {
+		width: 100%;
+		border-collapse: collapse;
+
+		tr {
+			border-top: 1px solid var(--c-box-3);
+
+			&:first-child {
+				border-top: none;
+			}
+		}
+
+		th,
+		td {
+			padding: 0.625rem 0;
+			font: var(--f-ui-md-roman);
+			text-align: left;
+		}
+
+		th {
+			color: var(--c-text-extra-light);
+			font-weight: normal;
+		}
+
+		td {
+			text-align: right;
+			color: var(--c-text-light);
+		}
+	}
+
+	.metric-label {
+		display: inline-flex;
+		align-items: center;
+		gap: 0.25rem;
+
+		:global(.icon) {
+			color: var(--c-text-extra-light);
+		}
+	}
+
+	:global(.xerberus-risk .tooltip .popup) {
+		max-width: 360px;
+	}
+</style>

--- a/src/lib/top-vaults/XerberusRisk.test.ts
+++ b/src/lib/top-vaults/XerberusRisk.test.ts
@@ -1,0 +1,55 @@
+import { cleanup, render, screen } from '@testing-library/svelte';
+import { afterEach, describe, expect, it } from 'vitest';
+import XerberusRisk from './XerberusRisk.svelte';
+
+afterEach(cleanup);
+
+const baseAssessment = {
+	score: 78,
+	score_scale: '0_100_higher_is_better',
+	entity_id: 'example-vault',
+	name: 'Example vault',
+	protocol_slug: null,
+	fetched_at: '2026-07-27T16:01:01.992171'
+};
+
+describe('XerberusRisk', () => {
+	it('renders direct pool assessments with their Xerberus report link', () => {
+		render(XerberusRisk, {
+			props: {
+				xerberus: {
+					...baseAssessment,
+					entity_type: 'pool',
+					report_url: 'https://app.xerberus.io/pool/dendrogram/example-vault'
+				}
+			}
+		});
+
+		expect(screen.getByRole('heading', { name: 'Xerberus risk rating' })).toBeInTheDocument();
+		expect(screen.getByAltText('Xerberus')).toHaveAttribute('src', 'https://app.xerberus.io/favicon.ico');
+		expect(screen.getByText('78 / 100')).toBeInTheDocument();
+		expect(screen.getByText('Pool-level')).toBeInTheDocument();
+		expect(screen.getByText('This is Xerberus risk rating for the vault. Higher is better.')).toBeInTheDocument();
+		expect(screen.getByRole('link', { name: 'View full rating on the Xerberus website' })).toHaveAttribute(
+			'href',
+			'https://app.xerberus.io/pool/dendrogram/example-vault'
+		);
+	});
+
+	it('explains when the assessment falls back to the underlying protocol', () => {
+		render(XerberusRisk, {
+			props: {
+				xerberus: {
+					...baseAssessment,
+					entity_type: 'protocol',
+					name: 'Example protocol',
+					protocol_slug: 'example',
+					report_url: null
+				}
+			}
+		});
+
+		expect(screen.getByText('Protocol-level')).toBeInTheDocument();
+		expect(screen.queryByRole('link', { name: 'View full rating on the Xerberus website' })).not.toBeInTheDocument();
+	});
+});

--- a/src/lib/top-vaults/inline-data.test.ts
+++ b/src/lib/top-vaults/inline-data.test.ts
@@ -7,6 +7,8 @@ describe('getInlineVaultListing', () => {
 		generated_at: '2026-07-24T00:00:00.000Z',
 		vaults: [createTestVault('Vault')],
 		core3_protocols: {},
+		xerberus_protocols: {},
+		xerberus_stats: null,
 		curators: {}
 	};
 

--- a/src/lib/top-vaults/schemas.test.ts
+++ b/src/lib/top-vaults/schemas.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { curatorInfoSchema, topVaultsSchema } from './schemas';
+import { createTestVault } from './test-utils';
 
 const validCurator = {
 	slug: 'steakhouse-financial',
@@ -53,5 +54,43 @@ describe('topVaultsSchema resilience', () => {
 		const result = curatorInfoSchema.parse(curator);
 		expect(result.recent_posts).toEqual([]);
 		expect(result.name).toBe('Steakhouse Financial');
+	});
+
+	it('preserves Xerberus protocol and per-vault assessments', () => {
+		const xerberus = {
+			score: 78,
+			score_scale: '0_100_higher_is_better',
+			entity_type: 'pool',
+			entity_id: 'lagoon-example-vault',
+			name: 'Example vault',
+			protocol_slug: null,
+			report_url: 'https://app.xerberus.io/pool/dendrogram/lagoon-example-vault',
+			fetched_at: '2026-07-27T16:01:01.992171'
+		};
+		const result = topVaultsSchema.parse({
+			...basePayload,
+			vaults: [createTestVault('Example vault', { xerberus })],
+			xerberus_protocols: {
+				example: {
+					protocol_slug: 'example',
+					entity_id: 'example-v1',
+					name: 'Example',
+					score: 78,
+					score_scale: '0_100_higher_is_better',
+					fetched_at: '2026-07-27T16:01:01.992171'
+				}
+			},
+			xerberus_stats: {
+				total_vaults: 1,
+				pool_matches: 1,
+				protocol_fallbacks: 0,
+				unmatched: 0,
+				coverage_pct: 100
+			}
+		});
+
+		expect(result.vaults[0].xerberus).toEqual(xerberus);
+		expect(result.xerberus_protocols.example?.score).toBe(78);
+		expect(result.xerberus_stats?.coverage_pct).toBe(100);
 	});
 });

--- a/src/lib/top-vaults/schemas.ts
+++ b/src/lib/top-vaults/schemas.ts
@@ -104,6 +104,33 @@ export const core3VaultSchema = z.object({
 export type Core3Vault = z.infer<typeof core3VaultSchema>;
 
 /**
+ * Xerberus risk assessment attached directly to a vault.
+ *
+ * `entity_type` distinguishes a direct pool assessment from a fallback
+ * protocol assessment. Xerberus scores are on a 0–100 scale where higher is
+ * better.
+ */
+export const xerberusVaultSchema = z.object({
+	/** Xerberus score on the scale described by `score_scale` */
+	score: z.number(),
+	/** Score interpretation supplied by Xerberus */
+	score_scale: z.string(),
+	/** Assessed entity level, currently `pool` or `protocol` */
+	entity_type: z.string(),
+	/** Xerberus's identifier for the assessed entity */
+	entity_id: z.string(),
+	/** Xerberus display name for the assessed entity */
+	name: z.string(),
+	/** Trading Strategy protocol slug; absent for direct pool matches */
+	protocol_slug: z.string().nullable(),
+	/** Direct Xerberus report URL, available for direct pool matches */
+	report_url: z.url().nullable(),
+	/** When the Xerberus record was fetched by the data pipeline */
+	fetched_at: isoDateTime
+});
+export type XerberusVault = z.infer<typeof xerberusVaultSchema>;
+
+/**
  * Latest exchange rate metadata for a vault denomination token.
  *
  * The backend attaches this to every vault as `denomination_token_rate`. For
@@ -409,7 +436,9 @@ export const vaultInfoSchema = z.object({
 	 * This duplicates the headline fields in `core3_protocols[protocol_slug]`
 	 * and is kept as a fallback for payloads where the top-level map changes.
 	 */
-	core3: core3VaultSchema.nullable().optional()
+	core3: core3VaultSchema.nullable().optional(),
+	/** Third-party Xerberus risk assessment, when the vault or its protocol is covered. */
+	xerberus: xerberusVaultSchema.nullable().optional()
 });
 export type VaultInfo = z.infer<typeof vaultInfoSchema>;
 
@@ -482,6 +511,33 @@ export const core3ProtocolSchema = z.object({
 	chains: z.object({ name: z.string() }).array().optional()
 });
 export type Core3Protocol = z.infer<typeof core3ProtocolSchema>;
+
+/**
+ * Xerberus protocol-level risk assessment, keyed by our protocol slug.
+ *
+ * This map is retained in the dataset for consumers that need the canonical
+ * protocol records. Vault pages use the compact `vault.xerberus` record so
+ * direct pool matches take precedence.
+ */
+export const xerberusProtocolSchema = z.object({
+	protocol_slug: z.string(),
+	entity_id: z.string(),
+	name: z.string(),
+	score: z.number(),
+	score_scale: z.string(),
+	fetched_at: isoDateTime
+});
+export type XerberusProtocol = z.infer<typeof xerberusProtocolSchema>;
+
+/** Coverage counters emitted alongside the Xerberus dataset. */
+export const xerberusStatsSchema = z.object({
+	total_vaults: z.int(),
+	pool_matches: z.int(),
+	protocol_fallbacks: z.int(),
+	unmatched: z.int(),
+	coverage_pct: z.number()
+});
+export type XerberusStats = z.infer<typeof xerberusStatsSchema>;
 
 /** Slim vault info with only the fields needed for listing/summary views (e.g., landing page). */
 export type SlimVaultInfo = Pick<
@@ -572,6 +628,22 @@ export const topVaultsSchema = z.object({
 		})
 		.catch({})
 		.default({}),
+	/**
+	 * Xerberus protocol risk assessments, keyed by protocol slug. The compact
+	 * per-vault record remains the source used on a vault detail page.
+	 */
+	xerberus_protocols: z
+		.record(z.string(), xerberusProtocolSchema.or(z.unknown().transform(() => null)))
+		.transform((records) => {
+			const entries = Object.entries(records).filter(
+				(entry): entry is [string, z.infer<typeof xerberusProtocolSchema>] => entry[1] !== null
+			);
+			return Object.fromEntries(entries);
+		})
+		.catch({})
+		.default({}),
+	/** Xerberus coverage counters, retained for aggregate consumers. */
+	xerberus_stats: xerberusStatsSchema.nullable().catch(null).default(null),
 	/**
 	 * Curator metadata keyed by curator slug; referenced by vault.curator_slug.
 	 * Partly built from external feeds — `.catch({})` guarantees a malformed

--- a/src/routes/vaults/[vault=slug]/+page.svelte
+++ b/src/routes/vaults/[vault=slug]/+page.svelte
@@ -20,6 +20,7 @@
 	import VaultProtocolInfo from './VaultProtocolInfo.svelte';
 	import VaultRankings from './VaultRankings.svelte';
 	import Core3Ratings from '$lib/top-vaults/Core3Ratings.svelte';
+	import XerberusRisk from '$lib/top-vaults/XerberusRisk.svelte';
 	import IconDiscord from '~icons/local/discord';
 	import {
 		getMorphoFlags,
@@ -140,6 +141,10 @@
 		{/if}
 
 		<VaultPeriodicMetrics {vault} {chain} />
+
+		{#if vault.xerberus}
+			<XerberusRisk xerberus={vault.xerberus} />
+		{/if}
 
 		{#if core3}
 			<Core3Ratings

--- a/src/routes/vaults/[vault=slug]/VaultMetrics.svelte
+++ b/src/routes/vaults/[vault=slug]/VaultMetrics.svelte
@@ -447,6 +447,10 @@ Displays supplementary vault information, including transaction status, performa
 			flex-wrap: wrap;
 			justify-content: space-between;
 			gap: var(--gap);
+
+			@media (--viewport-sm-down) {
+				justify-content: flex-start;
+			}
 		}
 
 		.vault-metrics-table {


### PR DESCRIPTION
## Why

Surface the Xerberus ratings already included in the production vault dataset, so users can assess covered vaults alongside CORE3 data.

## Lessons learnt

Xerberus can supply a direct pool match or a protocol fallback. The per-vault record is therefore the authoritative display source, and direct pool report links must remain optional.

## Summary

- Parse Xerberus protocol, coverage and per-vault assessment data.
- Show a Xerberus risk card above CORE3 for covered vaults.
- Add the official Xerberus icon, direct report link and component/schema tests.
- Left-align Other metrics on mobile.