### PR TITLE
Refine vault listing and dataset pages

### DIFF
--- a/src/lib/curator/CuratorDescription.svelte
+++ b/src/lib/curator/CuratorDescription.svelte
@@ -81,7 +81,7 @@ the vault protocol description widget. Sourced from the top-vaults dataset
 						{#if vaultCount}
 							{#if listingSummary}The current listing contains
 							{:else}{curator.name} has
-							{/if}<strong>{vaultCountLabel}</strong> with
+							{/if}{' '}<strong>{vaultCountLabel}</strong> with
 							<strong>{totalTvlLabel}</strong>{#if averageApyLabel}
 								{' '}and a <strong>{averageApyLabel}</strong> over the last 30 days{/if}.
 						{/if}

--- a/src/lib/top-vaults/TopVaultsTable.svelte
+++ b/src/lib/top-vaults/TopVaultsTable.svelte
@@ -19,7 +19,6 @@ Whitelisted vaults are marked as Private, except tokenised funds, which are mark
 	import { deserialiseSearchParams, serialiseSearchParams } from '$lib/helpers/url-search-state';
 	import Select from '$lib/components/Select.svelte';
 	import TargetableLink from '$lib/components/TargetableLink.svelte';
-	import TextInput from '$lib/components/TextInput.svelte';
 	import Timestamp from '$lib/components/Timestamp.svelte';
 	import Tooltip from '$lib/components/Tooltip.svelte';
 	import Spinner from '$lib/components/Spinner.svelte';
@@ -382,26 +381,8 @@ Whitelisted vaults are marked as Private, except tokenised funds, which are mark
 		hasLoadedFilterPreference = true;
 	});
 
-	// Text search: local state for responsive typing, synced to/from URL.
-	let filterValue = $state('');
-
-	$effect(() => {
-		const urlQ = urlState.q;
-		const current = untrack(() => filterValue);
-		if (urlQ !== current) {
-			filterValue = urlQ;
-		}
-	});
-
-	$effect(() => {
-		const value = filterValue;
-		const timer = setTimeout(() => {
-			if (value !== untrack(() => urlState.q)) {
-				updateSearchParams({ q: value });
-			}
-		}, 300);
-		return () => clearTimeout(timer);
-	});
+	// Preserve support for existing URL text-search links without exposing a listing-page search field.
+	let filterValue = $derived(urlState.q);
 
 	// --- Sort state (derived from URL) ---
 
@@ -1009,15 +990,6 @@ Whitelisted vaults are marked as Private, except tokenised funds, which are mark
 									</Tooltip>
 								</div>
 							{/if}
-
-							<div class="filter">
-								<TextInput
-									bind:value={filterValue}
-									type="search"
-									placeholder="Search by name, protocol, chain, denomination, risk or address"
-									data-testid="vault-search"
-								/>
-							</div>
 						</div>
 
 						<div class="secondary-filters">
@@ -1169,15 +1141,6 @@ Whitelisted vaults are marked as Private, except tokenised funds, which are mark
 						</div>
 					</div>
 				</details>
-			</div>
-		{:else}
-			<div class="filter">
-				<TextInput
-					bind:value={filterValue}
-					type="search"
-					placeholder="Search by name, protocol, chain, denomination, risk or address"
-					data-testid="vault-search"
-				/>
 			</div>
 		{/if}
 	</div>
@@ -1456,10 +1419,6 @@ Whitelisted vaults are marked as Private, except tokenised funds, which are mark
 			align-items: center;
 		}
 
