### PR TITLE
Update vaults page meta description

### DIFF
--- a/src/routes/vaults/+page.svelte
+++ b/src/routes/vaults/+page.svelte
@@ -8,7 +8,7 @@
 	let topVaults = $derived(data.initialTopVaults);
 
 	const title = 'Top DeFi stablecoin vaults';
-	const description = 'The best DeFi vaults for all blockchains.';
+	const description = 'Vaults rankings with the highest yield and the lowest risk.';
 	let pageUrl = $derived(new URL(page.url.pathname, page.url.origin).href);
 </script>
 


### PR DESCRIPTION
Why

The /vaults page needs updated search/social metadata matching the requested copy for vault rankings.

Lessons learnt

The page uses one shared description value for standard meta tags, Open Graph, Twitter cards, and JSON-LD.

Summary

Updated the /vaults page meta description to: "Vaults rankings with the highest yield and the lowest risk."