### PR TITLE
feat: add whitelisted vault ranking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Weblog of stuff
 
+- Add a whitelisted vault ranking for permissioned deposits (2026-08-03)
 - Consolidate vault listing controls into a persistent Filters disclosure (2026-08-01)
 - Add Xerberus protocol scores and tooltips to the vault protocol listing, and fix curator description spacing (2026-08-01)
 - Add TVL distribution charts for CORE3 and Xerberus risk-rated vaults (2026-07-30)

--- a/src/lib/top-vaults/VaultListingsSelector.svelte
+++ b/src/lib/top-vaults/VaultListingsSelector.svelte
@@ -21,6 +21,7 @@ Renders navigation links for vault listing and chart pages.
 		{ href: '/vaults/high-tvl', label: 'Top with $2M TVL' },
 		{ href: '/vaults/new-vaults', label: 'New' },
 		{ href: '/vaults/negative', label: 'Negative' },
+		{ href: '/vaults/whitelisted', label: 'Whitelisted' },
 		{ href: '/vaults/blacklisted', label: 'Blacklisted' },
 		{ href: '/vaults/all', label: 'All' },
 		{ href: '/vaults/core3-ratings', label: 'CORE3 ratings' },

--- a/src/lib/top-vaults/listing/definitions.ts
+++ b/src/lib/top-vaults/listing/definitions.ts
@@ -17,6 +17,7 @@ export const vaultListingKeys = [
 	'new-vaults',
 	'negative',
 	'blacklisted',
+	'whitelisted',
 	'chain',
 	'protocol',
 	'stablecoin',
@@ -69,6 +70,16 @@ export const vaultListingDefinitions: Record<VaultListingKey, VaultListingDefini
 		},
 		requiresScope: false
 	},
