### PR TITLE
Fix mobile vault chart and listing layouts

### DIFF
--- a/src/lib/charts/TvChart.svelte
+++ b/src/lib/charts/TvChart.svelte
@@ -296,6 +296,7 @@
 		contain: size;
 		display: grid;
 		width: 100%;
+		min-width: 0;
 		height: var(--chart-height);
 		aspect-ratio: var(--chart-aspect-ratio);
 		font: var(--f-ui-sm-roman);

--- a/src/lib/top-vaults/VaultGroupTable.svelte
+++ b/src/lib/top-vaults/VaultGroupTable.svelte
@@ -341,6 +341,7 @@
 			:global(table.datatable.responsive tbody tr td.name) {
 				grid-column: 1 / -1;
 				align-items: center;
+				box-sizing: border-box;
 				min-height: 2.5rem;
 				padding-inline: calc(2.5rem + 0.5rem + 2.5rem + 1.5rem) 2.25rem;
 				font: var(--f-ui-lg-bold);
@@ -401,6 +402,10 @@
 				display: none;
 			}
 
+			:global(table.datatable.responsive tbody tr td.full_name) {
+				display: none;
+			}
+
 			:global(table.datatable.responsive tbody tr td:not(.cta)::before) {
 				flex: none;
 				font: inherit;
@@ -409,6 +414,17 @@
 
 			:global(table.datatable.responsive tbody tr td.vault_count) {
 				grid-column: 2;
+				grid-row: 2;
+			}
+
+			:global(table.datatable.responsive tbody tr td.avg_apy) {
+				grid-column: 3;
+				grid-row: 2;
+			}
+
+			:global(table.datatable.responsive tbody tr td.tvl) {
+				grid-column: 2 / -1;
+				grid-row: 3;
 			}
 
 			:global(table.datatable.responsive tbody tr td.vault_count::before) {
@@ -416,17 +432,13 @@
 				order: 2;
 			}
 
-			:global(table.datatable.responsive tbody tr td.avg_apy) {
-				grid-column: 3;
-			}
-
-			:global(table.datatable.responsive tbody tr td.tvl) {
-				grid-column: 4;
-			}
-
 			:global(table.datatable.responsive tbody tr td.avg_apy::before),
 			:global(table.datatable.responsive tbody tr td.tvl::before) {
 				content: '·';
+			}
+
+			:global(table.datatable.responsive tbody tr td.tvl::before) {
+				content: none;
 			}
 
 			:global(table.datatable.responsive tbody tr td.avg_apy::after) {
@@ -460,6 +472,22 @@
 
 				:global(table.datatable.responsive tbody tr td.tvl::before) {
 					display: none;
+				}
+			}
+
+			@media (width < 360px) {
+				:global(table.datatable.responsive tbody tr td.avg_apy) {
+					grid-column: 2 / -1;
+					grid-row: 3;
+				}
+
+				:global(table.datatable.responsive tbody tr td.avg_apy::before) {
+					content: none;
+				}
+
+				:global(table.datatable.responsive tbody tr td.tvl) {
+					grid-column: 2 / -1;
+					grid-row: 4;
 				}
 			}
 		}

--- a/src/routes/vaults/[vault=slug]/ChartWithFeaturedMetrics.svelte
+++ b/src/routes/vaults/[vault=slug]/ChartWithFeaturedMetrics.svelte
@@ -120,8 +120,13 @@ amounts in the denomination's native currency.
 <style>
 	.chart-area {
 		display: grid;
-		grid-template-columns: 1fr auto auto;
+		grid-template-columns: minmax(0, 1fr) auto auto;
 		gap: 1.75rem;
+		min-width: 0;
+
+		:global(.vault-price-chart) {
+			min-width: 0;
+		}
 
 		.divider {
 			width: 2px;
@@ -172,7 +177,7 @@ amounts in the denomination's native currency.
 		}
 
 		@media (--viewport-md-down) {
-			grid-template-columns: auto;
+			grid-template-columns: minmax(0, 1fr);
 
 			.divider {
 				display: none;
@@ -181,6 +186,7 @@ amounts in the denomination's native currency.
 			.featured-metrics {
 				grid-row: 1;
 				display: flex;
+				min-width: 0;
 				justify-content: space-between;
 			}
 		}


### PR DESCRIPTION
## Why

Mobile vault pages could render chart/listing content wider than the viewport during Svelte client-side navigation and on small iPhone screens. This caused the vault chart area and stablecoin listing cards to clip or overlap text.

## Lessons learnt

Responsive table card layouts need explicit min-width and grid-track constraints for Safari-sized viewports. Hidden desktop-only columns should be hidden inside the responsive table rules so they cannot reappear as labelled mobile cells.

## Summary

- Constrained the shared TradingView chart root and vault chart grid tracks so chart areas shrink within mobile containers.
- Reworked mobile vault group rows to hide the full-name column, keep TVL on its own line, and stack metrics below 360px.
- Verified the affected vault detail and stablecoin listing layouts locally with Playwright at small mobile widths.