### PR TITLE
fix: use complete vault listing return summaries

### DIFF
--- a/docs/vault-listings.md
+++ b/docs/vault-listings.md
@@ -42,3 +42,10 @@ The server sends compact full-result aggregates with the first row batch.
 Listing counts, TVL, weighted returns, and SEO item counts must use those
 aggregates, not the initial 75 rows. Charts that need every member receive a
 separate, purpose-built payload rather than reusing table rows.
+
+Summary calculations use the same scope and filters as the listing. They omit
+blacklisted vaults by default, even on listings that display them; the dedicated
+blacklisted listing explicitly includes its matching vaults in its own summary.
+This keeps headline TVL and returns aligned with the established listing rules.
+The server resolves the cached US Treasury rate when that monthly-return filter
+is selected, so the initial batch and continuation requests apply the same rule.

--- a/src/lib/server/top-vaults/listing.ts
+++ b/src/lib/server/top-vaults/listing.ts
@@ -1,5 +1,6 @@
 import { fetchStablecoinMetadataIndex } from '$lib/stablecoin-metadata/client';
 import { buildStablecoinMetadataLookup, findStablecoinMetadata } from '$lib/stablecoin-metadata/helpers';
+import { fetchLatestTreasuryRate } from '$lib/reference-rates';
 import { getCachedTopVaults } from '$lib/top-vaults/cache';
 import {
 	getCurrencyUsdRates,
@@ -15,6 +16,7 @@ import {
 	type VaultListingKey
 } from '$lib/top-vaults/listing/definitions';
 import { queryVaultListing } from '$lib/top-vaults/listing/query';
+import type { VaultListingOptions, VaultListingQuery } from '$lib/top-vaults/listing/query';
 import { parseVaultListingQuery } from '$lib/top-vaults/listing/state';
 import { INITIAL_VAULT_LISTING_LIMIT } from '$lib/top-vaults/listing/types';
 import type { VaultInfo } from '$lib/top-vaults/schemas';
@@ -36,6 +38,12 @@ async function resolveListingVaults(fetchFn: typeof fetch, vaults: VaultInfo[], 
 		.filter((vault) => isNonUsdDenominatedVault(vault) && getVaultCurrentTvlUsd(vault) != null);
 }
 
+/** Add the cached Treasury rate only when the active server-side filter needs it. */
+async function getListingOptions(options: VaultListingOptions, query: VaultListingQuery): Promise<VaultListingOptions> {
+	if (query.mr !== 'treasury') return options;
+	return { ...options, treasuryRate: await fetchLatestTreasuryRate().catch(() => null) };
+}
+
 /**
  * Build an SSR-safe first listing page from the complete server-cached export.
  * The returned rows have already passed the definition scope, filters, and
@@ -46,7 +54,7 @@ export async function loadVaultListing(fetchFn: typeof fetch, url: URL, key: Vau
 	const topVaults = await getCachedTopVaults(fetchFn);
 	const scopedVaults = await resolveListingVaults(fetchFn, topVaults.vaults, key, scope);
 	const query = parseVaultListingQuery(url.searchParams, getVaultListingDefaults(key, scope));
-	const listing = queryVaultListing(scopedVaults, query, definition.options);
+	const listing = queryVaultListing(scopedVaults, query, await getListingOptions(definition.options, query));
 	const initialVaults = listing.vaults.slice(0, INITIAL_VAULT_LISTING_LIMIT);
 
 	return {
@@ -95,12 +103,9 @@ export async function loadVaultListingContinuation(
 	const definition = getVaultListingDefinition(key);
 	const topVaults = await getCachedTopVaults(fetchFn);
 	const scopedVaults = await resolveListingVaults(fetchFn, topVaults.vaults, key, scope);
+	const query = parseVaultListingQuery(url.searchParams, getVaultListingDefaults(key, scope));
 	return {
 		topVaults,
-		listing: queryVaultListing(
-			scopedVaults,
-			parseVaultListingQuery(url.searchParams, getVaultListingDefaults(key, scope)),
-			definition.options
-		)
+		listing: queryVaultListing(scopedVaults, query, await getListingOptions(definition.options, query))
 	};
 }

--- a/src/lib/top-vaults/TopVaultsPage.svelte
+++ b/src/lib/top-vaults/TopVaultsPage.svelte
@@ -87,6 +87,7 @@ Use `ratingProvider` to show a provider-specific risk rating column.
 		headingLogo?: { src: string; alt: string };
 		/** Show a third-party risk rating column beside the vault name. */
 		ratingProvider?: RiskRatingProvider;
+		/** Whether rows are fetched in pages from the server. */
 		progressive?: boolean;
 		listingKey?: string;
 		listingScope?: string;

--- a/src/lib/top-vaults/TopVaultsTable.svelte
+++ b/src/lib/top-vaults/TopVaultsTable.svelte
@@ -596,7 +596,7 @@ Use `ratingProvider` to add its risk-rating column beside the vault name.
 		progressive && listingSummary ? listingSummary.matchingCount : filteredVaults.length
 	);
 
