### PR TITLE
fix: synchronise vault chart summary metrics

### DIFF
--- a/src/lib/charts/ChartContainer.svelte
+++ b/src/lib/charts/ChartContainer.svelte
@@ -22,6 +22,8 @@
 		formatValue: Formatter<number>;
 		boxed?: boolean;
 		timeSpanOptions?: TimeSpanKey[];
+		/** Called when the chart range selector changes. */
+		onTimeSpanChange?: (timeSpan: TimeSpanKey) => void;
 		title?: Snippet<[TimeSpan]> | string;
 		subtitle?: Snippet | string;
 		series: Snippet<[SeriesSnippetOptions]>;
@@ -34,6 +36,7 @@
 		formatValue,
 		boxed = false,
 		timeSpanOptions = TimeSpans.keys,
+		onTimeSpanChange,
 		options,
 		title,
 		subtitle,
@@ -69,7 +72,12 @@
 		{:else}
 			<div>{@render title?.(timeSpan)}</div>
 		{/if}
-		<SegmentedControl secondary options={timeSpans.options} bind:selected={timeSpans.selected} />
+		<SegmentedControl
+			secondary
+			options={timeSpans.options}
+			bind:selected={timeSpans.selected}
+			onchange={({ value }) => onTimeSpanChange?.(value as TimeSpanKey)}
+		/>
 		<p>
 			{#if typeof subtitle === 'string'}
 				{subtitle}

--- a/src/lib/top-vaults/VaultPriceChart.svelte
+++ b/src/lib/top-vaults/VaultPriceChart.svelte
@@ -35,6 +35,7 @@ so relative performance is comparable on a single axis.
 	} from '$lib/helpers/formatters';
 	import { annualizedReturn } from '$lib/helpers/financial';
 	import { formatDate, resampleTimeSeries } from '$lib/charts/helpers';
+	import type { TimeSpanKey } from '$lib/charts/time-span';
 	const TRAILING_RETURN_DAYS = 30;
 	const TRAILING_RETURN_SECONDS = TRAILING_RETURN_DAYS * 86_400;
 
@@ -52,11 +53,14 @@ so relative performance is comparable on a single axis.
 		vault: VaultInfo;
 		/** Optional logo URL for the vault legend item, preferring curator over protocol logos. */
 		chartLogoUrl?: string;
+		/** Called when the chart range selector changes. */
+		onTimeSpanChange?: (timeSpan: TimeSpanKey) => void;
 	}
 
-	let { vault, chartLogoUrl }: Props = $props();
+	let { vault, chartLogoUrl, onTimeSpanChange }: Props = $props();
 
 	let showCryptoBenchmarks = $derived(isPerpetualFuturesVault(vault));
+	let assetType = $derived(vault.flags.includes('tokenised_fund') ? 'tokenised fund' : 'vault');
 
 	let loading = $state(true);
 	let priceData = $state<[number, number][]>();
@@ -170,8 +174,8 @@ so relative performance is comparable on a single axis.
 
 <div class={['vault-price-chart', showCryptoBenchmarks && 'has-drawdown']}>
 	<ChartContainer
-		title="Share token price"
 		timeSpanOptions={['1M', '3M', 'Max']}
+		{onTimeSpanChange}
 		{loading}
 		data={priceData}
 		{formatValue}
@@ -183,6 +187,20 @@ so relative performance is comparable on a single axis.
 			})
 		}}
 	>
