### PR TITLE
fix: warn on dusty position metrics

### DIFF
--- a/src/lib/trade-executor/models/position-info.test.ts
+++ b/src/lib/trade-executor/models/position-info.test.ts
@@ -5,6 +5,7 @@ import { tradingPositionSchema } from '../schemas/position';
 import { createTradingPositionInfo } from './position-info';
 
 type TradeExecutionInput = z.input<typeof tradeExecutionSchema>;
+type PositionStatisticsInput = z.input<typeof positionStatisticsSchema>;
 type PositionInput = z.input<typeof tradingPositionSchema>;
 
 const POSITION_OPEN_TS = 1735689600;
@@ -77,6 +78,18 @@ const stats = [
 	}
 ].map((s) => positionStatisticsSchema.parse(s));
 
+function positionStat(stat: Partial<PositionStatisticsInput> = {}) {
+	return positionStatisticsSchema.parse({
+		calculated_at: POSITION_OPEN_TS + HOUR,
+		last_valuation_at: POSITION_OPEN_TS + HOUR,
+		profitability: 0,
+		profit_usd: 0,
+		quantity: 100,
+		value: 100,
+		...stat
+	});
+}
+
 describe('TradingPositionInfo object with no stats', () => {
 	const position = tradingPositionSchema.parse(rawPosition);
 	const positionInfo = createTradingPositionInfo(position);
@@ -136,6 +149,64 @@ describe('closed position with stats entries', () => {
 		spy.mockImplementationOnce(() => 234.56);
 		expect(positionInfo.valueAtClose).toEqual(234.56);
 		expect(spy).toHaveBeenCalledOnce();
+	});
+});
+
+describe('dust position warning', () => {
+	test('detects an explicit dust note', () => {
+		const position = tradingPositionSchema.parse({
+			...rawPosition,
+			notes: 'Auto-closed as dust by correct-accounts (equity=$0.0106)'
+		});
+
+		expect(createTradingPositionInfo(position).isDustPositionWarning).toBe(true);
+	});
+
+	test('detects a tiny residual quantity in final stats', () => {
+		const position = tradingPositionSchema.parse({
+			...rawPosition,
+			closed_at: POSITION_OPEN_TS + 3 * HOUR,
+			last_token_price: 0.95
+		});
+		const residualStats = [
+			positionStat({
+				calculated_at: POSITION_OPEN_TS + 2 * HOUR,
+				last_valuation_at: POSITION_OPEN_TS + 2 * HOUR,
+				quantity: 1334,
+				value: 1272
+			}),
+			positionStat({
+				calculated_at: POSITION_OPEN_TS + 4 * HOUR,
+				last_valuation_at: POSITION_OPEN_TS + 4 * HOUR,
+				quantity: 1.0023875,
+				value: 0
+			})
+		];
+
+		expect(createTradingPositionInfo(position, residualStats).isDustPositionWarning).toBe(true);
+	});
+
+	test('does not flag a normal fully closed zero-quantity position', () => {
+		const position = tradingPositionSchema.parse({
+			...rawPosition,
+			closed_at: POSITION_OPEN_TS + 3 * HOUR
+		});
+		const closedStats = [
+			positionStat({
+				calculated_at: POSITION_OPEN_TS + 2 * HOUR,
+				last_valuation_at: POSITION_OPEN_TS + 2 * HOUR,
+				quantity: 100,
+				value: 100
+			}),
+			positionStat({
+				calculated_at: POSITION_OPEN_TS + 4 * HOUR,
+				last_valuation_at: POSITION_OPEN_TS + 4 * HOUR,
+				quantity: 0,
+				value: 0
+			})
+		];
+
+		expect(createTradingPositionInfo(position, closedStats).isDustPositionWarning).toBe(false);
 	});
 });
 

--- a/src/lib/trade-executor/models/position-info.ts
+++ b/src/lib/trade-executor/models/position-info.ts
@@ -13,6 +13,9 @@ import type { TimeBucket } from '$lib/schemas/utility';
 import { type TradeDirection, TradeDirections } from './trade-info';
 import { isNumber } from '$lib/helpers/formatters';
 