+	whitelisted: {
+		key: 'whitelisted',
+		defaults: { tvl: 'any', risk: 0, unknown: false, sort: 'tvl', direction: 'desc' },
+		options: {
+			...commonOptions,
+			includeBlacklisted: true,
+			includeBlacklistedInStats: true
+		},
+		requiresScope: false
+	},
 	chain: { key: 'chain', defaults: { tvl: '10k' }, options: commonOptions, requiresScope: true },
 	protocol: { key: 'protocol', defaults: { tvl: '10k', unknown: false }, options: commonOptions, requiresScope: true },
 	stablecoin: {
@@ -117,6 +128,8 @@ export function filterVaultListingScope(vaults: VaultInfo[], key: VaultListingKe
 	switch (key) {
 		case 'blacklisted':
 			return vaults.filter(isBlacklisted);
+		case 'whitelisted':
+			return vaults.filter((vault) => vault.whitelist?.status === 'whitelisted');
 		case 'chain': {
 			if (!scope) return [];
 			const chainIds = new Set(getChainsBySlug(scope).map((chain) => chain.id));

--- a/src/lib/top-vaults/listing/query.test.ts
+++ b/src/lib/top-vaults/listing/query.test.ts
@@ -96,6 +96,18 @@ describe('vault listing query', () => {
 		]);
 	});
 
+	it('keeps a whitelisted definition scoped to permissioned vaults', () => {
+		const permissionless = createTestVault('Permissionless', { current_nav: 100_000 });
+		const whitelisted = createTestVault('Whitelisted', {
+			current_nav: 100_000,
+			whitelist: { status: 'whitelisted', notes: null }
+		});
+
+		expect(filterVaultListingScope([permissionless, whitelisted], 'whitelisted').map((vault) => vault.name)).toEqual([
+			'Whitelisted'
+		]);
+	});
+
 	it('keeps the unknown-vault defaults aligned with detail listing routes', () => {
 		expect(getVaultListingDefaults('protocol', 'unknown').unknown).toBe(false);
 		expect(getVaultListingDefaults('stablecoin', 'usdc').unknown).toBe(false);

--- a/src/routes/vaults/sitemap.xml/+server.ts
+++ b/src/routes/vaults/sitemap.xml/+server.ts
@@ -18,6 +18,7 @@ const staticSubPages = [
 	'high-tvl',
 	'international',
 	'new-vaults',
+	'whitelisted',
 	'funds',
 	'current-peak-tvl',
 	'cumulative-tvl-apy',

--- a/src/routes/vaults/whitelisted/+page.server.ts
+++ b/src/routes/vaults/whitelisted/+page.server.ts
@@ -1,0 +1,5 @@
+import { loadVaultListing } from '$lib/server/top-vaults/listing';
+
+export async function load({ fetch, url }) {
+	return loadVaultListing(fetch, url, 'whitelisted');
+}

--- a/src/routes/vaults/whitelisted/+page.svelte
+++ b/src/routes/vaults/whitelisted/+page.svelte
@@ -1,0 +1,59 @@
+<!--
+Whitelisted vault listing for permissioned deposits.
+-->
+<script lang="ts">
+	import { page } from '$app/state';
+	import TopVaultsPage from '$lib/top-vaults/TopVaultsPage.svelte';
+	import { JsonLd } from 'svelte-meta-tags';
+	import MetaTags from '$lib/social-card/SocialCardMetaTags.svelte';
+
+	let { data } = $props();
+	let topVaults = $derived(data.initialTopVaults);
+
+	const title = 'Whitelisted DeFi stablecoin vaults';
+	const description =
+		'This ranking contains only vaults that are not open to public and have some sort of permissioned deposits.';
+	let pageUrl = $derived(new URL(page.url.pathname, page.url.origin).href);
+</script>
+
+<MetaTags
+	{title}
+	{description}
+	canonical={pageUrl}
+	openGraph={{ siteName: 'Trading Strategy', url: pageUrl, title, description, type: 'website' }}
+	twitter={{ site: '@TradingProtocol', cardType: 'summary', title, description }}
+/>
+
+<JsonLd
+	schema={{
+		'@context': 'http://schema.org',
+		'@type': 'CollectionPage',
+		name: title,
+		description,
+		url: pageUrl,
+		provider: { '@type': 'Organization', name: 'Trading Strategy' },
+		mainEntity: {
+			'@type': 'ItemList',
+			numberOfItems: data.listingSummary.matchingCount
+		}
+	}}
+/>
+
+<TopVaultsPage
+	{topVaults}
+	loading={false}
+	progressive={data.initialVaultListingHasMore}
+	listingKey={data.listingKey}
+	listingSummary={data.listingSummary}
+	totalVaultCount={data.totalVaultCount}
+	includeBlacklisted
+	includeBlacklistedInStats
+	title="Whitelisted stablecoin vaults"
+	subtitle={description}
+	showFilters
+	defaultTvlKey="any"
+	defaultRiskIndex={0}
+	defaultHideUnknown={0}
+	defaultSort="tvl"
+	defaultDirection="desc"
+/>

--- a/tests/integration/sitemap-index.test.ts
+++ b/tests/integration/sitemap-index.test.ts
@@ -96,6 +96,7 @@ test.describe('vaults sitemap', () => {
 			'/vaults/blacklisted',
 			'/vaults/high-tvl',
 			'/vaults/new-vaults',
+			'/vaults/whitelisted',
 			'/vaults/funds',
 			'/vaults/current-peak-tvl',
 			'/vaults/cumulative-tvl-apy',

--- a/tests/integration/vaults/index.test.ts
+++ b/tests/integration/vaults/index.test.ts
@@ -239,6 +239,20 @@ test.describe('vault index page', () => {
 		await expect(page.getByTestId('top-vaults-meta')).toContainText('Avg. return 20.00%');
 	});
 
+	test('shows only whitelisted vaults', async ({ page }) => {
+		await page.goto('/vaults/whitelisted');
+
+		const rows = page.locator('tbody tr.targetable');
+		await expect(rows).toHaveCount(2);
+		await expect(rows.first()).toContainText('Private vault');
+		await expect(rows.locator('td.lockup').filter({ hasText: 'Private' })).toHaveCount(2);
+		await expect(page.locator('h1')).toHaveText('Whitelisted stablecoin vaults');
+		await expect(page.locator('meta[name="description"]')).toHaveAttribute(
+			'content',
+			'This ranking contains only vaults that are not open to public and have some sort of permissioned deposits.'
+		);
+	});
+
 	test('displays vault count in table meta', async ({ page }) => {
 		const meta = page.getByTestId('top-vaults-meta');
 		// Should show 254 vaults (those above TVL threshold)


### PR DESCRIPTION
## Why

Permissioned vaults need a dedicated ranking so users can identify deposits that are not publicly available.

## Lessons learnt

Use the shared server-side vault-listing framework for filtered rankings; it avoids downloading and filtering the complete vault catalogue in the browser.

## Summary

- Add the Whitelisted ranking and sitemap entry.
- Filter to vaults with permissioned deposits and display their Private status.
- Add focused listing and page coverage.