-		.primary-filters > .filter {
-			flex: 1 12rem;
-		}
-
 		.filter-group {
 			display: flex;
 			align-items: center;
@@ -1592,10 +1551,6 @@ Whitelisted vaults are marked as Private, except tokenised funds, which are mark
 
 		.filter-group :global(.select) {
 			font: inherit;
-		}
-
-		.filter {
-			flex: 1 24rem;
 		}
 
 		.vault-filters {

--- a/src/routes/vaults/datasets/+page.svelte
+++ b/src/routes/vaults/datasets/+page.svelte
@@ -6,7 +6,7 @@ Vault datasets download page
 	import type { PageData } from './$types';
 	import { vaultApiUrl } from '$lib/config';
 	import { formatByteUnits } from '$lib/helpers/formatters';
-	import { Alert, Button, HeroBanner, Section, Spinner, TextInput, Timestamp } from '$lib/components';
+	import { Alert, Button, DataBadge, HeroBanner, Section, Spinner, TextInput, Timestamp } from '$lib/components';
 	import Breadcrumbs from '$lib/breadcrumb/Breadcrumbs.svelte';
 
 	let { data }: { data: PageData } = $props();
@@ -97,10 +97,18 @@ Vault datasets download page
 		<HeroBanner title="Vault datasets">
 			{#snippet subtitle()}
 				<p>
-					DeFi vault data download. For more information and purchasing a licence, see <a
+					Here you can find the vault information and historical performance datasets for analysis. The data can be read
+					in LLM, Python, Microsoft Excel and other applications. See the <a
 						class="body-link"
 						href={resolve('/pricing')}>pricing page</a
-					>.
+					> for information on how to purchase an API key to unlock professional datasets.
+				</p>
+				<p>
+					Find the <a
+						class="body-link"
+						href="https://tradingstrategy.ai/docs/overview/defi-vault-data.html"
+						rel="external">file and data description here</a
+					>. The page will also have instructions and examples for LLM agents on how to read and process this data.
 				</p>
 			{/snippet}
 		</HeroBanner>
@@ -159,7 +167,9 @@ Vault datasets download page
 				<tbody>
 					{#each data.datasets as row (row.id)}
 						<tr>
-							<td class="plan">{row.free ? 'Free' : 'PRO'}</td>
+							<td class="plan">
+								<DataBadge status={row.free ? 'success' : 'warning'}>{row.free ? 'Free' : 'Pro'}</DataBadge>
+							</td>
 							<td class="name">
 								<strong>{row.name}</strong>
 								<p class="filename">{row.filename}</p>

--- a/src/routes/vaults/protocols/+page.svelte
+++ b/src/routes/vaults/protocols/+page.svelte
@@ -7,6 +7,7 @@
 	import Section from '$lib/components/Section.svelte';
 	import VaultGroupTable from '$lib/top-vaults/VaultGroupTable.svelte';
 	import VaultListingsSelector from '$lib/top-vaults/VaultListingsSelector.svelte';
+	import { riskRatingProviders } from '$lib/top-vaults/risk-rating-providers';
 	import { formatDollar } from '$lib/helpers/formatters';
 	import { getVaultProtocolLogoUrl } from '$lib/vault-protocol/helpers.js';
 	import { JsonLd } from 'svelte-meta-tags';
@@ -80,6 +81,19 @@
 								<a class="body-link" href={glossaryLinks.apy}>APY</a>
 								represents the yield of the last thirty days.
 							</p>
+							<p>
+								Risk ratings from
+								<a class="risk-rating-link" href={resolve('/vaults/core3-ratings')}>
+									<img src={riskRatingProviders.core3.logoUrl} alt="" />
+									<span>CORE3</span>
+								</a>
+								and
+								<a class="risk-rating-link" href={resolve('/vaults/xerberus-ratings')}>
+									<img src={riskRatingProviders.xerberus.logoUrl} alt="" />
+									<span>Xerberus</span>
+								</a>
+								are provided.
+							</p>
 							<p>{totalTvlLabel} TVL tracked across {protocols.length} protocols.</p>
 						{/snippet}
 					</HeroBanner>
@@ -142,6 +156,23 @@
 
 		.chart-column :global(.market-share-pie-chart) {
 			align-self: stretch;
+		}
+
+		.risk-rating-link {
+			text-decoration: none;
+
+			span {
+				text-decoration: underline;
+			}
+
+			img {
+				display: inline-block;
+				width: 1em;
+				height: 1em;
+				margin-right: 0.25em;
+				object-fit: contain;
+				vertical-align: -0.1em;
+			}
 		}
 
 		@media (--viewport-sm-down) {

--- a/tests/integration/vaults/datasets.test.ts
+++ b/tests/integration/vaults/datasets.test.ts
@@ -19,6 +19,13 @@ test.describe('vault datasets page', () => {
 		await expect(page).toHaveTitle('Vault data');
 	});
 
+	test('links to the vault file and data description', async ({ page }) => {
+		await expect(page.getByRole('link', { name: 'file and data description here' })).toHaveAttribute(
+			'href',
+			'https://tradingstrategy.ai/docs/overview/defi-vault-data.html'
+		);
+	});
+
 	test('shows dataset catalogue table with all expected columns', async ({ page }) => {
 		for (const col of ['Plan', 'Name', 'Description', 'Format', 'Size', 'Last updated', 'Links']) {
 			await expect(page.getByRole('columnheader', { name: col })).toBeVisible();
@@ -33,6 +40,11 @@ test.describe('vault datasets page', () => {
 	test('lists free sample datasets', async ({ page }) => {
 		await expect(page.getByText('Vault metadata (sample)', { exact: true })).toBeVisible();
 		await expect(page.getByText('Vault prices (sample)', { exact: true })).toBeVisible();
+	});
+
+	test('marks Free and Pro datasets with coloured badges', async ({ page }) => {
+		await expect(page.locator('td.plan .data-badge.success').first()).toHaveText('Free');
+		await expect(page.locator('td.plan .data-badge.warning').first()).toHaveText('Pro');
 	});
 
 	test('shows expected filenames in dataset table', async ({ page }) => {

--- a/tests/integration/vaults/group-market-share-pages.test.ts
+++ b/tests/integration/vaults/group-market-share-pages.test.ts
@@ -88,3 +88,10 @@ for (const pageConfig of pages) {
 		});
 	});
 }
+
+test('protocols index links to CORE3 and Xerberus risk-rated vault listings', async ({ page }) => {
+	await page.goto('/vaults/protocols');
+
+	await expect(page.getByRole('link', { name: 'CORE3' })).toHaveAttribute('href', '/vaults/core3-ratings');
+	await expect(page.getByRole('link', { name: 'Xerberus' })).toHaveAttribute('href', '/vaults/xerberus-ratings');
+});

--- a/tests/integration/vaults/index.test.ts
+++ b/tests/integration/vaults/index.test.ts
@@ -110,7 +110,7 @@ test.describe('vault index page', () => {
 
 		await expect(primaryFilters.getByText('Technical risk', { exact: true })).toBeVisible();
 		await expect(primaryFilters.getByText('Hide undepositable', { exact: true })).toBeVisible();
-		await expect(primaryFilters.getByTestId('vault-search')).toBeVisible();
+		await expect(primaryFilters.getByTestId('vault-search')).toHaveCount(0);
 		await expect(page.locator('.filters-content').getByText('Min TVL')).toBeVisible();
 		await expect(page.locator('.filters-content').getByText('Age', { exact: true })).toBeVisible();
 		await expect(page.locator('.filters-content').getByText('Max drawdown')).toBeVisible();
@@ -171,7 +171,7 @@ test.describe('vault index page', () => {
 
 		await expect(mobileFiltersTrigger).toHaveAttribute('aria-expanded', 'true');
 		await expect(primaryFilters.getByText('Technical risk', { exact: true })).toBeVisible();
-		await expect(primaryFilters.getByTestId('vault-search')).toBeVisible();
+		await expect(primaryFilters.getByTestId('vault-search')).toHaveCount(0);
 		await expect(page.locator('.filters-content').getByText('Min TVL')).toBeVisible();
 		await expect(page.getByTestId('filters-summary')).not.toBeVisible();
 	});
@@ -338,11 +338,9 @@ test.describe('vault index page', () => {
 		await expect(sentinel).not.toBeVisible();
 	});
 
-	test('search filters displayed vaults', async ({ page }) => {
-		await openFilters(page);
-		const vaultSearch = page.getByTestId('vault-search');
+	test('applies text searches from the URL', async ({ page }) => {
+		await page.goto('/vaults?q=Above%20TVL%20042');
 		const rows = page.locator('tbody tr.targetable');
-		await vaultSearch.pressSequentially('Above TVL 042');
 		await expect(rows).toHaveCount(1);
 	});
 
@@ -513,9 +511,7 @@ test.describe('vault index page', () => {
 	});
 
 	test('marks private vaults and explains their whitelist status', async ({ page }) => {
-		await page.goto('/vaults/all');
-		await openFilters(page);
-		await page.getByTestId('vault-search').fill('Private vault');
+		await page.goto('/vaults/all?q=Private%20vault');
 
 		const cell = page.locator('tbody tr.targetable').filter({ hasText: 'Private vault' }).locator('td.lockup');
 		await expect(cell).toContainText('Private');
@@ -534,9 +530,7 @@ test.describe('vault index page', () => {
 			'Whitelist checks are handled by the vault'
 		);
 
-		await page.goto('/vaults/all');
-		await openFilters(page);
-		await page.getByTestId('vault-search').fill('Private tokenised fund');
+		await page.goto('/vaults/all?q=Private%20tokenised%20fund');
 		const fundCell = page
 			.locator('tbody tr.targetable')
 			.filter({ hasText: 'Private tokenised fund' })
@@ -547,9 +541,7 @@ test.describe('vault index page', () => {
 	});
 
 	test('shows capped instead of an unknown deposit delay when a vault has reached its cap', async ({ page }) => {
-		await page.goto('/vaults/all');
-		await openFilters(page);
-		await page.getByTestId('vault-search').fill('Deposit cap reached vault');
+		await page.goto('/vaults/all?q=Deposit%20cap%20reached%20vault');
 
 		const cell = page
 			.locator('tbody tr.targetable')


### PR DESCRIPTION
## Why

Improve the vault pages by making risk coverage discoverable, simplifying listing filters, and clarifying dataset access.

## Lessons learnt

Inline icons should align to the text baseline, and shared listing controls need one component-level change to stay consistent across every viewport.

## Summary

- Link CORE3 and Xerberus risk-rated listings from the protocol index, with inline provider logos.
- Remove the in-filter vault search field across listing pages while retaining URL search support.
- Improve curator summary spacing.
- Add Free and Pro dataset badges plus clearer dataset and API-key guidance.