### PR TITLE
feat: add vault risk rating listings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Weblog of stuff
 
 - Restore site-wide vault search with server-side vault JSON indexing, typeahead and responsive result listings, replacing the retired external integration (2026-07-30)
+- Add CORE3 and Xerberus risk-rating vault lists, per-vault Xerberus report links, and reordered footer social links (2026-07-30)
 - Rank strategy vaults by displayed annual return within green and red chart groups, and clarify the strategy listing description (2026-07-28)
 - Add ApeX perpetual futures DEX support — chain logo and entry, perp DEX detection, "Any" default TVL filter on the protocol page, and perp DEX wording in chain descriptions (2026-07-25)
 - Add tokenised fund listings, NAV market-share chart, and fund-specific vault detail messaging (2026-07-17)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Weblog of stuff
 
 - Restore site-wide vault search with server-side vault JSON indexing, typeahead and responsive result listings, replacing the retired external integration (2026-07-30)
-- Add CORE3 and Xerberus risk-rating vault lists, per-vault Xerberus report links, and reordered footer social links (2026-07-30)
+- Add CORE3 and Xerberus risk-rating vault lists, per-vault Xerberus report links, and a YouTube footer link with reordered social icons (2026-07-30)
 - Rank strategy vaults by displayed annual return within green and red chart groups, and clarify the strategy listing description (2026-07-28)
 - Add ApeX perpetual futures DEX support — chain logo and entry, perp DEX detection, "Any" default TVL filter on the protocol page, and perp DEX wording in chain descriptions (2026-07-25)
 - Add tokenised fund listings, NAV market-share chart, and fund-specific vault detail messaging (2026-07-17)

--- a/src/lib/components/Footer.svelte
+++ b/src/lib/components/Footer.svelte
@@ -1,4 +1,11 @@
+<!--
+@component
+Displays the site footer with social links and the Trading Strategy disclaimer.
+
+Set `small` to use the compact spacing variant.
+-->
 <script>
+	import { resolve } from '$app/paths';
 	import { Tooltip } from '$lib/components';
 	import { discordUrl } from '$lib/config';
 	import IconGithub from '~icons/local/github';
@@ -6,6 +13,7 @@
 	import IconTelegram from '~icons/local/telegram';
 	import IconTwitter from '~icons/local/twitter';
 	import IconLinkedin from '~icons/local/linkedin';
+	import IconYoutube from '~icons/local/youtube';
 	import IconRss from '~icons/local/rss';
 
 	export let small = false;
@@ -14,30 +22,6 @@
 <footer>
 	<div class="social-links" class:small>
 		<div class="link-group">
-			<Tooltip>
-				<a
-					slot="trigger"
-					href="https://github.com/tradingstrategy-ai"
-					aria-label="GitHub"
-					target="_blank"
-					rel="noreferrer"
-				>
-					<IconGithub />
-				</a>
-				<div slot="popup">GitHub</div>
-			</Tooltip>
-			<Tooltip>
-				<a slot="trigger" href={discordUrl} aria-label="Discord" target="_blank" rel="noreferrer">
-					<IconDiscord />
-				</a>
-				<div slot="popup">Discord</div>
-			</Tooltip>
-			<Tooltip>
-				<a slot="trigger" href="https://t.me/trading_protocol" aria-label="Telegram" target="_blank" rel="noreferrer">
-					<IconTelegram />
-				</a>
-				<div slot="popup">Telegram</div>
-			</Tooltip>
 			<Tooltip>
 				<a
 					slot="trigger"
@@ -50,9 +34,6 @@
 				</a>
 				<div slot="popup">Twitter</div>
 			</Tooltip>
-		</div>
-
-		<div class="link-group">
 			<Tooltip>
 				<a
 					slot="trigger"
@@ -66,10 +47,47 @@
 				<div slot="popup">LinkedIn</div>
 			</Tooltip>
 			<Tooltip>
-				<a slot="trigger" href="/blog/rss.xml" aria-label="RSS" target="_blank">
+				<a slot="trigger" href="https://t.me/trading_protocol" aria-label="Telegram" target="_blank" rel="noreferrer">
+					<IconTelegram />
+				</a>
+				<div slot="popup">Telegram</div>
+			</Tooltip>
+			<Tooltip>
+				<a
+					slot="trigger"
+					href="https://www.youtube.com/channel/UCXBQRclPxMY40n52-k3VhYQ"
+					aria-label="YouTube"
+					target="_blank"
+					rel="noreferrer"
+				>
+					<IconYoutube />
+				</a>
+				<div slot="popup">YouTube</div>
+			</Tooltip>
+			<Tooltip>
+				<a slot="trigger" href={resolve('/blog/rss.xml')} aria-label="RSS" target="_blank">
 					<IconRss />
 				</a>
 				<div slot="popup">RSS</div>
+			</Tooltip>
+			<Tooltip>
+				<a
+					slot="trigger"
+					href="https://github.com/tradingstrategy-ai"
+					aria-label="GitHub"
+					target="_blank"
+					rel="noreferrer"
+				>
+					<IconGithub />
+				</a>
+				<div slot="popup">GitHub</div>
+			</Tooltip>
+			<Tooltip>
+				<!-- eslint-disable-next-line svelte/no-navigation-without-resolve -->
+				<a slot="trigger" href={discordUrl} aria-label="Discord" target="_blank" rel="noreferrer">
+					<IconDiscord />
+				</a>
+				<div slot="popup">Discord</div>
 			</Tooltip>
 		</div>
 	</div>

--- a/src/lib/components/Footer.svelte
+++ b/src/lib/components/Footer.svelte
@@ -4,7 +4,7 @@ Displays the site footer with social links and the Trading Strategy disclaimer.
 
 Set `small` to use the compact spacing variant.
 -->
-<script>
+<script lang="ts">
 	import { resolve } from '$app/paths';
 	import { Tooltip } from '$lib/components';
 	import { discordUrl } from '$lib/config';
@@ -16,7 +16,7 @@ Set `small` to use the compact spacing variant.
 	import IconYoutube from '~icons/local/youtube';
 	import IconRss from '~icons/local/rss';
 
-	export let small = false;
+	let { small = false }: { small?: boolean } = $props();
 </script>
 
 <footer>

