### PR TITLE
Show stablecoin rate warnings and capped deposits

### DIFF
--- a/docs/vault-data-source.md
+++ b/docs/vault-data-source.md
@@ -58,6 +58,15 @@ Each vault may include a `whitelist` object that records whether deposits are pu
 
 The frontend treats unrecognised source values as `unknown`, and preserves optional `whitelist.notes` in the vault's Technical details table.
 
+#### Deposit availability and capacity
+
+`deposit_closed_reason` is the source of truth for whether deposits may be unavailable. The listing and vault detail page show the source message in Technical details. For a compact status label, the frontend displays **Capped** only when the reason contains a case-insensitive `deposit cap ... reached` confirmation. This recognises the current standard and Upshift forms:
+
+- `Max deposit cap reached (maxDeposit=0)`; or
+- the equivalent Upshift wording, `depositCap() has been reached`.
+
+Other reasons, including high utilisation or permissioning, remain their source-provided status rather than being inferred as a cap.
+
 ### Vault prices parquet
 
 **Code:** `src/lib/top-vaults/vault-prices-parquet.ts` → `ensureVaultPricesParquet()`

--- a/docs/vault-listings.md
+++ b/docs/vault-listings.md
@@ -49,3 +49,9 @@ blacklisted listing explicitly includes its matching vaults in its own summary.
 This keeps headline TVL and returns aligned with the established listing rules.
 The server resolves the cached US Treasury rate when that monthly-return filter
 is selected, so the initial batch and continuation requests apply the same rule.
+
+## Stablecoin safety notices
+
+Stablecoin detail pages show a red notice when stablecoin metadata identifies a likely depeg. When a native peg rate is available, the notice shows the inverse rate as token units per one unit of the peg currency and its fetch time.
+
+If metadata reports `rate_fetch_failed_reason: missing_coingecko_id`, the page instead shows a yellow notice explaining that a price feed is unavailable. It does not present a peg or depeg rate in that state.

