### PR TITLE
fix: clarify vault curator and protocol headings

### DIFF
--- a/src/routes/vaults/[vault=slug]/VaultCuratorInfo.svelte
+++ b/src/routes/vaults/[vault=slug]/VaultCuratorInfo.svelte
@@ -35,7 +35,7 @@ curator.
 			<img src={curatorLogoUrl} alt={curator.name} class="curator-logo" />
 		{/if}
 		<div class="content">
-			<h2>About {curator.name}</h2>
+			<h2>Curated by {curator.name}</h2>
 			<p class="description">
 				This {assetType} is curated by <a href={curatorPageUrl}>{curator.name}</a>.
 			</p>

--- a/src/routes/vaults/[vault=slug]/VaultProtocolInfo.svelte
+++ b/src/routes/vaults/[vault=slug]/VaultProtocolInfo.svelte
@@ -30,7 +30,7 @@
 			{/if}
 		{/if}
 		<div class="content">
-			<h2>About {protocolMetadata.name}</h2>
+			<h2>Running on {protocolMetadata.name} protocol</h2>
 			<p class="description">
 				This {assetType} is running on <a href={protocolPageUrl}>{protocolMetadata.name}</a>:
 			</p>


### PR DESCRIPTION
## Why

The vault detail cards should clearly state the curator and protocol relationship.

## Lessons learnt

When sharing a worktree dev server, use its assigned port rather than assuming the default Vite port is available.

## Summary

- Changed curator card headings to “Curated by {name}”.
- Changed protocol card headings to “Running on {name} protocol”.