### PR TITLE
Fix chain pie chart labels

### DIFF
--- a/src/routes/vaults/chains/+page.svelte
+++ b/src/routes/vaults/chains/+page.svelte
@@ -98,6 +98,8 @@
 							groupLabel="Chain"
 							groupLabelPlural="chains"
 							showLabelLogos
+							otherThreshold={0}
+							maxIndividualSlices={5}
 							testId="chain-tvl-pie-chart"
 						/>
 					</MarketShareWidgetBox>

--- a/src/routes/vaults/chains/+page.svelte
+++ b/src/routes/vaults/chains/+page.svelte
@@ -97,6 +97,7 @@
 							items={chartChains}
 							groupLabel="Chain"
 							groupLabelPlural="chains"
+							showLabelLogos
 							testId="chain-tvl-pie-chart"
 						/>
 					</MarketShareWidgetBox>


### PR DESCRIPTION
## Why

The chains market-share chart already supplies blockchain logo URLs, but did not enable the shared desktop label-logo rendering used by other vault grouping charts. It also grouped the fifth-largest chain into Other despite there being room for one more named item.

## Lessons learnt

The shared pie chart keeps labels text-only on mobile because logo images reduce the available space and can cause label collisions. A page-level zero threshold combined with a standalone-slice cap produces a predictable named breakdown without changing the shared mobile safeguard.

## Summary

- Enabled logo labels for standalone chain slices in the chains market-share pie chart.
- Shows five named chains plus Other, for six pie items in total.