--- a/src/lib/top-vaults/RiskRatingsPage.svelte
+++ b/src/lib/top-vaults/RiskRatingsPage.svelte
@@ -1,0 +1,122 @@
+<!--
+@component
+Displays every vault with a score from one third-party risk-rating provider.
+
+The list defaults to the provider's safest-first score direction and exposes
+the score in a column beside each vault name.
+
+@example
+
+```svelte
+  <RiskRatingsPage provider="core3" />
+```
+-->
+<script lang="ts">
+	import { resolve } from '$app/paths';
+	import { page } from '$app/state';
+	import { MetaTags, JsonLd } from 'svelte-meta-tags';
+	import { fetchAllVaultData, hasVaultCache } from './client-cache';
+	import { getCore3PolForVault } from './helpers';
+	import { riskRatingProviders, type RiskRatingProvider } from './risk-rating-providers';
+	import type { TopVaults, VaultInfo } from './schemas';
+	import TopVaultsPage from './TopVaultsPage.svelte';
+
+	interface Props {
+		provider: RiskRatingProvider;
+	}
+
+	let { provider }: Props = $props();
+	let topVaults = $state<TopVaults>();
+	let loading = $state(!hasVaultCache(page.data.generatedAt));
+	let providerDetails = $derived(riskRatingProviders[provider]);
+	let metadataDescription = $derived(`Compare DeFi stablecoin vaults by ${providerDetails.name} risk rating.`);
+	let pageUrl = $derived(new URL(page.url.pathname, page.url.origin).href);
+	let ratedTopVaults = $derived(
+		topVaults
+			? {
+					...topVaults,
+					vaults: topVaults.vaults.filter((vault) => hasProviderScore(vault, topVaults, provider))
+				}
+			: undefined
+	);
+
+	function hasProviderScore(vault: VaultInfo, vaultData: TopVaults, ratingProvider: RiskRatingProvider): boolean {
+		if (ratingProvider === 'xerberus') return vault.xerberus?.score != null;
+		return getCore3PolForVault(vault, vaultData.core3_protocols)?.score != null;
+	}
+
+	$effect(() => {
+		fetchAllVaultData(page.data.generatedAt)
+			.then((data) => (topVaults = data))
+			.catch((error) => console.error(`Failed to load ${providerDetails.name} ratings:`, error))
+			.finally(() => (loading = false));
+	});
+</script>
+
+<MetaTags
+	title={providerDetails.pageTitle}
+	description={metadataDescription}
+	canonical={pageUrl}
+	openGraph={{
+		siteName: 'Trading Strategy',
+		url: pageUrl,
+		title: providerDetails.pageTitle,
+		description: metadataDescription,
+		images: [{ url: providerDetails.logoUrl, alt: providerDetails.logoAlt }],
+		type: 'website'
+	}}
+	twitter={{
+		site: '@TradingProtocol',
+		cardType: 'summary',
+		title: providerDetails.pageTitle,
+		description: metadataDescription,
+		image: providerDetails.logoUrl
+	}}
+/>
+
+<JsonLd
+	schema={{
+		'@context': 'http://schema.org',
+		'@type': 'CollectionPage',
+		name: providerDetails.pageTitle,
+		description: metadataDescription,
+		url: pageUrl,
+		image: providerDetails.logoUrl,
+		provider: { '@type': 'Organization', name: 'Trading Strategy' },
+		mainEntity: {
+			'@type': 'ItemList',
+			numberOfItems: ratedTopVaults?.vaults.length ?? 0
+		}
+	}}
+/>
+
+<TopVaultsPage
+	topVaults={ratedTopVaults}
+	{loading}
+	includeBlacklisted
+	title={providerDetails.pageTitle}
+	headingLogo={{ src: providerDetails.logoUrl, alt: providerDetails.logoAlt }}
+	ratingProvider={provider}
+	defaultSort="provider_risk_rating"
+	defaultDirection={providerDetails.defaultDirection}
+>
+	{#snippet subtitle()}
+		{#if provider === 'core3'}
+			<!-- eslint-disable-next-line svelte/no-navigation-without-resolve -->
+			<a href={providerDetails.website} target="_blank" rel="noreferrer">CORE3</a> publishes Probability of Loss ratings
+			for DeFi protocols. Lower scores indicate lower estimated risk.
+			<a href={resolve('/vaults/core3-risk')}>See also CORE3 charts</a>.
+		{:else}
+			<!-- eslint-disable-next-line svelte/no-navigation-without-resolve -->
+			<a href={providerDetails.website} target="_blank" rel="noreferrer">Xerberus</a> provides independent risk ratings for
+			DeFi vaults and protocols. Higher scores indicate stronger ratings.
+		{/if}
+	{/snippet}
+</TopVaultsPage>
+
+<style>
+	:global(.hero-banner .subtitle a) {
+		text-decoration: underline;
+		text-underline-offset: 0.15em;
+	}
+</style>

--- a/src/lib/top-vaults/RiskRatingsPage.svelte
+++ b/src/lib/top-vaults/RiskRatingsPage.svelte
@@ -31,18 +31,20 @@ the score in a column beside each vault name.
 	let providerDetails = $derived(riskRatingProviders[provider]);
 	let metadataDescription = $derived(`Compare DeFi stablecoin vaults by ${providerDetails.name} risk rating.`);
 	let pageUrl = $derived(new URL(page.url.pathname, page.url.origin).href);
-	let ratedTopVaults = $derived(
-		topVaults
-			? {
-					...topVaults,
-					vaults: topVaults.vaults.filter((vault) => hasProviderScore(vault, topVaults, provider))
-				}
-			: undefined
-	);
+	let ratedTopVaults = $derived.by(() => {
+		const vaultData = topVaults;
+		if (!vaultData) return undefined;
 
-	function hasProviderScore(vault: VaultInfo, vaultData: TopVaults, ratingProvider: RiskRatingProvider): boolean {
+		return {
+			...vaultData,
+			vaults: vaultData.vaults.filter((vault) => hasProviderRating(vault, vaultData, provider))
+		};
+	});
+
+	function hasProviderRating(vault: VaultInfo, vaultData: TopVaults, ratingProvider: RiskRatingProvider): boolean {
 		if (ratingProvider === 'xerberus') return vault.xerberus?.score != null;
-		return getCore3PolForVault(vault, vaultData.core3_protocols)?.score != null;
+		const core3 = getCore3PolForVault(vault, vaultData.core3_protocols);
+		return core3?.score != null && core3.rating != null;
 	}
 
 	$effect(() => {

--- a/src/lib/top-vaults/RiskRatingsPage.svelte
+++ b/src/lib/top-vaults/RiskRatingsPage.svelte
@@ -96,6 +96,8 @@ the score in a column beside each vault name.
 	topVaults={ratedTopVaults}
 	{loading}
 	includeBlacklisted
+	tvlTriggerLabel="All TVL"
+	tvlTooltip="This list includes all vaults with a rating from this provider, regardless of TVL."
 	title={providerDetails.pageTitle}
 	headingLogo={{ src: providerDetails.logoUrl, alt: providerDetails.logoAlt }}
 	ratingProvider={provider}

--- a/src/lib/top-vaults/TopVaultsPage.svelte
+++ b/src/lib/top-vaults/TopVaultsPage.svelte
@@ -1,7 +1,14 @@
+<!--
+@component
+Composes a vault-listing page with its heading, navigation, metadata cards, and table.
+
+Use `ratingProvider` to show a provider-specific risk rating column.
+-->
 <script lang="ts">
 	import type { Snippet } from 'svelte';
 	import type { Chain } from '$lib/helpers/chain';
 	import type { TopVaults } from './schemas';
+	import type { RiskRatingProvider } from './risk-rating-providers';
 	import type { VaultProtocolMetadata } from '$lib/vault-protocol/schemas';
 	import type { StablecoinMetadata } from '$lib/stablecoin-metadata/schemas';
 	import type { CuratorInfo } from './schemas';
@@ -73,6 +80,10 @@
 		maxSummaryTvlUsd?: number;
 		/** Do not visually strike through blacklisted vault rows. */
 		disableBlacklistedStrikethrough?: boolean;
+		/** Optional logo shown in the page heading. */
+		headingLogo?: { src: string; alt: string };
+		/** Show a third-party risk rating column beside the vault name. */
+		ratingProvider?: RiskRatingProvider;
 	}
 
 	let {
@@ -106,7 +117,9 @@
 		totalVaultCount,
 		includeBlacklistedInStats,
 		maxSummaryTvlUsd,
-		disableBlacklistedStrikethrough
+		disableBlacklistedStrikethrough,
+		headingLogo,
+		ratingProvider
 	}: Props = $props();
 
 	let renderDetailAsideInHero = $derived(
@@ -129,6 +142,9 @@
 				<HeroBanner {subtitle}>
 					{#snippet title()}
 						<span class="page-title">
+							{#if headingLogo}
+								<img src={headingLogo.src} alt={headingLogo.alt} />
+							{/if}
 							{#if chain}
 								<img src={getLogoUrl('blockchain', chain.slug)} alt={chain.name} />
 							{/if}
@@ -237,6 +253,7 @@
 					{includeBlacklistedInStats}
 					{maxSummaryTvlUsd}
 					{disableBlacklistedStrikethrough}
+					{ratingProvider}
 				/>
 			{:else if !topVaults?.vaults.length}
 				{#if stablecoinMetadata}
@@ -266,6 +283,7 @@
 					{includeBlacklistedInStats}
 					{maxSummaryTvlUsd}
 					{disableBlacklistedStrikethrough}
+					{ratingProvider}
 				/>
 			{/if}
 		</div>

--- a/src/lib/top-vaults/TopVaultsTable.svelte
+++ b/src/lib/top-vaults/TopVaultsTable.svelte
@@ -9,6 +9,7 @@ Use `ratingProvider` to add its risk-rating column beside the vault name.
 	import type { TopVaults, VaultInfo } from './schemas';
 	import type { RiskRatingProvider } from './risk-rating-providers';
 	import type { ParamSchema } from '$lib/helpers/url-search-state';
+	import { untrack } from 'svelte';
 	import { goto } from '$app/navigation';
 	import { page } from '$app/state';
 	import { inview } from 'svelte-inview';
@@ -136,8 +137,6 @@ Use `ratingProvider` to add its risk-rating column beside the vault name.
 		generated_at: new Date().toISOString(),
 		vaults: [],
 		core3_protocols: {},
-		xerberus_protocols: {},
-		xerberus_stats: null,
 		curators: {}
 	};
 	const SKELETON_ROW_COUNT = 10;
@@ -186,6 +185,15 @@ Use `ratingProvider` to add its risk-rating column beside the vault name.
 		return formatNumber(score, 0, 0);
 	}
 
+	function compareProviderRiskRatings(a: VaultInfo, b: VaultInfo): number {
+		const aScore = getProviderRiskScore(a);
+		const bScore = getProviderRiskScore(b);
+		if (aScore == null && bScore == null) return 0;
+
+		const missingScore = ratingProvider === 'xerberus' ? -Infinity : Infinity;
+		return (aScore ?? missingScore) - (bScore ?? missingScore);
+	}
+
 	const returnSortColumnMap = Object.fromEntries(
 		returnColumnDefinitions.map((definition) => [
 			definition.id,
@@ -195,6 +203,16 @@ Use `ratingProvider` to add its risk-rating column beside the vault name.
 			}
 		])
 	) as Record<ReturnColumnId, { defaultDirection: 'desc'; compareFn: SortOptions['compareFn'] }>;
+
+	// The provider is a page-level configuration and does not change after the table mounts.
+	const providerSortColumnMap: Record<
+		string,
+		{ defaultDirection: 'asc' | 'desc'; compareFn: SortOptions['compareFn'] }
+	> = untrack(() =>
+		ratingProvider
+			? { provider_risk_rating: { defaultDirection: 'asc' as const, compareFn: compareProviderRiskRatings } }
+			: {}
+	);
 
 	const sortColumnMap: Record<string, { defaultDirection: 'asc' | 'desc'; compareFn: SortOptions['compareFn'] }> = {
 		...returnSortColumnMap,
@@ -229,13 +247,7 @@ Use `ratingProvider` to add its risk-rating column beside the vault name.
 		fees: { defaultDirection: 'asc', compareFn: rankVaultsBy(['mgmt_fee', 'perf_fee'], Infinity) },
 		lockup: { defaultDirection: 'asc', compareFn: rankVaultsBy(['lockup'], Infinity) },
 		risk: { defaultDirection: 'asc', compareFn: rankVaultsBy(['risk_numeric'], Infinity) },
-		provider_risk_rating: {
-			defaultDirection: 'asc',
-			compareFn: (a, b) => {
-				const missingScore = ratingProvider === 'xerberus' ? -Infinity : Infinity;
-				return (getProviderRiskScore(a) ?? missingScore) - (getProviderRiskScore(b) ?? missingScore);
-			}
-		}
+		...providerSortColumnMap
 	};
 
 	// --- URL search state schema ---
@@ -667,9 +679,14 @@ Use `ratingProvider` to add its risk-rating column beside the vault name.
 		<Tooltip>
 			<span slot="trigger" class="risk-rating-value">{getXerberusRiskRating(vault)}</span>
 			<svelte:fragment slot="popup">
-				<p>
-					Xerberus scores run from 0 to 100. Higher scores indicate a stronger risk rating and lower estimated risk.
-				</p>
+				{#if vault.xerberus?.entity_type === 'pool'}
+					<p>Xerberus scored this vault directly on a 0–100 scale. Higher scores indicate lower estimated risk.</p>
+				{:else}
+					<p>
+						Xerberus scored this vault's underlying protocol on a 0–100 scale. Higher scores indicate lower estimated
+						risk.
+					</p>
+				{/if}
 			</svelte:fragment>
 		</Tooltip>
 	{/if}
@@ -1003,7 +1020,12 @@ Use `ratingProvider` to add its risk-rating column beside the vault name.
 
 	<div class="table-wrapper">
 		<!-- --table-width needed for proper tr.targetable styling  -->
-		<table bind:offsetWidth style:--table-width="{offsetWidth}px" class:loading>
+		<table
+			bind:offsetWidth
+			style:--table-width="{offsetWidth}px"
+			class:loading
+			class:with-rating={showProviderRiskRating}
+		>
 			<thead>
 				<tr>
 					<th class="index"></th>
@@ -1482,7 +1504,7 @@ Use `ratingProvider` to add its risk-rating column beside the vault name.
 			position: relative;
 			table-layout: fixed;
 			border-collapse: collapse;
-			width: 92rem;
+			width: 86rem;
 			color: inherit;
 			font: var(--f-mono-xs-regular);
 			line-height: 1;
@@ -1501,6 +1523,15 @@ Use `ratingProvider` to add its risk-rating column beside the vault name.
 					button {
 						min-height: 2.5rem;
 					}
+				}
+			}
+
+			&.with-rating {
+				width: 92rem;
+
+				@media (--viewport-sm-down) {
+					width: 65.5rem;
+					min-width: 65.5rem;
 				}
 			}
 
@@ -1697,11 +1728,6 @@ Use `ratingProvider` to add its risk-rating column beside the vault name.
 			:is(.risk-rating, .provider_risk_rating) {
 				width: 7.5rem;
 				min-width: 7.5rem;
-
-				@media (--viewport-sm-down) {
-					width: 7.5rem;
-					min-width: 7.5rem;
-				}
 			}
 
 			.risk-rating {

--- a/src/lib/top-vaults/TopVaultsTable.svelte
+++ b/src/lib/top-vaults/TopVaultsTable.svelte
@@ -1,10 +1,13 @@
 <!--
 @component
-Interactive vault listing with filters, sorting and progressive row loading.
+Interactive vault listing with filters, sorting, and progressive row loading.
+
+Use `ratingProvider` to add its risk-rating column beside the vault name.
 -->
 <script lang="ts">
 	import type { Chain } from '$lib/helpers/chain';
 	import type { TopVaults, VaultInfo } from './schemas';
+	import type { RiskRatingProvider } from './risk-rating-providers';
 	import type { ParamSchema } from '$lib/helpers/url-search-state';
 	import { goto } from '$app/navigation';
 	import { page } from '$app/state';
@@ -16,6 +19,7 @@ Interactive vault listing with filters, sorting and progressive row loading.
 	import Timestamp from '$lib/components/Timestamp.svelte';
 	import Tooltip from '$lib/components/Tooltip.svelte';
 	import ChainCell from './ChainCell.svelte';
+	import Core3RiskCell from './Core3RiskCell.svelte';
 	import FeesCell from './FeesCell.svelte';
 	import RiskCell from './RiskCell.svelte';
 	import VaultSparkline from './VaultSparkline.svelte';
@@ -41,6 +45,7 @@ Interactive vault listing with filters, sorting and progressive row loading.
 		calculateTvlWeightedApy,
 		ddFilterOptions,
 		getFormattedLockup,
+		getCore3PolForVault,
 		getLockupTooltip,
 		getLifetimeMaxDrawdown,
 		getMonthlyReturn,
@@ -123,12 +128,16 @@ Interactive vault listing with filters, sorting and progressive row loading.
 		maxSummaryTvlUsd?: number;
 		/** Do not visually strike through blacklisted vault rows. */
 		disableBlacklistedStrikethrough?: boolean;
+		/** Show a third-party risk rating column immediately after the vault name. */
+		ratingProvider?: RiskRatingProvider;
 	}
 
 	const emptyTopVaults: TopVaults = {
 		generated_at: new Date().toISOString(),
 		vaults: [],
 		core3_protocols: {},
+		xerberus_protocols: {},
+		xerberus_stats: null,
 		curators: {}
 	};
 	const SKELETON_ROW_COUNT = 10;
@@ -155,13 +164,26 @@ Interactive vault listing with filters, sorting and progressive row loading.
 		totalVaultCount: totalVaultCountProp,
 		includeBlacklistedInStats = false,
 		maxSummaryTvlUsd,
-		disableBlacklistedStrikethrough = false
+		disableBlacklistedStrikethrough = false,
+		ratingProvider
 	}: Props = $props();
 
 	// --- Sort column registry (key → compareFn + default direction) ---
 
 	function stringCompare(fn: (v: VaultInfo) => string) {
 		return (a: VaultInfo, b: VaultInfo) => fn(a).localeCompare(fn(b));
+	}
+
+	function getProviderRiskScore(vault: VaultInfo): number | null {
+		if (ratingProvider === 'xerberus') return vault.xerberus?.score ?? null;
+		if (ratingProvider === 'core3') return getCore3PolForVault(vault, topVaults.core3_protocols)?.score ?? null;
+		return null;
+	}
+
+	function getXerberusRiskRating(vault: VaultInfo): string {
+		const score = vault.xerberus?.score;
+		if (score == null) return notFilledMarker;
+		return formatNumber(score, 0, 0);
 	}
 
 	const returnSortColumnMap = Object.fromEntries(
@@ -206,7 +228,14 @@ Interactive vault listing with filters, sorting and progressive row loading.
 		age: { defaultDirection: 'desc', compareFn: rankVaultsBy(['years']) },
 		fees: { defaultDirection: 'asc', compareFn: rankVaultsBy(['mgmt_fee', 'perf_fee'], Infinity) },
 		lockup: { defaultDirection: 'asc', compareFn: rankVaultsBy(['lockup'], Infinity) },
-		risk: { defaultDirection: 'asc', compareFn: rankVaultsBy(['risk_numeric'], Infinity) }
+		risk: { defaultDirection: 'asc', compareFn: rankVaultsBy(['risk_numeric'], Infinity) },
+		provider_risk_rating: {
+			defaultDirection: 'asc',
+			compareFn: (a, b) => {
+				const missingScore = ratingProvider === 'xerberus' ? -Infinity : Infinity;
+				return (getProviderRiskScore(a) ?? missingScore) - (getProviderRiskScore(b) ?? missingScore);
+			}
+		}
 	};
 
 	// --- URL search state schema ---
@@ -316,6 +345,7 @@ Interactive vault listing with filters, sorting and progressive row loading.
 	});
 
 	let showChainCol = $derived(!chain);
+	let showProviderRiskRating = $derived(ratingProvider != null);
 
 	let offsetWidth = $state<number>();
 
@@ -627,6 +657,22 @@ Interactive vault listing with filters, sorting and progressive row loading.
 			lifetimeData
 		)}
 	</td>
