### PR TITLE
perf: reduce homepage payload

### DIFF
--- a/.claude/docs/agent-tips-and-tricks.md
+++ b/.claude/docs/agent-tips-and-tricks.md
@@ -1,0 +1,18 @@
+# Agent tips and tricks
+
+This is the mandatory entry point for cross-agent CLI operations. The source
+repository, web3-ethereum-defi, calls its corresponding guide
+`agent-tricks-and-troubleshooting.md`; it does not contain a file named
+`agent-tips-and-tricks.md`. The detailed guide in this directory carries that
+guidance forward.
+
+Before any Grok, Claude or Codex CLI cross-agent operation — including a
+review, sanity check or one-off prompt — read this file and then the detailed
+guide at [agent-tricks-and-troubleshooting.md](agent-tricks-and-troubleshooting.md)
+in the current session.
+
+For reviews, use read-only tools, do not permit edits, and allow at least 15
+minutes before treating a non-trivial agent run as timed out. Grok reviews use
+headless `grok -p` mode with `--permission-mode dontAsk`, explicit read-only
+tool permissions, `--no-subagents`, and `--no-memory`. Claude and Codex review
+commands must follow their detailed streaming instructions in the linked guide.

--- a/.claude/docs/agent-tricks-and-troubleshooting.md
+++ b/.claude/docs/agent-tricks-and-troubleshooting.md
@@ -1,10 +1,35 @@
 # Agent tricks and troubleshooting
 
-Read this document before invoking Claude CLI or Codex CLI from another agent.
+Read this document before invoking Grok CLI, Claude CLI or Codex CLI from another agent.
 It contains local invocation details that are easy to get wrong, especially for
 non-interactive Claude review runs.
 
-This note covers practical ways to use Codex CLI and Claude CLI as local engineering agents, especially when one agent is used to review or debug the other agent's work.
+This note covers practical ways to use Grok CLI, Codex CLI and Claude CLI as local engineering agents, especially when one agent is used to review or debug the other agent's work.
+
+## Cross-agent requirement
+
+Before any Grok, Claude or Codex CLI cross-agent operation — including reviews,
+sanity checks and one-off prompts — read `.claude/docs/agent-tips-and-tricks.md`
+in the current session. The same requirement applies when one CLI is used to
+review or debug work produced by another.
+
+## Grok CLI
+
+Use Grok as an independent reviewer with a single, read-only prompt. Prefer
+headless `grok -p` invocations with `--permission-mode dontAsk`, explicitly
+allow only read-only tools, disable subagents, and use a 15-minute timeout for
+non-trivial reviews. Do not ask Grok to edit the worktree during a review.
+
+```shell
+timeout 900 grok -p "Review the current PR diff for correctness bugs only. Do not edit files or run tests. Return findings first with file:line references." \
+  --cwd . \
+  --permission-mode dontAsk \
+  --allow "Read,Grep,Glob,Bash(git status:*),Bash(git diff:*),Bash(sed:*),Bash(rg:*)" \
+  --no-subagents \
+  --no-memory \
+  --output-format streaming-json \
+  < /dev/null > /tmp/grok-review.jsonl
+```
 
 ## Codex CLI
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,14 +11,14 @@ SvelteKit-based frontend for the Trading Strategy protocol, featuring automated 
 Topic deep-dives live under `.claude/docs/`. Consult the relevant one before
 working on that area:
 
-| Doc                                                | Description                                                                                                |
-| -------------------------------------------------- | ---------------------------------------------------------------------------------------------------------- |
-| `.claude/docs/agent-tricks-and-troubleshooting.md` | **MANDATORY read before ANY Claude CLI or Codex CLI invocation** (reviews, sanity checks, or one-off runs) |
-| `.claude/docs/worktree.md`                         | Required local env and data symlinks when running dev servers or private-data checks from git worktrees    |
+| Doc                                     | Description                                                                                                             |
+| --------------------------------------- | ----------------------------------------------------------------------------------------------------------------------- |
+| `.claude/docs/agent-tips-and-tricks.md` | **MANDATORY read before any Grok, Claude or Codex CLI cross-agent operation** (reviews, sanity checks, or one-off runs) |
+| `.claude/docs/worktree.md`              | Required local env and data symlinks when running dev servers or private-data checks from git worktrees                 |
 
 ## Agent review workflows
 
