### PR TITLE
feat: show curator and protocol logos on chain vault listings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Weblog of stuff
 
+- Show curator or protocol logos in chain-specific vault listings (2026-08-06)
 - Show HyperAI's GuardV0 automated deposit and redemption settlement limit (2026-08-05)
 - Add a whitelisted vault ranking for permissioned deposits (2026-08-03)
 - Consolidate vault listing controls into a persistent Filters disclosure (2026-08-01)

--- a/src/lib/top-vaults/TopVaultsTable.svelte
+++ b/src/lib/top-vaults/TopVaultsTable.svelte
@@ -43,6 +43,7 @@ Whitelisted vaults are marked as Private, except tokenised funds, which are mark
 		notFilledMarker
 	} from '$lib/helpers/formatters';
 	import { isStablecoinDepegged } from '$lib/stablecoin-metadata/helpers';
+	import { getVaultProtocolLogoUrl } from '$lib/vault-protocol/helpers';
 	import {
 		DEFAULT_TVL_KEY,
 		DEFAULT_TVL_THRESHOLD,
@@ -1249,6 +1250,9 @@ Whitelisted vaults are marked as Private, except tokenised funds, which are mark
 					{@const isCapped = isVaultDepositCapped(vault)}
 					{@const depositStatusLabel = isTokenisedFund ? 'Fund' : 'Private'}
 					{@const protocolName = getVaultProtocolDisplayName(vault)}
+					{@const curatorLogos = vault.curator_slug ? topVaults.curators[vault.curator_slug]?.logos : undefined}
+					{@const curatorLogoUrl = curatorLogos?.generic ?? curatorLogos?.light ?? curatorLogos?.dark}
+					{@const vaultLogoUrl = curatorLogoUrl ?? getVaultProtocolLogoUrl(vault.protocol_slug)}
 					{@const statusReason = [vault.deposit_closed_reason, vault.redemption_closed_reason]
 						.filter(Boolean)
 						.join('; ')}
@@ -1261,11 +1265,16 @@ Whitelisted vaults are marked as Private, except tokenised funds, which are mark
 							</td>
 						{/if}
 						<td class="vault">
-							<div class="multiline">
-								<strong>{vault.name}</strong>
-								{#if protocolName}
-									<span class="secondary">{protocolName}</span>
+							<div class="vault-identity">
+								{#if !showChainCol && vaultLogoUrl}
+									<img class="vault-logo" src={vaultLogoUrl} alt="" />
 								{/if}
+								<div class="multiline">
+									<strong>{vault.name}</strong>
+									{#if protocolName}
+										<span class="secondary">{protocolName}</span>
+									{/if}
+								</div>
 							</div>
 						</td>
 						{#if showProviderRiskRating}
@@ -1928,6 +1937,19 @@ Whitelisted vaults are marked as Private, except tokenised funds, which are mark
 				@media (--viewport-sm-down) {
 					width: 10rem;
 					max-width: 10rem;
+				}
+
+				.vault-identity {
+					display: flex;
+					align-items: center;
+					gap: 0.5rem;
+				}
+
+				.vault-logo {
+					width: 1.5rem;
+					height: 1.5rem;
+					flex: none;
+					object-fit: contain;
 				}
 			}
 

--- a/src/lib/top-vaults/TopVaultsTable.test.ts
+++ b/src/lib/top-vaults/TopVaultsTable.test.ts
@@ -1,5 +1,6 @@
 import { cleanup, render, screen } from '@testing-library/svelte';
 import { afterEach, describe, expect, it, vi } from 'vitest';
+import { getChain } from '$lib/helpers/chain';
 import TopVaultsTable from './TopVaultsTable.svelte';
 import { createTestVault } from './test-utils';
 
@@ -13,6 +14,10 @@ vi.stubGlobal(
 		disconnect() {}
 	}
 );
+
+vi.mock('$lib/vault-protocol/helpers', () => ({
+	getVaultProtocolLogoUrl: (slug: string) => `https://example.com/protocol/${slug}.svg`
+}));
 
 function getRenderedVaultNames() {
 	return Array.from(document.querySelectorAll('tbody tr td.vault strong')).map((element) => element.textContent);
@@ -101,5 +106,48 @@ describe('TopVaultsTable risk rating column', () => {
 		expect(getRenderedVaultNames()).toEqual(['Safer Xerberus vault', 'Riskier Xerberus vault']);
 		expect(screen.getByText('91')).toBeInTheDocument();
 		expect(screen.getAllByText(/Xerberus scored this vault directly/)).toHaveLength(2);
+	});
+
+	it('uses curator logos before protocol logos when a chain column is hidden', () => {
+		const curatorVault = createTestVault('Curated vault', {
+			chain: 'arbitrum',
+			protocol: 'Aave',
+			curator_slug: 'curator'
+		});
+		const protocolVault = createTestVault('Protocol vault', { chain: 'arbitrum', protocol: 'Aave' });
+
+		render(TopVaultsTable, {
+			props: {
+				topVaults: {
+					generated_at: '2026-07-30T11:30:40Z',
+					vaults: [curatorVault, protocolVault],
+					core3_protocols: {},
+					curators: {
+						curator: {
+							slug: 'curator',
+							name: 'Example curator',
+							website: null,
+							twitter: null,
+							linkedin: null,
+							rss: null,
+							protocol_curator: false,
+							canonical_feeder_id: null,
+							logos: { generic: 'https://example.com/curator-logo.svg', light: null, dark: null },
+							recent_posts: []
+						}
+					}
+				},
+				chain: getChain('arbitrum')!
+			}
+		});
+
+		const curatorLogo = screen.getByText('Curated vault').closest('td')?.querySelector<HTMLImageElement>('.vault-logo');
+		const protocolLogo = screen
+			.getByText('Protocol vault')
+			.closest('td')
+			?.querySelector<HTMLImageElement>('.vault-logo');
+
+		expect(curatorLogo?.src).toBe('https://example.com/curator-logo.svg');
+		expect(protocolLogo?.src).toBe('https://example.com/protocol/aave.svg');
 	});
 });


### PR DESCRIPTION
## Why

Chain-specific vault listings omit the redundant chain column, leaving no visual identity for each vault.

## Lessons learnt

Curator metadata provides the preferred logo when available; protocol metadata is a reliable fallback.

## Summary

- Display curator logos first, then protocol logos, beside vault names on chain pages.
- Keep chain logos hidden on chain-specific listings.
- Add focused fallback coverage and a changelog entry.