--- a/src/lib/stablecoin-metadata/StablecoinDepegWarning.svelte
+++ b/src/lib/stablecoin-metadata/StablecoinDepegWarning.svelte
@@ -1,0 +1,69 @@
+<!--
+@component
+Displays a prominent warning on a stablecoin detail page when the denomination
+is likely below its native fiat peg, or when its price feed is unavailable.
+
+@example
+
+```svelte
+	<StablecoinDepegWarning metadata={stablecoinMetadata} />
+```
+-->
+<script lang="ts">
+	import Alert from '$lib/components/Alert.svelte';
+	import Timestamp from '$lib/components/Timestamp.svelte';
+	import { getStablecoinNativeRate, isStablecoinDepegged } from './helpers';
+	import type { StablecoinMetadata } from './schemas';
+
+	interface Props {
+		metadata: StablecoinMetadata;
+	}
+
+	let { metadata }: Props = $props();
+
+	let depegged = $derived(isStablecoinDepegged(metadata));
+	let priceFeedUnavailable = $derived(metadata.rate_fetch_failed_reason === 'missing_coingecko_id');
+	let nativeRate = $derived(getStablecoinNativeRate(metadata));
+	let pegCurrency = $derived((metadata.peg_rate_currency ?? 'usd').toUpperCase());
+	let rateTimestamp = $derived(metadata.usd_rate_fetched_at ?? metadata.usd_rate_updated_at);
+	let unitsPerFiat = $derived(nativeRate === undefined ? undefined : 1 / nativeRate);
+	let formattedUnitsPerFiat = $derived.by(() => {
+		if (unitsPerFiat === undefined || !Number.isFinite(unitsPerFiat)) return undefined;
+
+		return new Intl.NumberFormat('en', { maximumSignificantDigits: 6 }).format(unitsPerFiat);
+	});
+</script>
+
+{#if priceFeedUnavailable || depegged}
+	<div
+		class="stablecoin-depeg-warning"
+		data-testid={priceFeedUnavailable ? 'stablecoin-price-feed-warning' : 'stablecoin-depeg-warning'}
+	>
+		{#if priceFeedUnavailable}
+			<Alert status="warning" size="md">
+				This stablecoin does not have a price feed available at the moment and we are unable to display peg/depeg rates.
+			</Alert>
+		{:else}
+			<Alert status="error" size="md">
+				This stablecoin is likely depegged.
+				{#if formattedUnitsPerFiat}
+					The current rate is {formattedUnitsPerFiat}
+					{metadata.symbol} / 1 {pegCurrency}
+					{#if rateTimestamp}
+						fetched at
+						<Timestamp date={rateTimestamp} withTime />.
+					{:else}.
+					{/if}
+				{:else}
+					The current rate is unavailable.
+				{/if}
+			</Alert>
+		{/if}
+	</div>
+{/if}
+
+<style>
+	.stablecoin-depeg-warning {
+		margin-top: 1rem;
+	}
+</style>

--- a/src/lib/top-vaults/TopVaultsPage.svelte
+++ b/src/lib/top-vaults/TopVaultsPage.svelte
@@ -24,6 +24,7 @@ Use `ratingProvider` to show a provider-specific risk rating column.
 	import CuratorDescription from '$lib/curator/CuratorDescription.svelte';
 	import CuratorRecentPosts from '$lib/curator/CuratorRecentPosts.svelte';
 	import StablecoinDescription from '$lib/stablecoin-metadata/StablecoinDescription.svelte';
+	import StablecoinDepegWarning from '$lib/stablecoin-metadata/StablecoinDepegWarning.svelte';
 	import { getLogoUrl } from '$lib/helpers/assets';
 	import { getStablecoinLogoUrl } from '$lib/stablecoin-metadata/helpers.js';
 	import { getVaultProtocolLogoUrl } from '$lib/vault-protocol/helpers.js';
@@ -181,6 +182,9 @@ Use `ratingProvider` to show a provider-specific risk rating column.
 						</span>
 					{/snippet}
 				</HeroBanner>
+				{#if stablecoinMetadata}
+					<StablecoinDepegWarning metadata={stablecoinMetadata} />
+				{/if}
 
 				{#if heroAside}
 					<aside class="hero-aside">

--- a/src/lib/top-vaults/TopVaultsTable.svelte
+++ b/src/lib/top-vaults/TopVaultsTable.svelte
@@ -64,6 +64,7 @@ Whitelisted vaults are marked as Private, except tokenised funds, which are mark
 		getVaultTvlNative,
 		hasSupportedProtocol,
 		isBlacklisted,
+		isVaultDepositCapped,
 		isGoodVaultStatus,
 		monthlyReturnFilterOptions,
 		rankVaultsBy,
@@ -1245,6 +1246,7 @@ Whitelisted vaults are marked as Private, except tokenised funds, which are mark
 					{@const badStatus = !isGoodVaultStatus(vault)}
 					{@const isPrivate = vault.whitelist?.status === 'whitelisted'}
 					{@const isTokenisedFund = vault.flags.includes('tokenised_fund')}
+					{@const isCapped = isVaultDepositCapped(vault)}
 					{@const depositStatusLabel = isTokenisedFund ? 'Fund' : 'Private'}
 					{@const protocolName = getVaultProtocolDisplayName(vault)}
 					{@const statusReason = [vault.deposit_closed_reason, vault.redemption_closed_reason]
@@ -1311,7 +1313,18 @@ Whitelisted vaults are marked as Private, except tokenised funds, which are mark
 							<FeesCell mgmt_fee={vault.mgmt_fee} perf_fee={vault.perf_fee} />
 						</td>
 						<td class={['lockup', vault.lockup === null && 'unknown', isPrivate && 'private']}>
-							{#if isPrivate}
+							{#if isCapped}
+								<Tooltip>
+									<svelte:fragment slot="trigger">
+										<span class="status-wrapper">
+											<IconStop />Capped
+										</span>
+									</svelte:fragment>
+									<svelte:fragment slot="popup"
+										>This vault has reached its deposit cap. {getLockupDescription(vault)}</svelte:fragment
+									>
+								</Tooltip>
+							{:else if isPrivate}
 								<Tooltip>
 									<svelte:fragment slot="trigger">
 										<span class="status-wrapper">

--- a/src/lib/top-vaults/helpers.test.ts
+++ b/src/lib/top-vaults/helpers.test.ts
@@ -12,6 +12,7 @@ import {
 	getLockupDescription,
 	getFormattedLockup,
 	getLockupTooltip,
+	isVaultDepositCapped,
 	getFormattedFeeMode,
 	getFeeModeLabel,
 	getFeeModeDescription,
@@ -566,6 +567,30 @@ describe('getFormattedLockup', () => {
 	test('uses abbreviated unit for 1 unit', () => {
 		const vault = createTestVault('Test vault', { lockup: 60 }); // 1 minute
 		expect(getFormattedLockup(vault)).toBe('1m');
+	});
+});
+
+describe('isVaultDepositCapped', () => {
+	test('does not infer a cap from a Royco tranche feature', () => {
+		const vault = createTestVault('Royco tranche', { features: ['royco_tranche_like'] });
+		expect(isVaultDepositCapped(vault)).toBe(false);
+	});
+
+	test('recognises the standard cap-reached deposit reason as capped', () => {
+		const vault = createTestVault('Capacity reached', {
+			deposit_closed_reason: 'Max deposit cap reached (maxDeposit=0)'
+		});
+		expect(isVaultDepositCapped(vault)).toBe(true);
+	});
+
+	test('recognises the equivalent Upshift depositCap reason as capped', () => {
+		const vault = createTestVault('Upshift capped', { deposit_closed_reason: 'Upshift depositCap() has been reached' });
+		expect(isVaultDepositCapped(vault)).toBe(true);
+	});
+
+	test('does not treat a general deposit pause as a capacity cap', () => {
+		const vault = createTestVault('Paused deposits', { deposit_closed_reason: 'Deposits paused' });
+		expect(isVaultDepositCapped(vault)).toBe(false);
 	});
 });
 

--- a/src/lib/top-vaults/helpers.ts
+++ b/src/lib/top-vaults/helpers.ts
@@ -305,6 +305,19 @@ export function isGoodVaultStatus(vault: VaultInfo): boolean {
 }
 
 /**
+ * Whether a vault is no longer accepting deposits because its capacity is full.
+ *
+ * The upstream export expresses this through the human-readable deposit-closed
+ * reason. Accept both its standard wording and the equivalent camel-case
+ * `depositCap()` form emitted by Upshift.
+ *
+ * @param vault vault operational metadata
+ */
+export function isVaultDepositCapped(vault: Pick<VaultInfo, 'deposit_closed_reason'>): boolean {
+	return /deposit\s*cap(?:\(\))?\s+(?:has\s+been\s+)?reached/i.test(vault.deposit_closed_reason ?? '');
+}
+
+/**
  * Check if vault meets minimum TVL threshold
  */
 export function meetsMinTvl(vault: Pick<VaultInfo, 'current_nav'>, threshold = MIN_TVL_THRESHOLD) {

--- a/src/routes/vaults/[vault=slug]/+page.svelte
+++ b/src/routes/vaults/[vault=slug]/+page.svelte
@@ -29,7 +29,8 @@ Vault detail page with performance, protocol, private-deposit, and third-party r
 		getMorphoFlags,
 		getVaultProtocolDisplayName,
 		hasSupportedProtocol,
-		isBlacklisted
+		isBlacklisted,
+		isVaultDepositCapped
 	} from '$lib/top-vaults/helpers';
 	import { getCuratorSocialLogoUrl } from '$lib/social-card/helpers';
 	import { getVaultProtocolLogoUrl } from '$lib/vault-protocol/helpers.js';
@@ -46,16 +47,21 @@ Vault detail page with performance, protocol, private-deposit, and third-party r
 	let showNotes = $derived(vault.notes != null && !notesDuplicateMorphoFlags);
 	let isTokenisedFund = $derived(vault.flags.includes('tokenised_fund'));
 	let isPrivate = $derived(vault.whitelist?.status === 'whitelisted');
+	let isCapped = $derived(isVaultDepositCapped(vault));
 	let depositMayBeDisabled = $derived(vault.deposit_closed_reason != null);
 	let redemptionMayBeDisabled = $derived(vault.redemption_closed_reason != null);
 	let operationWarning = $derived(
-		depositMayBeDisabled && redemptionMayBeDisabled
-			? 'Deposits and withdrawals may be disabled for this vault'
-			: depositMayBeDisabled
-				? 'Deposits may be disabled for this vault'
-				: redemptionMayBeDisabled
-					? 'Withdrawals may be disabled for this vault'
-					: undefined
+		isCapped
+			? redemptionMayBeDisabled
+				? 'Deposits are capped and withdrawals may be disabled for this vault'
+				: 'Deposits are capped for this vault'
+			: depositMayBeDisabled && redemptionMayBeDisabled
+				? 'Deposits and withdrawals may be disabled for this vault'
+				: depositMayBeDisabled
+					? 'Deposits may be disabled for this vault'
+					: redemptionMayBeDisabled
+						? 'Withdrawals may be disabled for this vault'
+						: undefined
 	);
 	let chartLogoUrl = $derived(
 		getCuratorSocialLogoUrl(curatorMetadata) ??

--- a/src/routes/vaults/[vault=slug]/VaultMetrics.svelte
+++ b/src/routes/vaults/[vault=slug]/VaultMetrics.svelte
@@ -9,7 +9,7 @@ Displays supplementary vault information, including transaction status, performa
 	import Risk from '$lib/top-vaults/Risk.svelte';
 	import Metric from './Metric.svelte';
 	import { resolve } from '$app/paths';
-	import { getFormattedLockup, isGoodVaultStatus } from '$lib/top-vaults/helpers';
+	import { getFormattedLockup, isGoodVaultStatus, isVaultDepositCapped } from '$lib/top-vaults/helpers';
 	import { formatNumber, formatPercent, formatPercentProfit } from '$lib/helpers/formatters';
 	import { getChain, getChainDisplayName } from '$lib/helpers/chain';
 	import {
@@ -36,12 +36,17 @@ Displays supplementary vault information, including transaction status, performa
 	let chain = $derived(getChain(vault.chain_id));
 	let hasLimitedHistory = $derived(LIMITED_HISTORY_CHAINS.includes(vault.chain_id));
 	let isPrivate = $derived(vault.whitelist?.status === 'whitelisted');
+	let isCapped = $derived(isVaultDepositCapped(vault));
 	let depositStatus = $derived(
 		isPrivate
-			? vault.deposit_closed_reason
-				? `Private — ${vault.deposit_closed_reason}`
-				: 'Private'
-			: vault.deposit_closed_reason
+			? isCapped
+				? 'Private — Capped'
+				: vault.deposit_closed_reason
+					? `Private — ${vault.deposit_closed_reason}`
+					: 'Private'
+			: isCapped
+				? 'Capped'
+				: vault.deposit_closed_reason
 	);
 	let showTransactionStatus = $derived(isPrivate || !isGoodVaultStatus(vault));
 	let hasNetFeeInformation = $derived(vault.net_fees?.fee_mode != null);

--- a/tests/integration/vaults/index.test.ts
+++ b/tests/integration/vaults/index.test.ts
@@ -250,7 +250,7 @@ test.describe('vault index page', () => {
 
 		const rows = page.locator('tbody tr.targetable');
 		await expect(rows).toHaveCount(2);
-		await expect(rows.first()).toContainText('Private vault');
+		await expect(rows.filter({ hasText: 'Private vault' })).toHaveCount(1);
 		await expect(rows.locator('td.lockup').filter({ hasText: 'Private' })).toHaveCount(1);
 		await expect(rows.locator('td.lockup').filter({ hasText: 'Fund' })).toHaveCount(1);
 		await expect(page.locator('h1')).toHaveText('Whitelisted stablecoin vaults');
@@ -480,6 +480,14 @@ test.describe('vault index page', () => {
 		await expect(alert).toContainText('Deposit disabled vault is a tokenised fund');
 	});
 
+	test('does not show deposits as open when a vault capacity is reached', async ({ page }) => {
+		await page.goto('/vaults/deposit-cap-reached-vault');
+
+		const transactionStatus = page.locator('.transaction-status');
+		await expect(transactionStatus).toContainText('Deposits Capped');
+		await expect(transactionStatus).not.toContainText('Deposits Open');
+	});
+
 	test('warns when withdrawals may be disabled on a vault detail page', async ({ page }) => {
 		await page.goto('/vaults/withdrawal-disabled-vault');
 
@@ -494,6 +502,14 @@ test.describe('vault index page', () => {
 		const alert = page.locator('.alert-list.warning').first();
 		await expect(alert).toBeVisible();
 		await expect(alert).toContainText('Deposits and withdrawals may be disabled for this vault');
+	});
+
+	test('retains a withdrawal warning when a vault deposit cap is reached', async ({ page }) => {
+		await page.goto('/vaults/capped-and-withdrawal-disabled-vault');
+
+		const alert = page.locator('.alert-list.warning').first();
+		await expect(alert).toBeVisible();
+		await expect(alert).toContainText('Deposits are capped and withdrawals may be disabled for this vault');
 	});
 
 	test('marks private vaults and explains their whitelist status', async ({ page }) => {
@@ -528,6 +544,19 @@ test.describe('vault index page', () => {
 		await expect(fundCell).toContainText('Fund');
 		await expect(fundCell).not.toContainText('Private');
 		await expect(fundCell).not.toContainText('Unknown');
+	});
+
+	test('shows capped instead of an unknown deposit delay when a vault has reached its cap', async ({ page }) => {
+		await page.goto('/vaults/all');
+		await openFilters(page);
+		await page.getByTestId('vault-search').fill('Deposit cap reached vault');
+
+		const cell = page
+			.locator('tbody tr.targetable')
+			.filter({ hasText: 'Deposit cap reached vault' })
+			.locator('td.lockup');
+		await expect(cell).toContainText('Capped');
+		await expect(cell).not.toContainText('Unknown');
 	});
 
 	test('shows the tokenised-fund disclaimer instead of the permissioned warning', async ({ page }) => {

--- a/tests/integration/vaults/stablecoins.test.ts
+++ b/tests/integration/vaults/stablecoins.test.ts
@@ -63,6 +63,29 @@ test.describe('stablecoins index page', () => {
 		await expect(page.getByText(/Fetched 2026.*ago/)).toHaveCount(2);
 	});
 
+	test('warns when a stablecoin is likely depegged', async ({ page }) => {
+		await page.goto('/vaults/stablecoins/frax');
+
+		const warning = page.getByTestId('stablecoin-depeg-warning');
+		await expect(warning).toBeVisible();
+		await expect(warning).toContainText('This stablecoin is likely depegged.');
+		await expect(warning).toContainText('The current rate is 1.21951 FRAX / 1 USD');
+		await expect(warning).toContainText('fetched at 2026-06-26 12:16');
+	});
+
+	test('shows a price-feed availability warning when the rate source is missing', async ({ page }) => {
+		await page.goto('/vaults/stablecoins/ausd');
+
+		const warning = page.getByTestId('stablecoin-price-feed-warning');
+		await expect(warning).toBeVisible();
+		await expect(warning).toHaveClass(/stablecoin-depeg-warning/);
+		await expect(warning).toContainText(
+			'This stablecoin does not have a price feed available at the moment and we are unable to display peg/depeg rates.'
+		);
+		await expect(warning.locator('.alert-list')).toHaveClass(/warning/);
+		await expect(page.getByTestId('stablecoin-depeg-warning')).toHaveCount(0);
+	});
+
 	test('uses the updated metadata title and description', async ({ page }) => {
 		await page.goto('/vaults/stablecoins');
 

--- a/tests/mocks/stablecoin-metadata/index.mock.ts
+++ b/tests/mocks/stablecoin-metadata/index.mock.ts
@@ -154,6 +154,35 @@ export const mockStablecoins: StablecoinMetadata[] = [
 		rate_fetch_failed_at: null,
 		rate_fetch_failed_reason: null,
 		depegged_at: '2026-06-26T12:15:26'
+	},
+	{
+		symbol: 'AUSD',
+		slug: 'ausd',
+		name: 'Acala Dollar',
+		short_description: 'Acala Dollar is a decentralised stablecoin.',
+		description: 'Acala Dollar is a decentralised stablecoin.',
+		category: 'stablecoin',
+		links: {
+			homepage: 'https://acala.network/',
+			coingecko: null,
+			defillama: 'https://defillama.com/stablecoin/acala-dollar',
+			twitter: null
+		},
+		logos: {
+			light: 'http://localhost:4173/api/stablecoin-metadata/ausd/light.png'
+		},
+		coingecko_id: null,
+		coingecko_link: null,
+		coingecko_id_source: null,
+		coingecko_id_verified_at: null,
+		usd_rate: null,
+		usd_rate_fetched_at: null,
+		usd_rate_updated_at: null,
+		peg_rate: null,
+		peg_rate_currency: null,
+		rate_fetch_failed_at: '2026-06-26T12:16:16',
+		rate_fetch_failed_reason: 'missing_coingecko_id',
+		depegged_at: '2026-06-26T12:15:26'
 	}
 ];
 

--- a/tests/mocks/top-vaults/list.mock.ts
+++ b/tests/mocks/top-vaults/list.mock.ts
@@ -448,6 +448,13 @@ const depositDisabledVault = createTestVault('Deposit disabled vault', {
 	period_results: [closedVaultPeriodResult]
 });
 
+const cappedVault = createTestVault('Deposit cap reached vault', {
+	chain: 'base',
+	current_nav: 20_000,
+	deposit_closed_reason: 'Max deposit cap reached (maxDeposit=0)',
+	period_results: [closedVaultPeriodResult]
+});
+
 const redemptionDisabledVault = createTestVault('Withdrawal disabled vault', {
 	chain: 'base',
 	current_nav: 20_000,
@@ -459,6 +466,14 @@ const depositAndRedemptionDisabledVault = createTestVault('Deposit and withdrawa
 	chain: 'base',
 	current_nav: 20_000,
 	deposit_closed_reason: 'Deposits paused',
+	redemption_closed_reason: 'Withdrawals paused',
+	period_results: [closedVaultPeriodResult]
+});
+
+const cappedAndRedemptionDisabledVault = createTestVault('Capped and withdrawal disabled vault', {
+	chain: 'base',
+	current_nav: 20_000,
+	deposit_closed_reason: 'Max deposit cap reached (maxDeposit=0)',
 	redemption_closed_reason: 'Withdrawals paused',
 	period_results: [closedVaultPeriodResult]
 });
@@ -582,8 +597,10 @@ export default defineMock({
 			abnormalTvlBlacklistedVault,
 			morphoFlaggedBlacklistedVault,
 			depositDisabledVault,
+			cappedVault,
 			redemptionDisabledVault,
 			depositAndRedemptionDisabledVault,
+			cappedAndRedemptionDisabledVault,
 			privateVault,
 			privateTokenisedFund,
 			limitedCoverageVault,


### PR DESCRIPTION
## Why

Stablecoin detail pages need clear, source-aware warnings when a peg is likely broken or no price feed exists. Vault listings and detail pages also need to identify deposit caps without inferring capacity from protocol features.

## Lessons learnt

- `deposit_closed_reason` is the source of truth for a reached deposit cap; Royco tranche metadata alone is not sufficient evidence.
- A missing CoinGecko identifier means a price feed is unavailable, not that a stablecoin is necessarily depegged.

## Summary

- Added red likely-depeg and yellow price-feed-unavailable stablecoin warnings.
- Labelled explicit cap-reached vaults as Capped while preserving the original status in Technical details.
- Added focused regression coverage and documented both source-backed rules.