### PR TITLE
Fix stablecoin pie chart labels

### DIFF
--- a/src/routes/vaults/stablecoins/+page.svelte
+++ b/src/routes/vaults/stablecoins/+page.svelte
@@ -90,6 +90,7 @@
 							items={chartStablecoins}
 							groupLabel="Stablecoin"
 							groupLabelPlural="stablecoins"
+							showLabelLogos
 							testId="stablecoin-tvl-pie-chart"
 						/>
 					</MarketShareWidgetBox>


### PR DESCRIPTION
## Why

The stablecoin market-share chart already has stablecoin logo URLs, but did not enable the shared label-logo rendering used by other vault grouping charts.

## Lessons learnt

The shared pie chart keeps labels text-only on mobile because logo images reduce the available space and cause label collisions. Individual pages can opt into logo labels for desktop without affecting that mobile safeguard.

## Summary

- Enabled logo labels for standalone stablecoin slices in the stablecoin market-share pie chart.