### PR TITLE
Add Xerberus risk cards to protocol pages

### DIFF
--- a/src/lib/top-vaults/XerberusRisk.svelte
+++ b/src/lib/top-vaults/XerberusRisk.svelte
@@ -1,6 +1,6 @@
 <!--
 @component
-Displays the third-party Xerberus risk assessment for an individual vault.
+Displays the third-party Xerberus risk assessment for a vault or protocol.
 
 Xerberus may rate a vault pool directly or fall back to an assessment of its
 underlying protocol. This distinction is stated in the card so users do not
@@ -18,14 +18,18 @@ mistake protocol coverage for a vault-specific assessment.
 	import { formatNumber } from '$lib/helpers/formatters';
 	import { riskRatingProviders } from './risk-rating-providers';
 	import type { XerberusVault } from './schemas';
+	import type { XerberusProtocolScore } from '$lib/xerberus/protocol-scores';
 	import IconQuestionCircle from '~icons/local/question-circle';
 
 	interface Props {
-		xerberus: XerberusVault;
+		xerberus: XerberusVault | XerberusProtocolScore;
+		context?: 'protocol' | 'vault';
 	}
 
-	let { xerberus }: Props = $props();
-	let isPoolAssessment = $derived(xerberus.entity_type === 'pool');
+	let { xerberus, context = 'vault' }: Props = $props();
+	let score = $derived('entity_type' in xerberus ? xerberus.score : xerberus.score * 100);
+	let reportUrl = $derived('entity_type' in xerberus ? xerberus.report_url : xerberus.url);
+	let isPoolAssessment = $derived('entity_type' in xerberus && xerberus.entity_type === 'pool');
 	let assessmentLabel = $derived(isPoolAssessment ? 'Pool-level' : 'Protocol-level');
 	let assessmentDescription = $derived(
 		isPoolAssessment
@@ -38,11 +42,13 @@ mistake protocol coverage for a vault-specific assessment.
 	<div class="content">
 		<header class="box-header">
 			<img class="xerberus-icon" src={riskRatingProviders.xerberus.logoUrl} alt={riskRatingProviders.xerberus.name} />
-			<div class="score">{formatNumber(xerberus.score, 0, 0)}</div>
+			{#if context !== 'protocol'}
+				<div class="score">{formatNumber(score, 0, 0)}</div>
+			{/if}
 			<h2>Xerberus risk rating</h2>
 		</header>
 
-		<table class="data">
+		<table class="data" class:protocol={context === 'protocol'}>
 			<tbody>
 				<tr>
 					<th>
@@ -56,26 +62,34 @@ mistake protocol coverage for a vault-specific assessment.
 							</svelte:fragment>
 						</Tooltip>
 					</th>
-					<td>{formatNumber(xerberus.score, 0, 0)} / 100</td>
+					<td>{formatNumber(score, 0, 0)} / 100</td>
 				</tr>
-				<tr>
-					<th>Assessment level</th>
-					<td>{assessmentLabel}</td>
-				</tr>
-				<tr>
-					<th>Rated entity</th>
-					<td>{xerberus.name}</td>
-				</tr>
+				{#if context !== 'protocol'}
+					<tr>
+						<th>Assessment level</th>
+						<td>{assessmentLabel}</td>
+					</tr>
+					<tr>
+						<th>Rated entity</th>
+						<td>{xerberus.name}</td>
+					</tr>
+				{/if}
 			</tbody>
 		</table>
 
 		<footer class="footer">
-			<p>{assessmentDescription} Higher is better.</p>
-			{#if xerberus.report_url}
+			{#if context !== 'protocol'}
+				<p>{assessmentDescription}</p>
+			{/if}
+			{#if reportUrl}
 				<!-- eslint-disable-next-line svelte/no-navigation-without-resolve -->
-				<a href={xerberus.report_url} target="_blank" rel="noreferrer"
-					>View this {isPoolAssessment ? 'vault' : 'protocol'} rating on Xerberus</a
-				>
+				<a href={reportUrl} target="_blank" rel="noreferrer" class:protocol-link={context === 'protocol'}>
+					{#if context === 'protocol'}
+						<span>View this protocol on Xerberus</span> to understand the protocol risk score.
+					{:else}
+						View this {isPoolAssessment ? 'vault' : 'protocol'} rating on Xerberus
+					{/if}
+				</a>
 			{/if}
 		</footer>
 	</div>
@@ -150,11 +164,33 @@ mistake protocol coverage for a vault-specific assessment.
 		text-decoration: underline;
 		font-weight: 500;
 		color: var(--c-text-light);
+
+		&.protocol-link {
+			text-decoration: none;
+
+			span {
+				text-decoration: underline;
+			}
+		}
 	}
 
 	table.data {
 		width: 100%;
 		border-collapse: collapse;
+
+		&.protocol {
+			width: auto;
+			justify-self: start;
+
+			th,
+			td {
+				text-align: left;
+			}
+
+			th {
+				padding-right: 1rem;
+			}
+		}
 
 		tr {
 			border-top: 1px solid var(--c-box-3);

--- a/src/lib/top-vaults/XerberusRisk.test.ts
+++ b/src/lib/top-vaults/XerberusRisk.test.ts
@@ -29,7 +29,7 @@ describe('XerberusRisk', () => {
 		expect(screen.getByAltText('Xerberus')).toHaveAttribute('src', 'https://app.xerberus.io/favicon.ico');
 		expect(screen.getByText('78 / 100')).toBeInTheDocument();
 		expect(screen.getByText('Pool-level')).toBeInTheDocument();
-		expect(screen.getByText('This is a Xerberus risk rating for this vault. Higher is better.')).toBeInTheDocument();
+		expect(screen.getByText('This is a Xerberus risk rating for this vault.')).toBeInTheDocument();
 		expect(screen.getByRole('link', { name: 'View this vault rating on Xerberus' })).toHaveAttribute(
 			'href',
 			'https://app.xerberus.io/pool/dendrogram/example-vault'
@@ -51,7 +51,7 @@ describe('XerberusRisk', () => {
 
 		expect(screen.getByText('Protocol-level')).toBeInTheDocument();
 		expect(
-			screen.getByText('This is a Xerberus risk rating for this vault’s underlying protocol. Higher is better.')
+			screen.getByText('This is a Xerberus risk rating for this vault’s underlying protocol.')
 		).toBeInTheDocument();
 		expect(screen.getByRole('link', { name: 'View this protocol rating on Xerberus' })).toHaveAttribute(
 			'href',
@@ -71,5 +71,31 @@ describe('XerberusRisk', () => {
 		});
 
 		expect(screen.queryByRole('link', { name: /Xerberus/ })).not.toBeInTheDocument();
+	});
+
+	it('renders a protocol score on the 0–100 scale', () => {
+		render(XerberusRisk, {
+			props: {
+				xerberus: {
+					id: 'example-protocol',
+					name: 'Example protocol',
+					score: 0.78,
+					url: 'https://app.xerberus.io/protocol/dendrogram/example-protocol'
+				},
+				context: 'protocol'
+			}
+		});
+
+		expect(screen.getByText('78 / 100')).toBeInTheDocument();
+		expect(
+			screen.queryByText('This is a Xerberus risk rating for this protocol. It applies to all vaults on the protocol.')
+		).not.toBeInTheDocument();
+		expect(screen.queryByText('Higher is better.', { exact: false })).not.toBeInTheDocument();
+		expect(screen.queryByText('Assessment level')).not.toBeInTheDocument();
+		expect(screen.queryByText('Rated entity')).not.toBeInTheDocument();
+		expect(screen.queryByText('78', { exact: true })).not.toBeInTheDocument();
+		expect(
+			screen.getByRole('link', { name: 'View this protocol on Xerberus to understand the protocol risk score.' })
+		).toHaveAttribute('href', 'https://app.xerberus.io/protocol/dendrogram/example-protocol');
 	});
 });

--- a/src/routes/vaults/protocols/[protocol=slug]/+page.server.ts
+++ b/src/routes/vaults/protocols/[protocol=slug]/+page.server.ts
@@ -9,6 +9,7 @@ import {
 	UNKNOWN_VAULT_PROTOCOL_DISPLAY_NAME,
 	UNKNOWN_VAULT_PROTOCOL_SLUG
 } from '$lib/top-vaults/helpers.js';
+import { getCachedXerberusProtocolScoreIndex, resolveXerberusProtocolScore } from '$lib/xerberus/protocol-scores';
 
 export async function load({ params, fetch, url }) {
 	const { protocol } = params;
@@ -28,14 +29,20 @@ export async function load({ params, fetch, url }) {
 	const core3 =
 		protocolVaults.map((vault) => getCore3ProtocolForVault(vault, core3_protocols)).find((rating) => rating !== null) ??
 		null;
+	const protocolName = isUnknownGroup
+		? UNKNOWN_VAULT_PROTOCOL_DISPLAY_NAME
+		: getProtocolDisplayName(protocolVault.protocol, protocolVault.protocol_slug);
+	const xerberusScoreIndex = await getCachedXerberusProtocolScoreIndex(fetch).catch(() => null);
+	const xerberus = xerberusScoreIndex
+		? resolveXerberusProtocolScore(xerberusScoreIndex, { slug: protocol, name: protocolName })
+		: null;
 
 	return {
 		protocolSlug: protocol,
-		protocolName: isUnknownGroup
-			? UNKNOWN_VAULT_PROTOCOL_DISPLAY_NAME
-			: getProtocolDisplayName(protocolVault.protocol, protocolVault.protocol_slug),
+		protocolName,
 		protocolMetadata,
 		core3,
+		xerberus,
 		...(await loadVaultListing(fetch, url, 'protocol', protocol))
 	};
 }

--- a/src/routes/vaults/protocols/[protocol=slug]/+page.svelte
+++ b/src/routes/vaults/protocols/[protocol=slug]/+page.svelte
@@ -6,12 +6,13 @@
 	import { page } from '$app/state';
 	import TopVaultsPage from '$lib/top-vaults/TopVaultsPage.svelte';
 	import Core3Ratings from '$lib/top-vaults/Core3Ratings.svelte';
+	import XerberusRisk from '$lib/top-vaults/XerberusRisk.svelte';
 	import { JsonLd } from 'svelte-meta-tags';
 	import MetaTags from '$lib/social-card/SocialCardMetaTags.svelte';
 	import VaultGroupMiniChart from '../../VaultGroupMiniChart.svelte';
 
 	let { data } = $props();
-	let { protocolSlug, protocolName, protocolMetadata, core3, initialTopVaults } = $derived(data);
+	let { protocolSlug, protocolName, protocolMetadata, core3, xerberus, initialTopVaults } = $derived(data);
 	let isUnknownVaultProtocolGroup = $derived(protocolSlug === UNKNOWN_VAULT_PROTOCOL_SLUG);
 	let isHyperliquidProtocolGroup = $derived(protocolSlug === 'hyperliquid');
 	let isApexProtocolGroup = $derived(protocolSlug === 'apex');
@@ -144,6 +145,9 @@
 	{#snippet beforeTable()}
 		{#if core3}
 			<Core3Ratings {core3} {protocolName} collapsible />
+		{/if}
+		{#if xerberus}
+			<XerberusRisk {xerberus} context="protocol" />
 		{/if}
 	{/snippet}
 </TopVaultsPage>


### PR DESCRIPTION
## Why

Protocol pages show CORE3 ratings but did not surface the available Xerberus protocol risk scores.

## Lessons learnt

Xerberus protocol scores use a 0–1 value, while vault assessments use 0–100, so the shared card converts only protocol scores for display.

## Summary

- Display the Xerberus protocol risk card when a protocol score is available.
- Simplify the protocol card to one aligned score and a contextual Xerberus link.
- Cover protocol-score rendering in the Xerberus card test.