+{/snippet}
+
+{#snippet providerRiskRatingCell(vault: VaultInfo)}
+	{#if ratingProvider === 'core3'}
+		<!-- Reuse the protocol-list grade and tone treatment for consistency. -->
+		<Core3RiskCell rating={getCore3PolForVault(vault, topVaults.core3_protocols)?.rating} slug={vault.protocol_slug} />
+	{:else}
+		<Tooltip>
+			<span slot="trigger" class="risk-rating-value">{getXerberusRiskRating(vault)}</span>
+			<svelte:fragment slot="popup">
+				<p>
+					Xerberus scores run from 0 to 100. Higher scores indicate a stronger risk rating and lower estimated risk.
+				</p>
+			</svelte:fragment>
+		</Tooltip>
+	{/if}
 {/snippet}
 
 {#snippet tvlValues(vault: VaultInfo)}
@@ -965,6 +1011,13 @@ Interactive vault listing with filters, sorting and progressive row loading.
 						{@render sortColHeader('', 'chain', 'asc')}
 					{/if}
 					{@render sortColHeader('Vault', 'vault', 'asc')}
+					{#if showProviderRiskRating}
+						{@render sortColHeader(
+							'Risk rating',
+							'provider_risk_rating',
+							ratingProvider === 'xerberus' ? 'desc' : 'asc'
+						)}
+					{/if}
 					{#each selectedReturnColumns as column (column.id)}
 						{@render sortColHeader(column.headerLabel, column.id, column.sortDirection)}
 					{/each}
@@ -987,6 +1040,7 @@ Interactive vault listing with filters, sorting and progressive row loading.
 							<td class="index"></td>
 							{#if showChainCol}<td class="chain"></td>{/if}
 							<td class="vault"></td>
+							{#if showProviderRiskRating}<td class="risk-rating right"></td>{/if}
 							{#each selectedReturnColumns as column (column.id)}
 								<td class={`${getReturnCellClass(column)} right`}></td>
 							{/each}
@@ -1027,6 +1081,9 @@ Interactive vault listing with filters, sorting and progressive row loading.
 								{/if}
 							</div>
 						</td>
+						{#if showProviderRiskRating}
+							<td class="risk-rating right">{@render providerRiskRatingCell(vault)}</td>
+						{/if}
 						{#each selectedReturnColumns as column (column.id)}
 							{@render returnColumnCell(vault, column)}
 						{/each}
@@ -1104,7 +1161,7 @@ Interactive vault listing with filters, sorting and progressive row loading.
 				{/each}
 				{#if hasMoreRows}
 					<tr class="load-more-sentinel" data-testid="load-more-sentinel">
-						<td colspan={12 + selectedReturnColumns.length + (showChainCol ? 1 : 0)}>
+						<td colspan={12 + selectedReturnColumns.length + (showChainCol ? 1 : 0) + (showProviderRiskRating ? 1 : 0)}>
 							<div use:inview={{ rootMargin: '300px' }} oninview_enter={() => (maxVisibleRows += ROW_BATCH_SIZE)}>
 								Loading more vaults... ({maxVisibleRows} of {sortedVaults.length})
 							</div>
@@ -1425,7 +1482,7 @@ Interactive vault listing with filters, sorting and progressive row loading.
 			position: relative;
 			table-layout: fixed;
 			border-collapse: collapse;
-			width: 86rem;
+			width: 92rem;
 			color: inherit;
 			font: var(--f-mono-xs-regular);
 			line-height: 1;
@@ -1633,6 +1690,33 @@ Interactive vault listing with filters, sorting and progressive row loading.
 				@media (--viewport-sm-down) {
 					width: 10rem;
 					max-width: 10rem;
+				}
+			}
+
+			/* Apply the fixed width to both the cells and its sortable header. */
+			:is(.risk-rating, .provider_risk_rating) {
+				width: 7.5rem;
+				min-width: 7.5rem;
+
+				@media (--viewport-sm-down) {
+					width: 7.5rem;
+					min-width: 7.5rem;
+				}
+			}
+
+			.risk-rating {
+				/* The tooltip trigger only appears in body cells. */
+				.risk-rating-value {
+					white-space: nowrap;
+					text-decoration: underline;
+					text-decoration-style: dashed;
+					text-underline-offset: 0.2em;
+					cursor: help;
+				}
+
+				:global(.popup) {
+					right: 0;
+					width: min(20rem, 80vw);
 				}
 			}
 

--- a/src/lib/top-vaults/TopVaultsTable.test.ts
+++ b/src/lib/top-vaults/TopVaultsTable.test.ts
@@ -40,8 +40,6 @@ describe('TopVaultsTable risk rating column', () => {
 							pol: { score: 76, rating: 'D', confidence: 'High' }
 						}
 					},
-					xerberus_protocols: {},
-					xerberus_stats: null,
 					curators: {}
 				},
 				ratingProvider: 'core3',
@@ -89,8 +87,6 @@ describe('TopVaultsTable risk rating column', () => {
 					generated_at: '2026-07-30T11:30:40Z',
 					vaults: [riskierVault, saferVault],
 					core3_protocols: {},
-					xerberus_protocols: {},
-					xerberus_stats: null,
 					curators: {}
 				},
 				ratingProvider: 'xerberus',
@@ -101,6 +97,6 @@ describe('TopVaultsTable risk rating column', () => {
 
 		expect(getRenderedVaultNames()).toEqual(['Safer Xerberus vault', 'Riskier Xerberus vault']);
 		expect(screen.getByText('91')).toBeInTheDocument();
-		expect(screen.getAllByText(/Higher scores indicate a stronger risk rating/)).toHaveLength(2);
+		expect(screen.getAllByText(/Xerberus scored this vault directly/)).toHaveLength(2);
 	});
 });

--- a/src/lib/top-vaults/TopVaultsTable.test.ts
+++ b/src/lib/top-vaults/TopVaultsTable.test.ts
@@ -1,0 +1,106 @@
+import { cleanup, render, screen } from '@testing-library/svelte';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import TopVaultsTable from './TopVaultsTable.svelte';
+import { createTestVault } from './test-utils';
+
+afterEach(cleanup);
+
+vi.stubGlobal(
+	'ResizeObserver',
+	class {
+		observe() {}
+		unobserve() {}
+		disconnect() {}
+	}
+);
+
+function getRenderedVaultNames() {
+	return Array.from(document.querySelectorAll('tbody tr td.vault strong')).map((element) => element.textContent);
+}
+
+describe('TopVaultsTable risk rating column', () => {
+	it('shows and sorts CORE3 ratings from lowest Probability of Loss first', () => {
+		const saferVault = createTestVault('Safer CORE3 vault', { protocol: 'Safer CORE3' });
+		const riskierVault = createTestVault('Riskier CORE3 vault', { protocol: 'Riskier CORE3' });
+
+		render(TopVaultsTable, {
+			props: {
+				topVaults: {
+					generated_at: '2026-07-30T11:30:40Z',
+					vaults: [riskierVault, saferVault],
+					core3_protocols: {
+						'safer-core3': {
+							slug: 'safer-core3',
+							name: 'Safer CORE3',
+							pol: { score: 12, rating: 'AA', confidence: 'High' }
+						},
+						'riskier-core3': {
+							slug: 'riskier-core3',
+							name: 'Riskier CORE3',
+							pol: { score: 76, rating: 'D', confidence: 'High' }
+						}
+					},
+					xerberus_protocols: {},
+					xerberus_stats: null,
+					curators: {}
+				},
+				ratingProvider: 'core3',
+				defaultSort: 'provider_risk_rating',
+				defaultDirection: 'asc'
+			}
+		});
+
+		expect(screen.getByRole('columnheader', { name: 'Risk rating' })).toBeInTheDocument();
+		expect(getRenderedVaultNames()).toEqual(['Safer CORE3 vault', 'Riskier CORE3 vault']);
+		expect(screen.getByText('AA')).toHaveAttribute('data-tone', 'excellent');
+		expect(screen.getByText('D')).toHaveAttribute('data-tone', 'poor');
+		expect(screen.getAllByText(/graded from AA \(lowest risk\) down to D/)).toHaveLength(2);
+	});
+
+	it('shows and sorts Xerberus ratings from highest score first', () => {
+		const saferVault = createTestVault('Safer Xerberus vault', {
+			xerberus: {
+				score: 91,
+				score_scale: '0_100_higher_is_better',
+				entity_type: 'pool',
+				entity_id: 'safer-xerberus-vault',
+				name: 'Safer Xerberus vault',
+				protocol_slug: null,
+				report_url: 'https://app.xerberus.io/pool/dendrogram/safer-xerberus-vault',
+				fetched_at: '2026-07-30T11:30:40Z'
+			}
+		});
+		const riskierVault = createTestVault('Riskier Xerberus vault', {
+			xerberus: {
+				score: 58,
+				score_scale: '0_100_higher_is_better',
+				entity_type: 'pool',
+				entity_id: 'riskier-xerberus-vault',
+				name: 'Riskier Xerberus vault',
+				protocol_slug: null,
+				report_url: 'https://app.xerberus.io/pool/dendrogram/riskier-xerberus-vault',
+				fetched_at: '2026-07-30T11:30:40Z'
+			}
+		});
+
+		render(TopVaultsTable, {
+			props: {
+				topVaults: {
+					generated_at: '2026-07-30T11:30:40Z',
+					vaults: [riskierVault, saferVault],
+					core3_protocols: {},
+					xerberus_protocols: {},
+					xerberus_stats: null,
+					curators: {}
+				},
+				ratingProvider: 'xerberus',
+				defaultSort: 'provider_risk_rating',
+				defaultDirection: 'desc'
+			}
+		});
+
+		expect(getRenderedVaultNames()).toEqual(['Safer Xerberus vault', 'Riskier Xerberus vault']);
+		expect(screen.getByText('91')).toBeInTheDocument();
+		expect(screen.getAllByText(/Higher scores indicate a stronger risk rating/)).toHaveLength(2);
+	});
+});

--- a/src/lib/top-vaults/VaultListingsSelector.svelte
+++ b/src/lib/top-vaults/VaultListingsSelector.svelte
@@ -1,3 +1,7 @@
+<!--
+@component
+Renders navigation links for vault listing and chart pages.
+-->
 <script lang="ts">
 	import { resolve } from '$app/paths';
 	import { page } from '$app/state';
@@ -18,7 +22,9 @@
 		{ href: '/vaults/new-vaults', label: 'New' },
 		{ href: '/vaults/negative', label: 'Negative' },
 		{ href: '/vaults/blacklisted', label: 'Blacklisted' },
-		{ href: '/vaults/all', label: 'All' }
+		{ href: '/vaults/all', label: 'All' },
+		{ href: '/vaults/core3-ratings', label: 'CORE3 ratings' },
+		{ href: '/vaults/xerberus-ratings', label: 'Xerberus ratings' }
 	] as const;
 
 	const chartLinks = [

--- a/src/lib/top-vaults/XerberusRisk.svelte
+++ b/src/lib/top-vaults/XerberusRisk.svelte
@@ -1,0 +1,193 @@
+<!--
+@component
+Displays the third-party Xerberus risk assessment for an individual vault.
+
+Xerberus may rate a vault pool directly or fall back to an assessment of its
+underlying protocol. This distinction is stated in the card so users do not
+mistake protocol coverage for a vault-specific assessment.
+
+@example
+
+```svelte
+  <XerberusRisk xerberus={vault.xerberus} />
+```
+-->
+<script lang="ts">
+	import MetricsBox from '$lib/components/MetricsBox.svelte';
+	import Tooltip from '$lib/components/Tooltip.svelte';
+	import { formatNumber } from '$lib/helpers/formatters';
+	import { riskRatingProviders } from './risk-rating-providers';
+	import type { XerberusVault } from './schemas';
+	import IconQuestionCircle from '~icons/local/question-circle';
+
+	interface Props {
+		xerberus: XerberusVault;
+	}
+
+	let { xerberus }: Props = $props();
+	let isPoolAssessment = $derived(xerberus.entity_type === 'pool');
+	let assessmentLabel = $derived(isPoolAssessment ? 'Pool-level' : 'Protocol-level');
+</script>
+
+<MetricsBox class="xerberus-risk">
+	<div class="content">
+		<header class="box-header">
+			<img class="xerberus-icon" src={riskRatingProviders.xerberus.logoUrl} alt={riskRatingProviders.xerberus.name} />
+			<div class="score">{formatNumber(xerberus.score, 0, 0)}</div>
+			<h2>Xerberus risk rating</h2>
+		</header>
+
+		<table class="data">
+			<tbody>
+				<tr>
+					<th>
+						<Tooltip>
+							<span slot="trigger" class="metric-label">
+								Xerberus score
+								<IconQuestionCircle />
+							</span>
+							<svelte:fragment slot="popup">
+								The Xerberus assessment uses a 0–100 scale. Higher scores represent a stronger rating.
+							</svelte:fragment>
+						</Tooltip>
+					</th>
+					<td>{formatNumber(xerberus.score, 0, 0)} / 100</td>
+				</tr>
+				<tr>
+					<th>Assessment level</th>
+					<td>{assessmentLabel}</td>
+				</tr>
+				<tr>
+					<th>Rated entity</th>
+					<td>{xerberus.name}</td>
+				</tr>
+			</tbody>
+		</table>
+
+		<footer class="footer">
+			<p>This is Xerberus risk rating for the vault. Higher is better.</p>
+			{#if xerberus.report_url}
+				<!-- eslint-disable-next-line svelte/no-navigation-without-resolve -->
+				<a href={xerberus.report_url} target="_blank" rel="noreferrer"
+					>View this {isPoolAssessment ? 'vault' : 'protocol'} rating on Xerberus</a
+				>
+			{/if}
+		</footer>
+	</div>
+</MetricsBox>
+
+<style>
+	.content {
+		display: grid;
+		gap: 1.25rem;
+	}
+
+	.box-header {
+		display: flex;
+		align-items: center;
+		gap: 0.875rem;
+
+		h2 {
+			margin: 0;
+			font: var(--f-ui-sm-bold);
+			font-size: 1rem;
+			letter-spacing: 0.06em;
+			text-transform: uppercase;
+			color: var(--c-text-light);
+
+			@media (--viewport-sm-down) {
+				font-size: 0.875rem;
+			}
+		}
+	}
+
+	.xerberus-icon {
+		width: 2.5rem;
+		height: 2.5rem;
+		border-radius: var(--radius-sm);
+		object-fit: contain;
+	}
+
+	.score {
+		display: grid;
+		place-items: center;
+		min-width: 3.25rem;
+		padding: 0.25rem 0.75rem;
+		border: 2px solid color-mix(in srgb, var(--c-link), transparent 55%);
+		border-radius: var(--radius-md);
+		background: color-mix(in srgb, var(--c-link), transparent 88%);
+		font: var(--f-heading-md-medium);
+		color: color-mix(in srgb, var(--c-text), var(--c-link) 80%);
+	}
+
+	.footer {
+		border-top: 1px solid var(--c-box-3);
+		padding-top: 1.25rem;
+		display: grid;
+		gap: 0.5rem;
+
+		p {
+			margin: 0;
+		}
+
+		a {
+			justify-self: start;
+		}
+	}
+
+	.footer p,
+	.footer a {
+		font: var(--f-ui-md-roman);
+		color: var(--c-text-extra-light);
+	}
+
+	.footer a {
+		text-decoration: underline;
+		font-weight: 500;
+		color: var(--c-text-light);
+	}
+
+	table.data {
+		width: 100%;
+		border-collapse: collapse;
+
+		tr {
+			border-top: 1px solid var(--c-box-3);
+
+			&:first-child {
+				border-top: none;
+			}
+		}
+
+		th,
+		td {
+			padding: 0.625rem 0;
+			font: var(--f-ui-md-roman);
+			text-align: left;
+		}
+
+		th {
+			color: var(--c-text-extra-light);
+			font-weight: normal;
+		}
+
+		td {
+			text-align: right;
+			color: var(--c-text-light);
+		}
+	}
+
+	.metric-label {
+		display: inline-flex;
+		align-items: center;
+		gap: 0.25rem;
+
+		:global(.icon) {
+			color: var(--c-text-extra-light);
+		}
+	}
+
+	:global(.xerberus-risk .tooltip .popup) {
+		max-width: 360px;
+	}
+</style>

--- a/src/lib/top-vaults/XerberusRisk.svelte
+++ b/src/lib/top-vaults/XerberusRisk.svelte
@@ -27,6 +27,11 @@ mistake protocol coverage for a vault-specific assessment.
 	let { xerberus }: Props = $props();
 	let isPoolAssessment = $derived(xerberus.entity_type === 'pool');
 	let assessmentLabel = $derived(isPoolAssessment ? 'Pool-level' : 'Protocol-level');
+	let assessmentDescription = $derived(
+		isPoolAssessment
+			? 'This is a Xerberus risk rating for this vault.'
+			: 'This is a Xerberus risk rating for this vault’s underlying protocol.'
+	);
 </script>
 
 <MetricsBox class="xerberus-risk">
@@ -65,7 +70,7 @@ mistake protocol coverage for a vault-specific assessment.
 		</table>
 
 		<footer class="footer">
-			<p>This is Xerberus risk rating for the vault. Higher is better.</p>
+			<p>{assessmentDescription} Higher is better.</p>
 			{#if xerberus.report_url}
 				<!-- eslint-disable-next-line svelte/no-navigation-without-resolve -->
 				<a href={xerberus.report_url} target="_blank" rel="noreferrer"

--- a/src/lib/top-vaults/XerberusRisk.test.ts
+++ b/src/lib/top-vaults/XerberusRisk.test.ts
@@ -29,7 +29,7 @@ describe('XerberusRisk', () => {
 		expect(screen.getByAltText('Xerberus')).toHaveAttribute('src', 'https://app.xerberus.io/favicon.ico');
 		expect(screen.getByText('78 / 100')).toBeInTheDocument();
 		expect(screen.getByText('Pool-level')).toBeInTheDocument();
-		expect(screen.getByText('This is Xerberus risk rating for the vault. Higher is better.')).toBeInTheDocument();
+		expect(screen.getByText('This is a Xerberus risk rating for this vault. Higher is better.')).toBeInTheDocument();
 		expect(screen.getByRole('link', { name: 'View this vault rating on Xerberus' })).toHaveAttribute(
 			'href',
 			'https://app.xerberus.io/pool/dendrogram/example-vault'
@@ -50,6 +50,9 @@ describe('XerberusRisk', () => {
 		});
 
 		expect(screen.getByText('Protocol-level')).toBeInTheDocument();
+		expect(
+			screen.getByText('This is a Xerberus risk rating for this vault’s underlying protocol. Higher is better.')
+		).toBeInTheDocument();
 		expect(screen.getByRole('link', { name: 'View this protocol rating on Xerberus' })).toHaveAttribute(
 			'href',
 			'https://app.xerberus.io/protocol/dendrogram/example-protocol'

--- a/src/lib/top-vaults/XerberusRisk.test.ts
+++ b/src/lib/top-vaults/XerberusRisk.test.ts
@@ -1,0 +1,72 @@
+import { cleanup, render, screen } from '@testing-library/svelte';
+import { afterEach, describe, expect, it } from 'vitest';
+import XerberusRisk from './XerberusRisk.svelte';
+
+afterEach(cleanup);
+
+const baseAssessment = {
+	score: 78,
+	score_scale: '0_100_higher_is_better',
+	entity_id: 'example-vault',
+	name: 'Example vault',
+	protocol_slug: null,
+	fetched_at: '2026-07-27T16:01:01.992171'
+};
+
+describe('XerberusRisk', () => {
+	it('renders direct pool assessments with their Xerberus report link', () => {
+		render(XerberusRisk, {
+			props: {
+				xerberus: {
+					...baseAssessment,
+					entity_type: 'pool',
+					report_url: 'https://app.xerberus.io/pool/dendrogram/example-vault'
+				}
+			}
+		});
+
+		expect(screen.getByRole('heading', { name: 'Xerberus risk rating' })).toBeInTheDocument();
+		expect(screen.getByAltText('Xerberus')).toHaveAttribute('src', 'https://app.xerberus.io/favicon.ico');
+		expect(screen.getByText('78 / 100')).toBeInTheDocument();
+		expect(screen.getByText('Pool-level')).toBeInTheDocument();
+		expect(screen.getByText('This is Xerberus risk rating for the vault. Higher is better.')).toBeInTheDocument();
+		expect(screen.getByRole('link', { name: 'View this vault rating on Xerberus' })).toHaveAttribute(
+			'href',
+			'https://app.xerberus.io/pool/dendrogram/example-vault'
+		);
+	});
+
+	it('explains when the assessment falls back to the underlying protocol', () => {
+		render(XerberusRisk, {
+			props: {
+				xerberus: {
+					...baseAssessment,
+					entity_type: 'protocol',
+					name: 'Example protocol',
+					protocol_slug: 'example',
+					report_url: 'https://app.xerberus.io/protocol/dendrogram/example-protocol'
+				}
+			}
+		});
+
+		expect(screen.getByText('Protocol-level')).toBeInTheDocument();
+		expect(screen.getByRole('link', { name: 'View this protocol rating on Xerberus' })).toHaveAttribute(
+			'href',
+			'https://app.xerberus.io/protocol/dendrogram/example-protocol'
+		);
+	});
+
+	it('does not fall back to the Xerberus landing page when a report URL is absent', () => {
+		render(XerberusRisk, {
+			props: {
+				xerberus: {
+					...baseAssessment,
+					entity_type: 'pool',
+					report_url: null
+				}
+			}
+		});
+
+		expect(screen.queryByRole('link', { name: /Xerberus/ })).not.toBeInTheDocument();
+	});
+});

--- a/src/lib/top-vaults/inline-data.test.ts
+++ b/src/lib/top-vaults/inline-data.test.ts
@@ -7,6 +7,8 @@ describe('getInlineVaultListing', () => {
 		generated_at: '2026-07-24T00:00:00.000Z',
 		vaults: [createTestVault('Vault')],
 		core3_protocols: {},
+		xerberus_protocols: {},
+		xerberus_stats: null,
 		curators: {}
 	};
 

--- a/src/lib/top-vaults/inline-data.test.ts
+++ b/src/lib/top-vaults/inline-data.test.ts
@@ -7,8 +7,6 @@ describe('getInlineVaultListing', () => {
 		generated_at: '2026-07-24T00:00:00.000Z',
 		vaults: [createTestVault('Vault')],
 		core3_protocols: {},
-		xerberus_protocols: {},
-		xerberus_stats: null,
 		curators: {}
 	};
 

--- a/src/lib/top-vaults/risk-rating-providers.ts
+++ b/src/lib/top-vaults/risk-rating-providers.ts
@@ -8,7 +8,7 @@ export const riskRatingProviders = {
 	core3: {
 		name: 'CORE3',
 		pageTitle: 'CORE3 risk ratings for DeFi vaults',
-		website: 'https://core3.io/',
+		website: 'https://core3.io/?utm_source=tradingstrategy',
 		logoUrl: 'https://core3.io/images/fav-icon-32.png',
 		logoAlt: 'CORE3 logo',
 		defaultDirection: 'asc' as const

--- a/src/lib/top-vaults/risk-rating-providers.ts
+++ b/src/lib/top-vaults/risk-rating-providers.ts
@@ -1,0 +1,26 @@
+/**
+ * Third-party risk-rating providers displayed in vault listings.
+ *
+ * Each provider has a different score direction, so the listing can default
+ * to the safest rated vaults without treating the numeric scores alike.
+ */
+export const riskRatingProviders = {
+	core3: {
+		name: 'CORE3',
+		pageTitle: 'CORE3 risk ratings for DeFi vaults',
+		website: 'https://core3.io/',
+		logoUrl: 'https://core3.io/images/fav-icon-32.png',
+		logoAlt: 'CORE3 logo',
+		defaultDirection: 'asc' as const
+	},
+	xerberus: {
+		name: 'Xerberus',
+		pageTitle: 'Xerberus risk ratings for DeFi vaults',
+		website: 'https://xerberus.io/',
+		logoUrl: 'https://app.xerberus.io/favicon.ico',
+		logoAlt: 'Xerberus logo',
+		defaultDirection: 'desc' as const
+	}
+} as const;
+
+export type RiskRatingProvider = keyof typeof riskRatingProviders;

--- a/src/lib/top-vaults/schemas.test.ts
+++ b/src/lib/top-vaults/schemas.test.ts
@@ -56,7 +56,7 @@ describe('topVaultsSchema resilience', () => {
 		expect(result.name).toBe('Steakhouse Financial');
 	});
 
-	it('preserves Xerberus protocol and per-vault assessments', () => {
+	it('preserves valid Xerberus per-vault assessments and drops malformed ones', () => {
 		const xerberus = {
 			score: 78,
 			score_scale: '0_100_higher_is_better',
@@ -69,32 +69,15 @@ describe('topVaultsSchema resilience', () => {
 		};
 		const result = topVaultsSchema.parse({
 			...basePayload,
-			vaults: [createTestVault('Example vault', { xerberus })],
-			xerberus_protocols: {
-				example: {
-					protocol_slug: 'example',
-					entity_id: 'example-v1',
-					name: 'Example',
-					score: 78,
-					score_scale: '0_100_higher_is_better',
-					report_url: 'https://app.xerberus.io/protocol/dendrogram/example-v1',
-					fetched_at: '2026-07-27T16:01:01.992171'
-				}
-			},
-			xerberus_stats: {
-				total_vaults: 1,
-				pool_matches: 1,
-				protocol_fallbacks: 0,
-				unmatched: 0,
-				coverage_pct: 100
-			}
+			vaults: [
+				createTestVault('Example vault', { xerberus }),
+				createTestVault('Malformed Xerberus vault', {
+					xerberus: { ...xerberus, report_url: 'not a URL' }
+				})
+			]
 		});
 
 		expect(result.vaults[0].xerberus).toEqual(xerberus);
-		expect(result.xerberus_protocols.example?.score).toBe(78);
-		expect(result.xerberus_protocols.example?.report_url).toBe(
-			'https://app.xerberus.io/protocol/dendrogram/example-v1'
-		);
-		expect(result.xerberus_stats?.coverage_pct).toBe(100);
+		expect(result.vaults[1].xerberus).toBeNull();
 	});
 });

--- a/src/lib/top-vaults/schemas.test.ts
+++ b/src/lib/top-vaults/schemas.test.ts
@@ -67,14 +67,13 @@ describe('topVaultsSchema resilience', () => {
 			report_url: 'https://app.xerberus.io/pool/dendrogram/lagoon-example-vault',
 			fetched_at: '2026-07-27T16:01:01.992171'
 		};
+		const malformedVault = {
+			...createTestVault('Malformed Xerberus vault'),
+			xerberus: { ...xerberus, report_url: 'not a URL' }
+		};
 		const result = topVaultsSchema.parse({
 			...basePayload,
-			vaults: [
-				createTestVault('Example vault', { xerberus }),
-				createTestVault('Malformed Xerberus vault', {
-					xerberus: { ...xerberus, report_url: 'not a URL' }
-				})
-			]
+			vaults: [createTestVault('Example vault', { xerberus }), malformedVault]
 		});
 
 		expect(result.vaults[0].xerberus).toEqual(xerberus);

--- a/src/lib/top-vaults/schemas.test.ts
+++ b/src/lib/top-vaults/schemas.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { curatorInfoSchema, topVaultsSchema } from './schemas';
+import { createTestVault } from './test-utils';
 
 const validCurator = {
 	slug: 'steakhouse-financial',
@@ -53,5 +54,47 @@ describe('topVaultsSchema resilience', () => {
 		const result = curatorInfoSchema.parse(curator);
 		expect(result.recent_posts).toEqual([]);
 		expect(result.name).toBe('Steakhouse Financial');
+	});
+
+	it('preserves Xerberus protocol and per-vault assessments', () => {
+		const xerberus = {
+			score: 78,
+			score_scale: '0_100_higher_is_better',
+			entity_type: 'pool',
+			entity_id: 'lagoon-example-vault',
+			name: 'Example vault',
+			protocol_slug: null,
+			report_url: 'https://app.xerberus.io/pool/dendrogram/lagoon-example-vault',
+			fetched_at: '2026-07-27T16:01:01.992171'
+		};
+		const result = topVaultsSchema.parse({
+			...basePayload,
+			vaults: [createTestVault('Example vault', { xerberus })],
+			xerberus_protocols: {
+				example: {
+					protocol_slug: 'example',
+					entity_id: 'example-v1',
+					name: 'Example',
+					score: 78,
+					score_scale: '0_100_higher_is_better',
+					report_url: 'https://app.xerberus.io/protocol/dendrogram/example-v1',
+					fetched_at: '2026-07-27T16:01:01.992171'
+				}
+			},
+			xerberus_stats: {
+				total_vaults: 1,
+				pool_matches: 1,
+				protocol_fallbacks: 0,
+				unmatched: 0,
+				coverage_pct: 100
+			}
+		});
+
+		expect(result.vaults[0].xerberus).toEqual(xerberus);
+		expect(result.xerberus_protocols.example?.score).toBe(78);
+		expect(result.xerberus_protocols.example?.report_url).toBe(
+			'https://app.xerberus.io/protocol/dendrogram/example-v1'
+		);
+		expect(result.xerberus_stats?.coverage_pct).toBe(100);
 	});
 });

--- a/src/lib/top-vaults/schemas.ts
+++ b/src/lib/top-vaults/schemas.ts
@@ -104,6 +104,33 @@ export const core3VaultSchema = z.object({
 export type Core3Vault = z.infer<typeof core3VaultSchema>;
 
 /**
+ * Xerberus risk assessment attached directly to a vault.
+ *
+ * `entity_type` distinguishes a direct pool assessment from a fallback
+ * protocol assessment. Xerberus scores are on a 0–100 scale where higher is
+ * better.
+ */
+export const xerberusVaultSchema = z.object({
+	/** Xerberus score on the scale described by `score_scale` */
+	score: z.number(),
+	/** Score interpretation supplied by Xerberus */
+	score_scale: z.string(),
+	/** Assessed entity level, currently `pool` or `protocol` */
+	entity_type: z.string(),
+	/** Xerberus's identifier for the assessed entity */
+	entity_id: z.string(),
+	/** Xerberus display name for the assessed entity */
+	name: z.string(),
+	/** Trading Strategy protocol slug; absent for direct pool matches */
+	protocol_slug: z.string().nullable(),
+	/** Direct Xerberus report URL for this exact pool or protocol assessment */
+	report_url: z.url().nullable(),
+	/** When the Xerberus record was fetched by the data pipeline */
+	fetched_at: isoDateTime
+});
+export type XerberusVault = z.infer<typeof xerberusVaultSchema>;
+
+/**
  * Latest exchange rate metadata for a vault denomination token.
  *
  * The backend attaches this to every vault as `denomination_token_rate`. For
@@ -409,7 +436,9 @@ export const vaultInfoSchema = z.object({
 	 * This duplicates the headline fields in `core3_protocols[protocol_slug]`
 	 * and is kept as a fallback for payloads where the top-level map changes.
 	 */
-	core3: core3VaultSchema.nullable().optional()
+	core3: core3VaultSchema.nullable().optional(),
+	/** Third-party Xerberus risk assessment, when the vault or its protocol is covered. */
+	xerberus: xerberusVaultSchema.nullable().optional()
 });
 export type VaultInfo = z.infer<typeof vaultInfoSchema>;
 
@@ -482,6 +511,35 @@ export const core3ProtocolSchema = z.object({
 	chains: z.object({ name: z.string() }).array().optional()
 });
 export type Core3Protocol = z.infer<typeof core3ProtocolSchema>;
+
+/**
+ * Xerberus protocol-level risk assessment, keyed by our protocol slug.
+ *
+ * This map is retained in the dataset for consumers that need the canonical
+ * protocol records. Vault pages use the compact `vault.xerberus` record so
+ * direct pool matches take precedence.
+ */
+export const xerberusProtocolSchema = z.object({
+	protocol_slug: z.string(),
+	entity_id: z.string(),
+	name: z.string(),
+	score: z.number(),
+	score_scale: z.string(),
+	/** Direct Xerberus report URL for this exact protocol assessment */
+	report_url: z.url().nullable(),
+	fetched_at: isoDateTime
+});
+export type XerberusProtocol = z.infer<typeof xerberusProtocolSchema>;
+
+/** Coverage counters emitted alongside the Xerberus dataset. */
+export const xerberusStatsSchema = z.object({
+	total_vaults: z.int(),
+	pool_matches: z.int(),
+	protocol_fallbacks: z.int(),
+	unmatched: z.int(),
+	coverage_pct: z.number()
+});
+export type XerberusStats = z.infer<typeof xerberusStatsSchema>;
 
 /** Slim vault info with only the fields needed for listing/summary views (e.g., landing page). */
 export type SlimVaultInfo = Pick<
@@ -572,6 +630,22 @@ export const topVaultsSchema = z.object({
 		})
 		.catch({})
 		.default({}),
+	/**
+	 * Xerberus protocol risk assessments, keyed by protocol slug. The compact
+	 * per-vault record remains the source used on a vault detail page.
+	 */
+	xerberus_protocols: z
+		.record(z.string(), xerberusProtocolSchema.or(z.unknown().transform(() => null)))
+		.transform((records) => {
+			const entries = Object.entries(records).filter(
+				(entry): entry is [string, z.infer<typeof xerberusProtocolSchema>] => entry[1] !== null
+			);
+			return Object.fromEntries(entries);
+		})
+		.catch({})
+		.default({}),
+	/** Xerberus coverage counters, retained for aggregate consumers. */
+	xerberus_stats: xerberusStatsSchema.nullable().catch(null).default(null),
 	/**
 	 * Curator metadata keyed by curator slug; referenced by vault.curator_slug.
 	 * Partly built from external feeds — `.catch({})` guarantees a malformed

--- a/src/lib/top-vaults/schemas.ts
+++ b/src/lib/top-vaults/schemas.ts
@@ -438,7 +438,7 @@ export const vaultInfoSchema = z.object({
 	 */
 	core3: core3VaultSchema.nullable().optional(),
 	/** Third-party Xerberus risk assessment, when the vault or its protocol is covered. */
-	xerberus: xerberusVaultSchema.nullable().optional()
+	xerberus: xerberusVaultSchema.nullable().catch(null).optional()
 });
 export type VaultInfo = z.infer<typeof vaultInfoSchema>;
 
@@ -511,35 +511,6 @@ export const core3ProtocolSchema = z.object({
 	chains: z.object({ name: z.string() }).array().optional()
 });
 export type Core3Protocol = z.infer<typeof core3ProtocolSchema>;
-
-/**
- * Xerberus protocol-level risk assessment, keyed by our protocol slug.
- *
- * This map is retained in the dataset for consumers that need the canonical
- * protocol records. Vault pages use the compact `vault.xerberus` record so
- * direct pool matches take precedence.
- */
-export const xerberusProtocolSchema = z.object({
-	protocol_slug: z.string(),
-	entity_id: z.string(),
-	name: z.string(),
-	score: z.number(),
-	score_scale: z.string(),
-	/** Direct Xerberus report URL for this exact protocol assessment */
-	report_url: z.url().nullable(),
-	fetched_at: isoDateTime
-});
-export type XerberusProtocol = z.infer<typeof xerberusProtocolSchema>;
-
-/** Coverage counters emitted alongside the Xerberus dataset. */
-export const xerberusStatsSchema = z.object({
-	total_vaults: z.int(),
-	pool_matches: z.int(),
-	protocol_fallbacks: z.int(),
-	unmatched: z.int(),
-	coverage_pct: z.number()
-});
-export type XerberusStats = z.infer<typeof xerberusStatsSchema>;
 
 /** Slim vault info with only the fields needed for listing/summary views (e.g., landing page). */
 export type SlimVaultInfo = Pick<
@@ -630,22 +601,6 @@ export const topVaultsSchema = z.object({
 		})
 		.catch({})
 		.default({}),
-	/**
-	 * Xerberus protocol risk assessments, keyed by protocol slug. The compact
-	 * per-vault record remains the source used on a vault detail page.
-	 */
-	xerberus_protocols: z
-		.record(z.string(), xerberusProtocolSchema.or(z.unknown().transform(() => null)))
-		.transform((records) => {
-			const entries = Object.entries(records).filter(
-				(entry): entry is [string, z.infer<typeof xerberusProtocolSchema>] => entry[1] !== null
-			);
-			return Object.fromEntries(entries);
-		})
-		.catch({})
-		.default({}),
-	/** Xerberus coverage counters, retained for aggregate consumers. */
-	xerberus_stats: xerberusStatsSchema.nullable().catch(null).default(null),
 	/**
 	 * Curator metadata keyed by curator slug; referenced by vault.curator_slug.
 	 * Partly built from external feeds — `.catch({})` guarantees a malformed

--- a/src/routes/vaults/[vault=slug]/+page.svelte
+++ b/src/routes/vaults/[vault=slug]/+page.svelte
@@ -1,3 +1,6 @@
+<!--
+Vault detail page with performance metrics, protocol information, and third-party risk ratings.
+-->
 <script lang="ts">
 	import { resolve } from '$app/paths';
 	import { discordUrl } from '$lib/config';
@@ -20,6 +23,7 @@
 	import VaultProtocolInfo from './VaultProtocolInfo.svelte';
 	import VaultRankings from './VaultRankings.svelte';
 	import Core3Ratings from '$lib/top-vaults/Core3Ratings.svelte';
+	import XerberusRisk from '$lib/top-vaults/XerberusRisk.svelte';
 	import IconDiscord from '~icons/local/discord';
 	import {
 		getMorphoFlags,
@@ -140,6 +144,10 @@
 		{/if}
 
 		<VaultPeriodicMetrics {vault} {chain} />
+
+		{#if vault.xerberus}
+			<XerberusRisk xerberus={vault.xerberus} />
+		{/if}
 
 		{#if core3}
 			<Core3Ratings

--- a/src/routes/vaults/core3-ratings/+page.svelte
+++ b/src/routes/vaults/core3-ratings/+page.svelte
@@ -1,0 +1,8 @@
+<!--
+CORE3-rated DeFi stablecoin vaults
+-->
+<script lang="ts">
+	import RiskRatingsPage from '$lib/top-vaults/RiskRatingsPage.svelte';
+</script>
+
+<RiskRatingsPage provider="core3" />

--- a/src/routes/vaults/sitemap.xml/+server.ts
+++ b/src/routes/vaults/sitemap.xml/+server.ts
@@ -23,7 +23,9 @@ const staticSubPages = [
 	'cumulative-tvl-apy',
 	'yield-chain',
 	'yield-protocol',
-	'yield-risk'
+	'yield-risk',
+	'core3-ratings',
+	'xerberus-ratings'
 ];
 
 export async function GET({ fetch, setHeaders, url }) {

--- a/src/routes/vaults/xerberus-ratings/+page.svelte
+++ b/src/routes/vaults/xerberus-ratings/+page.svelte
@@ -1,0 +1,8 @@
+<!--
+Xerberus-rated DeFi stablecoin vaults
+-->
+<script lang="ts">
+	import RiskRatingsPage from '$lib/top-vaults/RiskRatingsPage.svelte';
+</script>
+
+<RiskRatingsPage provider="xerberus" />


### PR DESCRIPTION
## Why

Vault users need a consistent way to compare provider-backed risk ratings and reach the exact Xerberus assessment behind each rating.

## Lessons learnt

The served vault export already contains per-vault Xerberus backlinks; frontend schemas must retain those optional provider fields so they reach the UI.

## Summary

- Add CORE3 and Xerberus vault rating pages and navigation links.
- Add provider-aware rating columns, safest-first ordering, metadata, tooltips, and CORE3 chart link.
- Show exact Xerberus report links on vault pages, preserve provider data in schemas, and reorder footer social links.