+		{#snippet title()}
+			<h2 class="chart-title">
+				<Tooltip>
+					<span slot="trigger" class="underline">Share token price</span>
+					<svelte:fragment slot="popup">
+						Share token represents a single fungible unit of this {assetType}, which depositors receive in exchange for
+						their money. This chart tracks the onchain reported value of a single share token, which reflects the
+						{assetType}'s performance. Different smart contracts have different methods to report share token price, and
+						sometimes the information may be incorrect.
+					</svelte:fragment>
+				</Tooltip>
+			</h2>
+		{/snippet}
+
 		{#snippet series({ data, timeSpan, range })}
 			{@const vaultSeriesData = withChartSeriesKind(data, 'vault-price')}
 			{@const tvlSeriesData = withChartSeriesKind(resampleTimeSeries(tvlData ?? [], timeSpan.interval), 'tvl')}
@@ -374,6 +392,11 @@ so relative performance is comparable on a single axis.
 <style>
 	.vault-price-chart {
 		margin-bottom: -0.25rem;
+
+		.chart-title {
+			font: var(--f-heading-md-medium);
+			letter-spacing: var(--f-heading-md-spacing, normal);
+		}
 
 		:global([data-css-props]) {
 			--chart-aspect-ratio: auto;

--- a/src/routes/vaults/[vault=slug]/ChartWithFeaturedMetrics.svelte
+++ b/src/routes/vaults/[vault=slug]/ChartWithFeaturedMetrics.svelte
@@ -13,6 +13,7 @@ amounts in the denomination's native currency.
 	import Tooltip from '$lib/components/Tooltip.svelte';
 	import Metric from './Metric.svelte';
 	import { formatDollar, formatNumber, formatPercent, formatTokenAmount } from '$lib/helpers/formatters';
+	import type { TimeSpanKey } from '$lib/charts/time-span';
 	import {
 		getVaultCurrentTvlUsd,
 		getVaultDenominationCurrency,
@@ -26,6 +27,31 @@ amounts in the denomination's native currency.
 	}
 
 	let { vault, chartLogoUrl }: Props = $props();
+	let selectedReturnPeriod = $state<'1M' | '3M' | 'Max'>('3M');
+	let oneMonthMetrics = $derived(vault.period_results.find((period) => period.period.toLowerCase() === '1m'));
+	let lifetimeMetrics = $derived(vault.period_results.find((period) => period.period.toLowerCase() === 'lifetime'));
+	let featuredPerformance = $derived(
+		selectedReturnPeriod === '1M'
+			? {
+					label: '1M',
+					return: { gross: vault.one_month_cagr, net: vault.one_month_cagr_net },
+					sharpe: oneMonthMetrics?.sharpe,
+					volatility: oneMonthMetrics?.volatility
+				}
+			: selectedReturnPeriod === '3M'
+				? {
+						label: '3M',
+						return: { gross: vault.three_months_cagr, net: vault.three_months_cagr_net },
+						sharpe: vault.three_months_sharpe,
+						volatility: vault.three_months_volatility
+					}
+				: {
+						label: 'Lifetime',
+						return: { gross: vault.cagr, net: vault.cagr_net },
+						sharpe: lifetimeMetrics?.sharpe,
+						volatility: lifetimeMetrics?.volatility
+					}
+	);
 
 	let denominationCurrency = $derived(getVaultDenominationCurrency(vault));
 	let showNativeTvl = $derived(denominationCurrency != null && denominationCurrency !== 'usd');
@@ -49,22 +75,26 @@ amounts in the denomination's native currency.
 	function formatNativeTvlAmount(value: number | null): string {
 		return value == null ? '' : formatTokenAmount(value, 2);
 	}
+
+	function handleTimeSpanChange(timeSpan: TimeSpanKey): void {
+		selectedReturnPeriod = timeSpan === '1M' || timeSpan === '3M' ? timeSpan : 'Max';
+	}
 </script>
 
 <MetricsBox>
 	<div class="chart-area">
-		<VaultPriceChart {vault} {chartLogoUrl} />
+		<VaultPriceChart {vault} {chartLogoUrl} onTimeSpanChange={handleTimeSpanChange} />
 
 		<div class="divider"></div>
 
 		<div class="featured-metrics">
-			<Metric size="xl" label="1M return (ann)">
-				{#if vault.one_month_cagr_net}
-					<Profitability of={vault.one_month_cagr_net} />
+			<Metric size="xl" label={`${featuredPerformance.label} return (ann)`}>
+				{#if featuredPerformance.return.net != null}
+					<Profitability of={featuredPerformance.return.net} />
 				{:else}
 					<Tooltip>
 						<span slot="trigger" style:white-space="nowrap">
-							<Profitability of={vault.one_month_cagr} /><span class="gross-indicator">*</span>
+							<Profitability of={featuredPerformance.return.gross} /><span class="gross-indicator">*</span>
 						</span>
 						<svelte:fragment slot="popup">
 							Fee information for this protocol is not yet available. The calculation is based on gross profit and fees
@@ -106,11 +136,11 @@ amounts in the denomination's native currency.
 				{/if}
 			</Metric>
 			<div class="desktop">
-				<Metric size="lg" label="3M Sharpe">
-					{formatNumber(vault.three_months_sharpe, 1)}
+				<Metric size="lg" label={`${featuredPerformance.label} Sharpe`}>
+					{formatNumber(featuredPerformance.sharpe, 1)}
 				</Metric>
-				<Metric size="lg" label="3M volatility">
-					{formatPercent(vault.three_months_volatility, 1)}
+				<Metric size="lg" label={`${featuredPerformance.label} volatility`}>
+					{formatPercent(featuredPerformance.volatility, 1)}
 				</Metric>
 			</div>
 		</div>


### PR DESCRIPTION
## Why

The featured vault-chart statistics did not match the selected chart period, which made performance comparisons misleading.

## Lessons learnt

Pass chart range changes through the shared chart container so adjacent vault summary metrics can remain synchronised.

## Summary

- Synchronise return, Sharpe and volatility with the 1M, 3M and Max chart selections.
- Add context-aware share-token-price guidance for vaults and tokenised funds.