+const DUST_POSITION_VALUE_THRESHOLD_USD = 2;
+const MIN_RESIDUAL_QUANTITY = 1e-12;
+
 export const createTradingPositionInfo = <T extends TradingPosition>(base: T, stats: PositionStatistics[] = []) => ({
 	...base,
 
@@ -133,6 +136,43 @@ export const createTradingPositionInfo = <T extends TradingPosition>(base: T, st
 	 */
 	get valueAtPeak() {
 		return Math.max(...this.stats.map((s) => s.value));
+	},
+
+	get hasDustNote() {
+		const hasPositionDustNote = /dust/i.test(this.notes ?? '');
+		const hasTradeDustNote = this.trades.some((trade) => /dust/i.test(trade.notes ?? ''));
+		return hasPositionDustNote || hasTradeDustNote;
+	},
+
+	get latestQuantity() {
+		return this.latestStats?.quantity;
+	},
+
+	get latestRecordedValue() {
+		return this.latestStats?.value;
+	},
+
+	get latestNominalValue() {
+		if (isNumber(this.latestQuantity) && isNumber(this.last_token_price)) {
+			return Math.abs(this.latestQuantity * this.last_token_price);
+		}
+	},
+
+	get hasResidualQuantity() {
+		return isNumber(this.latestQuantity) && Math.abs(this.latestQuantity) > MIN_RESIDUAL_QUANTITY;
+	},
+
+	get isDustPositionWarning() {
+		if (this.hasDustNote) return true;
+		if (!this.hasResidualQuantity) return false;
+
+		const latestRecordedValue = isNumber(this.latestRecordedValue) ? Math.abs(this.latestRecordedValue) : undefined;
+		const latestNominalValue = this.latestNominalValue;
+
+		return (
+			(isNumber(latestRecordedValue) && latestRecordedValue <= DUST_POSITION_VALUE_THRESHOLD_USD) ||
+			(isNumber(latestNominalValue) && latestNominalValue <= DUST_POSITION_VALUE_THRESHOLD_USD)
+		);
 	},
 
 	get quantityAtOpen() {

--- a/src/routes/strategies/[strategy=apiStrategy]/[status=positionStatus]-positions/[position=integer]/+page.svelte
+++ b/src/routes/strategies/[strategy=apiStrategy]/[status=positionStatus]-positions/[position=integer]/+page.svelte
@@ -67,6 +67,12 @@
 				</div>
 			</svelte:fragment>
 		</PageHeading>
+
+		{#if position.isDustPositionWarning}
+			<div class="dust-position-warning">
+				<Alert size="sm" status="warning">The metrics might be off because the position is too small (dusty).</Alert>
+			</div>
+		{/if}
 	</Section>
 
 	<Section class={position.failedOpen || position.frozen ? 'has-error' : ''}>
@@ -168,6 +174,10 @@
 			flex-wrap: wrap;
 			gap: 0.75rem;
 			justify-content: flex-end;
+		}
+
+		.dust-position-warning {
+			margin-top: var(--space-lg);
 		}
 	}
 </style>

--- a/src/routes/strategies/[strategy=apiStrategy]/[status=positionStatus]-positions/[position=integer]/TradeTable.svelte
+++ b/src/routes/strategies/[strategy=apiStrategy]/[status=positionStatus]-positions/[position=integer]/TradeTable.svelte
@@ -71,7 +71,7 @@
 </script>
 
 <section class="trade-table">
-	<h2>Trades</h2>
+	<h2>Rebalances</h2>
 	<DataTable {tableViewModel} targetableRows size="sm" />
 </section>
 


### PR DESCRIPTION
**Why**

Dust residuals can make closed position metrics look economically meaningful even when the remaining balance is too small to claim or trade. Position pages need to warn users when metrics may be distorted by this state.

**Lessons learnt**

Closed positions can end with a non-zero residual quantity and near-zero recorded value without an explicit close trade flag, so the frontend needs a generic residual-value dust signal in addition to explicit dust notes.

**Summary**

- Add a dust warning predicate to enriched trading positions.
- Show a warning alert below the position page heading when the position looks dusty.
- Rename the position trade table heading from Trades to Rebalances.
