### PR TITLE
fix: label tokenised funds independently of eligibility

### DIFF
--- a/src/lib/top-vaults/TopVaultsTable.svelte
+++ b/src/lib/top-vaults/TopVaultsTable.svelte
@@ -3,7 +3,8 @@
 Interactive vault listing with filters, sorting, and progressive row loading.
 
 Use `ratingProvider` to add its risk-rating column beside the vault name.
-Whitelisted vaults are marked as Private, except tokenised funds, which are marked as Fund.
+Tokenised funds are marked as Fund regardless of deposit eligibility. Other
+whitelisted vaults are marked as Private.
 -->
 <script lang="ts">
 	import type { Chain } from '$lib/helpers/chain';
@@ -1247,7 +1248,6 @@ Whitelisted vaults are marked as Private, except tokenised funds, which are mark
 					{@const isPrivate = vault.whitelist?.status === 'whitelisted'}
 					{@const isTokenisedFund = vault.flags.includes('tokenised_fund')}
 					{@const isCapped = isVaultDepositCapped(vault)}
-					{@const depositStatusLabel = isTokenisedFund ? 'Fund' : 'Private'}
 					{@const protocolName = getVaultProtocolDisplayName(vault)}
 					{@const statusReason = [vault.deposit_closed_reason, vault.redemption_closed_reason]
 						.filter(Boolean)
@@ -1313,7 +1313,29 @@ Whitelisted vaults are marked as Private, except tokenised funds, which are mark
 							<FeesCell mgmt_fee={vault.mgmt_fee} perf_fee={vault.perf_fee} />
 						</td>
 						<td class={['lockup', vault.lockup === null && 'unknown', isPrivate && 'private']}>
-							{#if isCapped}
+							{#if isTokenisedFund}
+								<Tooltip>
+									<svelte:fragment slot="trigger">
+										<span class="status-wrapper">
+											<IconStop />Fund
+										</span>
+									</svelte:fragment>
+									<svelte:fragment slot="popup">
+										This is a tokenised fund.
+										{#if isCapped}
+											This fund has reached its deposit cap. {getLockupDescription(vault)}
+										{:else if isPrivate}
+											This fund does not accept public deposits.
+										{:else if badStatus}
+											The fund deposit or redemption may be currently closed: {statusReason}. {getLockupDescription(
+												vault
+											)}
+										{:else}
+											{getLockupDescription(vault)}
+										{/if}
+									</svelte:fragment>
+								</Tooltip>
+							{:else if isCapped}
 								<Tooltip>
 									<svelte:fragment slot="trigger">
 										<span class="status-wrapper">
@@ -1328,7 +1350,7 @@ Whitelisted vaults are marked as Private, except tokenised funds, which are mark
 								<Tooltip>
 									<svelte:fragment slot="trigger">
 										<span class="status-wrapper">
-											<IconStop />{depositStatusLabel}
+											<IconStop />Private
 										</span>
 									</svelte:fragment>
 									<svelte:fragment slot="popup">

--- a/tests/integration/vaults/index.test.ts
+++ b/tests/integration/vaults/index.test.ts
@@ -544,6 +544,16 @@ test.describe('vault index page', () => {
 		await expect(fundCell).toContainText('Fund');
 		await expect(fundCell).not.toContainText('Private');
 		await expect(fundCell).not.toContainText('Unknown');
+
+		await page.getByTestId('vault-search').fill('Deposit disabled vault');
+		const unclassifiedFundCell = page
+			.locator('tbody tr.targetable')
+			.filter({ hasText: 'Deposit disabled vault' })
+			.locator('td.lockup');
+		await expect(unclassifiedFundCell).toContainText('Fund');
+		const unclassifiedFundTooltip = unclassifiedFundCell.locator('.tooltip');
+		await unclassifiedFundTooltip.hover();
+		await expect(unclassifiedFundTooltip.locator('.popup')).toContainText('This is a tokenised fund.');
 	});
 
 	test('shows capped instead of an unknown deposit delay when a vault has reached its cap', async ({ page }) => {


### PR DESCRIPTION
## Why

The vault table used whitelist status to decide whether a vault was labelled Fund. A correctly flagged tokenised fund with unknown or closed deposit eligibility could therefore be shown as Unknown, which conflates product type with availability.

## Lessons learnt

Fund classification and deposit eligibility are independent dimensions. The UI must use the `tokenised_fund` flag for product type and show eligibility only as explanatory status.

## Summary

- Labels every tokenised fund as Fund, even when deposits are not currently public.
- Keeps Private for non-fund whitelisted vaults.
- Adds coverage for a deposit-disabled tokenised fund and its tooltip.

## Related issues and PRs

- Registry, metadata and production migration: https://github.com/tradingstrategy-ai/web3-ethereum-defi/pull/1441

## Unrelated CI and test fixes

None.