### PR TITLE
fix: restore vault position details

### DIFF
--- a/src/lib/trade-executor/models/position-info.test.ts
+++ b/src/lib/trade-executor/models/position-info.test.ts
@@ -133,6 +133,28 @@ describe('open position with stats entries', () => {
 	});
 });
 
+describe('rebalance count', () => {
+	test('counts only completed adjustments after the position has opened', () => {
+		const position = tradingPositionSchema.parse({
+			...rawPosition,
+			trades: {
+				1: { ...rawTrade, trade_id: 1, executed_at: POSITION_OPEN_TS, flags: ['open'] },
+				2: { ...rawTrade, trade_id: 2, executed_at: POSITION_OPEN_TS + HOUR, flags: ['increase'] },
+				3: { ...rawTrade, trade_id: 3, executed_at: POSITION_OPEN_TS + 2 * HOUR, flags: ['close'] },
+				4: {
+					...rawTrade,
+					trade_id: 4,
+					executed_at: POSITION_OPEN_TS + 3 * HOUR,
+					failed_at: POSITION_OPEN_TS + 3 * HOUR,
+					flags: ['increase']
+				}
+			}
+		});
+
+		expect(createTradingPositionInfo(position).rebalanceCount).toBe(1);
+	});
+});
+
 describe('closed position with stats entries', () => {
 	const position = tradingPositionSchema.parse({
 		...rawPosition,

--- a/src/lib/trade-executor/models/position-info.ts
+++ b/src/lib/trade-executor/models/position-info.ts
@@ -83,6 +83,18 @@ export const createTradingPositionInfo = <T extends TradingPosition>(base: T, st
 		return this.closed ? tradeCount > 2 : tradeCount > 1;
 	},
 
+	get rebalanceCount() {
+		return this.trades.filter(
+			(trade) =>
+				trade.trade_type === 'rebalance' &&
+				trade.executed_at != null &&
+				!trade.didFail &&
+				!trade.isRepair &&
+				!trade.flags?.includes('open') &&
+				!trade.flags?.includes('close')
+		).length;
+	},
+
 	get openPrice() {
 		return this.firstTrade.executed_price;
 	},

--- a/src/lib/trade-executor/models/position-tooltips.ts
+++ b/src/lib/trade-executor/models/position-tooltips.ts
@@ -30,6 +30,7 @@ export const positionTooltips = {
 	quantityAtOpen: 'The position size in tokens when the position was opened.',
 	quantityAtClose: 'The position size in tokens when the position was closed.',
 	currentQuantity: 'The latest recorded position size in tokens.',
+	rebalanceCount: 'The number of successfully executed position adjustments, excluding the opening and closing trades.',
 	estimatedMaximumRisk: 'How much % of the portfolio is at the risk if this position is completely lost.',
 	stopLossPercentOpen:
 		'Stop loss % for this position, relative to the opening price. Stop loss may be dynamic and trailing stop loss may increase over time. BETA WARNING: Currently calculated relative to the open price, not the current price.',

--- a/src/routes/strategies/[strategy=apiStrategy]/[status=positionStatus]-positions/+page.svelte
+++ b/src/routes/strategies/[strategy=apiStrategy]/[status=positionStatus]-positions/+page.svelte
@@ -1,3 +1,6 @@
+<!--
+Strategy position listing page.
+-->
 <script lang="ts">
 	import type { ComponentEvents, ComponentProps } from 'svelte';
 	import { page } from '$app/state';
@@ -12,7 +15,7 @@
 	import { capitalize } from '$lib/helpers/formatters';
 
 	let { data } = $props();
-	let { admin, positions, status, strategy, reserves } = $derived(data);
+	let { admin, positions, status, strategy, reserves, positionVaultSparklines } = $derived(data);
 
 	let exchangeAccount = $derived.by(() => {
 		// Try tag-based detection first
@@ -81,6 +84,7 @@
 			hasSearch={positions.length > 5}
 			hiddenPositions={strategy.hiddenPositions}
 			{exchangeAccount}
+			{positionVaultSparklines}
 			{reserves}
 			{onChange}
 		/>

--- a/src/routes/strategies/[strategy=apiStrategy]/[status=positionStatus]-positions/+page.ts
+++ b/src/routes/strategies/[strategy=apiStrategy]/[status=positionStatus]-positions/+page.ts
@@ -1,6 +1,8 @@
 import { getTradingPositionInfoArray } from 'trade-executor/models/position-info';
+import { topVaultsSchema } from '$lib/top-vaults/schemas';
+import { getPositionVaultSparklines } from './vault-sparklines';
 
-export async function load({ params, parent }) {
+export async function load({ params, parent, fetch }) {
 	// status can be `open`, `closed` or `frozen` (see params/positionStatus.ts)
 	const { status } = params;
 	const { admin, strategy, state } = await parent();
@@ -13,6 +15,23 @@ export async function load({ params, parent }) {
 	}
 
 	const reserves = Object.values(state.portfolio.reserves)[0];
+	const positionVaultSparklines = await loadPositionVaultSparklines(fetch, positions);
 
-	return { positions, status, reserves };
+	return { positions, status, reserves, positionVaultSparklines };
+}
+
+async function loadPositionVaultSparklines(fetch: Fetch, positions: ReturnType<typeof getTradingPositionInfoArray>) {
+	const hasVaultPositions = positions.some((position) => position.pair.isVault);
+	if (!hasVaultPositions) return {};
+
+	try {
+		const response = await fetch('/top-vaults/all-data');
+		if (!response.ok) throw new Error(`Failed to fetch top vaults: ${response.status}`);
+
+		const topVaults = topVaultsSchema.parse(await response.json());
+		return getPositionVaultSparklines(positions, topVaults.vaults);
+	} catch (error) {
+		console.warn('Failed to resolve vault sparklines for position table', error);
+		return {};
+	}
 }

--- a/src/routes/strategies/[strategy=apiStrategy]/[status=positionStatus]-positions/PositionTable.svelte
+++ b/src/routes/strategies/[strategy=apiStrategy]/[status=positionStatus]-positions/PositionTable.svelte
@@ -1,3 +1,7 @@
+<!--
+@component
+Table of strategy positions with vault-specific details.
+-->
 <script lang="ts">
 	import type { ComponentProps } from 'svelte';
 	import type { PositionStatus } from 'trade-executor/schemas/position';
@@ -13,8 +17,10 @@
 	import TableRowTarget from '$lib/components/datatable/TableRowTarget.svelte';
 	import TradingDescription from 'trade-executor/components/TradingDescription.svelte';
 	import RemarksCell from './RemarksCell.svelte';
+	import PositionVaultSparklineCell from './PositionVaultSparklineCell.svelte';
 	import ReservesRow from './ReservesRow.svelte';
 	import { formatDollar } from '$lib/helpers/formatters';
+	import type { PositionVaultSparkline } from './vault-sparklines';
 
 	type DataTableProps = Omit<ComponentProps<typeof DataTable>, 'tableViewModel'>;
 
@@ -28,6 +34,7 @@
 		hiddenPositions?: number[];
 		reserves: ReservePosition;
 		exchangeAccount?: { url: string; name: string };
+		positionVaultSparklines?: Record<number, PositionVaultSparkline>;
 	}
 
 	let {
@@ -40,6 +47,7 @@
 		hiddenPositions = [],
 		reserves,
 		exchangeAccount,
+		positionVaultSparklines = {},
 		...restProps
 	}: Props = $props();
 
@@ -52,10 +60,30 @@
 		frozen: ['description', 'flags', 'frozen_on', 'frozen_value', 'frozen_at', 'cta']
 	};
 
+	function getStatusColumns(status: PositionStatus, showVaultSparklineColumn: boolean) {
+		return showVaultSparklineColumn ? [...statusColumns[status], 'vault_sparkline'] : statusColumns[status];
+	}
+
+	let showVaultSparklineColumn = $derived(positions.some((position) => position.pair.isVault));
+	let columnOrder = $derived(getStatusColumns(status, showVaultSparklineColumn));
+
+	function getPositionTarget(positionId: number) {
+		const href = exchangeAccount ? exchangeAccount.url : `./${status}-positions/${positionId}`;
+		return {
+			href,
+			...(exchangeAccount
+				? { label: `View on ${exchangeAccount.name}`, target: '_blank', rel: 'noreferrer' }
+				: { label: 'Details' })
+		};
+	}
+
 	// svelte-ignore state_referenced_locally
 	const table = createTable(positionsStore, {
 		colOrder: addColumnOrder({
-			initialColumnIdOrder: statusColumns[status],
+			initialColumnIdOrder: getStatusColumns(
+				status,
+				positions.some((position) => position.pair.isVault)
+			),
 			hideUnspecifiedColumns: true
 		}),
 		tableFilter: addTableFilter({
@@ -149,12 +177,23 @@
 		table.column({
 			header: '',
 			id: 'cta',
-			accessor: ({ position_id }) => (exchangeAccount ? exchangeAccount.url : `./${status}-positions/${position_id}`),
+			accessor: ({ position_id }) => getPositionTarget(position_id),
 			cell: ({ value }) =>
 				createRender(TableRowTarget, {
-					href: value,
-					...(exchangeAccount ? { label: `View on ${exchangeAccount.name}`, target: '_blank', rel: 'noreferrer' } : {})
+					...value,
+					targetable: !showVaultSparklineColumn
 				}),
+			plugins: { sort: { disable: true } }
+		}),
+		table.column({
+			header: '3M price',
+			id: 'vault_sparkline',
+			accessor: (position) => ({
+				vault: positionVaultSparklines[position.position_id],
+				isVault: position.pair.isVault,
+				...getPositionTarget(position.position_id)
+			}),
+			cell: ({ value }) => createRender(PositionVaultSparklineCell, value),
 			plugins: { sort: { disable: true } }
 		})
 	]);
@@ -166,7 +205,7 @@
 
 	$effect(() => {
 		$positionsStore = positions;
-		$columnIdOrder = statusColumns[status];
+		$columnIdOrder = columnOrder;
 		$sortKeys = [{ id: sort, order: direction }];
 	});
 </script>
@@ -174,7 +213,7 @@
 <div class="position-table">
 	<DataTable {tableViewModel} targetableRows size="sm" {...restProps}>
 		{#if status === 'open'}
-			<ReservesRow {reserves} />
+			<ReservesRow {reserves} {showVaultSparklineColumn} />
 		{/if}
 	</DataTable>
 </div>
@@ -215,6 +254,23 @@
 
 		:global(:is(.profit, .current_value, .value_at_open, .frozen_value, .opened_at, .closed_at, .frozen_at)) {
 			text-align: right;
+		}
+
+		:global(.vault_sparkline) {
+			width: 7rem;
+			text-align: center;
+			vertical-align: middle;
+
+			@media (--viewport-sm-down) {
+				width: 4.5rem;
+				padding-inline: 0.125rem;
+
+				:global(.position-vault-sparkline-cell) {
+					min-width: 4rem;
+
+					--sparkline-width: 4rem;
+				}
+			}
 		}
 	}
 </style>

--- a/src/routes/strategies/[strategy=apiStrategy]/[status=positionStatus]-positions/PositionVaultSparklineCell.svelte
+++ b/src/routes/strategies/[strategy=apiStrategy]/[status=positionStatus]-positions/PositionVaultSparklineCell.svelte
@@ -1,0 +1,49 @@
+<!--
+@component
+Vault price sparkline cell for strategy position tables.
+
+Adds the full-row target link when the sparkline is the final table column.
+-->
+<script lang="ts">
+	import TargetableLink from '$lib/components/TargetableLink.svelte';
+	import VaultSparkline from '$lib/top-vaults/VaultSparkline.svelte';
+	import type { PositionVaultSparkline } from './vault-sparklines';
+
+	interface Props {
+		vault?: PositionVaultSparkline;
+		isVault: boolean;
+		href: string;
+		label: string;
+		target?: string;
+		rel?: string;
+	}
+
+	let { vault, isVault, href, label, target, rel }: Props = $props();
+</script>
+
+<div class="position-vault-sparkline-cell">
+	{#if vault}
+		<VaultSparkline {vault} />
+	{:else if isVault}
+		<span>chart unavailable</span>
+	{/if}
+	<TargetableLink {href} {label} {target} {rel} />
+</div>
+
+<style>
+	.position-vault-sparkline-cell {
+		display: grid;
+		place-items: center;
+		min-width: 6rem;
+		min-height: 1.75rem;
+
+		--sparkline-width: 6rem;
+	}
+
+	span {
+		font: var(--f-ui-xs-roman);
+		letter-spacing: var(--ls-ui-xs, normal);
+		color: var(--c-text-ultra-light);
+		text-align: center;
+	}
+</style>

--- a/src/routes/strategies/[strategy=apiStrategy]/[status=positionStatus]-positions/ReservesRow.svelte
+++ b/src/routes/strategies/[strategy=apiStrategy]/[status=positionStatus]-positions/ReservesRow.svelte
@@ -1,3 +1,7 @@
+<!--
+@component
+Summary row for strategy reserve balances.
+-->
 <script lang="ts">
 	import type { ReservePosition } from 'trade-executor/schemas/reserve';
 	import TradingDescription from 'trade-executor/components/TradingDescription.svelte';
@@ -7,9 +11,10 @@
 
 	type Props = {
 		reserves: ReservePosition;
+		showVaultSparklineColumn?: boolean;
 	};
 
-	let { reserves }: Props = $props();
+	let { reserves, showVaultSparklineColumn = false }: Props = $props();
 </script>
 
 <tr class="reserves">
@@ -28,6 +33,9 @@
 	</td>
 	<td class="opened_at">always open</td>
 	<td class="cta"></td>
+	{#if showVaultSparklineColumn}
+		<td class="vault_sparkline"></td>
+	{/if}
 </tr>
 
 <style>

--- a/src/routes/strategies/[strategy=apiStrategy]/[status=positionStatus]-positions/[position=integer]/+layout.ts
+++ b/src/routes/strategies/[strategy=apiStrategy]/[status=positionStatus]-positions/[position=integer]/+layout.ts
@@ -1,7 +1,9 @@
 import { error } from '@sveltejs/kit';
 import { getTradingPositionInfo } from 'trade-executor/models/position-info';
+import { topVaultsSchema } from '$lib/top-vaults/schemas';
+import { getPositionVault } from '../vault-sparklines';
 
-export async function load({ params, parent }) {
+export async function load({ params, parent, fetch }) {
 	// status can be `open`, `closed` or `frozen` (see params/positionStatus.ts)
 	const { position: id, status } = params;
 	const { state } = await parent();
@@ -12,10 +14,28 @@ export async function load({ params, parent }) {
 		error(404, 'Not found');
 	}
 
+	const positionVault = await loadPositionVault(fetch, position);
+
 	return {
 		breadcrumbs: { [id]: `Position #${id}` },
 		position,
+		positionVault,
 		status,
 		skipSideNav: true
 	};
+}
+
+async function loadPositionVault(fetch: Fetch, position: NonNullable<ReturnType<typeof getTradingPositionInfo>>) {
+	if (!position.pair.isVault) return null;
+
+	try {
+		const response = await fetch('/top-vaults/all-data');
+		if (!response.ok) throw new Error(`Failed to fetch top vaults: ${response.status}`);
+
+		const topVaults = topVaultsSchema.parse(await response.json());
+		return getPositionVault(position, topVaults.vaults) ?? null;
+	} catch (error) {
+		console.warn('Failed to resolve vault about data for position page', error);
+		return null;
+	}
 }

--- a/src/routes/strategies/[strategy=apiStrategy]/[status=positionStatus]-positions/[position=integer]/+page.svelte
+++ b/src/routes/strategies/[strategy=apiStrategy]/[status=positionStatus]-positions/[position=integer]/+page.svelte
@@ -1,3 +1,6 @@
+<!--
+Individual strategy position page.
+-->
 <script lang="ts">
 	import { getExplorerUrl } from '$lib/helpers/chain';
 	import { Alert, Button, HashAddress, PageHeading, Section } from '$lib/components';
@@ -11,13 +14,17 @@
 	import PositionSummary from './PositionSummary.svelte';
 	import OtherMetrics from './OtherMetrics.svelte';
 	import PositionCharts from './PositionCharts.svelte';
+	import PositionVaultAbout from './PositionVaultAbout.svelte';
+	import { resolve } from '$app/paths';
 
 	export let data;
-	const { position, chain, strategy, status } = data;
+	const { position, positionVault, chain, strategy, status } = data;
 
 	const isVaultPosition = position.pair.isVault;
 	const assetUrl = isVaultPosition
-		? `https://tradingstrategy.ai/vaults/address/${position.pair.pool_address}`
+		? position.pair.pool_address
+			? resolve(`/vaults/address/${position.pair.pool_address}`)
+			: undefined
 		: position.pricingPair.info_url;
 	const hyperliquidVaultUrl =
 		isVaultPosition && strategy.on_chain_data.chain_id === 9999
@@ -75,6 +82,12 @@
 		{/if}
 	</Section>
 
+	{#if positionVault}
+		<Section>
+			<PositionVaultAbout vault={positionVault} />
+		</Section>
+	{/if}
+
 	<Section class={position.failedOpen || position.frozen ? 'has-error' : ''}>
 		{#if position.failedOpen}
 			<Alert size="sm" status="error" title="Failed entry">
@@ -104,21 +117,23 @@
 		{/if}
 	</Section>
 
+	<Section class="position-info-section">
+		<div class="position-info">
+			<PositionProfitability {position} {exchangeUrl} {exchangeName} />
+			<PositionSummary {position} />
+			{#if !isExchangeAccountPosition}
+				<div class="position-side-info">
+					<OtherMetrics {position} />
+				</div>
+			{/if}
+		</div>
+	</Section>
+
 	{#if status !== 'frozen'}
 		<Section padding="sm">
 			<PositionCharts executorUrl={strategy.url} positionId={position.position_id} {tradePathBase} />
 		</Section>
 	{/if}
-
-	<Section>
-		<div class="position-info">
-			<PositionProfitability {position} {exchangeUrl} {exchangeName} />
-			<PositionSummary {position} />
-			{#if !isExchangeAccountPosition}
-				<OtherMetrics {position} />
-			{/if}
-		</div>
-	</Section>
 
 	{#if !isExchangeAccountPosition}
 		<Section padding="sm">
@@ -133,6 +148,18 @@
 
 <style>
 	.position-page {
+		:global(.position-info-section) {
+			margin-top: var(--space-3xl);
+
+			@media (--viewport-md-down) {
+				margin-top: var(--space-lg);
+			}
+
+			@media (--viewport-sm-down) {
+				margin-top: var(--space-ml);
+			}
+		}
+
 		:global(.has-error) {
 			margin-bottom: 1.5rem;
 		}
@@ -157,11 +184,17 @@
 				grid-template-rows: auto 1fr;
 				row-gap: 1.5rem;
 
-				/* position OtherMetrics in 2nd column, spanning 2 rows */
-				> :global(:last-child) {
+				/* position side info in 2nd column, spanning 2 rows */
+				.position-side-info {
 					grid-column: 2;
 					grid-row: 1 / span 2;
 				}
+			}
+
+			.position-side-info {
+				display: grid;
+				gap: 1.5rem;
+				align-content: start;
 			}
 		}
 

--- a/src/routes/strategies/[strategy=apiStrategy]/[status=positionStatus]-positions/[position=integer]/PositionSummary.svelte
+++ b/src/routes/strategies/[strategy=apiStrategy]/[status=positionStatus]-positions/[position=integer]/PositionSummary.svelte
@@ -1,3 +1,7 @@
+<!--
+@component
+Summary metrics for an individual strategy position.
+-->
 <script lang="ts">
 	import type { TradingPositionInfo } from 'trade-executor/models/position-info';
 	import { positionTooltips } from 'trade-executor/models/position-tooltips';
@@ -6,6 +10,7 @@
 	import Tooltip from '$lib/components/Tooltip.svelte';
 	import {
 		formatDuration,
+		formatNumber,
 		formatPercent,
 		formatPrice,
 		formatTokenAmount,
@@ -27,6 +32,7 @@
 	let currentPrice = $derived(position.stillOpen ? position.currentPrice : position.closePrice);
 	let currentQuantity = $derived(position.stillOpen ? position.currentQuantity : position.quantityAtClose);
 	let currentValue = $derived(position.stillOpen ? position.currentValue : position.valueAtClose);
+	let rebalanceCount = $derived(position.rebalanceCount);
 
 	const changeOptions: Intl.NumberFormatOptions = { signDisplay: 'exceptZero' };
 </script>
@@ -262,6 +268,18 @@
 						{notFilledMarker}
 					{/if}
 				</td>
+			</tr>
+
+			<tr>
+				<td>
+					<Tooltip>
+						<span slot="trigger" class="underline">Number of rebalances</span>
+						<span slot="popup">{positionTooltips.rebalanceCount}</span>
+					</Tooltip>
+				</td>
+				<td></td>
+				<td></td>
+				<td>{formatNumber(rebalanceCount, 0)}</td>
 			</tr>
 		</tbody>
 	</table>

--- a/src/routes/strategies/[strategy=apiStrategy]/[status=positionStatus]-positions/[position=integer]/PositionVaultAbout.svelte
+++ b/src/routes/strategies/[strategy=apiStrategy]/[status=positionStatus]-positions/[position=integer]/PositionVaultAbout.svelte
@@ -1,0 +1,178 @@
+<!--
+@component
+Compact vault metadata card for vault position detail pages.
+-->
+<script lang="ts">
+	import { resolve } from '$app/paths';
+	import MetricsBox from '$lib/components/MetricsBox.svelte';
+	import VaultSparkline from '$lib/top-vaults/VaultSparkline.svelte';
+	import type { VaultInfo } from '$lib/top-vaults/schemas';
+	import { formatDollar, formatNumber, formatPercentProfit } from '$lib/helpers/formatters';
+	import { getVaultCurrentTvlUsd, getVaultProtocolDisplayName } from '$lib/top-vaults/helpers';
+
+	interface Props {
+		vault: VaultInfo;
+	}
+
+	let { vault }: Props = $props();
+
+	let description = $derived(vault.short_description ?? vault.description ?? '');
+	let threeMonthCagr = $derived(vault.three_months_cagr_net ?? vault.three_months_cagr);
+	let datasheetHref = $derived(resolve(`/vaults/${vault.vault_slug}`));
+	let protocolName = $derived(getVaultProtocolDisplayName(vault));
+</script>
+
+<MetricsBox class="position-vault-about" title="About {vault.name} vault">
+	<div class="about-content">
+		<div class="description">
+			<p>
+				This position is held on {vault.name} on {protocolName}.
+				{#if description}
+					{description}
+				{/if}
+			</p>
+			<a href={datasheetHref}>View full information</a>
+		</div>
+
+		<dl>
+			<div>
+				<dt>TVL</dt>
+				<dd>{formatDollar(getVaultCurrentTvlUsd(vault), 1)}</dd>
+			</div>
+			<div>
+				<dt>Age</dt>
+				<dd>{formatNumber(vault.years, 1)} years</dd>
+			</div>
+			<div>
+				<dt>3M Sharpe</dt>
+				<dd>{formatNumber(vault.three_months_sharpe, 1)}</dd>
+			</div>
+			<div>
+				<dt>3M CAGR</dt>
+				<dd>{formatPercentProfit(threeMonthCagr, 1)}</dd>
+			</div>
+		</dl>
+
+		<div class="sparkline">
+			<span class="metric-label">90-day performance</span>
+			<div class="sparkline-chart">
+				<VaultSparkline {vault} />
+			</div>
+		</div>
+	</div>
+</MetricsBox>
+
+<style>
+	:global(.position-vault-about) {
+		--position-vault-about-font-size: 1rem;
+	}
+
+	:global(.metrics-box.position-vault-about h2) {
+		font-size: var(--position-vault-about-font-size);
+	}
+
+	.about-content {
+		display: grid;
+		grid-template-columns: minmax(0, 1fr);
+		gap: 1.25rem;
+		align-content: start;
+
+		@media (--viewport-md-up) {
+			grid-template-columns: minmax(0, 1fr) minmax(16rem, 20rem) minmax(12rem, 14rem);
+			align-items: start;
+			gap: clamp(1.5rem, 3vw, 3.5rem);
+		}
+	}
+
+	.description {
+		display: grid;
+		gap: 0.75rem;
+	}
+
+	p {
+		margin: 0;
+		color: var(--c-text-light);
+		font: var(--f-ui-sm-roman);
+		letter-spacing: var(--ls-ui-sm, normal);
+		line-height: 1.5;
+	}
+
+	a {
+		width: fit-content;
+		justify-self: end;
+		color: var(--c-link);
+		font: var(--f-ui-sm-medium);
+		letter-spacing: var(--ls-ui-sm, normal);
+		text-align: right;
+		text-decoration: underline;
+	}
+
+	.sparkline {
+		display: grid;
+		gap: 0.5rem;
+		justify-items: start;
+		align-content: start;
+	}
+
+	.sparkline-chart {
+		box-sizing: border-box;
+		display: grid;
+		width: 10rem;
+		padding: 0.45rem;
+		border: 1px solid var(--c-box-4);
+		border-radius: var(--radius-sm);
+		background: #000;
+
+		--sparkline-width: 100%;
+	}
+
+	dl {
+		display: grid;
+		gap: 0.65rem;
+		margin: 0;
+	}
+
+	@media (--viewport-md-up) {
+		dl,
+		.sparkline {
+			align-self: stretch;
+			padding-left: clamp(1.5rem, 2vw, 2.5rem);
+			border-left: 1px solid var(--c-box-4);
+		}
+	}
+
+	dl > div {
+		display: flex;
+		align-items: baseline;
+		justify-content: space-between;
+		gap: 1rem;
+	}
+
+	dt,
+	dd {
+		margin: 0;
+	}
+
+	dt,
+	.metric-label {
+		color: var(--c-text-light);
+		font: var(--f-ui-md-medium);
+		font-weight: bold;
+		letter-spacing: var(--ls-ui-md, normal);
+	}
+
+	dd {
+		color: var(--c-text-extra-light);
+		font: var(--f-ui-md-medium);
+		letter-spacing: var(--ls-ui-md, normal);
+		text-align: right;
+	}
+
+	p,
+	a,
+	dt,
+	dd,
+	.metric-label {
+		font-size: var(--position-vault-about-font-size);
+	}
+</style>

--- a/src/routes/strategies/[strategy=apiStrategy]/[status=positionStatus]-positions/[position=integer]/TradeTable.svelte
+++ b/src/routes/strategies/[strategy=apiStrategy]/[status=positionStatus]-positions/[position=integer]/TradeTable.svelte
@@ -71,7 +71,7 @@
 </script>
 
 <section class="trade-table">
-	<h2>Rebalances</h2>
+	<h2>Trades</h2>
 	<DataTable {tableViewModel} targetableRows size="sm" />
 </section>
 

--- a/src/routes/strategies/[strategy=apiStrategy]/[status=positionStatus]-positions/vault-sparklines.test.ts
+++ b/src/routes/strategies/[strategy=apiStrategy]/[status=positionStatus]-positions/vault-sparklines.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, test } from 'vitest';
+import { getPositionVault, getPositionVaultSparklines, type VaultSparklinePosition } from './vault-sparklines';
+
+const vaults = [
+	{
+		id: 'ethereum-aave-v3-usdc',
+		name: 'Aave USDC',
+		address: '0xabc0000000000000000000000000000000000000',
+		chain_id: 1
+	},
+	{
+		id: 'base-morpho-usdc',
+		name: 'Morpho USDC',
+		address: '0xdef0000000000000000000000000000000000000',
+		chain_id: 8453
+	}
+];
+
+function position(position: Partial<VaultSparklinePosition>): VaultSparklinePosition {
+	return {
+		position_id: 1,
+		pair: {
+			isVault: true,
+			pool_address: '0xabc0000000000000000000000000000000000000',
+			symbol: 'Aave USDC',
+			base: { chain_id: 1 },
+			other_data: null
+		},
+		...position
+	};
+}
+
+describe('getPositionVaultSparklines', () => {
+	test('resolves vault positions by chain and address', () => {
+		const result = getPositionVaultSparklines([position({})], vaults);
+
+		expect(result).toEqual({
+			1: {
+				id: 'ethereum-aave-v3-usdc',
+				name: 'Aave USDC'
+			}
+		});
+	});
+
+	test('uses direct vault ids from position metadata', () => {
+		const result = getPositionVaultSparklines(
+			[
+				position({
+					position_id: 2,
+					pair: {
+						isVault: true,
+						symbol: 'Direct vault',
+						other_data: { vault_id: 'direct-vault-id' }
+					}
+				})
+			],
+			[]
+		);
+
+		expect(result).toEqual({
+			2: {
+				id: 'direct-vault-id',
+				name: 'Direct vault'
+			}
+		});
+	});
+
+	test('ignores non-vault positions', () => {
+		const result = getPositionVaultSparklines(
+			[
+				position({
+					position_id: 3,
+					pair: {
+						isVault: false,
+						pool_address: '0xabc0000000000000000000000000000000000000',
+						base: { chain_id: 1 }
+					}
+				})
+			],
+			vaults
+		);
+
+		expect(result).toEqual({});
+	});
+
+	test('does not cross-match the same address on a different chain', () => {
+		const result = getPositionVaultSparklines(
+			[
+				position({
+					position_id: 4,
+					pair: {
+						isVault: true,
+						pool_address: '0xdef0000000000000000000000000000000000000',
+						base: { chain_id: 1 }
+					}
+				})
+			],
+			vaults
+		);
+
+		expect(result).toEqual({});
+	});
+
+	test('resolves a full vault record for one position', () => {
+		const result = getPositionVault(position({ position_id: 5 }), vaults);
+
+		expect(result).toEqual(vaults[0]);
+	});
+});

--- a/src/routes/strategies/[strategy=apiStrategy]/[status=positionStatus]-positions/vault-sparklines.ts
+++ b/src/routes/strategies/[strategy=apiStrategy]/[status=positionStatus]-positions/vault-sparklines.ts
@@ -1,0 +1,129 @@
+import type { VaultInfo } from '$lib/top-vaults/schemas';
+
+export interface PositionVaultSparkline {
+	id: string;
+	name: string;
+}
+
+type VaultPositionPair = {
+	isVault: boolean;
+	pool_address?: string | null;
+	symbol?: string;
+	base?: { address?: string | null; chain_id?: number };
+	other_data?: Record<string, unknown> | null;
+};
+
+export type VaultSparklinePosition = {
+	position_id: number;
+	pair: VaultPositionPair;
+};
+
+type SparklineVaultInfo = Pick<VaultInfo, 'id' | 'name' | 'address' | 'chain_id'>;
+
+const vaultIdKeys = ['vault_id', 'vaultId', 'top_vault_id', 'topVaultId'] as const;
+
+function normaliseAddress(address: string | null | undefined) {
+	return address?.trim().toLowerCase();
+}
+
+function getDirectVaultId(position: VaultSparklinePosition) {
+	const otherData = position.pair.other_data;
+	if (!otherData) return;
+
+	for (const key of vaultIdKeys) {
+		const value = otherData[key];
+		if (typeof value === 'string' && value.trim()) {
+			return value.trim();
+		}
+	}
+}
+
+function getPositionLabel(position: VaultSparklinePosition) {
+	return position.pair.symbol ?? 'Vault';
+}
+
+function getVaultAddressKey(chainId: number, address: string) {
+	return `${chainId}:${address}`;
+}
+
+function buildVaultAddressIndex(vaults: SparklineVaultInfo[]) {
+	return new Map(
+		vaults
+			.map((vault) => {
+				const address = normaliseAddress(vault.address);
+				return address ? [getVaultAddressKey(vault.chain_id, address), vault] : undefined;
+			})
+			.filter((entry): entry is [string, SparklineVaultInfo] => entry !== undefined)
+	);
+}
+
+function buildVaultIdIndex<TVault extends SparklineVaultInfo>(vaults: TVault[]) {
+	return new Map(vaults.map((vault) => [vault.id, vault]));
+}
+
+export function getPositionVault<TVault extends SparklineVaultInfo>(
+	position: VaultSparklinePosition,
+	vaults: TVault[]
+): TVault | undefined {
+	if (!position.pair.isVault) return;
+
+	const directVaultId = getDirectVaultId(position);
+	if (directVaultId) {
+		const vault = buildVaultIdIndex(vaults).get(directVaultId);
+		if (vault) return vault;
+	}
+
+	const poolAddress = normaliseAddress(position.pair.pool_address);
+	if (!poolAddress) return;
+
+	const positionChainId = position.pair.base?.chain_id;
+	if (positionChainId == null) return;
+
+	const vaultsByAddress = buildVaultAddressIndex(vaults);
+	return vaultsByAddress.get(getVaultAddressKey(positionChainId, poolAddress)) as TVault | undefined;
+}
+
+/**
+ * Resolve the vault sparkline identifier for each vault-backed position.
+ *
+ * Positions may include the top-vaults id directly in `pair.other_data`; when
+ * they do not, we join against the top-vaults feed by chain and vault address.
+ */
+export function getPositionVaultSparklines(
+	positions: VaultSparklinePosition[],
+	vaults: SparklineVaultInfo[]
+): Record<number, PositionVaultSparkline> {
+	const vaultsById = buildVaultIdIndex(vaults);
+	const vaultsByAddress = buildVaultAddressIndex(vaults);
+	const resolved: Record<number, PositionVaultSparkline> = {};
+
+	for (const position of positions) {
+		if (!position.pair.isVault) continue;
+
+		const directVaultId = getDirectVaultId(position);
+		const poolAddress = normaliseAddress(position.pair.pool_address);
+		const positionChainId = position.pair.base?.chain_id;
+		const vault =
+			(directVaultId ? vaultsById.get(directVaultId) : undefined) ??
+			(poolAddress && positionChainId != null
+				? vaultsByAddress.get(getVaultAddressKey(positionChainId, poolAddress))
+				: undefined);
+
+		if (vault) {
+			resolved[position.position_id] = {
+				id: vault.id,
+				name: vault.name
+			};
+			continue;
+		}
+
+		if (directVaultId) {
+			resolved[position.position_id] = {
+				id: directVaultId,
+				name: getPositionLabel(position)
+			};
+		}
+	}
+
+	return resolved;
+}


### PR DESCRIPTION
## Why

The vault position-page implementation was retained locally but was not included in the earlier merged search/listings PR. As a result, production still uses the old position layout and does not show the vault description and metrics.

## Lessons learnt

Keep recoverable UI work in a focused branch and verify that its route files are present in the final pull request before merging.

## Summary

- restore the vault about card, metadata, and 90-day performance chart on vault-backed open and closed position pages
- add vault sparklines to position listings
- show completed rebalance counts and clarify the trade-table heading