-	// Uses filteredVaults so all active listing filters are reflected in the stats row.
+	// Uses filteredVaults so all active filters (TVL, age, risk, search) are reflected in the stats row.
 	let statsVaults = $derived(
 		includeBlacklistedInStats ? filteredVaults : filteredVaults.filter((v) => !isBlacklisted(v))
 	);

--- a/src/lib/top-vaults/TopVaultsTable.svelte
+++ b/src/lib/top-vaults/TopVaultsTable.svelte
@@ -517,9 +517,13 @@ Use `ratingProvider` to add its risk-rating column beside the vault name.
 		if (!filterTvl && !showFilters) return [];
 		return baseVaults.filter((v) => getVaultCurrentTvl(v) < getVaultTvlThreshold(v));
 	});
+	let serverListingSummary = $derived(progressive ? listingSummary : undefined);
+	let hiddenVaultNames = $derived(
+		serverListingSummary?.hiddenVaultNames ?? hiddenVaults.slice(0, 2).map((vault) => vault.name)
+	);
 
 	// Count of hidden vaults
-	let hiddenByTvl = $derived(progressive && listingSummary ? listingSummary.hiddenByTvl : hiddenVaults.length);
+	let hiddenByTvl = $derived(serverListingSummary?.hiddenByTvl ?? hiddenVaults.length);
 
 	// Total vault count for the listing meta — the whole-database count when
 	// provided by the page, otherwise the vaults available to this listing
@@ -592,9 +596,7 @@ Use `ratingProvider` to add its risk-rating column beside the vault name.
 
 	// A progressive listing contains only its initial page here, while the server
 	// summary describes every vault matching the same filters.
-	let matchingVaultCount = $derived(
-		progressive && listingSummary ? listingSummary.matchingCount : filteredVaults.length
-	);
+	let matchingVaultCount = $derived(serverListingSummary?.matchingCount ?? filteredVaults.length);
 
 	// Uses filteredVaults so all active filters (TVL, age, risk, search) are reflected in the stats row.
 	let statsVaults = $derived(
@@ -610,17 +612,21 @@ Use `ratingProvider` to add its risk-rating column beside the vault name.
 
 	// Calculate total TVL from fully-filtered vaults
 	let totalTvl = $derived(
-		progressive && listingSummary
-			? listingSummary.totalTvl
+		serverListingSummary
+			? serverListingSummary.totalTvl
 			: calculateTotalTvl(statsVaultsWithTvl, { maxTvlUsd: maxSummaryTvlUsd })
 	);
 
-	// Calculate TVL-weighted average 1M APY from fully-filtered vaults
+	// A progressive listing only contains its initial row batch in the browser.
+	// Use the server calculation over the complete filtered listing so the headline
+	// does not become skewed by the current batch or its sort order.
 	let avgTvlWeightedApy1M = $derived(
-		calculateTvlWeightedApy(statsVaultsWithTvl, {
-			includeBlacklisted: includeBlacklistedInStats,
-			maxTvlUsd: maxSummaryTvlUsd
-		})
+		serverListingSummary
+			? serverListingSummary.avgTvlWeightedApy1M
+			: calculateTvlWeightedApy(statsVaultsWithTvl, {
+					includeBlacklisted: includeBlacklistedInStats,
+					maxTvlUsd: maxSummaryTvlUsd
+				})
 	);
 
 	// sort vaults
@@ -867,10 +873,7 @@ Use `ratingProvider` to add its risk-rating column beside the vault name.
 							? 'it does'
 							: 'they do'}
 						not meet the minimum TVL threshold:
