### PR TITLE
fix: label tokenised funds in vault listings

### DIFF
--- a/src/lib/top-vaults/TopVaultsTable.svelte
+++ b/src/lib/top-vaults/TopVaultsTable.svelte
@@ -3,7 +3,7 @@
 Interactive vault listing with filters, sorting, and progressive row loading.
 
 Use `ratingProvider` to add its risk-rating column beside the vault name.
-Whitelisted vaults are marked as Private because they do not accept public deposits.
+Whitelisted vaults are marked as Private, except tokenised funds, which are marked as Fund.
 -->
 <script lang="ts">
 	import type { Chain } from '$lib/helpers/chain';
@@ -1244,6 +1244,8 @@ Whitelisted vaults are marked as Private because they do not accept public depos
 					{@const blacklisted = isBlacklisted(vault)}
 					{@const badStatus = !isGoodVaultStatus(vault)}
 					{@const isPrivate = vault.whitelist?.status === 'whitelisted'}
+					{@const isTokenisedFund = vault.flags.includes('tokenised_fund')}
+					{@const depositStatusLabel = isTokenisedFund ? 'Fund' : 'Private'}
 					{@const protocolName = getVaultProtocolDisplayName(vault)}
 					{@const statusReason = [vault.deposit_closed_reason, vault.redemption_closed_reason]
 						.filter(Boolean)
@@ -1313,7 +1315,7 @@ Whitelisted vaults are marked as Private because they do not accept public depos
 								<Tooltip>
 									<svelte:fragment slot="trigger">
 										<span class="status-wrapper">
-											<IconStop />Private
+											<IconStop />{depositStatusLabel}
 										</span>
 									</svelte:fragment>
 									<svelte:fragment slot="popup">

--- a/src/lib/top-vaults/listing/definitions.ts
+++ b/src/lib/top-vaults/listing/definitions.ts
@@ -47,7 +47,7 @@ export const vaultListingDefinitions: Record<VaultListingKey, VaultListingDefini
 	top: { key: 'top', defaults: { tvl: DEFAULT_TVL_KEY }, options: commonOptions, requiresScope: false },
 	all: {
 		key: 'all',
-		defaults: { tvl: '10k', risk: 0 },
+		defaults: { tvl: '10k', risk: 1 },
 		options: { ...commonOptions, includeBlacklisted: true },
 		requiresScope: false
 	},

--- a/src/routes/vaults/all/+page.svelte
+++ b/src/routes/vaults/all/+page.svelte
@@ -50,5 +50,5 @@ All vaults listing including problematic/blacklisted vaults
 	subtitle="All stablecoin vaults, including ones with stuck funds and oracle problems"
 	showFilters
 	defaultTvlKey="10k"
-	defaultRiskIndex={0}
+	defaultRiskIndex={1}
 />

--- a/tests/integration/vaults/index.test.ts
+++ b/tests/integration/vaults/index.test.ts
@@ -216,6 +216,12 @@ test.describe('vault index page', () => {
 		await expect(page.getByTestId('filters-note')).toHaveCount(0);
 	});
 
+	test('defaults the all-vaults listing to Dangerous technical risk', async ({ page }) => {
+		await page.goto('/vaults/all');
+		await openFilters(page);
+		await expect(page.locator('.filter-group:has-text("Technical risk") .tvl-trigger')).toHaveText('Dangerous');
+	});
+
 	test('shows blacklisted-only vaults sorted by TVL by default', async ({ page }) => {
 		await page.goto('/vaults/blacklisted');
 
@@ -245,7 +251,8 @@ test.describe('vault index page', () => {
 		const rows = page.locator('tbody tr.targetable');
 		await expect(rows).toHaveCount(2);
 		await expect(rows.first()).toContainText('Private vault');
-		await expect(rows.locator('td.lockup').filter({ hasText: 'Private' })).toHaveCount(2);
+		await expect(rows.locator('td.lockup').filter({ hasText: 'Private' })).toHaveCount(1);
+		await expect(rows.locator('td.lockup').filter({ hasText: 'Fund' })).toHaveCount(1);
 		await expect(page.locator('h1')).toHaveText('Whitelisted stablecoin vaults');
 		await expect(page.locator('meta[name="description"]')).toHaveAttribute(
 			'content',
@@ -510,6 +517,17 @@ test.describe('vault index page', () => {
 		await expect(page.getByText('Whitelist notes', { exact: true }).locator('..')).toContainText(
 			'Whitelist checks are handled by the vault'
 		);
+
+		await page.goto('/vaults/all');
+		await openFilters(page);
+		await page.getByTestId('vault-search').fill('Private tokenised fund');
+		const fundCell = page
+			.locator('tbody tr.targetable')
+			.filter({ hasText: 'Private tokenised fund' })
+			.locator('td.lockup');
+		await expect(fundCell).toContainText('Fund');
+		await expect(fundCell).not.toContainText('Private');
+		await expect(fundCell).not.toContainText('Unknown');
 	});
 
 	test('shows the tokenised-fund disclaimer instead of the permissioned warning', async ({ page }) => {


### PR DESCRIPTION
## Why

Tokenised funds that are whitelisted were labelled Private in the deposit-and-delay column, which does not describe their fund structure clearly. The all-vaults listing also needed a safer default risk threshold.

## Lessons learnt

The deposit label should reflect the tokenised-fund structure when it overlaps with a whitelist restriction. Server and client listing defaults must remain aligned.

## Summary

- Label whitelisted tokenised funds as Fund with the existing stop icon.
- Keep Private for other whitelisted vaults.
- Default the all-vaults listing to Dangerous technical risk.
- Add browser regression coverage for both behaviours.