### PR TITLE
feat: add risk rating TVL charts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Weblog of stuff
 
+- Add TVL distribution charts for CORE3 and Xerberus risk-rated vaults (2026-07-30)
 - Restore site-wide vault search with server-side vault JSON indexing, typeahead and responsive result listings, replacing the retired external integration (2026-07-30)
 - Add CORE3 and Xerberus risk-rating vault lists, per-vault Xerberus report links, and a YouTube footer link with reordered social icons (2026-07-30)
 - Rank strategy vaults by displayed annual return within green and red chart groups, and clarify the strategy listing description (2026-07-28)

--- a/src/lib/top-vaults/RiskRatingsPage.svelte
+++ b/src/lib/top-vaults/RiskRatingsPage.svelte
@@ -18,16 +18,25 @@ the score in a column beside each vault name.
 	import { formatDollar, formatPercent } from '$lib/helpers/formatters';
 	import { fetchAllVaultData, hasVaultCache } from './client-cache';
 	import { riskRatingProviders, type RiskRatingProvider } from './risk-rating-providers';
-	import { getRiskRatedVaults, getRiskRatingStatistics, type RiskRatingStatistics } from './risk-rating-statistics';
+	import {
+		getRiskRatedVaults,
+		getRiskRatingStatistics,
+		getRiskRatingTvlBands,
+		type RiskRatingStatistics,
+		type RiskRatingTvlBand
+	} from './risk-rating-statistics';
 	import type { TopVaults } from './schemas';
 	import TopVaultsPage from './TopVaultsPage.svelte';
+	import MarketSharePieChart from '../../routes/vaults/MarketSharePieChart.svelte';
+	import MarketShareWidgetBox from '../../routes/vaults/MarketShareWidgetBox.svelte';
 
 	interface Props {
 		provider: RiskRatingProvider;
 		initialRatingStatistics?: RiskRatingStatistics;
+		initialRiskRatingTvlBands?: RiskRatingTvlBand[];
 	}
 
-	let { provider, initialRatingStatistics }: Props = $props();
+	let { provider, initialRatingStatistics, initialRiskRatingTvlBands }: Props = $props();
 	let topVaults = $state<TopVaults>();
 	let loading = $state(!hasVaultCache(page.data.generatedAt));
 	let providerDetails = $derived(riskRatingProviders[provider]);
@@ -44,6 +53,9 @@ the score in a column beside each vault name.
 	let ratingStatistics = $derived.by(() => {
 		return ratedTopVaults ? getRiskRatingStatistics(ratedTopVaults.vaults) : initialRatingStatistics;
 	});
