### PR TITLE
fix: sort ApeX vaults by TVL by default

### DIFF
--- a/src/routes/vaults/protocols/[protocol=slug]/+page.svelte
+++ b/src/routes/vaults/protocols/[protocol=slug]/+page.svelte
@@ -156,6 +156,8 @@
 	showFilters
 	showUnknownFilter={false}
 	{defaultTvlKey}
+	defaultSort={data.protocolSlug === 'apex' ? 'tvl' : undefined}
+	defaultDirection={data.protocolSlug === 'apex' ? 'desc' : undefined}
 	defaultHideUnknown={isUnknownVaultProtocolGroup ? 0 : 1}
 >
 	{#snippet detailAside()}

--- a/tests/integration/vaults/protocol-detail.test.ts
+++ b/tests/integration/vaults/protocol-detail.test.ts
@@ -1,0 +1,13 @@
+import { expect, test } from '@playwright/test';
+
+test.describe('vault protocol detail pages', () => {
+	test('sorts ApeX vaults by TVL by default', async ({ page }) => {
+		await page.goto('/vaults/protocols/apex');
+
+		const rows = page.locator('tbody tr.targetable');
+		await expect(rows).toHaveCount(2);
+		await expect(rows.first()).toContainText('ApeX high TVL vault');
+		await expect(rows.nth(1)).toContainText('ApeX high return vault');
+		await expect(page.locator('thead th.tvl svg')).toBeVisible();
+	});
+});

--- a/tests/mocks/top-vaults/list.mock.ts
+++ b/tests/mocks/top-vaults/list.mock.ts
@@ -242,6 +242,27 @@ const limitedCoverageVault = createTestVault('Limited coverage vault', {
 	]
 });
 
+const apexVaults = [
+	createTestVault('ApeX high TVL vault', {
+		address: '0x1000000000000000000000000000000000000001',
+		chain: 'apex',
+		protocol: 'ApeX',
+		current_nav: 9_000,
+		peak_nav: 10_000,
+		one_month_cagr: 0.01,
+		three_months_cagr: 0.01
+	}),
+	createTestVault('ApeX high return vault', {
+		address: '0x1000000000000000000000000000000000000002',
+		chain: 'apex',
+		protocol: 'ApeX',
+		current_nav: 1_000,
+		peak_nav: 1_500,
+		one_month_cagr: 0.5,
+		three_months_cagr: 0.5
+	})
+];
+
 // Named vault for YAML strategy integration tests
 const yamlStrategyVault = createTestVault('Trading Strategy ICHIv3 LS 2', {
 	address: '0x1234567890abcdef1234567890abcdef12345678',
@@ -520,6 +541,7 @@ export default defineMock({
 			redemptionDisabledVault,
 			depositAndRedemptionDisabledVault,
 			limitedCoverageVault,
+			...apexVaults,
 			...parquetMatchedVaults,
 			...returnLeaders,
 			...belowTvl,


### PR DESCRIPTION
## Why
ApeX vaults do not have enough return history for the normal return-based default sort to produce the most useful ordering. The protocol detail page should match the TVL-sorted URL behaviour by showing the largest ApeX vaults first by default.

## Lessons learnt
The ApeX protocol page already overrides the default TVL filter because these vaults can sit below the usual listing threshold. Keeping the sort override on the same route keeps this exception local to ApeX and avoids changing the shared vault table defaults.

## Summary
- Default the ApeX protocol vault listing to TVL descending.
- Add deterministic ApeX mock vaults with different TVL and return values.
- Add an integration regression test for the default ApeX row order.