-- **BLOCKING REQUIREMENT: before running ANY `codex` / `codex exec` or `claude` CLI command — reviews, sanity checks, or one-off runs — you MUST first read `.claude/docs/agent-tricks-and-troubleshooting.md`.** Do not invoke either CLI until you have read it in the current session. This is not optional and applies even when the call "looks trivial".
+- **BLOCKING REQUIREMENT: before running ANY Grok, Claude or Codex CLI cross-agent operation — reviews, sanity checks, or one-off runs — you MUST first read `.claude/docs/agent-tips-and-tricks.md`.** Do not invoke one of these CLIs until you have read it in the current session. This is not optional and applies even when the call "looks trivial".
 - Follow its recommended invocation patterns for plan reviews, code reviews, PR reviews, tool restrictions, timeouts, and handling silent or hanging agent runs. Review requests must allow at least 15 minutes before being treated as timed out.
 - Always run non-interactive Codex reviews in **streaming mode** (`codex exec --json`) written to a raw file — never plain text mode piped through `tail`/`head`, which buffers output until completion and makes the run look hung.
 - `codex exec` selects the sandbox directly (`--sandbox read-only` for reviews) and does **not** accept `--ask-for-approval` (that flag is interactive-only).

--- a/docs/speed.md
+++ b/docs/speed.md
@@ -7,6 +7,21 @@ Page speed utilities to see First Contentful Paint (FCP) and Largest Contentful 
 - https://www.webpagetest.org/
   - Example: https://www.webpagetest.org/result/211230_BiDc5M_0b72ec65b0eb6523fddb06496ab832d4/1/details/#waterfall_view_step1
 
+## Homepage payloads
+
+The homepage is server-rendered and its `load` result is serialised into the
+initial HTML. Keep that payload limited to data that the route renders:
+
+- Return only the vault cards displayed by `TopVaults`.
+- For strategy tiles, retain only the selected chart series. Downsample it to
+  daily points before serialisation because the tile renderer uses daily data.
+- Do not add a server-side fetch for data that no homepage component consumes.
+
+For a local before/after comparison, open a fresh Playwright browser context
+against the Vite development server and compare the navigation entry's
+`transferSize`. Development-server timing includes variable upstream data fetches,
+so treat document transfer size as the reliable signal for frontend-only changes.
+
 ## Enabling early hint testing
 
 https://blog.cloudflare.com/early-hints/#testing-early-hints-with-web-page-test

--- a/src/lib/charts/helpers.test.ts
+++ b/src/lib/charts/helpers.test.ts
@@ -1,16 +1,16 @@
 import { describe, expect, it } from 'vitest';
-import { downsampleSharePriceReturns } from './share-price';
+import { downsampleDailySeries } from './helpers';
 