+	let riskRatingTvlBands = $derived(
+		topVaults ? getRiskRatingTvlBands(topVaults, provider) : (initialRiskRatingTvlBands ?? [])
+	);
 	let ratingSummary = $derived.by(() => {
 		const { totalTvl, vaultCount, blockchainCount, averageMonthlyReturn } = ratingStatistics ?? {
 			totalTvl: 0,
@@ -118,6 +130,18 @@ the score in a column beside each vault name.
 	defaultSort="provider_risk_rating"
 	defaultDirection={providerDetails.defaultDirection}
 >
+	{#snippet heroAside()}
+		<MarketShareWidgetBox title="Risk by TVL">
+			<MarketSharePieChart
+				items={riskRatingTvlBands}
+				groupLabel="Risk bracket"
+				groupLabelPlural="risk brackets"
+				otherThreshold={0}
+				testId={`${provider}-risk-by-tvl-pie-chart`}
+			/>
+		</MarketShareWidgetBox>
+	{/snippet}
+
 	{#snippet subtitle()}
 		{#if provider === 'core3'}
 			<p>

--- a/src/lib/top-vaults/RiskRatingsPage.svelte
+++ b/src/lib/top-vaults/RiskRatingsPage.svelte
@@ -88,10 +88,10 @@ the score in a column beside each vault name.
 	};
 	const xerberusRiskColourValues = [
 		'var(--c-error)',
-		'color-mix(in srgb, var(--c-error), var(--c-warning))',
+		'hsl(18 92% 52%)',
 		'var(--c-warning)',
-		'color-mix(in srgb, var(--c-warning), var(--c-success))',
-		'color-mix(in srgb, var(--c-warning), var(--c-success) 72%)',
+		'hsl(82 70% 43%)',
+		'hsl(174 70% 40%)',
 		'var(--c-success)'
 	];
 

--- a/src/lib/top-vaults/RiskRatingsPage.svelte
+++ b/src/lib/top-vaults/RiskRatingsPage.svelte
@@ -83,17 +83,38 @@ the score in a column beside each vault name.
 		fair: 'var(--c-warning)',
 		poor: 'var(--c-error)'
 	};
+	const xerberusRiskColourValues = [
+		'var(--c-error)',
+		'color-mix(in srgb, var(--c-error), var(--c-warning))',
+		'var(--c-warning)',
+		'color-mix(in srgb, var(--c-warning), var(--c-success))',
+		'color-mix(in srgb, var(--c-warning), var(--c-success) 72%)',
+		'var(--c-success)'
+	];
 
-	function getCore3SliceColour(slice: MarketSharePieSlice): string | undefined {
-		const colourValue = core3ToneColourValues[slice.tone as keyof typeof core3ToneColourValues];
-		if (!colourValue) return undefined;
-
+	function resolveCssColour(colourValue: string): string {
 		const probe = document.createElement('span');
 		probe.style.color = colourValue;
 		document.body.append(probe);
 		const resolvedColour = getComputedStyle(probe).color;
 		probe.remove();
 		return resolvedColour;
+	}
+
+	function getCore3SliceColour(slice: MarketSharePieSlice): string | undefined {
+		const colourValue = core3ToneColourValues[slice.tone as keyof typeof core3ToneColourValues];
+		if (!colourValue) return undefined;
+		return resolveCssColour(colourValue);
+	}
+
+	function getXerberusSliceColour(slice: MarketSharePieSlice): string | undefined {
+		const bandIndex = Number(slice.slug?.replace('risk-', '')) - 1;
+		const colourValue = xerberusRiskColourValues[bandIndex];
+		return colourValue ? resolveCssColour(colourValue) : undefined;
+	}
+
+	function getRiskSliceColour(slice: MarketSharePieSlice): string | undefined {
+		return provider === 'core3' ? getCore3SliceColour(slice) : getXerberusSliceColour(slice);
 	}
 
 	function formatRiskChartTvl(slice: MarketSharePieSlice): string {
@@ -164,7 +185,7 @@ the score in a column beside each vault name.
 				groupLabelPlural={riskRatingGroupLabelPlural}
 				otherThreshold={0}
 				labelValueFormatter={formatRiskChartTvl}
-				getSliceColour={provider === 'core3' ? getCore3SliceColour : undefined}
+				getSliceColour={getRiskSliceColour}
 				centreImageUrl={providerDetails.logoUrl}
 				testId={`${provider}-risk-by-tvl-pie-chart`}
 			/>

--- a/src/lib/top-vaults/RiskRatingsPage.svelte
+++ b/src/lib/top-vaults/RiskRatingsPage.svelte
@@ -153,7 +153,7 @@ the score in a column beside each vault name.
 	defaultDirection={providerDetails.defaultDirection}
 >
 	{#snippet heroAside()}
-		<MarketShareWidgetBox title="Risk by TVL">
+		<MarketShareWidgetBox title={`TVL by ${providerDetails.name} rated risk`}>
 			<MarketSharePieChart
 				items={riskRatingTvlBands}
 				groupLabel={riskRatingGroupLabel}

--- a/src/lib/top-vaults/RiskRatingsPage.svelte
+++ b/src/lib/top-vaults/RiskRatingsPage.svelte
@@ -96,6 +96,10 @@ the score in a column beside each vault name.
 		return resolvedColour;
 	}
 
+	function formatRiskChartTvl(slice: MarketSharePieSlice): string {
+		return formatDollar(slice.tvl, 1, 1);
+	}
+
 	$effect(() => {
 		fetchAllVaultData(page.data.generatedAt)
 			.then((data) => (topVaults = data))
@@ -159,6 +163,7 @@ the score in a column beside each vault name.
 				groupLabel={riskRatingGroupLabel}
 				groupLabelPlural={riskRatingGroupLabelPlural}
 				otherThreshold={0}
+				labelValueFormatter={formatRiskChartTvl}
 				getSliceColour={provider === 'core3' ? getCore3SliceColour : undefined}
 				testId={`${provider}-risk-by-tvl-pie-chart`}
 			/>

--- a/src/lib/top-vaults/RiskRatingsPage.svelte
+++ b/src/lib/top-vaults/RiskRatingsPage.svelte
@@ -59,6 +59,9 @@ the score in a column beside each vault name.
 	);
 	let riskRatingGroupLabel = $derived(provider === 'core3' ? 'CORE3 rating' : 'Risk bracket');
 	let riskRatingGroupLabelPlural = $derived(provider === 'core3' ? 'CORE3 ratings' : 'risk brackets');
+	let riskChartTitle = $derived(
+		`${formatDollar(ratingStatistics?.totalTvl ?? 0, 1, 1)} TVL by ${providerDetails.name} rated risk`
+	);
 	let ratingSummary = $derived.by(() => {
 		const { totalTvl, vaultCount, blockchainCount, averageMonthlyReturn } = ratingStatistics ?? {
 			totalTvl: 0,
@@ -178,7 +181,7 @@ the score in a column beside each vault name.
 	defaultDirection={providerDetails.defaultDirection}
 >
 	{#snippet heroAside()}
-		<MarketShareWidgetBox title={`TVL by ${providerDetails.name} rated risk`}>
+		<MarketShareWidgetBox title={riskChartTitle}>
 			<MarketSharePieChart
 				items={riskRatingTvlBands}
 				groupLabel={riskRatingGroupLabel}

--- a/src/lib/top-vaults/RiskRatingsPage.svelte
+++ b/src/lib/top-vaults/RiskRatingsPage.svelte
@@ -29,6 +29,7 @@ the score in a column beside each vault name.
 	import TopVaultsPage from './TopVaultsPage.svelte';
 	import MarketSharePieChart from '../../routes/vaults/MarketSharePieChart.svelte';
 	import MarketShareWidgetBox from '../../routes/vaults/MarketShareWidgetBox.svelte';
+	import type { MarketSharePieSlice } from '../../routes/vaults/market-share-pie';
 
 	interface Props {
 		provider: RiskRatingProvider;
@@ -56,6 +57,8 @@ the score in a column beside each vault name.
 	let riskRatingTvlBands = $derived(
 		topVaults ? getRiskRatingTvlBands(topVaults, provider) : (initialRiskRatingTvlBands ?? [])
 	);
+	let riskRatingGroupLabel = $derived(provider === 'core3' ? 'CORE3 rating' : 'Risk bracket');
+	let riskRatingGroupLabelPlural = $derived(provider === 'core3' ? 'CORE3 ratings' : 'risk brackets');
 	let ratingSummary = $derived.by(() => {
 		const { totalTvl, vaultCount, blockchainCount, averageMonthlyReturn } = ratingStatistics ?? {
 			totalTvl: 0,
@@ -73,6 +76,25 @@ the score in a column beside each vault name.
 			ratingStatistics?.vaultCount ?? 0
 		} ${(ratingStatistics?.vaultCount ?? 0) === 1 ? 'vault' : 'vaults'}`
 	);
+
+	const core3ToneColourValues = {
+		excellent: 'var(--c-success)',
+		good: 'color-mix(in srgb, var(--c-success), var(--c-warning))',
+		fair: 'var(--c-warning)',
+		poor: 'var(--c-error)'
+	};
+
+	function getCore3SliceColour(slice: MarketSharePieSlice): string | undefined {
+		const colourValue = core3ToneColourValues[slice.tone as keyof typeof core3ToneColourValues];
+		if (!colourValue) return undefined;
+
+		const probe = document.createElement('span');
+		probe.style.color = colourValue;
+		document.body.append(probe);
+		const resolvedColour = getComputedStyle(probe).color;
+		probe.remove();
+		return resolvedColour;
+	}
 
 	$effect(() => {
 		fetchAllVaultData(page.data.generatedAt)
@@ -134,9 +156,10 @@ the score in a column beside each vault name.
 		<MarketShareWidgetBox title="Risk by TVL">
 			<MarketSharePieChart
 				items={riskRatingTvlBands}
-				groupLabel="Risk bracket"
-				groupLabelPlural="risk brackets"
+				groupLabel={riskRatingGroupLabel}
+				groupLabelPlural={riskRatingGroupLabelPlural}
 				otherThreshold={0}
+				getSliceColour={provider === 'core3' ? getCore3SliceColour : undefined}
 				testId={`${provider}-risk-by-tvl-pie-chart`}
 			/>
 		</MarketShareWidgetBox>

--- a/src/lib/top-vaults/RiskRatingsPage.svelte
+++ b/src/lib/top-vaults/RiskRatingsPage.svelte
@@ -165,6 +165,7 @@ the score in a column beside each vault name.
 				otherThreshold={0}
 				labelValueFormatter={formatRiskChartTvl}
 				getSliceColour={provider === 'core3' ? getCore3SliceColour : undefined}
+				centreImageUrl={providerDetails.logoUrl}
 				testId={`${provider}-risk-by-tvl-pie-chart`}
 			/>
 		</MarketShareWidgetBox>

--- a/src/lib/top-vaults/TopVaultsPage.svelte
+++ b/src/lib/top-vaults/TopVaultsPage.svelte
@@ -67,6 +67,8 @@ Use `ratingProvider` to show a provider-specific risk rating column.
 		loading?: boolean;
 		/** Optional right-hand content for listing detail page overview panels */
 		detailAside?: Snippet;
+		/** Optional right-hand content rendered alongside the page heading. */
+		heroAside?: Snippet;
 		/** Optional left-hand description box rendered next to detailAside (used by
 		    chain pages on its own, and by stablecoin pages above the about box) */
 		detailDescription?: Snippet;
@@ -112,6 +114,7 @@ Use `ratingProvider` to show a provider-specific risk rating column.
 		defaultDirection,
 		loading = false,
 		detailAside,
+		heroAside,
 		detailDescription,
 		beforeTable,
 		totalVaultCount,
@@ -125,6 +128,7 @@ Use `ratingProvider` to show a provider-specific risk rating column.
 	let renderDetailAsideInHero = $derived(
 		chain && detailAside && !detailDescription && !protocolMetadata && !stablecoinMetadata
 	);
+	let showHeroAside = $derived(renderDetailAsideInHero || heroAside);
 </script>
 
 <main class="top-vaults-page ds-3">
@@ -138,7 +142,7 @@ Use `ratingProvider` to show a provider-specific risk rating column.
 					</div>
 				{/if}
 			</div>
-			<div class:hero-layout={renderDetailAsideInHero}>
+			<div class:hero-layout={showHeroAside}>
 				<HeroBanner {subtitle}>
 					{#snippet title()}
 						<span class="page-title">
@@ -168,7 +172,11 @@ Use `ratingProvider` to show a provider-specific risk rating column.
 					{/snippet}
 				</HeroBanner>
 
-				{#if renderDetailAsideInHero && detailAside}
+				{#if heroAside}
+					<aside class="hero-aside">
+						{@render heroAside()}
+					</aside>
+				{:else if renderDetailAsideInHero && detailAside}
 					<aside class="hero-aside">
 						{@render detailAside()}
 					</aside>
@@ -401,6 +409,11 @@ Use `ratingProvider` to show a provider-specific risk rating column.
 			.detail-overview-single .detail-aside {
 				grid-column: auto;
 			}
+
+			.hero-layout {
+				grid-template-columns: 1fr;
+				align-items: stretch;
+			}
 		}
 
 		@media (--viewport-sm-down) {
@@ -411,11 +424,6 @@ Use `ratingProvider` to show a provider-specific risk rating column.
 			.top-vaults-header :global(.hero-banner) {
 				min-height: 0;
 				padding-block: var(--space-xs);
-			}
-
-			.hero-layout {
-				grid-template-columns: 1fr;
-				align-items: stretch;
 			}
 
 			.page-title {

--- a/src/lib/top-vaults/risk-rating-statistics.test.ts
+++ b/src/lib/top-vaults/risk-rating-statistics.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from 'vitest';
+import { getRiskRatingTvlBands } from './risk-rating-statistics';
+import { createTestVault } from './test-utils';
+
+describe('getRiskRatingTvlBands', () => {
+	it('groups Xerberus-rated TVL into six score bands with the highest scores safest', () => {
+		const lowerScoreVault = createTestVault('Lower score vault', {
+			current_nav: 10,
+			xerberus: {
+				score: 0,
+				score_scale: '0_100_higher_is_better',
+				entity_type: 'pool',
+				entity_id: 'lower-score-vault',
+				name: 'Lower score vault',
+				protocol_slug: null,
+				report_url: 'https://app.xerberus.io/pool/dendrogram/lower-score-vault',
+				fetched_at: '2026-07-30T11:30:40Z'
+			}
+		});
+		const higherScoreVault = createTestVault('Higher score vault', {
+			current_nav: 90,
+			xerberus: {
+				score: 100,
+				score_scale: '0_100_higher_is_better',
+				entity_type: 'pool',
+				entity_id: 'higher-score-vault',
+				name: 'Higher score vault',
+				protocol_slug: null,
+				report_url: 'https://app.xerberus.io/pool/dendrogram/higher-score-vault',
+				fetched_at: '2026-07-30T11:30:40Z'
+			}
+		});
+
+		const bands = getRiskRatingTvlBands(
+			{
+				generated_at: '2026-07-30T11:30:40Z',
+				vaults: [lowerScoreVault, higherScoreVault],
+				core3_protocols: {},
+				curators: {}
+			},
+			'xerberus'
+		);
+
+		expect(bands.map(({ label }) => label)).toEqual(['0–16', '17–33', '34–49', '50–66', '67–83', '84–100']);
+		expect(bands[0]).toMatchObject({ tvl: 10, name: '0–16 · highest risk scores' });
+		expect(bands[5]).toMatchObject({ tvl: 90, name: '84–100 · safest scores' });
+	});
+
+	it('uses the compact CORE3 score when no protocol record is present', () => {
+		const saferVault = createTestVault('Safer CORE3 vault', {
+			current_nav: 75,
+			core3: {
+				risk_score: 10,
+				risk_rating_label: 'AA',
+				market_cap: null,
+				core3_ranking: null,
+				data_coverage: null,
+				confidence: null
+			}
+		});
+		const riskierVault = createTestVault('Riskier CORE3 vault', {
+			current_nav: 25,
+			core3: {
+				risk_score: 90,
+				risk_rating_label: 'D',
+				market_cap: null,
+				core3_ranking: null,
+				data_coverage: null,
+				confidence: null
+			}
+		});
+
+		const bands = getRiskRatingTvlBands(
+			{ generated_at: '2026-07-30T11:30:40Z', vaults: [saferVault, riskierVault], core3_protocols: {}, curators: {} },
+			'core3'
+		);
+
+		expect(bands[0]).toMatchObject({ tvl: 75, name: '0–16 · safest scores' });
+		expect(bands[5]).toMatchObject({ tvl: 25, name: '84–100 · highest risk scores' });
+	});
+});

--- a/src/lib/top-vaults/risk-rating-statistics.test.ts
+++ b/src/lib/top-vaults/risk-rating-statistics.test.ts
@@ -46,7 +46,7 @@ describe('getRiskRatingTvlBands', () => {
 		expect(bands[5]).toMatchObject({ tvl: 90, name: '84–100 · safest scores' });
 	});
 
-	it('uses the compact CORE3 score when no protocol record is present', () => {
+	it('uses compact CORE3 letter ratings and their existing risk tones', () => {
 		const saferVault = createTestVault('Safer CORE3 vault', {
 			current_nav: 75,
 			core3: {
@@ -75,7 +75,9 @@ describe('getRiskRatingTvlBands', () => {
 			'core3'
 		);
 
-		expect(bands[0]).toMatchObject({ tvl: 75, name: '0–16 · safest scores' });
-		expect(bands[5]).toMatchObject({ tvl: 25, name: '84–100 · highest risk scores' });
+		expect(bands).toMatchObject([
+			{ label: 'AA', name: 'AA · lowest risk', tvl: 75, tone: 'excellent' },
+			{ label: 'D', name: 'D · highest risk', tvl: 25, tone: 'poor' }
+		]);
 	});
 });

--- a/src/lib/top-vaults/risk-rating-statistics.ts
+++ b/src/lib/top-vaults/risk-rating-statistics.ts
@@ -7,9 +7,11 @@ import {
 	calculateTotalTvl,
 	calculateTvlWeightedApy,
 	getCore3PolForVault,
+	getCore3RatingTone,
 	getVaultCurrentTvlUsd,
 	isBlacklisted
 } from './helpers';
+import type { Core3RatingTone } from './helpers';
 
 export type RiskRatingStatistics = {
 	totalTvl: number;
@@ -25,10 +27,12 @@ export type RiskRatingTvlBand = {
 	name: string;
 	tvl: number;
 	avgApy: number | null;
+	tone?: Core3RatingTone;
 };
 
 const RISK_RATING_BAND_COUNT = 6;
 const RISK_RATING_SCORE_MAX = 100;
+const CORE3_RATING_ORDER = ['AAA', 'AA', 'A', 'BBB', 'BB', 'B', 'CCC', 'CC', 'C', 'DDD', 'DD', 'D'];
 
 function getRiskScore(vault: VaultInfo, topVaults: TopVaults, provider: RiskRatingProvider): number | null {
 	if (provider === 'xerberus') return vault.xerberus?.score ?? null;
@@ -79,6 +83,52 @@ export function getRiskRatingStatistics(vaults: VaultInfo[]): RiskRatingStatisti
 	};
 }
 
+function getCore3RatingDescription(tone: Core3RatingTone): string {
+	if (tone === 'excellent') return 'lowest risk';
+	if (tone === 'good') return 'lower risk';
+	if (tone === 'fair') return 'higher risk';
+	if (tone === 'poor') return 'highest risk';
+
+	return 'risk rating';
+}
+
+/** Group CORE3-rated vault TVL by its published letter grades, safest first. */
+function getCore3RatingTvlBands(topVaults: TopVaults): RiskRatingTvlBand[] {
+	const vaultsByRating = new Map<string, VaultInfo[]>();
+
+	for (const vault of getRiskRatedVaults(topVaults, 'core3')) {
+		const rating = getCore3PolForVault(vault, topVaults.core3_protocols)?.rating?.toUpperCase();
+		if (!rating) continue;
+
+		const ratedVaults = vaultsByRating.get(rating) ?? [];
+		ratedVaults.push(vault);
+		vaultsByRating.set(rating, ratedVaults);
+	}
+
+	return Array.from(vaultsByRating.entries())
+		.toSorted(([leftRating], [rightRating]) => {
+			const leftIndex = CORE3_RATING_ORDER.indexOf(leftRating);
+			const rightIndex = CORE3_RATING_ORDER.indexOf(rightRating);
+			return (
+				(leftIndex < 0 ? Infinity : leftIndex) - (rightIndex < 0 ? Infinity : rightIndex) ||
+				leftRating.localeCompare(rightRating)
+			);
+		})
+		.map(([rating, vaults]) => {
+			const tone = getCore3RatingTone(rating);
+			const vaultsWithUsdTvl = vaults.map((vault) => ({ ...vault, current_nav: getVaultCurrentTvlUsd(vault) }));
+
+			return {
+				slug: `core3-${rating.toLowerCase()}`,
+				label: rating,
+				name: `${rating} · ${getCore3RatingDescription(tone)}`,
+				tvl: calculateTotalTvl(vaultsWithUsdTvl),
+				avgApy: calculateTvlWeightedApy(vaultsWithUsdTvl),
+				tone
+			};
+		});
+}
+
 /**
  * Group a provider's rated vault TVL into six evenly sized score ranges.
  * CORE3 considers lower scores safer, whereas Xerberus considers higher
@@ -88,6 +138,8 @@ export function getRiskRatingStatistics(vaults: VaultInfo[]): RiskRatingStatisti
  * @param provider - Risk provider whose rated vaults are grouped.
  */
 export function getRiskRatingTvlBands(topVaults: TopVaults, provider: RiskRatingProvider): RiskRatingTvlBand[] {
+	if (provider === 'core3') return getCore3RatingTvlBands(topVaults);
+
 	const bands = Array.from({ length: RISK_RATING_BAND_COUNT }, (_, index) => ({
 		slug: `risk-${index + 1}`,
 		label: getRiskBandLabel(index),

--- a/src/lib/top-vaults/risk-rating-statistics.ts
+++ b/src/lib/top-vaults/risk-rating-statistics.ts
@@ -18,6 +18,44 @@ export type RiskRatingStatistics = {
 	averageMonthlyReturn: number | null;
 };
 
+/** One of the six score bands used to visualise rated TVL. */
+export type RiskRatingTvlBand = {
+	slug: string;
+	label: string;
+	name: string;
+	tvl: number;
+	avgApy: number | null;
+};
+
+const RISK_RATING_BAND_COUNT = 6;
+const RISK_RATING_SCORE_MAX = 100;
+
+function getRiskScore(vault: VaultInfo, topVaults: TopVaults, provider: RiskRatingProvider): number | null {
+	if (provider === 'xerberus') return vault.xerberus?.score ?? null;
+
+	return getCore3PolForVault(vault, topVaults.core3_protocols)?.score ?? null;
+}
+
+function getRiskBandLabel(index: number): string {
+	const lowerBound = Math.ceil((index * RISK_RATING_SCORE_MAX) / RISK_RATING_BAND_COUNT);
+	const upperBound =
+		index === RISK_RATING_BAND_COUNT - 1
+			? RISK_RATING_SCORE_MAX
+			: Math.ceil(((index + 1) * RISK_RATING_SCORE_MAX) / RISK_RATING_BAND_COUNT) - 1;
+
+	return `${lowerBound}–${upperBound}`;
+}
+
+function getRiskBandDescription(provider: RiskRatingProvider, index: number): string {
+	const safestBand = provider === 'core3' ? 0 : RISK_RATING_BAND_COUNT - 1;
+	const riskiestBand = provider === 'core3' ? RISK_RATING_BAND_COUNT - 1 : 0;
+
+	if (index === safestBand) return 'safest scores';
+	if (index === riskiestBand) return 'highest risk scores';
+
+	return 'risk score range';
+}
+
 /** Return all non-blacklisted vaults with a rating from the selected provider. */
 export function getRiskRatedVaults(topVaults: TopVaults, provider: RiskRatingProvider): VaultInfo[] {
 	return topVaults.vaults.filter((vault) => {
@@ -39,4 +77,43 @@ export function getRiskRatingStatistics(vaults: VaultInfo[]): RiskRatingStatisti
 		blockchainCount: new Set(vaults.map((vault) => vault.chain_id)).size,
 		averageMonthlyReturn: calculateTvlWeightedApy(vaultsWithUsdTvl)
 	};
+}
+
+/**
+ * Group a provider's rated vault TVL into six evenly sized score ranges.
+ * CORE3 considers lower scores safer, whereas Xerberus considers higher
+ * scores safer; the ranges stay numeric so both distributions are comparable.
+ *
+ * @param topVaults - Complete vault payload, including CORE3 protocol scores.
+ * @param provider - Risk provider whose rated vaults are grouped.
+ */
+export function getRiskRatingTvlBands(topVaults: TopVaults, provider: RiskRatingProvider): RiskRatingTvlBand[] {
+	const bands = Array.from({ length: RISK_RATING_BAND_COUNT }, (_, index) => ({
+		slug: `risk-${index + 1}`,
+		label: getRiskBandLabel(index),
+		name: `${getRiskBandLabel(index)} · ${getRiskBandDescription(provider, index)}`,
+		vaults: [] as VaultInfo[]
+	}));
+
+	for (const vault of getRiskRatedVaults(topVaults, provider)) {
+		const score = getRiskScore(vault, topVaults, provider);
+		if (score == null || !Number.isFinite(score)) continue;
+
+		const clampedScore = Math.max(0, Math.min(RISK_RATING_SCORE_MAX, score));
+		const bandIndex = Math.min(
+			RISK_RATING_BAND_COUNT - 1,
+			Math.floor((clampedScore / RISK_RATING_SCORE_MAX) * RISK_RATING_BAND_COUNT)
+		);
+		bands[bandIndex].vaults.push(vault);
+	}
+
+	return bands.map(({ vaults, ...band }) => {
+		const vaultsWithUsdTvl = vaults.map((vault) => ({ ...vault, current_nav: getVaultCurrentTvlUsd(vault) }));
+
+		return {
+			...band,
+			tvl: calculateTotalTvl(vaultsWithUsdTvl),
+			avgApy: calculateTvlWeightedApy(vaultsWithUsdTvl)
+		};
+	});
 }

--- a/src/routes/vaults/MarketSharePieChart.svelte
+++ b/src/routes/vaults/MarketSharePieChart.svelte
@@ -22,6 +22,8 @@
 		wrapLabels?: boolean;
 		/** Label for the value shown in chart tooltips. */
 		valueLabel?: string;
+		/** Format the secondary label shown beside each pie slice. Defaults to its share percentage. */
+		labelValueFormatter?: (slice: MarketSharePieSlice) => string;
 		/** Resolve a chart and label colour for an individual pie slice. */
 		getSliceColour?: (slice: MarketSharePieSlice) => string | undefined;
 		testId?: string;
@@ -37,6 +39,7 @@
 		showLabelLogos = false,
 		wrapLabels = false,
 		valueLabel = 'TVL',
+		labelValueFormatter,
 		getSliceColour,
 		testId = 'market-share-pie-chart',
 		class: classes = ''
@@ -75,6 +78,10 @@
 
 	function formatLabelPercentage(value: number): string {
 		return value >= 10 ? value.toFixed(0) : value.toFixed(1);
+	}
+
+	function formatSliceValue(slice: MarketSharePieSlice): string {
+		return labelValueFormatter?.(slice) ?? `${formatLabelPercentage(slice.percentage)}%`;
 	}
 
 	function getLogoRichKey(slice: MarketSharePieSlice): string {
@@ -325,7 +332,7 @@
 						formatter: (params: { data?: MarketSharePieSlice }) => {
 							const slice = params.data;
 							if (!slice) return '';
-							return `${formatSliceLabel(slice, includeLabelLogos)}\n{${getValueLabelStyle(slice)}|${formatLabelPercentage(slice.percentage)}%}`;
+							return `${formatSliceLabel(slice, includeLabelLogos)}\n{${getValueLabelStyle(slice)}|${formatSliceValue(slice)}}`;
 						},
 						rich: labelRichStyles
 					},
@@ -407,6 +414,7 @@
 			showLabelLogos,
 			wrapLabels,
 			valueLabel,
+			labelValueFormatter,
 			getSliceColour
 		);
 		if (!runtimeReady || !echartsApi || !chartContainer) return;

--- a/src/routes/vaults/MarketSharePieChart.svelte
+++ b/src/routes/vaults/MarketSharePieChart.svelte
@@ -26,6 +26,8 @@
 		labelValueFormatter?: (slice: MarketSharePieSlice) => string;
 		/** Resolve a chart and label colour for an individual pie slice. */
 		getSliceColour?: (slice: MarketSharePieSlice) => string | undefined;
+		/** Optional image displayed in the centre of the donut. */
+		centreImageUrl?: string;
 		testId?: string;
 		class?: string;
 	}
@@ -41,6 +43,7 @@
 		valueLabel = 'TVL',
 		labelValueFormatter,
 		getSliceColour,
+		centreImageUrl,
 		testId = 'market-share-pie-chart',
 		class: classes = ''
 	}: Props = $props();
@@ -273,6 +276,7 @@
 		const includeLabelLogos = showLabelLogos && !isMobile;
 		const currentSlices = slices.map((slice) => ({ ...slice, colour: getSliceColour?.(slice) }));
 		const labelRichStyles = buildLabelRichStyles(isMobile, currentSlices);
+		const centreImageSize = isMobile ? 28 : 40;
 		chartInstance = echartsApi.init(chartContainer);
 		chartInstance.setOption({
 			animationDuration: 450,
@@ -304,6 +308,28 @@
 					return slice ? buildTooltip(slice) : '';
 				}
 			},
+			graphic: centreImageUrl
+				? [
+						{
+							type: 'group',
+							left: 'center',
+							top: '53%',
+							z: 10,
+							children: [
+								{
+									type: 'image',
+									style: {
+										image: centreImageUrl,
+										x: -centreImageSize / 2,
+										y: -centreImageSize / 2,
+										width: centreImageSize,
+										height: centreImageSize
+									}
+								}
+							]
+						}
+					]
+				: [],
 			series: [
 				{
 					name: `${groupLabel} ${valueLabel}`,
@@ -415,7 +441,8 @@
 			wrapLabels,
 			valueLabel,
 			labelValueFormatter,
-			getSliceColour
+			getSliceColour,
+			centreImageUrl
 		);
 		if (!runtimeReady || !echartsApi || !chartContainer) return;
 

--- a/src/routes/vaults/MarketSharePieChart.svelte
+++ b/src/routes/vaults/MarketSharePieChart.svelte
@@ -22,6 +22,8 @@
 		wrapLabels?: boolean;
 		/** Label for the value shown in chart tooltips. */
 		valueLabel?: string;
+		/** Resolve a chart and label colour for an individual pie slice. */
+		getSliceColour?: (slice: MarketSharePieSlice) => string | undefined;
 		testId?: string;
 		class?: string;
 	}
@@ -35,6 +37,7 @@
 		showLabelLogos = false,
 		wrapLabels = false,
 		valueLabel = 'TVL',
+		getSliceColour,
 		testId = 'market-share-pie-chart',
 		class: classes = ''
 	}: Props = $props();
@@ -78,6 +81,15 @@
 		return `logo_${(slice.slug ?? slice.label).replace(/\W+/g, '_')}`;
 	}
 
+	function getSliceRichKey(slice: MarketSharePieSlice): string {
+		return (slice.slug ?? slice.label).replace(/\W+/g, '_');
+	}
+
+	function getLabelStyleName(slice: MarketSharePieSlice, compact: boolean): string {
+		const baseStyle = compact ? 'labelCompact' : 'label';
+		return slice.colour ? `${baseStyle}_${getSliceRichKey(slice)}` : baseStyle;
+	}
+
 	function splitLabelIntoTwoLines(label: string): string[] {
 		const words = label.trim().split(/\s+/);
 		if (label.length <= 24 || words.length < 2) return [label];
@@ -102,7 +114,7 @@
 	function formatSliceLabel(slice: MarketSharePieSlice, includeLogo: boolean): string {
 		const { label } = slice;
 		const lines = wrapLabels ? splitLabelIntoTwoLines(label) : [label];
-		const style = wrapLabels && label.length > 45 ? 'labelCompact' : 'label';
+		const style = getLabelStyleName(slice, wrapLabels && label.length > 45);
 		const labelText = lines.map((line) => `{${style}|${line}}`).join('\n');
 
 		if (includeLogo && slice.logoUrl && !slice.isOther) {
@@ -112,8 +124,9 @@
 		return labelText;
 	}
 
-	function getValueLabelStyle(label: string): string {
-		return wrapLabels && label.length > 45 ? 'valueCompact' : 'value';
+	function getValueLabelStyle(slice: MarketSharePieSlice): string {
+		const baseStyle = wrapLabels && slice.label.length > 45 ? 'valueCompact' : 'value';
+		return slice.colour ? `${baseStyle}_${getSliceRichKey(slice)}` : baseStyle;
 	}
 
 	function trackChartInputs(...inputs: unknown[]): void {
@@ -167,6 +180,13 @@
 		};
 
 		for (const slice of currentSlices) {
+			if (slice.colour) {
+				for (const [baseStyle, style] of Object.entries(rich)) {
+					if (!['label', 'labelCompact', 'value', 'valueCompact'].includes(baseStyle)) continue;
+					rich[`${baseStyle}_${getSliceRichKey(slice)}`] = { ...style, color: slice.colour };
+				}
+			}
+
 			if (!showLabelLogos || isMobile || !slice.logoUrl || slice.isOther) continue;
 			rich[getLogoRichKey(slice)] = {
 				width: logoSize,
@@ -244,7 +264,7 @@
 
 		const isMobile = window.innerWidth <= 768;
 		const includeLabelLogos = showLabelLogos && !isMobile;
-		const currentSlices = slices;
+		const currentSlices = slices.map((slice) => ({ ...slice, colour: getSliceColour?.(slice) }));
 		const labelRichStyles = buildLabelRichStyles(isMobile, currentSlices);
 		chartInstance = echartsApi.init(chartContainer);
 		chartInstance.setOption({
@@ -305,7 +325,7 @@
 						formatter: (params: { data?: MarketSharePieSlice }) => {
 							const slice = params.data;
 							if (!slice) return '';
-							return `${formatSliceLabel(slice, includeLabelLogos)}\n{${getValueLabelStyle(slice.label)}|${formatLabelPercentage(slice.percentage)}%}`;
+							return `${formatSliceLabel(slice, includeLabelLogos)}\n{${getValueLabelStyle(slice)}|${formatLabelPercentage(slice.percentage)}%}`;
 						},
 						rich: labelRichStyles
 					},
@@ -386,7 +406,8 @@
 			maxIndividualSlices,
 			showLabelLogos,
 			wrapLabels,
-			valueLabel
+			valueLabel,
+			getSliceColour
 		);
 		if (!runtimeReady || !echartsApi || !chartContainer) return;
 

--- a/src/routes/vaults/MarketSharePieChart.svelte
+++ b/src/routes/vaults/MarketSharePieChart.svelte
@@ -274,9 +274,15 @@
 
 		const isMobile = window.innerWidth <= 768;
 		const includeLabelLogos = showLabelLogos && !isMobile;
-		const currentSlices = slices.map((slice) => ({ ...slice, colour: getSliceColour?.(slice) }));
+		const currentSlices = slices.map((slice) => {
+			const colour = getSliceColour?.(slice);
+			return {
+				...slice,
+				colour,
+				itemStyle: colour ? { ...slice.itemStyle, color: colour } : slice.itemStyle
+			};
+		});
 		const labelRichStyles = buildLabelRichStyles(isMobile, currentSlices);
-		const centreImageSize = isMobile ? 28 : 40;
 		chartInstance = echartsApi.init(chartContainer);
 		chartInstance.setOption({
 			animationDuration: 450,
@@ -308,28 +314,6 @@
 					return slice ? buildTooltip(slice) : '';
 				}
 			},
-			graphic: centreImageUrl
-				? [
-						{
-							type: 'group',
-							left: 'center',
-							top: '53%',
-							z: 10,
-							children: [
-								{
-									type: 'image',
-									style: {
-										image: centreImageUrl,
-										x: -centreImageSize / 2,
-										y: -centreImageSize / 2,
-										width: centreImageSize,
-										height: centreImageSize
-									}
-								}
-							]
-						}
-					]
-				: [],
 			series: [
 				{
 					name: `${groupLabel} ${valueLabel}`,
@@ -463,6 +447,9 @@
 		<div class="chart-stage-glow"></div>
 		<div class="chart-stage-reflection"></div>
 		<div bind:this={chartContainer} class="chart"></div>
+		{#if centreImageUrl}
+			<img class="centre-logo" src={centreImageUrl} alt="" aria-hidden="true" />
+		{/if}
 	</div>
 	{#if loading}
 		<div class="loading-overlay">
@@ -565,6 +552,24 @@
 		z-index: 1;
 		width: 100%;
 		height: 23rem;
+	}
+
+	.centre-logo {
+		position: absolute;
+		top: 53%;
+		left: 50%;
+		z-index: 2;
+		display: none;
+		width: 2.5rem;
+		height: 2.5rem;
+		transform: translate(-50%, -50%);
+		pointer-events: none;
+	}
+
+	@media (--viewport-lg-up) {
+		.centre-logo {
+			display: block;
+		}
 	}
 
 	.chart-stage.obscured .chart {

--- a/src/routes/vaults/core3-ratings/+page.server.ts
+++ b/src/routes/vaults/core3-ratings/+page.server.ts
@@ -1,7 +1,14 @@
 import { getCachedTopVaults } from '$lib/top-vaults/cache';
-import { getRiskRatedVaults, getRiskRatingStatistics } from '$lib/top-vaults/risk-rating-statistics';
+import {
+	getRiskRatedVaults,
+	getRiskRatingStatistics,
+	getRiskRatingTvlBands
+} from '$lib/top-vaults/risk-rating-statistics';
 
 export async function load({ fetch }) {
 	const topVaults = await getCachedTopVaults(fetch);
-	return { initialRatingStatistics: getRiskRatingStatistics(getRiskRatedVaults(topVaults, 'core3')) };
+	return {
+		initialRatingStatistics: getRiskRatingStatistics(getRiskRatedVaults(topVaults, 'core3')),
+		initialRiskRatingTvlBands: getRiskRatingTvlBands(topVaults, 'core3')
+	};
 }

--- a/src/routes/vaults/core3-ratings/+page.svelte
+++ b/src/routes/vaults/core3-ratings/+page.svelte
@@ -7,4 +7,8 @@ CORE3-rated DeFi stablecoin vaults
 	let { data } = $props();
 </script>
 
-<RiskRatingsPage provider="core3" initialRatingStatistics={data.initialRatingStatistics} />
+<RiskRatingsPage
+	provider="core3"
+	initialRatingStatistics={data.initialRatingStatistics}
+	initialRiskRatingTvlBands={data.initialRiskRatingTvlBands}
+/>

--- a/src/routes/vaults/market-share-pie.ts
+++ b/src/routes/vaults/market-share-pie.ts
@@ -10,6 +10,8 @@ export interface MarketShareChartItem {
 	avgApy: number | null;
 	logoUrl?: string;
 	href?: string;
+	/** Optional semantic tone used by charts that need domain-specific colours. */
+	tone?: string;
 }
 
 export interface MarketSharePieSlice {
@@ -22,6 +24,9 @@ export interface MarketSharePieSlice {
 	logoUrl?: string;
 	url?: string;
 	slug?: string;
+	tone?: string;
+	/** Resolved chart and label colour, set client-side when needed. */
+	colour?: string;
 	isOther: boolean;
 	memberCount?: number;
 	itemStyle?: {
@@ -97,6 +102,7 @@ export function buildMarketSharePieSlices(
 			logoUrl: item.logoUrl,
 			url: item.href,
 			slug: item.slug,
+			tone: item.tone,
 			isOther: false
 		});
 	}

--- a/src/routes/vaults/xerberus-ratings/+page.server.ts
+++ b/src/routes/vaults/xerberus-ratings/+page.server.ts
@@ -1,7 +1,14 @@
 import { getCachedTopVaults } from '$lib/top-vaults/cache';
-import { getRiskRatedVaults, getRiskRatingStatistics } from '$lib/top-vaults/risk-rating-statistics';
+import {
+	getRiskRatedVaults,
+	getRiskRatingStatistics,
+	getRiskRatingTvlBands
+} from '$lib/top-vaults/risk-rating-statistics';
 
 export async function load({ fetch }) {
 	const topVaults = await getCachedTopVaults(fetch);
-	return { initialRatingStatistics: getRiskRatingStatistics(getRiskRatedVaults(topVaults, 'xerberus')) };
+	return {
+		initialRatingStatistics: getRiskRatingStatistics(getRiskRatedVaults(topVaults, 'xerberus')),
+		initialRiskRatingTvlBands: getRiskRatingTvlBands(topVaults, 'xerberus')
+	};
 }

--- a/src/routes/vaults/xerberus-ratings/+page.svelte
+++ b/src/routes/vaults/xerberus-ratings/+page.svelte
@@ -7,4 +7,8 @@ Xerberus-rated DeFi stablecoin vaults
 	let { data } = $props();
 </script>
 
-<RiskRatingsPage provider="xerberus" initialRatingStatistics={data.initialRatingStatistics} />
+<RiskRatingsPage
+	provider="xerberus"
+	initialRatingStatistics={data.initialRatingStatistics}
+	initialRiskRatingTvlBands={data.initialRiskRatingTvlBands}
+/>


### PR DESCRIPTION
## Why

Risk-rating listing pages need a clear, TVL-weighted view of CORE3 and Xerberus coverage, with provider-specific risk semantics.

## Lessons learnt

A reusable market-share pie needs caller-provided colours and label values; risk providers do not share a score direction or rating notation.

## Summary

- Add TVL distribution pies to CORE3 and Xerberus vault rating pages.
- Group CORE3 by letter grade and Xerberus by six score bands, with provider-aware colours and TVL labels.
- Add responsive provider branding, update shared pie extensibility, and record the feature in the changelog.