### PR TITLE
feat: show GuardV0 deposit flow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Weblog of stuff
 
+- Show HyperAI's GuardV0 automated deposit and redemption settlement limit (2026-08-05)
 - Add a whitelisted vault ranking for permissioned deposits (2026-08-03)
 - Consolidate vault listing controls into a persistent Filters disclosure (2026-08-01)
 - Add Xerberus protocol scores and tooltips to the vault protocol listing, and fix curator description spacing (2026-08-01)

--- a/src/lib/trade-executor/components/LagoonGuardV0Flow.svelte
+++ b/src/lib/trade-executor/components/LagoonGuardV0Flow.svelte
@@ -1,0 +1,64 @@
+<!--
+@component
+Display GuardV0's daily automated settlement allowance for a Lagoon vault.
+
+The card is hidden unless GuardV0 enables a positive limit with its expected
+24-hour cooldown, preventing the UI from misrepresenting a different policy.
+-->
+<script lang="ts">
+	import type { LagoonSmartContracts } from 'trade-executor/schemas/summary';
+	import MetricsBox from '$lib/components/MetricsBox.svelte';
+	import { formatDollar } from '$lib/helpers/formatters';
+
+	type Props = {
+		guard: LagoonSmartContracts['lagoon_guard_v0'];
+	};
+
+	let { guard }: Props = $props();
+
+	let automatedSettlementLimit = $derived(
+		guard?.daily_automatic_settlement_limit_enabled &&
+			guard.daily_automatic_settlement_limit != null &&
+			Number(guard.daily_automatic_settlement_limit) > 0 &&
+			guard.settlement_cooldown_seconds === 86_400
+			? guard.daily_automatic_settlement_limit
+			: undefined
+	);
+</script>
+
+{#if automatedSettlementLimit}
+	<MetricsBox title="Deposit and redemption flow">
+		<p class="limit">{formatDollar(automatedSettlementLimit, 0, 0, { notation: 'standard' })}<span>/24h</span></p>
+		<p class="description">
+			Automated settlement is limited to this amount of combined deposit and redemption flow each day. Larger flows
+			require manual settlement by the vault's Safe and may take longer to process.
+		</p>
+	</MetricsBox>
+{/if}
+
+<style>
+	.limit,
+	.description {
+		margin: 0;
+	}
+
+	.limit {
+		font: var(--f-heading-xl-medium);
+		letter-spacing: var(--ls-heading-xl);
+		color: var(--c-text);
+
+		span {
+			margin-left: 0.25rem;
+			font: var(--f-ui-md-medium);
+			letter-spacing: var(--ls-ui-md);
+			color: var(--c-text-extra-light);
+		}
+	}
+
+	.description {
+		margin-top: 0.5rem;
+		color: var(--c-text-extra-light);
+		font: var(--f-ui-sm-medium);
+		letter-spacing: var(--ls-ui-sm);
+	}
+</style>

--- a/src/lib/trade-executor/components/LagoonGuardV0Flow.test.ts
+++ b/src/lib/trade-executor/components/LagoonGuardV0Flow.test.ts
@@ -1,0 +1,30 @@
+import { render, screen } from '@testing-library/svelte';
+import { describe, expect, it } from 'vitest';
+import LagoonGuardV0Flow from './LagoonGuardV0Flow.svelte';
+
+const guard = {
+	daily_automatic_settlement_limit_enabled: true,
+	daily_automatic_settlement_limit: '5000',
+	settlement_cooldown_seconds: 86_400
+};
+
+describe('LagoonGuardV0Flow', () => {
+	it('displays the daily automated settlement allowance', () => {
+		render(LagoonGuardV0Flow, { guard });
+
+		expect(screen.getByRole('heading', { name: 'Deposit and redemption flow' })).toBeInTheDocument();
+		expect(screen.getByText('$5,000')).toBeInTheDocument();
+		expect(screen.getByText('/24h')).toBeInTheDocument();
+	});
+
+	it.each([
+		{ ...guard, daily_automatic_settlement_limit_enabled: false },
+		{ ...guard, daily_automatic_settlement_limit: '0' },
+		{ ...guard, settlement_cooldown_seconds: 3_600 },
+		null,
+		undefined
+	])('hides an unavailable or unsupported policy', (policy) => {
+		render(LagoonGuardV0Flow, { guard: policy });
+		expect(screen.queryByRole('heading', { name: 'Deposit and redemption flow' })).not.toBeInTheDocument();
+	});
+});

--- a/src/lib/trade-executor/schemas/summary.test.ts
+++ b/src/lib/trade-executor/schemas/summary.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+import { lagoonSmartContractSchema } from './summary';
+
+const lagoonContracts = {
+	address: '0xC723aDd84EE4646044ff28e552808E0a3ac48b54',
+	feeReceiver: '0xa8F8DEbb722c6174B814b432169BF569603F673F',
+	feeRegistry: '0xd70937AA2B73A8a2100932c4f5a8D32c9bE8b80f',
+	valuationManager: '0x005B8d2FF173C8bCc980F275884B1E717082F10C',
+	safe: '0xa8F8DEbb722c6174B814b432169BF569603F673F',
+	asset: '0xb88339CB7199b77E23DB6E890353E22632Ba630f'
+};
+
+describe('lagoonSmartContractSchema', () => {
+	it('parses GuardV0 automated settlement policy metadata', () => {
+		const result = lagoonSmartContractSchema.parse({
+			...lagoonContracts,
+			lagoon_guard_v0: {
+				daily_automatic_settlement_limit_enabled: true,
+				daily_automatic_settlement_limit: '5000',
+				settlement_cooldown_seconds: '86400'
+			}
+		});
+
+		expect(result.lagoon_guard_v0).toEqual({
+			daily_automatic_settlement_limit_enabled: true,
+			daily_automatic_settlement_limit: '5000',
+			settlement_cooldown_seconds: 86_400
+		});
+	});
+
+	it.each([undefined, null])('allows an absent GuardV0 policy (%s)', (lagoon_guard_v0) => {
+		const result = lagoonSmartContractSchema.parse({ ...lagoonContracts, lagoon_guard_v0 });
+		expect(result.lagoon_guard_v0).toBe(lagoon_guard_v0);
+	});
+});

--- a/src/lib/trade-executor/schemas/summary.ts
+++ b/src/lib/trade-executor/schemas/summary.ts
@@ -13,6 +13,7 @@ import { z } from 'zod';
 import {
 	chainId,
 	count,
+	decimal,
 	duration,
 	hexString,
 	percent,
@@ -41,13 +42,20 @@ export const velvetSmartContractSchema = z.object({
 });
 export type VelvetSmartContracts = z.infer<typeof velvetSmartContractSchema>;
 
+const lagoonGuardV0Schema = z.object({
+	daily_automatic_settlement_limit_enabled: z.boolean(),
+	daily_automatic_settlement_limit: decimal.nullish(),
+	settlement_cooldown_seconds: duration.positive()
+});
+
 export const lagoonSmartContractSchema = z.object({
 	address: hexString,
 	feeReceiver: hexString,
 	feeRegistry: hexString,
 	valuationManager: hexString,
 	safe: hexString,
-	asset: hexString
+	asset: hexString,
+	lagoon_guard_v0: lagoonGuardV0Schema.nullish()
 });
 export type LagoonSmartContracts = z.infer<typeof lagoonSmartContractSchema>;
 

--- a/src/routes/strategies/[strategy=apiStrategy]/+page.svelte
+++ b/src/routes/strategies/[strategy=apiStrategy]/+page.svelte
@@ -1,8 +1,12 @@
+<!--
+Strategy overview dashboard.
+-->
 <script lang="ts">
 	import Button from '$lib/components/Button.svelte';
 	import MyDeposits from '$lib/wallet/MyDeposits.svelte';
 	import SummaryMetrics from './SummaryMetrics.svelte';
 	import StrategyPerformanceChart from './StrategyPerformanceChart.svelte';
+	import LagoonGuardV0Flow from 'trade-executor/components/LagoonGuardV0Flow.svelte';
 	import { getMetricsWithAltCAGR } from 'trade-executor/helpers/metrics';
 	import { getExchangeAccountInfo } from 'trade-executor/helpers/exchange-account';
 
@@ -40,7 +44,11 @@
 		{/if}
 	</div>
 	<StrategyPerformanceChart {strategy} />
-	<SummaryMetrics {keyMetrics} {backtestLink} hideTimeframes={strategy.hiddenElements.timeframes} />
+	<SummaryMetrics {keyMetrics} {backtestLink} hideTimeframes={strategy.hiddenElements.timeframes}>
+		{#if strategy.on_chain_data.asset_management_mode === 'lagoon'}
+			<LagoonGuardV0Flow guard={strategy.on_chain_data.smart_contracts.lagoon_guard_v0} />
+		{/if}
+	</SummaryMetrics>
 </div>
 
 <style>
@@ -65,6 +73,11 @@
 				margin: 0;
 			}
 
+			p {
+				color: var(--c-text-extra-light);
+				font: var(--f-ui-md-medium);
+				letter-spacing: var(--ls-ui-md);
+			}
 			h2 {
 				display: flex;
 				gap: 0.75rem;
@@ -77,12 +90,6 @@
 					border-radius: 999px;
 					flex: 0 0 auto;
 				}
-			}
-
-			p {
-				color: var(--c-text-extra-light);
-				font: var(--f-ui-md-medium);
-				letter-spacing: var(--ls-ui-md);
 			}
 
 			:global(.button) {

--- a/src/routes/strategies/[strategy=apiStrategy]/SummaryMetrics.svelte
+++ b/src/routes/strategies/[strategy=apiStrategy]/SummaryMetrics.svelte
@@ -1,4 +1,9 @@
+<!--
+@component
+Strategy performance and risk dashboard metrics.
+-->
 <script lang="ts">
+	import type { Snippet } from 'svelte';
 	import type { SummaryKeyMetrics } from 'trade-executor/schemas/summary';
 	import MetricsBox from '$lib/components/MetricsBox.svelte';
 	import Profitability from '$lib/components/Profitability.svelte';
@@ -11,9 +16,10 @@
 		keyMetrics: SummaryKeyMetrics;
 		backtestLink: string;
 		hideTimeframes?: boolean;
+		children?: Snippet;
 	};
 
-	let { keyMetrics, backtestLink, hideTimeframes = false }: Props = $props();
+	let { keyMetrics, backtestLink, hideTimeframes = false, children }: Props = $props();
 </script>
 
 <div class="summary-metrics">
@@ -109,6 +115,10 @@
 			/>
 		</div>
 	</MetricsBox>
+
+	{#if children}
+		{@render children()}
+	{/if}
 </div>
 
 <style>


### PR DESCRIPTION
## Why

HyperAI publishes a GuardV0 policy that constrains automated investor settlement. The strategy dashboard should show the verified daily flow allowance without overstating what happens to larger flows.

## Lessons learnt

GuardV0 limits gross deposit and redemption flow together. The policy metadata may be absent or null, and the daily display is only valid with its 24-hour cooldown.

## Summary

- Parse nullable GuardV0 settlement metadata safely.
- Add a standard dashboard box for the validated $5,000-per-24-hour automated flow allowance.
- Explain that larger flows require manual Safe settlement.
- Add schema and component coverage, plus a changelog entry.