-describe('downsampleSharePriceReturns', () => {
-	it('keeps the final sample in each UTC day', () => {
-		const returns: [number, number][] = [
+describe('downsampleDailySeries', () => {
+	it('keeps the final sample in each UTC day and a carry-in point', () => {
+		const values: [number, number][] = [
 			[Date.UTC(2026, 0, 1, 10) / 1000, 0],
 			[Date.UTC(2026, 0, 1, 16) / 1000, 0.1],
 			[Date.UTC(2026, 0, 2, 8) / 1000, 0.2],
 			[Date.UTC(2026, 0, 2, 20) / 1000, 0.3]
 		];
 
-		expect(downsampleSharePriceReturns(returns)).toEqual([
+		expect(downsampleDailySeries(values)).toEqual([
 			[Date.UTC(2025, 11, 31) / 1000, 0],
 			[Date.UTC(2026, 0, 1) / 1000, 0.1],
 			[Date.UTC(2026, 0, 2) / 1000, 0.3]

--- a/src/lib/charts/helpers.ts
+++ b/src/lib/charts/helpers.ts
@@ -130,6 +130,16 @@ export function resampleTimeSeries(
 }
 
 /**
+ * Downsample a time series to daily timestamp/value pairs.
+ *
+ * @param data Raw timestamp/value pairs
+ * @returns Daily points, including a carry-in point when required
+ */
+export function downsampleDailySeries(data: [UnixTimestamp, number][]): [UnixTimestamp, number][] {
+	return resampleTimeSeries(data, utcDay).map(({ time, value }) => [time, value]);
+}
+
+/**
  * Get the date range for given chart data and time span (ending at the last date in the data)
  *
  * @param data chart data array

--- a/src/lib/strategies/yaml/share-price.test.ts
+++ b/src/lib/strategies/yaml/share-price.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest';
+import { downsampleSharePriceReturns } from './share-price';
+
+describe('downsampleSharePriceReturns', () => {
+	it('keeps the final sample in each UTC day', () => {
+		const returns: [number, number][] = [
+			[Date.UTC(2026, 0, 1, 10) / 1000, 0],
+			[Date.UTC(2026, 0, 1, 16) / 1000, 0.1],
+			[Date.UTC(2026, 0, 2, 8) / 1000, 0.2],
+			[Date.UTC(2026, 0, 2, 20) / 1000, 0.3]
+		];
+
+		expect(downsampleSharePriceReturns(returns)).toEqual([
+			[Date.UTC(2025, 11, 31) / 1000, 0],
+			[Date.UTC(2026, 0, 1) / 1000, 0.1],
+			[Date.UTC(2026, 0, 2) / 1000, 0.3]
+		]);
+	});
+});

--- a/src/lib/strategies/yaml/share-price.ts
+++ b/src/lib/strategies/yaml/share-price.ts
@@ -3,8 +3,26 @@
  * for use in strategy tile chart thumbnails.
  */
 import swrCache from '$lib/swrCache';
+import { resampleTimeSeries } from '$lib/charts/helpers';
+import { utcDay } from 'd3-time';
+import type { PerformanceData } from 'trade-executor/schemas/utility-types';
 
 const NINETY_DAYS_SECONDS = 90 * 24 * 60 * 60;
+
+/**
+ * Reduce a price-return series to the daily resolution used by strategy tile charts.
+ *
+ * The metrics endpoint exposes hourly (and sometimes more frequent) samples, while
+ * the tile renderer already displays one value per UTC day. Compacting before the
+ * page data is serialised avoids sending thousands of samples that cannot affect
+ * the rendered chart.
+ *
+ * @param returns Relative price returns as timestamp/value pairs
+ * @returns The latest return for each UTC day, with an initial carry-in sample
+ */
+export function downsampleSharePriceReturns(returns: PerformanceData): PerformanceData {
+	return resampleTimeSeries(returns, utcDay).map(({ time, value }) => [time, value]);
+}
 
 /**
  * Fetch share price data for a vault and convert to 90-day relative returns.
@@ -27,7 +45,9 @@ async function fetchSharePriceReturns90d(fetch: Fetch, vaultId: string): Promise
 		const firstPrice = clipped[0][1];
 		if (firstPrice === 0) return undefined;
 
-		return clipped.map(([ts, price]) => [ts, (price - firstPrice) / firstPrice]);
+		const returns = clipped.map(([ts, price]) => [ts, (price - firstPrice) / firstPrice] as [number, number]);
+
+		return downsampleSharePriceReturns(returns);
 	} catch {
 		return undefined;
 	}

--- a/src/lib/strategies/yaml/share-price.ts
+++ b/src/lib/strategies/yaml/share-price.ts
@@ -3,26 +3,9 @@
  * for use in strategy tile chart thumbnails.
  */
 import swrCache from '$lib/swrCache';
-import { resampleTimeSeries } from '$lib/charts/helpers';
-import { utcDay } from 'd3-time';
-import type { PerformanceData } from 'trade-executor/schemas/utility-types';
+import { downsampleDailySeries } from '$lib/charts/helpers';
 
 const NINETY_DAYS_SECONDS = 90 * 24 * 60 * 60;
-
-/**
- * Reduce a price-return series to the daily resolution used by strategy tile charts.
- *
- * The metrics endpoint exposes hourly (and sometimes more frequent) samples, while
- * the tile renderer already displays one value per UTC day. Compacting before the
- * page data is serialised avoids sending thousands of samples that cannot affect
- * the rendered chart.
- *
- * @param returns Relative price returns as timestamp/value pairs
- * @returns The latest return for each UTC day, with an initial carry-in sample
- */
-export function downsampleSharePriceReturns(returns: PerformanceData): PerformanceData {
-	return resampleTimeSeries(returns, utcDay).map(({ time, value }) => [time, value]);
-}
 
 /**
  * Fetch share price data for a vault and convert to 90-day relative returns.
@@ -47,7 +30,7 @@ async function fetchSharePriceReturns90d(fetch: Fetch, vaultId: string): Promise
 
 		const returns = clipped.map(([ts, price]) => [ts, (price - firstPrice) / firstPrice] as [number, number]);
 
-		return downsampleSharePriceReturns(returns);
+		return downsampleDailySeries(returns);
 	} catch {
 		return undefined;
 	}

--- a/src/lib/trade-executor/helpers/chart.test.ts
+++ b/src/lib/trade-executor/helpers/chart.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest';
+import type { StrategyInfo } from '../models/strategy-info';
+import { compactStrategyTileChartData } from './chart';
+
+function makeStrategy(useSharePrice: boolean): StrategyInfo {
+	return {
+		useSharePrice,
+		summary_statistics: {
+			share_price_returns_90_days: [
+				[Date.UTC(2026, 0, 1, 10) / 1000, 0],
+				[Date.UTC(2026, 0, 1, 16) / 1000, 0.1]
+			],
+			compounding_unrealised_trading_profitability: [
+				[Date.UTC(2026, 0, 1, 10) / 1000, 0],
+				[Date.UTC(2026, 0, 1, 16) / 1000, 0.2]
+			]
+		}
+	} as StrategyInfo;
+}
+
+describe('compactStrategyTileChartData', () => {
+	it('keeps and downsamples only the selected share-price series', () => {
+		const compacted = compactStrategyTileChartData(makeStrategy(true));
+
+		expect(compacted.summary_statistics?.share_price_returns_90_days).toEqual([
+			[Date.UTC(2025, 11, 31) / 1000, 0],
+			[Date.UTC(2026, 0, 1) / 1000, 0.1]
+		]);
+		expect(compacted.summary_statistics?.compounding_unrealised_trading_profitability).toBeUndefined();
+	});
+
+	it('keeps and downsamples only the selected profitability series', () => {
+		const compacted = compactStrategyTileChartData(makeStrategy(false));
+
+		expect(compacted.summary_statistics?.compounding_unrealised_trading_profitability).toEqual([
+			[Date.UTC(2025, 11, 31) / 1000, 0],
+			[Date.UTC(2026, 0, 1) / 1000, 0.2]
+		]);
+		expect(compacted.summary_statistics?.share_price_returns_90_days).toBeUndefined();
+	});
+});

--- a/src/lib/trade-executor/helpers/chart.ts
+++ b/src/lib/trade-executor/helpers/chart.ts
@@ -1,7 +1,7 @@
 import type { StrategyInfo } from 'trade-executor/models/strategy-info';
 import { max } from 'd3-array';
 import { utcDay } from 'd3-time';
-import { tsToDate } from '$lib/charts/helpers';
+import { downsampleDailySeries, tsToDate } from '$lib/charts/helpers';
 
 // Determine the chart min/max dates from all strategies to standardize x-axis range
 export function getStrategyChartDateRange(strategies: StrategyInfo[]): [Date, Date] {
@@ -20,4 +20,32 @@ export function getStrategyChartDateRange(strategies: StrategyInfo[]): [Date, Da
 	const minDate = utcDay.offset(maxDate, -89);
 
 	return [minDate, maxDate];
+}
+
+/**
+ * Keep only the chart series used by a strategy tile at daily resolution.
+ *
+ * @param strategy Strategy data that will be serialised for a tile
+ * @returns Strategy data without the unused chart series
+ */
+export function compactStrategyTileChartData(strategy: StrategyInfo): StrategyInfo {
+	const summary = strategy.summary_statistics;
+	if (!summary) return strategy;
+
+	const selectedKey = strategy.useSharePrice
+		? 'share_price_returns_90_days'
+		: 'compounding_unrealised_trading_profitability';
+	const discardedKey = strategy.useSharePrice
+		? 'compounding_unrealised_trading_profitability'
+		: 'share_price_returns_90_days';
+	const selectedSeries = summary[selectedKey];
+
+	return {
+		...strategy,
+		summary_statistics: {
+			...summary,
+			[discardedKey]: undefined,
+			[selectedKey]: selectedSeries ? downsampleDailySeries(selectedSeries) : undefined
+		}
+	};
 }

--- a/src/routes/+page.server.ts
+++ b/src/routes/+page.server.ts
@@ -12,10 +12,12 @@ import {
 	rankVaultsBy,
 	slimVault
 } from '$lib/top-vaults/helpers';
-import { getCachedSharePriceReturns } from '$lib/strategies/yaml/share-price';
+import { downsampleSharePriceReturns, getCachedSharePriceReturns } from '$lib/strategies/yaml/share-price';
+import type { StrategyInfo } from 'trade-executor/models/strategy-info';
 import { fetchLatestFredValue, fetchLatestTreasuryRate } from '$lib/reference-rates';
 
 const HOME_PAGE_EDGE_CACHE_TTL_SECONDS = 30 * 60;
+const FRONT_PAGE_VAULT_COUNT = 5;
 
 function getAgeSeconds(dateValue: Date | string | null | undefined) {
 	if (!dateValue) return null;
@@ -24,6 +26,46 @@ function getAgeSeconds(dateValue: Date | string | null | undefined) {
 	if (Number.isNaN(parsed.valueOf())) return null;
 
 	return Math.max(0, Math.floor((Date.now() - parsed.valueOf()) / 1000));
+}
+
+/**
+ * Compact chart samples before the strategy is serialised into the page data.
+ *
+ * Strategy tile charts render daily values, so retaining intra-day samples only
+ * increases the initial HTML response and hydration work.
+ *
+ * @param strategy Strategy listing data returned by the API
+ * @returns The same strategy shape with daily chart data
+ */
+function compactStrategyChartData(strategy: StrategyInfo): StrategyInfo {
+	const summary = strategy.summary_statistics;
+	if (!summary) return strategy;
+
+	if (strategy.useSharePrice) {
+		return {
+			...strategy,
+			summary_statistics: {
+				...summary,
+				// A tile only reads one chart type. Discard the alternative raw
+				// series instead of serialising it alongside the selected chart.
+				compounding_unrealised_trading_profitability: undefined,
+				share_price_returns_90_days: summary.share_price_returns_90_days
+					? downsampleSharePriceReturns(summary.share_price_returns_90_days)
+					: undefined
+			}
+		};
+	}
+
+	return {
+		...strategy,
+		summary_statistics: {
+			...summary,
+			share_price_returns_90_days: undefined,
+			compounding_unrealised_trading_profitability: summary.compounding_unrealised_trading_profitability
+				? downsampleSharePriceReturns(summary.compounding_unrealised_trading_profitability)
+				: undefined
+		}
+	};
 }
 
 export async function load({ fetch }) {
@@ -36,7 +78,7 @@ export async function load({ fetch }) {
 		Promise.all([fetchLatestFredValue('SNDR'), fetchLatestTreasuryRate()])
 	]);
 
-	const frontpageStrategies = strategies.filter((s) => s.frontpage);
+	const frontpageStrategies = strategies.filter((s) => s.frontpage).map(compactStrategyChartData);
 	const yamlTileFreshness: {
 		strategyId: string;
 		vaultId: string | null;
@@ -101,7 +143,9 @@ export async function load({ fetch }) {
 
 		topVaults = {
 			generated_at: topVaultsResult.generated_at,
-			vaults: rankedVaults.slice(0, 30),
+			// TopVaults renders five cards. Avoid serialising the unused 25 vaults
+			// into the initial HTML response.
+			vaults: rankedVaults.slice(0, FRONT_PAGE_VAULT_COUNT),
 			aggregates: {
 				totalTvl,
 				weightedAvgApy,

--- a/src/routes/+page.server.ts
+++ b/src/routes/+page.server.ts
@@ -12,8 +12,8 @@ import {
 	rankVaultsBy,
 	slimVault
 } from '$lib/top-vaults/helpers';
-import { downsampleSharePriceReturns, getCachedSharePriceReturns } from '$lib/strategies/yaml/share-price';
-import type { StrategyInfo } from 'trade-executor/models/strategy-info';
+import { getCachedSharePriceReturns } from '$lib/strategies/yaml/share-price';
+import { compactStrategyTileChartData } from 'trade-executor/helpers/chart';
 import { fetchLatestFredValue, fetchLatestTreasuryRate } from '$lib/reference-rates';
 
 const HOME_PAGE_EDGE_CACHE_TTL_SECONDS = 30 * 60;
@@ -28,46 +28,6 @@ function getAgeSeconds(dateValue: Date | string | null | undefined) {
 	return Math.max(0, Math.floor((Date.now() - parsed.valueOf()) / 1000));
 }
 
-/**
- * Compact chart samples before the strategy is serialised into the page data.
- *
- * Strategy tile charts render daily values, so retaining intra-day samples only
- * increases the initial HTML response and hydration work.
- *
- * @param strategy Strategy listing data returned by the API
- * @returns The same strategy shape with daily chart data
- */
-function compactStrategyChartData(strategy: StrategyInfo): StrategyInfo {
-	const summary = strategy.summary_statistics;
-	if (!summary) return strategy;
-
-	if (strategy.useSharePrice) {
-		return {
-			...strategy,
-			summary_statistics: {
-				...summary,
-				// A tile only reads one chart type. Discard the alternative raw
-				// series instead of serialising it alongside the selected chart.
-				compounding_unrealised_trading_profitability: undefined,
-				share_price_returns_90_days: summary.share_price_returns_90_days
-					? downsampleSharePriceReturns(summary.share_price_returns_90_days)
-					: undefined
-			}
-		};
-	}
-
-	return {
-		...strategy,
-		summary_statistics: {
-			...summary,
-			share_price_returns_90_days: undefined,
-			compounding_unrealised_trading_profitability: summary.compounding_unrealised_trading_profitability
-				? downsampleSharePriceReturns(summary.compounding_unrealised_trading_profitability)
-				: undefined
-		}
-	};
-}
-
 export async function load({ fetch }) {
 	const [strategies, topVaultsResult, ratesResult] = await Promise.all([
 		getCachedStrategies(fetch),
@@ -78,7 +38,7 @@ export async function load({ fetch }) {
 		Promise.all([fetchLatestFredValue('SNDR'), fetchLatestTreasuryRate()])
 	]);
 
-	const frontpageStrategies = strategies.filter((s) => s.frontpage).map(compactStrategyChartData);
+	const frontpageStrategies = strategies.filter((s) => s.frontpage).map(compactStrategyTileChartData);
 	const yamlTileFreshness: {
 		strategyId: string;
 		vaultId: string | null;

--- a/src/routes/+page.ts
+++ b/src/routes/+page.ts
@@ -1,5 +1,5 @@
-import { fetchPublicApi, optionalDataError } from '$lib/helpers/public-api';
 import { getPosts } from '$lib/blog/client';
+import { optionalDataError } from '$lib/helpers/public-api';
 
 export async function load({ fetch, setHeaders, data }) {
 	// Cache the landing page at Cloudflare edge for 30 minutes.
@@ -15,7 +15,6 @@ export async function load({ fetch, setHeaders, data }) {
 		savingsRate: data.savingsRate,
 		treasuryRate: data.treasuryRate,
 		topVaults: data.topVaults,
-		impressiveNumbers: await fetchPublicApi(fetch, 'impressive-numbers').catch(optionalDataError('impressive-numbers')),
 		posts: await getPosts(fetch, { limit: 4 })
 			.then((r) => r.posts)
 			.catch(optionalDataError('blog posts'))


### PR DESCRIPTION
## Why

The front page serialised high-resolution and unused chart series, unused metrics data, and vault records that were never rendered. This increased transfer size and hydration work, especially on cold visits.

## Lessons learnt

Lazy-loading a chart component does not defer its input data. Compact or remove data before SvelteKit serialises the page load result.

## Summary

- Downsample strategy chart data to the daily resolution rendered by tiles and remove the unused alternate series.
- Return only the five top vaults displayed on the front page.
- Remove the unused impressive-numbers request from the page load.
- Add coverage for daily chart-series compaction.