### PR TITLE
feat: add Xerberus protocol scores

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Weblog of stuff
 
+- Add Xerberus protocol scores and tooltips to the vault protocol listing, and fix curator description spacing (2026-08-01)
 - Add TVL distribution charts for CORE3 and Xerberus risk-rated vaults (2026-07-30)
 - Restore site-wide vault search with server-side vault JSON indexing, typeahead and responsive result listings, replacing the retired external integration (2026-07-30)
 - Add CORE3 and Xerberus risk-rating vault lists, per-vault Xerberus report links, and a YouTube footer link with reordered social icons (2026-07-30)

--- a/src/lib/curator/CuratorDescription.svelte
+++ b/src/lib/curator/CuratorDescription.svelte
@@ -83,7 +83,7 @@ the vault protocol description widget. Sourced from the top-vaults dataset
 							{:else}{curator.name} has
 							{/if}<strong>{vaultCountLabel}</strong> with
 							<strong>{totalTvlLabel}</strong>{#if averageApyLabel}
-								and a <strong>{averageApyLabel}</strong> over the last 30 days{/if}.
+								{' '}and a <strong>{averageApyLabel}</strong> over the last 30 days{/if}.
 						{/if}
 						{#if curator.short_description}
 							{' '}{curator.short_description}

--- a/src/lib/top-vaults/VaultGroupTable.svelte
+++ b/src/lib/top-vaults/VaultGroupTable.svelte
@@ -28,8 +28,8 @@ logos, target links, sorting, pagination and the shared responsive card layout.
 	import AvgApyHeader from './AvgApyHeader.svelte';
 	import VaultGroupNameCell from './VaultGroupNameCell.svelte';
 	import VaultSparkline from './VaultSparkline.svelte';
-	import RiskCell from './RiskCell.svelte';
 	import Core3RiskCell from './Core3RiskCell.svelte';
+	import XerberusRiskCell from './XerberusRiskCell.svelte';
 	import { formatDollar, formatPercent } from '$lib/helpers/formatters';
 
 	type DataTableProps = Omit<ComponentProps<typeof DataTable>, 'tableViewModel'>;
@@ -185,13 +185,12 @@ logos, target links, sorting, pagination and the shared responsive card layout.
 		}),
 		table.column({
 			id: 'risk',
-			header: 'Technical Risk',
-			accessor: (row) => ({ risk: row.risk, risk_numeric: row.risk_numeric }),
-			cell: ({ value }) => createRender(RiskCell, { risk: value.risk }),
+			header: 'Xerberus',
+			accessor: (row) => ({ score: row.xerberus_score ?? null, url: row.xerberus_url ?? null }),
+			cell: ({ value }) => createRender(XerberusRiskCell, { score: value.score, url: value.url }),
 			plugins: {
 				sort: {
-					getSortValue: (v) => v.risk_numeric ?? Infinity,
-					invert: true
+					getSortValue: (v) => v.score ?? -Infinity
 				}
 			}
 		}),
