### PR TITLE
fix: warn about long-duration vault redemptions

### DIFF
--- a/src/routes/vaults/[vault=slug]/VaultPageHeader.svelte
+++ b/src/routes/vaults/[vault=slug]/VaultPageHeader.svelte
@@ -1,5 +1,10 @@
+<!--
+@component
+Displays a vault's heading, external link, update action, and important operational warnings.
+-->
 <script lang="ts">
 	import type { VaultInfo } from '$lib/top-vaults/schemas';
+	import Alert from '$lib/components/Alert.svelte';
 	import Button from '$lib/components/Button.svelte';
 	import PageHeader from '$lib/components/PageHeader.svelte';
 	import UpdateInfoButton from '$lib/top-vaults/UpdateInfoButton.svelte';
@@ -37,6 +42,15 @@
 	{/snippet}
 </PageHeader>
 
+{#if vault.flags.includes('long_duration')}
+	<div class="long-duration-warning ds-container">
+		<Alert size="md" status="error">
+			This vault may have especially long duration redemption periods. Make sure you check the redemptions before
+			depositing.
+		</Alert>
+	</div>
+{/if}
+
 {#if vault.short_description}
 	<p class="vault-description ds-container">{vault.short_description}</p>
 {/if}
@@ -63,6 +77,10 @@
 		@media (--viewport-md-up) {
 			margin-top: 1rem;
 		}
+	}
+
+	.long-duration-warning {
+		margin-top: var(--space-md);
 	}
 
 	.page-title {


### PR DESCRIPTION
## Why

Vaults marked with `long_duration` have especially long redemption periods. Depositors need a prominent warning before following a vault link or depositing.

## Lessons learnt

`long_duration` is a descriptive operational flag rather than a blacklist flag, so it should be shown as contextual vault-detail information.

## Summary

- Display a red warning directly beneath the vault heading when `vault.flags` includes `long_duration`.
- Use the approved redemption-period warning copy.