### PR TITLE
feat: add risk-rated vault listings and tokenised fund search

### DIFF
--- a/src/lib/components/css/color.css
+++ b/src/lib/components/css/color.css
@@ -14,6 +14,7 @@
 	--c-success: hsl(149 64% 44%);
 	--c-warning: hsl(43 92% 50%);
 	--c-search-entity-vault: hsl(187 86% 68%);
+	--c-search-entity-tokenised-fund: hsl(203 89% 71%);
 	--c-search-entity-blacklisted-vault: var(--c-bearish);
 	--c-search-entity-curator: hsl(43 96% 68%);
 	--c-search-entity-protocol: hsl(267 86% 76%);
@@ -91,6 +92,7 @@
 		--c-bullish: hsl(var(--hue-bullish) 68% 42%);
 		--c-bearish: hsl(var(--hue-bearish) 92% 57%);
 		--c-search-entity-vault: hsl(190 85% 30%);
+		--c-search-entity-tokenised-fund: hsl(205 72% 36%);
 		--c-search-entity-curator: hsl(35 90% 30%);
 		--c-search-entity-protocol: hsl(266 65% 43%);
 		--c-search-entity-stablecoin: hsl(145 65% 30%);

--- a/src/lib/search/entities.ts
+++ b/src/lib/search/entities.ts
@@ -4,10 +4,18 @@
  * The server-side index keeps additional matching terms private; browser code
  * only receives this serialisable result shape.
  */