@@ -252,7 +251,7 @@ logos, target links, sorting, pagination and the shared responsive card layout.
 <style>
 	.vault-protocol-table {
 		/* flip the sort indicator on columns that use inverted sort */
-		:global(:is(th.name, th.risk, th.core3_risk) .icon) {
+		:global(:is(th.name, th.core3_risk) .icon) {
 			rotate: 180deg;
 		}
 
@@ -328,15 +327,23 @@ logos, target links, sorting, pagination and the shared responsive card layout.
 				width: max(calc(20vw), 12rem);
 			}
 
-			/* layout with a leading rating column (technical risk and/or CORE3); the
-			   percentage widths must sum to 100% so the cells fill the table edge-to-edge */
+			/* layout with leading rating columns; keep third-party risk ratings compact
+			   so the numeric columns stay scannable on protocol listings */
 			:global(:has(:is(.risk, .core3_risk))) {
 				:global(:is(th, td):not(.index)) {
 					width: 15%;
 				}
 
 				:global(.name) {
-					width: 29%;
+					width: 24%;
+				}
+
+				:global(.core3_risk) {
+					width: 8%;
+				}
+
+				:global(.risk) {
+					width: 12%;
 				}
 
 				:global(.cta) {
@@ -448,6 +455,7 @@ logos, target links, sorting, pagination and the shared responsive card layout.
 			}
 
 			:global(table.datatable.responsive tbody tr td.name .group-name > span:last-child) {
+				display: block;
 				min-width: 0;
 				overflow: hidden;
 				text-overflow: ellipsis;
@@ -458,7 +466,8 @@ logos, target links, sorting, pagination and the shared responsive card layout.
 				display: none;
 			}
 
-			:global(table.datatable.responsive tbody tr td.core3_risk) {
+			:global(table.datatable.responsive tbody tr td.core3_risk),
+			:global(table.datatable.responsive tbody tr td.risk) {
 				display: none;
 			}
 

--- a/src/lib/top-vaults/XerberusRiskCell.svelte
+++ b/src/lib/top-vaults/XerberusRiskCell.svelte
@@ -1,0 +1,62 @@
+<!--
+@component
+Table cell showing the Xerberus Dendrogram protocol composite score.
+Renders a dash when Xerberus does not publish a score for the protocol.
+
+@example
+
+```svelte
+  <XerberusRiskCell score={0.784} url="https://app.xerberus.io/protocol/dendrogram/morpho-v1" />
+```
+-->
+<script lang="ts">
+	import Tooltip from '$lib/components/Tooltip.svelte';
+	import { formatXerberusScore, getXerberusScoreBand, getXerberusScoreColour } from './helpers';
+
+	interface Props {
+		score?: number | null;
+		url?: string | null;
+	}
+
+	let { score = null, url = null }: Props = $props();
+
+	let label = $derived(formatXerberusScore(score));
+	let band = $derived(getXerberusScoreBand(score));
+	let colour = $derived(getXerberusScoreColour(score));
+</script>
+
+{#if score == null}
+	<span class="empty">–</span>
+{:else}
+	<span class="xerberus-risk-cell">
+		<Tooltip>
+			<svelte:fragment slot="trigger">
+				<span class="score" style:--xerberus-score-colour={colour}>{label}</span>
+			</svelte:fragment>
+			<svelte:fragment slot="popup">
+				Xerberus Dendrogram overall protocol score on a 0 to 100 scale. Higher scores mean lower risk.
+				{#if band}
+					Risk band: <strong>{band}</strong>.
+				{/if}
+				{#if url}
+					<a href={url} target="_blank" rel="noreferrer">View scorecard</a>
+				{/if}
+			</svelte:fragment>
+		</Tooltip>
+	</span>
+{/if}
+
+<style>
+	.score {
+		font-weight: 600;
+		color: var(--xerberus-score-colour, var(--c-text-light));
+	}
+
+	.empty {
+		color: var(--c-text-extra-light);
+	}
+
+	:global(.xerberus-risk-cell .tooltip .popup) {
+		max-width: 400px;
+	}
+</style>

--- a/src/lib/top-vaults/helpers.test.ts
+++ b/src/lib/top-vaults/helpers.test.ts
@@ -20,11 +20,14 @@ import {
 	getCore3ScoreTone,
 	getCore3CategoryScores,
 	getCurrencyUsdRates,
+	formatXerberusScore,
 	getVaultCurrentTvlUsd,
 	getVaultDenominationCurrency,
 	getVaultDenominationUsdRate,
 	getVaultPeakTvlUsd,
 	getVaultTvlNative,
+	getXerberusScoreBand,
+	getXerberusScoreColour,
 	isNonUsdDenominatedVault,
 	normaliseKinexysVaultDenomination,
 	normaliseVaultProtocolDisplayName,
@@ -91,6 +94,22 @@ describe('isBlacklisted', () => {
 		const vault = createTestVault('Test vault');
 		expect(vault.risk_numeric).toBeNull();
 		expect(isBlacklisted(vault)).toBe(false);
+	});
+});
+
+describe('Xerberus protocol score helpers', () => {
+	test('maps scores to Xerberus risk bands and colours', () => {
+		expect(getXerberusScoreBand(0.7)).toBe('Low risk');
+		expect(getXerberusScoreColour(0.7)).toBe('#34d399');
+		expect(getXerberusScoreBand(0.4)).toBe('Moderate');
+		expect(getXerberusScoreColour(0.4)).toBe('#fbbf24');
+		expect(getXerberusScoreBand(0.399)).toBe('Elevated');
+		expect(getXerberusScoreColour(0.399)).toBe('#f87171');
+	});
+
+	test('formats real Xerberus scores and missing values as a dash', () => {
+		expect(formatXerberusScore(0.7843137254901961)).toBe('78');
+		expect(formatXerberusScore(null)).toBe('–');
 	});
 });
 

--- a/src/lib/top-vaults/helpers.ts
+++ b/src/lib/top-vaults/helpers.ts
@@ -119,6 +119,34 @@ export const riskFilterOptions = [
 	{ label: 'Negligible', optionLabel: 'Negligible only', minValue: 0, maxValue: 1 }
 ];
 
+export const XERBERUS_SCORE_COLOURS = {
+	lowRisk: '#34d399',
+	moderate: '#fbbf24',
+	elevated: '#f87171'
+} as const;
+
+export type XerberusScoreBand = 'Low risk' | 'Moderate' | 'Elevated';
+
+export function getXerberusScoreBand(score: number | null | undefined): XerberusScoreBand | null {
+	if (score == null || !Number.isFinite(score)) return null;
+	if (score >= 0.7) return 'Low risk';
+	if (score >= 0.4) return 'Moderate';
+	return 'Elevated';
+}
+
+export function getXerberusScoreColour(score: number | null | undefined): string | null {
+	const band = getXerberusScoreBand(score);
+	if (band === 'Low risk') return XERBERUS_SCORE_COLOURS.lowRisk;
+	if (band === 'Moderate') return XERBERUS_SCORE_COLOURS.moderate;
+	if (band === 'Elevated') return XERBERUS_SCORE_COLOURS.elevated;
+	return null;
+}
+
+export function formatXerberusScore(score: number | null | undefined): string {
+	if (score == null || !Number.isFinite(score)) return '–';
+	return Math.round(score * 100).toString();
+}
+
 export interface DdFilterOption {
 	key: string;
 	label: string;

--- a/src/lib/top-vaults/schemas.ts
+++ b/src/lib/top-vaults/schemas.ts
@@ -632,6 +632,12 @@ export interface VaultGroup {
 	risk?: string | null;
 	/** Numeric risk score — only present on protocol groups */
 	risk_numeric?: number | null;
+	/** Xerberus Dendrogram composite protocol score, stored as 0..1 where higher means lower risk */
+	xerberus_score?: number | null;
+	/** Xerberus Dendrogram protocol identifier */
+	xerberus_id?: string | null;
+	/** Xerberus Dendrogram protocol scorecard URL */
+	xerberus_url?: string | null;
 	/** CORE3 protocol risk rating letter (e.g. "AA", "BB") — only present on protocol groups with a CORE3 rating */
 	core3_rating?: string | null;
 	/** CORE3 numeric risk score (lower = better) — used to sort the CORE3 rating column */

--- a/src/lib/xerberus/protocol-scores.ts
+++ b/src/lib/xerberus/protocol-scores.ts
@@ -1,0 +1,146 @@
+import { z } from 'zod';
+import { slugify } from '$lib/helpers/slugify';
+
+const XERBERUS_APP_URL = 'https://app.xerberus.io';
+const XERBERUS_CACHE_TTL_MS = 60 * 60 * 1000;
+
+const XERBERUS_PROTOCOL_ALIASES = new Map([
+	['silo-finance', 'silo-v2'],
+	['usdai', 'usd-ai']
+]);
+
+const registryResponseSchema = z.object({
+	data: z.object({
+		protocols: z.array(
+			z.object({
+				id: z.string(),
+				name: z.string(),
+				has_scorecard: z.boolean().catch(false)
+			})
+		)
+	})
+});
+
+const scoreResponseSchema = z.object({
+	data: z.object({
+		protocols: z.record(
+			z.string(),
+			z
+				.object({
+					composite_score: z.number().min(0).max(1).nullable().optional()
+				})
+				.passthrough()
+		)
+	})
+});
+
+export interface XerberusProtocolScore {
+	id: string;
+	name: string;
+	score: number;
+	url: string;
+}
+
+export interface XerberusProtocolScoreIndex {
+	byId: Map<string, XerberusProtocolScore>;
+	byLookupKey: Map<string, XerberusProtocolScore>;
+}
+
+let cachedScoreIndex: { expiresAt: number; promise: Promise<XerberusProtocolScoreIndex> } | null = null;
+
+function stripVersionSuffix(value: string) {
+	return value.replace(/-v\d+$/i, '');
+}
+
+function addLookupKey(index: XerberusProtocolScoreIndex, key: string, score: XerberusProtocolScore) {
+	if (!key || index.byLookupKey.has(key)) return;
+	index.byLookupKey.set(key, score);
+}
+
+function addScore(index: XerberusProtocolScoreIndex, score: XerberusProtocolScore) {
+	index.byId.set(score.id, score);
+	addLookupKey(index, score.id, score);
+	addLookupKey(index, stripVersionSuffix(score.id), score);
+
+	const slugifiedName = slugify(score.name);
+	addLookupKey(index, slugifiedName, score);
+	addLookupKey(index, stripVersionSuffix(slugifiedName), score);
+}
+
+async function fetchJson(fetchFn: typeof fetch, pathname: string) {
+	const response = await fetchFn(`${XERBERUS_APP_URL}${pathname}`, {
+		headers: { accept: 'application/json' }
+	});
+	if (!response.ok) {
+		throw new Error(`Xerberus API request failed (${response.status})`);
+	}
+	return response.json();
+}
+
+async function fetchXerberusProtocolScoreIndex(fetchFn: typeof fetch): Promise<XerberusProtocolScoreIndex> {
+	const [registryJson, scoreJson] = await Promise.all([
+		fetchJson(fetchFn, '/api/dendrogram/registry?classes=Protocol&fields=list'),
+		fetchJson(fetchFn, '/api/dendrogram/scores?classes=Protocol')
+	]);
+
+	const registry = registryResponseSchema.parse(registryJson);
+	const scores = scoreResponseSchema.parse(scoreJson);
+	const index: XerberusProtocolScoreIndex = {
+		byId: new Map(),
+		byLookupKey: new Map()
+	};
+
+	for (const protocol of registry.data.protocols) {
+		const score = scores.data.protocols[protocol.id]?.composite_score;
+		if (!protocol.has_scorecard || score == null) continue;
+
+		addScore(index, {
+			id: protocol.id,
+			name: protocol.name,
+			score,
+			url: `${XERBERUS_APP_URL}/protocol/dendrogram/${protocol.id}`
+		});
+	}
+
+	return index;
+}
+
+export async function getCachedXerberusProtocolScoreIndex(fetchFn: typeof fetch) {
+	const now = Date.now();
+	if (cachedScoreIndex && cachedScoreIndex.expiresAt > now) return cachedScoreIndex.promise;
+
+	const promise = fetchXerberusProtocolScoreIndex(fetchFn);
+	cachedScoreIndex = {
+		expiresAt: now + XERBERUS_CACHE_TTL_MS,
+		promise
+	};
+
+	try {
+		return await promise;
+	} catch (error) {
+		if (cachedScoreIndex.promise === promise) cachedScoreIndex = null;
+		throw error;
+	}
+}
+
+export function resolveXerberusProtocolScore(
+	index: XerberusProtocolScoreIndex,
+	protocol: { slug: string; name: string }
+): XerberusProtocolScore | null {
+	const alias = XERBERUS_PROTOCOL_ALIASES.get(protocol.slug);
+	const nameSlug = slugify(protocol.name);
+	const candidates = [
+		protocol.slug,
+		alias,
+		stripVersionSuffix(protocol.slug),
+		nameSlug,
+		stripVersionSuffix(nameSlug)
+	].filter((candidate): candidate is string => Boolean(candidate));
+
+	for (const candidate of candidates) {
+		const score = index.byLookupKey.get(candidate);
+		if (score) return score;
+	}
+
+	return null;
+}

--- a/src/routes/vaults/protocols/+page.server.ts
+++ b/src/routes/vaults/protocols/+page.server.ts
@@ -13,10 +13,12 @@ import {
 import { sortOptions } from '$lib/top-vaults/VaultGroupTable.svelte';
 import { getNumberParam, getStringParam } from '$lib/helpers/url-params';
 import { getVaultProtocolLogoUrl } from '$lib/vault-protocol/helpers.js';
+import { getCachedXerberusProtocolScoreIndex, resolveXerberusProtocolScore } from '$lib/xerberus/protocol-scores';
 import type { MarketShareChartItem } from '../market-share-pie';
 
 export async function load({ fetch, url: { searchParams } }) {
 	const { vaults, core3_protocols } = await getCachedTopVaults(fetch);
+	const xerberusScoreIndex = await getCachedXerberusProtocolScoreIndex(fetch).catch(() => null);
 
 	const eligibleVaults = vaults.filter((v) => !isBlacklisted(v) && meetsMinTvl(v));
 
@@ -45,6 +47,13 @@ export async function load({ fetch, url: { searchParams } }) {
 
 		return acc;
 	}, {});
+
+	for (const protocol of Object.values(protocols)) {
+		const xerberusScore = xerberusScoreIndex ? resolveXerberusProtocolScore(xerberusScoreIndex, protocol) : null;
+		protocol.xerberus_score = xerberusScore?.score ?? null;
+		protocol.xerberus_id = xerberusScore?.id ?? null;
+		protocol.xerberus_url = xerberusScore?.url ?? null;
+	}
 
 	// Calculate TVL-weighted average APY for each protocol
 	const protocolGroups: VaultGroup[] = Object.values(protocols).map((group) => ({

--- a/src/routes/vaults/protocols/+page.svelte
+++ b/src/routes/vaults/protocols/+page.svelte
@@ -102,6 +102,7 @@
 	<Section padding="sm">
 		<VaultGroupTable
 			groupLabel="Protocol"
+			includeRisk
 			includeCore3Risk
 			getLogoHref={getVaultProtocolLogoUrl}
 			rows={protocols}


### PR DESCRIPTION
## Why

Protocol listings need the current Xerberus risk score alongside CORE3, without using the legacy bucketed technical-risk field.

## Lessons learnt

Xerberus exposes a fractional composite score through its API, while its scorecards present the equivalent 0-100 value. Keep fractional values for banding and sorting, and format only at the presentation boundary.

## Summary

- Add cached Xerberus protocol-score retrieval, matching and scorecard links.
- Add a compact Xerberus column with official score bands, tooltip, and dash for unrated protocols.
- Hide CORE3 and Xerberus columns on mobile, and fix curator description spacing.