### PR TITLE
Update pricing page metadata

### DIFF
--- a/src/routes/pricing/+page.svelte
+++ b/src/routes/pricing/+page.svelte
@@ -147,17 +147,14 @@ Pricing page with Basic and Pro tier comparison
 </script>
 
 <svelte:head>
-	<title>Vault data pricing</title>
-	<meta
-		name="description"
-		content="Compare Trading Strategy pricing plans. Free Basic tier with 1000+ stablecoin vaults, or Pro at $199/month with API access and developer support."
-	/>
+	<title>DeFi vault API and datasets</title>
+	<meta name="description" content="Download datasets for vault analysis" />
 </svelte:head>
 
 <main>
 	<Section padding="md" gap="sm">
 		<header class="hero">
-			<h1>Vault data pricing</h1>
+			<h1>Professional vault data analytics</h1>
 			<p>The most comprehensive DeFi vault datasets and API</p>
 		</header>
 	</Section>

--- a/tests/integration/pricing.test.ts
+++ b/tests/integration/pricing.test.ts
@@ -6,7 +6,18 @@ test.describe('pricing page', () => {
 	});
 
 	test('renders with correct title', async ({ page }) => {
-		await expect(page).toHaveTitle('Vault data pricing');
+		await expect(page).toHaveTitle('DeFi vault API and datasets');
+	});
+
+	test('renders with correct meta description', async ({ page }) => {
+		await expect(page.locator('meta[name="description"]')).toHaveAttribute(
+			'content',
+			'Download datasets for vault analysis'
+		);
+	});
+
+	test('renders with correct in-page title', async ({ page }) => {
+		await expect(page.getByRole('heading', { name: 'Professional vault data analytics' })).toBeVisible();
 	});
 
 	test('shows Free and Pro tier cards', async ({ page }) => {


### PR DESCRIPTION
Why
Update the pricing page SEO metadata and visible title to match the current vault data API and datasets positioning.

Lessons learnt
The pricing page keeps its document metadata inline in `src/routes/pricing/+page.svelte`, with integration coverage in `tests/integration/pricing.test.ts`.

Summary
- Update the pricing page meta title and description.
- Change the in-page pricing heading to professional vault data analytics.
- Update pricing integration assertions for the new title, description, and heading.