-export type SearchEntityType = 'vault' | 'blacklisted-vault' | 'curator' | 'protocol' | 'stablecoin' | 'chain';
+export type SearchEntityType =
+	| 'vault'
+	| 'tokenised-fund'
+	| 'blacklisted-vault'
+	| 'curator'
+	| 'protocol'
+	| 'stablecoin'
+	| 'chain';
 
 export const searchEntityColours: Record<SearchEntityType, string> = {
 	vault: 'var(--c-search-entity-vault)',
+	'tokenised-fund': 'var(--c-search-entity-tokenised-fund)',
 	'blacklisted-vault': 'var(--c-search-entity-blacklisted-vault)',
 	curator: 'var(--c-search-entity-curator)',
 	protocol: 'var(--c-search-entity-protocol)',
@@ -17,6 +25,7 @@ export const searchEntityColours: Record<SearchEntityType, string> = {
 
 export const searchEntityLabels: Record<SearchEntityType, string> = {
 	vault: 'Vault',
+	'tokenised-fund': 'Tokenised fund',
 	'blacklisted-vault': 'Blacklisted vault',
 	curator: 'Curator',
 	protocol: 'Protocol',

--- a/src/lib/search/vault-search.server.ts
+++ b/src/lib/search/vault-search.server.ts
@@ -120,7 +120,11 @@ function buildIndex(topVaults: TopVaults, stablecoins: StablecoinMetadata[]): In
 			{
 				id: `vault:${vault.id}`,
 				name: vault.name,
-				entityType: isBlacklisted(vault) ? 'blacklisted-vault' : 'vault',
+				entityType: isBlacklisted(vault)
+					? 'blacklisted-vault'
+					: vault.flags.includes('tokenised_fund')
+						? 'tokenised-fund'
+						: 'vault',
 				vaultId: vault.id,
 				address: vault.address,
 				averageApy1m: getMonthlyReturn(vault),

--- a/src/lib/top-vaults/RiskRatingsPage.svelte
+++ b/src/lib/top-vaults/RiskRatingsPage.svelte
@@ -15,21 +15,22 @@ the score in a column beside each vault name.
 	import { resolve } from '$app/paths';
 	import { page } from '$app/state';
 	import { MetaTags, JsonLd } from 'svelte-meta-tags';
+	import { formatDollar, formatPercent } from '$lib/helpers/formatters';
 	import { fetchAllVaultData, hasVaultCache } from './client-cache';
-	import { getCore3PolForVault } from './helpers';
 	import { riskRatingProviders, type RiskRatingProvider } from './risk-rating-providers';
-	import type { TopVaults, VaultInfo } from './schemas';
+	import { getRiskRatedVaults, getRiskRatingStatistics, type RiskRatingStatistics } from './risk-rating-statistics';
+	import type { TopVaults } from './schemas';
 	import TopVaultsPage from './TopVaultsPage.svelte';
 
 	interface Props {
 		provider: RiskRatingProvider;
+		initialRatingStatistics?: RiskRatingStatistics;
 	}
 
-	let { provider }: Props = $props();
+	let { provider, initialRatingStatistics }: Props = $props();
 	let topVaults = $state<TopVaults>();
 	let loading = $state(!hasVaultCache(page.data.generatedAt));
 	let providerDetails = $derived(riskRatingProviders[provider]);
-	let metadataDescription = $derived(`Compare DeFi stablecoin vaults by ${providerDetails.name} risk rating.`);
 	let pageUrl = $derived(new URL(page.url.pathname, page.url.origin).href);
 	let ratedTopVaults = $derived.by(() => {
 		const vaultData = topVaults;
@@ -37,15 +38,29 @@ the score in a column beside each vault name.
 
 		return {
 			...vaultData,
-			vaults: vaultData.vaults.filter((vault) => hasProviderRating(vault, vaultData, provider))
+			vaults: getRiskRatedVaults(vaultData, provider)
 		};
 	});
+	let ratingStatistics = $derived.by(() => {
+		return ratedTopVaults ? getRiskRatingStatistics(ratedTopVaults.vaults) : initialRatingStatistics;
+	});
+	let ratingSummary = $derived.by(() => {
+		const { totalTvl, vaultCount, blockchainCount, averageMonthlyReturn } = ratingStatistics ?? {
+			totalTvl: 0,
+			vaultCount: 0,
+			blockchainCount: 0,
+			averageMonthlyReturn: null
+		};
+		const vaultLabel = vaultCount === 1 ? 'vault' : 'vaults';
+		const blockchainLabel = blockchainCount === 1 ? 'blockchain' : 'blockchains';
 
-	function hasProviderRating(vault: VaultInfo, vaultData: TopVaults, ratingProvider: RiskRatingProvider): boolean {
-		if (ratingProvider === 'xerberus') return vault.xerberus?.score != null;
-		const core3 = getCore3PolForVault(vault, vaultData.core3_protocols);
-		return core3?.score != null && core3.rating != null;
-	}
+		return `${providerDetails.name} risk rates ${formatDollar(totalTvl, 0)} TVL in ${vaultCount} ${vaultLabel} on ${blockchainCount} ${blockchainLabel}. The current TVL-weighted average monthly return is ${formatPercent(averageMonthlyReturn, 1)}.`;
+	});
+	let metadataDescription = $derived(
+		`${providerDetails.name} risk rates ${formatDollar(ratingStatistics?.totalTvl ?? 0, 0)} TVL in ${
+			ratingStatistics?.vaultCount ?? 0
+		} ${(ratingStatistics?.vaultCount ?? 0) === 1 ? 'vault' : 'vaults'}`
+	);
 
 	$effect(() => {
 		fetchAllVaultData(page.data.generatedAt)
@@ -95,7 +110,6 @@ the score in a column beside each vault name.
 <TopVaultsPage
 	topVaults={ratedTopVaults}
 	{loading}
-	includeBlacklisted
 	tvlTriggerLabel="All TVL"
 	tvlTooltip="This list includes all vaults with a rating from this provider, regardless of TVL."
 	title={providerDetails.pageTitle}
@@ -106,19 +120,34 @@ the score in a column beside each vault name.
 >
 	{#snippet subtitle()}
 		{#if provider === 'core3'}
-			<!-- eslint-disable-next-line svelte/no-navigation-without-resolve -->
-			<a href={providerDetails.website} target="_blank" rel="noreferrer">CORE3</a> publishes Probability of Loss ratings
-			for DeFi protocols. Lower scores indicate lower estimated risk.
-			<a href={resolve('/vaults/core3-risk')}>See also CORE3 charts</a>.
+			<p>
+				<!-- eslint-disable-next-line svelte/no-navigation-without-resolve -->
+				<a href={providerDetails.website} target="_blank" rel="noreferrer">CORE3</a> publishes Probability of Loss
+				ratings for DeFi protocols. Lower scores indicate lower estimated risk.
+				<a href={resolve('/vaults/core3-risk')}>See also CORE3 charts</a>.
+			</p>
 		{:else}
-			<!-- eslint-disable-next-line svelte/no-navigation-without-resolve -->
-			<a href={providerDetails.website} target="_blank" rel="noreferrer">Xerberus</a> provides independent risk ratings for
-			DeFi vaults and protocols. Higher scores indicate stronger ratings.
+			<p>
+				<!-- eslint-disable-next-line svelte/no-navigation-without-resolve -->
+				<a href={providerDetails.website} target="_blank" rel="noreferrer">Xerberus</a> provides independent risk ratings
+				for DeFi vaults and protocols. Higher scores indicate stronger ratings.
+			</p>
+		{/if}
+		{#if ratedTopVaults}
+			<p>{ratingSummary}</p>
 		{/if}
 	{/snippet}
 </TopVaultsPage>
 
 <style>
+	:global(.hero-banner .subtitle p) {
+		margin: 0;
+	}
+
+	:global(.hero-banner .subtitle p + p) {
+		margin-top: var(--space-sm);
+	}
+
 	:global(.hero-banner .subtitle a) {
 		text-decoration: underline;
 		text-underline-offset: 0.15em;

--- a/src/lib/top-vaults/TopVaultsTable.svelte
+++ b/src/lib/top-vaults/TopVaultsTable.svelte
@@ -358,6 +358,7 @@ Use `ratingProvider` to add its risk-rating column beside the vault name.
 
 	let showChainCol = $derived(!chain);
 	let showProviderRiskRating = $derived(ratingProvider != null);
+	let showTechnicalRisk = $derived(ratingProvider == null);
 
 	let offsetWidth = $state<number>();
 
@@ -1034,11 +1035,7 @@ Use `ratingProvider` to add its risk-rating column beside the vault name.
 					{/if}
 					{@render sortColHeader('Vault', 'vault', 'asc')}
 					{#if showProviderRiskRating}
-						{@render sortColHeader(
-							'Risk rating',
-							'provider_risk_rating',
-							ratingProvider === 'xerberus' ? 'desc' : 'asc'
-						)}
+						{@render sortColHeader('Risk', 'provider_risk_rating', ratingProvider === 'xerberus' ? 'desc' : 'asc')}
 					{/if}
 					{#each selectedReturnColumns as column (column.id)}
 						{@render sortColHeader(column.headerLabel, column.id, column.sortDirection)}
@@ -1051,7 +1048,9 @@ Use `ratingProvider` to add its risk-rating column beside the vault name.
 					{@render sortColHeader('Age (y)', 'age', 'desc')}
 					{@render sortColHeader('Fees<br />(mgmt/&ZeroWidthSpace;perf)', 'fees', 'asc')}
 					{@render sortColHeader('Deposit and delays', 'lockup', 'asc')}
-					{@render sortColHeader('Protocol Technical Risk', 'risk', 'asc')}
+					{#if showTechnicalRisk}
+						{@render sortColHeader('Protocol Technical Risk', 'risk', 'asc')}
+					{/if}
 					<th class="sparkline">3M price</th>
 				</tr>
 			</thead>
@@ -1074,7 +1073,7 @@ Use `ratingProvider` to add its risk-rating column beside the vault name.
 							<td class="age right"></td>
 							<td class="fees right"></td>
 							<td class="lockup"></td>
-							<td class="risk"></td>
+							{#if showTechnicalRisk}<td class="risk"></td>{/if}
 							<td class="sparkline"></td>
 						</tr>
 					{/each}
@@ -1172,9 +1171,11 @@ Use `ratingProvider` to add its risk-rating column beside the vault name.
 								</Tooltip>
 							{/if}
 						</td>
-						<td class="risk">
-							<RiskCell risk={vault.risk} />
-						</td>
+						{#if showTechnicalRisk}
+							<td class="risk">
+								<RiskCell risk={vault.risk} />
+							</td>
+						{/if}
 						<td class="sparkline">
 							<VaultSparkline {vault} />
 							<TargetableLink label="View {vault.name} details" href={resolveVaultDetails(vault)} class="row-link" />
@@ -1726,8 +1727,8 @@ Use `ratingProvider` to add its risk-rating column beside the vault name.
 
 			/* Apply the fixed width to both the cells and its sortable header. */
 			:is(.risk-rating, .provider_risk_rating) {
-				width: 7.5rem;
-				min-width: 7.5rem;
+				width: 4.5rem;
+				min-width: 4.5rem;
 			}
 
 			.risk-rating {

--- a/src/lib/top-vaults/TopVaultsTable.test.ts
+++ b/src/lib/top-vaults/TopVaultsTable.test.ts
@@ -48,7 +48,8 @@ describe('TopVaultsTable risk rating column', () => {
 			}
 		});
 
-		expect(screen.getByRole('columnheader', { name: 'Risk rating' })).toBeInTheDocument();
+		expect(screen.getByRole('columnheader', { name: 'Risk' })).toBeInTheDocument();
+		expect(screen.queryByRole('columnheader', { name: 'Protocol Technical Risk' })).not.toBeInTheDocument();
 		expect(getRenderedVaultNames()).toEqual(['Safer CORE3 vault', 'Riskier CORE3 vault']);
 		expect(screen.getByText('AA')).toHaveAttribute('data-tone', 'excellent');
 		expect(screen.getByText('D')).toHaveAttribute('data-tone', 'poor');
@@ -95,6 +96,8 @@ describe('TopVaultsTable risk rating column', () => {
 			}
 		});
 
+		expect(screen.getByRole('columnheader', { name: 'Risk' })).toBeInTheDocument();
+		expect(screen.queryByRole('columnheader', { name: 'Protocol Technical Risk' })).not.toBeInTheDocument();
 		expect(getRenderedVaultNames()).toEqual(['Safer Xerberus vault', 'Riskier Xerberus vault']);
 		expect(screen.getByText('91')).toBeInTheDocument();
 		expect(screen.getAllByText(/Xerberus scored this vault directly/)).toHaveLength(2);

--- a/src/lib/top-vaults/risk-rating-statistics.ts
+++ b/src/lib/top-vaults/risk-rating-statistics.ts
@@ -1,0 +1,42 @@
+/**
+ * Filter and summarise vaults covered by a third-party risk-rating provider.
+ */
+import type { RiskRatingProvider } from './risk-rating-providers';
+import type { TopVaults, VaultInfo } from './schemas';
+import {
+	calculateTotalTvl,
+	calculateTvlWeightedApy,
+	getCore3PolForVault,
+	getVaultCurrentTvlUsd,
+	isBlacklisted
+} from './helpers';
+
+export type RiskRatingStatistics = {
+	totalTvl: number;
+	vaultCount: number;
+	blockchainCount: number;
+	averageMonthlyReturn: number | null;
+};
+
+/** Return all non-blacklisted vaults with a rating from the selected provider. */
+export function getRiskRatedVaults(topVaults: TopVaults, provider: RiskRatingProvider): VaultInfo[] {
+	return topVaults.vaults.filter((vault) => {
+		if (isBlacklisted(vault)) return false;
+		if (provider === 'xerberus') return vault.xerberus?.score != null;
+
+		const core3 = getCore3PolForVault(vault, topVaults.core3_protocols);
+		return core3?.score != null && core3.rating != null;
+	});
+}
+
+/** Calculate USD TVL, coverage, and TVL-weighted one-month return for rated vaults. */
+export function getRiskRatingStatistics(vaults: VaultInfo[]): RiskRatingStatistics {
+	const vaultsWithUsdTvl = vaults.map((vault) => ({ ...vault, current_nav: getVaultCurrentTvlUsd(vault) }));
+
+	return {
+		totalTvl: calculateTotalTvl(vaultsWithUsdTvl),
+		vaultCount: vaults.length,
+		blockchainCount: new Set(vaults.map((vault) => vault.chain_id)).size,
+		averageMonthlyReturn: calculateTvlWeightedApy(vaultsWithUsdTvl)
+	};
+}

--- a/src/routes/vaults/core3-ratings/+page.server.ts
+++ b/src/routes/vaults/core3-ratings/+page.server.ts
@@ -1,0 +1,7 @@
+import { getCachedTopVaults } from '$lib/top-vaults/cache';
+import { getRiskRatedVaults, getRiskRatingStatistics } from '$lib/top-vaults/risk-rating-statistics';
+
+export async function load({ fetch }) {
+	const topVaults = await getCachedTopVaults(fetch);
+	return { initialRatingStatistics: getRiskRatingStatistics(getRiskRatedVaults(topVaults, 'core3')) };
+}

--- a/src/routes/vaults/core3-ratings/+page.svelte
+++ b/src/routes/vaults/core3-ratings/+page.svelte
@@ -3,6 +3,8 @@ CORE3-rated DeFi stablecoin vaults
 -->
 <script lang="ts">
 	import RiskRatingsPage from '$lib/top-vaults/RiskRatingsPage.svelte';
+
+	let { data } = $props();
 </script>
 
-<RiskRatingsPage provider="core3" />
+<RiskRatingsPage provider="core3" initialRatingStatistics={data.initialRatingStatistics} />

--- a/src/routes/vaults/xerberus-ratings/+page.server.ts
+++ b/src/routes/vaults/xerberus-ratings/+page.server.ts
@@ -1,0 +1,7 @@
+import { getCachedTopVaults } from '$lib/top-vaults/cache';
+import { getRiskRatedVaults, getRiskRatingStatistics } from '$lib/top-vaults/risk-rating-statistics';
+
+export async function load({ fetch }) {
+	const topVaults = await getCachedTopVaults(fetch);
+	return { initialRatingStatistics: getRiskRatingStatistics(getRiskRatedVaults(topVaults, 'xerberus')) };
+}

--- a/src/routes/vaults/xerberus-ratings/+page.svelte
+++ b/src/routes/vaults/xerberus-ratings/+page.svelte
@@ -3,6 +3,8 @@ Xerberus-rated DeFi stablecoin vaults
 -->
 <script lang="ts">
 	import RiskRatingsPage from '$lib/top-vaults/RiskRatingsPage.svelte';
+
+	let { data } = $props();
 </script>
 
-<RiskRatingsPage provider="xerberus" />
+<RiskRatingsPage provider="xerberus" initialRatingStatistics={data.initialRatingStatistics} />


### PR DESCRIPTION
## Why

Risk-provider listings need compact, accurate provider-specific summaries, and tokenised funds need a distinct search entity type.

## Lessons learnt

Risk-listing headline statistics must exclude blacklisted vaults and be calculated server-side so crawler-visible metadata matches the rendered page.

## Summary

- Add the `tokenised_fund` search entity type.
- Add CORE3 and Xerberus risk-rated vault listings with provider risk, blacklisted-vault filtering, and compact risk columns.
- Add provider-specific TVL, vault, blockchain, and weighted-return descriptions to page metadata and content.