### PR TITLE
fix: prioritise private vault status

### DIFF
--- a/src/lib/top-vaults/TopVaultsTable.svelte
+++ b/src/lib/top-vaults/TopVaultsTable.svelte
@@ -1314,7 +1314,6 @@ Whitelisted vaults are marked as Private because they do not accept public depos
 									<svelte:fragment slot="trigger">
 										<span class="status-wrapper">
 											<IconStop />Private
-											{#if badStatus}<IconHourglass />{/if}{getFormattedLockup(vault)}
 										</span>
 									</svelte:fragment>
 									<svelte:fragment slot="popup">

--- a/src/lib/top-vaults/listing/types.ts
+++ b/src/lib/top-vaults/listing/types.ts
@@ -1,5 +1,5 @@
 /** Rows included directly in the server-rendered page response. */
-export const INITIAL_VAULT_LISTING_LIMIT = 75;
+export const INITIAL_VAULT_LISTING_LIMIT = 125;
 
 /** Rows returned by each browser continuation request. */
 export const VAULT_LISTING_PAGE_SIZE = 50;

--- a/tests/integration/vaults/funds.test.ts
+++ b/tests/integration/vaults/funds.test.ts
@@ -13,13 +13,15 @@ test.describe('funds page', () => {
 		await expect(
 			page.getByRole('link', { name: 'Read more about the differences between vaults and tokenised funds here.' })
 		).toHaveAttribute('href', '/glossary/tokenised-fund');
-		await expect(page.getByText('Tracking $20.00K net asset value across 1 fund.')).toBeVisible();
-		await expect(page.getByText('Total $20.00K tokenised fund NAV')).toBeVisible();
+		await expect(page.getByText('Tracking $40.00K net asset value across 2 funds.')).toBeVisible();
+		await expect(page.getByText('Total $40.00K tokenised fund NAV')).toBeVisible();
 		await expect(page.getByTestId('tokenised-fund-nav-pie-chart').locator('canvas')).toBeVisible({
 			timeout: 15000
 		});
-		await expect(page.locator('tbody tr.targetable')).toHaveCount(1);
-		await expect(page.locator('tbody tr.targetable')).toContainText('Deposit disabled vault');
+		const rows = page.locator('tbody tr.targetable');
+		await expect(rows).toHaveCount(2);
+		await expect(rows.filter({ hasText: 'Private tokenised fund' })).toHaveCount(1);
+		await expect(rows.filter({ hasText: 'Deposit disabled vault' })).toHaveCount(1);
 	});
 
 	test('permanently redirects the legacy tokenised funds URL', async ({ request }) => {

--- a/tests/integration/vaults/index.test.ts
+++ b/tests/integration/vaults/index.test.ts
@@ -245,11 +245,11 @@ test.describe('vault index page', () => {
 		await expect(meta).toContainText('254 vaults');
 	});
 
-	test('renders initial batch of 75 rows', async ({ page }) => {
+	test('renders an initial batch of more than 100 rows', async ({ page }) => {
 		const rows = page.locator('tbody tr.targetable');
 		// Wait for rows to be visible
 		await expect(rows.first()).toBeVisible();
-		await expect(rows).toHaveCount(75);
+		await expect(rows).toHaveCount(125);
 	});
 
 	test('shows load-more sentinel when more rows available', async ({ page }) => {
@@ -262,7 +262,7 @@ test.describe('vault index page', () => {
 		await page.goto('/vaults?tvl=any&q=Summary%20regression&unknown=0');
 
 		const rows = page.locator('tbody tr.targetable');
-		await expect(rows).toHaveCount(75);
+		await expect(rows).toHaveCount(125);
 		await expect(page.getByTestId('top-vaults-meta')).toContainText('151 vaults');
 		await expect(page.getByTestId('top-vaults-meta')).toContainText('Avg. return 76.61%');
 	});
@@ -270,14 +270,14 @@ test.describe('vault index page', () => {
 	test('loads 50 more rows when scrolling to sentinel', async ({ page }) => {
 		// Check initial row count
 		const rows = page.locator('tbody tr.targetable');
-		await expect(rows).toHaveCount(75);
+		await expect(rows).toHaveCount(125);
 
 		// Scroll the sentinel into view
 		const sentinel = page.getByTestId('load-more-sentinel');
 		await sentinel.scrollIntoViewIfNeeded();
 
 		// Confirm additional rows
-		await expect(rows).toHaveCount(125);
+		await expect(rows).toHaveCount(175);
 	});
 
 	test('loads 500 vaults through progressive scrolling', async ({ page }) => {
@@ -285,9 +285,9 @@ test.describe('vault index page', () => {
 
 		const rows = page.locator('tbody tr.targetable');
 		const sentinel = page.getByTestId('load-more-sentinel');
-		await expect(rows).toHaveCount(75);
+		await expect(rows).toHaveCount(125);
 
-		for (let expectedCount = 125; expectedCount < 500; expectedCount += 50) {
+		for (let expectedCount = 175; expectedCount < 500; expectedCount += 50) {
 			await sentinel.scrollIntoViewIfNeeded();
 			await expect(rows).toHaveCount(expectedCount);
 		}
@@ -303,16 +303,13 @@ test.describe('vault index page', () => {
 
 		// scroll once - loads additional 50
 		await sentinel.scrollIntoViewIfNeeded();
-		await expect(rows).toHaveCount(125);
-
-		// scroll again - loads another 50
-		await sentinel.scrollIntoViewIfNeeded();
 		await expect(rows).toHaveCount(175);
 
-		// Scroll twice more: a full batch, then the final 29 rows.
+		// Scroll again - loads another full batch.
 		await sentinel.scrollIntoViewIfNeeded();
 		await expect(rows).toHaveCount(225);
 
+		// The final continuation contains the remaining 29 rows.
 		await sentinel.scrollIntoViewIfNeeded();
 		await expect(rows).toHaveCount(254);
 
@@ -485,6 +482,7 @@ test.describe('vault index page', () => {
 
 		const cell = page.locator('tbody tr.targetable').filter({ hasText: 'Private vault' }).locator('td.lockup');
 		await expect(cell).toContainText('Private');
+		await expect(cell).not.toContainText('Unknown');
 		const tooltip = cell.locator('.tooltip');
 		await tooltip.hover();
 		await expect(tooltip.locator('.popup')).toContainText('This vault does not accept public deposits.');


### PR DESCRIPTION
## Why

Whitelisted vaults could display a conflicting operational delay label beside their Private status, and the initial vault listing was shorter than needed for browsing. The tokenised-fund regression test also no longer matched the two funds now present in its fixture.

## Lessons learnt

The private access classification must take visual precedence over operational deposit-delay state. Keep the state detail in the tooltip, preserve enough initial listing rows for the table to be useful before progressive loading starts, and make fixture-based assertions reflect the complete fixture.

## Summary

- Render only Private in whitelisted vault deposit-and-delay cells.
- Add regression coverage for Private precedence over Unknown.
- Increase the initial vault listing batch from 75 to 125 rows.
- Correct tokenised-fund fixture expectations for both included funds.