-						{hiddenVaults
-							.slice(0, 2)
-							.map((v) => v.name)
-							.join(', ')}{#if hiddenByTvl > 2}, and {hiddenByTvl - 2} more{/if}.
+						{hiddenVaultNames.join(', ')}{#if hiddenByTvl > 2}, and {hiddenByTvl - 2} more{/if}.
 					{:else}
 						The number of vaults listed on this page.
 					{/if}</svelte:fragment

--- a/src/lib/top-vaults/TopVaultsTable.svelte
+++ b/src/lib/top-vaults/TopVaultsTable.svelte
@@ -141,6 +141,7 @@ Use `ratingProvider` to add its risk-rating column beside the vault name.
 		disableBlacklistedStrikethrough?: boolean;
 		/** Show a third-party risk rating column immediately after the vault name. */
 		ratingProvider?: RiskRatingProvider;
+		/** Whether rows are fetched in pages from the server. */
 		progressive?: boolean;
 		listingKey?: string;
 		listingScope?: string;

--- a/src/lib/top-vaults/listing/query.test.ts
+++ b/src/lib/top-vaults/listing/query.test.ts
@@ -46,6 +46,40 @@ describe('vault listing query', () => {
 		expect(result.hiddenByTvl).toBe(1);
 	});
 
+	it('excludes blacklisted vaults from the listing summary by default', () => {
+		const included = createTestVault('Included', {
+			current_nav: 100_000,
+			one_month_cagr: 0.05,
+			risk: 'Low'
+		});
+		const blacklisted = createTestVault('Blacklisted', {
+			current_nav: 10_000_000,
+			one_month_cagr: 5,
+			risk: 'Blacklisted'
+		});
+		const query = parseVaultListingQuery(new URLSearchParams(), { tvl: '10k', risk: 0 });
+
+		const result = queryVaultListing([included, blacklisted], query, {
+			...options,
+			includeBlacklisted: true,
+			includeBlacklistedInStats: false
+		});
+
+		expect(result.vaults).toHaveLength(2);
+		expect(result.totalTvl).toBe(100_000);
+		expect(result.avgTvlWeightedApy1M).toBe(0.05);
+	});
+
+	it('applies the supplied Treasury rate to monthly-return filters', () => {
+		const aboveTreasury = createTestVault('Above Treasury', { current_nav: 100_000, one_month_cagr: 0.06 });
+		const belowTreasury = createTestVault('Below Treasury', { current_nav: 100_000, one_month_cagr: 0.04 });
+		const query = parseVaultListingQuery(new URLSearchParams('mr=treasury'), { tvl: '10k' });
+
+		const result = queryVaultListing([aboveTreasury, belowTreasury], query, { ...options, treasuryRate: 5 });
+
+		expect(result.vaults.map((vault) => vault.name)).toEqual(['Above Treasury']);
+	});
+
 	it('uses defaults when URL filter indexes are absent', () => {
 		const query = parseVaultListingQuery(new URLSearchParams(), { risk: 1, tvl: '10k' });
 

--- a/src/lib/top-vaults/listing/query.ts
+++ b/src/lib/top-vaults/listing/query.ts
@@ -21,7 +21,8 @@ import {
 	monthlyReturnFilterOptions,
 	rankVaultsBy,
 	riskFilterOptions,
-	tvlFilterOptions
+	tvlFilterOptions,
+	withVaultCurrentTvlUsd
 } from '../helpers';
 import { compareVaultsByReturn, type ReturnColumnId } from '../return-columns';
 
@@ -179,17 +180,15 @@ export function queryVaultListing(
 			? matchesWithoutTvl.filter((vault) => (getVaultCurrentTvlUsd(vault) ?? 0) >= threshold(vault))
 			: matchesWithoutTvl;
 	const stats = options.includeBlacklistedInStats ? matches : matches.filter((vault) => !isBlacklisted(vault));
+	const statsWithUsdTvl = stats.map(withVaultCurrentTvlUsd);
 	return {
 		vaults: sortVaults(matches, query.sort, query.direction),
 		hiddenByTvl: hiddenVaults.length,
 		hiddenVaults,
-		totalTvl: calculateTotalTvl(
-			stats.map((vault) => ({ ...vault, current_nav: getVaultCurrentTvlUsd(vault) })),
-			{ maxTvlUsd: options.maxSummaryTvlUsd }
-		),
-		avgTvlWeightedApy1M: calculateTvlWeightedApy(
-			stats.map((vault) => ({ ...vault, current_nav: getVaultCurrentTvlUsd(vault) })),
-			{ includeBlacklisted: options.includeBlacklistedInStats, maxTvlUsd: options.maxSummaryTvlUsd }
-		)
+		totalTvl: calculateTotalTvl(statsWithUsdTvl, { maxTvlUsd: options.maxSummaryTvlUsd }),
+		avgTvlWeightedApy1M: calculateTvlWeightedApy(statsWithUsdTvl, {
+			includeBlacklisted: options.includeBlacklistedInStats,
+			maxTvlUsd: options.maxSummaryTvlUsd
+		})
 	};
 }

--- a/tests/integration/vaults/index.test.ts
+++ b/tests/integration/vaults/index.test.ts
@@ -288,6 +288,21 @@ test.describe('vault index page', () => {
 		await expect(sentinel).not.toBeVisible();
 	});
 
+	test('loads 500 vaults through progressive scrolling', async ({ page }) => {
+		await page.goto('/vaults?tvl=any&q=Progressive%20scroll%20vault');
+
+		const rows = page.locator('tbody tr.targetable');
+		const sentinel = page.getByTestId('load-more-sentinel');
+		await expect(rows).toHaveCount(150);
+
+		for (let expectedCount = 200; expectedCount <= 500; expectedCount += 50) {
+			await sentinel.scrollIntoViewIfNeeded();
+			await expect(rows).toHaveCount(expectedCount);
+		}
+
+		await expect(sentinel).not.toBeVisible();
+	});
+
 	test('sentinel disappears when all rows loaded', async ({ page }) => {
 		const rows = page.locator('tbody tr.targetable');
 		const sentinel = page.getByTestId('load-more-sentinel');

--- a/tests/integration/vaults/index.test.ts
+++ b/tests/integration/vaults/index.test.ts
@@ -258,6 +258,15 @@ test.describe('vault index page', () => {
 		await expect(sentinel).toContainText(/Loading more vaults/);
 	});
 
+	test('uses the full server-side listing summary for the average return', async ({ page }) => {
+		await page.goto('/vaults?tvl=any&q=Summary%20regression&unknown=0');
+
+		const rows = page.locator('tbody tr.targetable');
+		await expect(rows).toHaveCount(75);
+		await expect(page.getByTestId('top-vaults-meta')).toContainText('151 vaults');
+		await expect(page.getByTestId('top-vaults-meta')).toContainText('Avg. return 76.61%');
+	});
+
 	test('loads 50 more rows when scrolling to sentinel', async ({ page }) => {
 		// Check initial row count
 		const rows = page.locator('tbody tr.targetable');
@@ -284,21 +293,6 @@ test.describe('vault index page', () => {
 		}
 		await sentinel.scrollIntoViewIfNeeded();
 		await expect(rows).toHaveCount(500);
-
-		await expect(sentinel).not.toBeVisible();
-	});
-
-	test('loads 500 vaults through progressive scrolling', async ({ page }) => {
-		await page.goto('/vaults?tvl=any&q=Progressive%20scroll%20vault');
-
-		const rows = page.locator('tbody tr.targetable');
-		const sentinel = page.getByTestId('load-more-sentinel');
-		await expect(rows).toHaveCount(150);
-
-		for (let expectedCount = 200; expectedCount <= 500; expectedCount += 50) {
-			await sentinel.scrollIntoViewIfNeeded();
-			await expect(rows).toHaveCount(expectedCount);
-		}
 
 		await expect(sentinel).not.toBeVisible();
 	});

--- a/tests/mocks/top-vaults/list.mock.ts
+++ b/tests/mocks/top-vaults/list.mock.ts
@@ -105,6 +105,23 @@ const progressiveScrollVaults = generateMockVaults('Progressive scroll vault', 5
 	three_months_cagr: 0.08
 });
 
+// These rows exercise the headline statistics used with progressive listings.
+// Keep them below the normal $50k threshold so they do not affect other vault
+// index fixtures. The regression test opts into TVL "Any".
+const summaryRegressionHighReturnVaults = generateMockVaults('Summary regression high return vault', 150, {
+	protocol: '<Summary regression protocol>',
+	current_nav: 1_000,
+	peak_nav: 1_000,
+	one_month_cagr: 1
+});
+
+const summaryRegressionAnchorVault = createTestVault('Summary regression large low return vault', {
+	protocol: '<Summary regression protocol>',
+	current_nav: 49_000,
+	peak_nav: 49_000,
+	one_month_cagr: 0.05
+});
+
 const returnLeaders = [
 	createTestVault('Return leader alpha', {
 		chain: 'ethereum',
@@ -560,7 +577,9 @@ export default defineMock({
 			...returnLeaders,
 			...belowTvl,
 			...aboveTvl,
-			...progressiveScrollVaults
+			...progressiveScrollVaults,
+			...summaryRegressionHighReturnVaults,
+			summaryRegressionAnchorVault
 		]
 	}
 });


### PR DESCRIPTION
## Why

Progressively rendered vault tables initially contain only 75 rows. Calculating the headline TVL-weighted monthly return in the browser from that prefix can materially overstate the result when the sort order favours a high-return vault.

## Lessons learnt

Listing headline aggregates must come from the server-side result set, not from the paginated browser rows. Their calculation must keep the listing’s blacklist policy intact.

## Summary

- Use the complete server-provided listing summary for progressive table return headlines.
- Cover the full-summary and blacklist behaviour with unit and browser regression tests.
- Simplify shared aggregate handling and document the server-summary and blacklist rules.