### PR TITLE
feat: show pending treasury flow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Weblog of stuff
 
+- Show pending treasury deposits and redemptions in the GuardV0 deposit flow tooltip (2026-08-07)
 - Show curator or protocol logos in chain-specific vault listings (2026-08-06)
 - Show HyperAI's GuardV0 automated deposit and redemption settlement limit (2026-08-05)
 - Add a whitelisted vault ranking for permissioned deposits (2026-08-03)

--- a/src/lib/trade-executor/components/LagoonGuardV0Flow.svelte
+++ b/src/lib/trade-executor/components/LagoonGuardV0Flow.svelte
@@ -7,14 +7,18 @@ The card is hidden unless GuardV0 enables a positive limit with its expected
 -->
 <script lang="ts">
 	import type { LagoonSmartContracts } from 'trade-executor/schemas/summary';
+	import type { TreasurySync } from 'trade-executor/schemas/state';
 	import MetricsBox from '$lib/components/MetricsBox.svelte';
+	import Tooltip from '$lib/components/Tooltip.svelte';
 	import { formatDollar } from '$lib/helpers/formatters';
 
 	type Props = {
 		guard: LagoonSmartContracts['lagoon_guard_v0'];
+		treasury?: TreasurySync | null;
+		treasuryPromise?: Promise<TreasurySync | null | undefined>;
 	};
 
-	let { guard }: Props = $props();
+	let { guard, treasury, treasuryPromise }: Props = $props();
 
 	let automatedSettlementLimit = $derived(
 		guard?.daily_automatic_settlement_limit_enabled &&
@@ -24,11 +28,53 @@ The card is hidden unless GuardV0 enables a positive limit with its expected
 			? guard.daily_automatic_settlement_limit
 			: undefined
 	);
+
+	/**
+	 * Render pending treasury flow values from the trade-executor state sync section.
+	 */
+	function formatPendingFlow(value: number | null | undefined) {
+		return formatDollar(value ?? 0, 0, 2, { notation: 'standard' });
+	}
 </script>
+
+{#snippet pendingFlowTooltip(treasury: TreasurySync | null | undefined)}
+	<div class="pending-flow-tooltip">
+		<p>Pending deposit and redemption flow currently waiting in the treasury.</p>
+		<dl>
+			<div>
+				<dt>Pending deposits</dt>
+				<dd>{formatPendingFlow(treasury?.pending_deposits)}</dd>
+			</div>
+			<div>
+				<dt>Pending redemptions</dt>
+				<dd>{formatPendingFlow(treasury?.pending_redemptions)}</dd>
+			</div>
+		</dl>
+	</div>
+{/snippet}
 
 {#if automatedSettlementLimit}
 	<MetricsBox title="Deposit and redemption flow">
-		<p class="limit">{formatDollar(automatedSettlementLimit, 0, 0, { notation: 'standard' })}<span>/24h</span></p>
+		<p class="limit">
+			<Tooltip>
+				<span slot="trigger" class="underline"
+					>{formatDollar(automatedSettlementLimit, 0, 0, { notation: 'standard' })}</span
+				>
+				<svelte:fragment slot="popup">
+					{#if treasuryPromise}
+						{#await treasuryPromise}
+							Pending treasury flow is loading.
+						{:then resolvedTreasury}
+							{@render pendingFlowTooltip(resolvedTreasury)}
+						{:catch}
+							Pending treasury flow is not available.
+						{/await}
+					{:else}
+						{@render pendingFlowTooltip(treasury)}
+					{/if}
+				</svelte:fragment>
+			</Tooltip><span>/24h</span>
+		</p>
 		<p class="description">
 			Automated settlement is limited to this amount of combined deposit and redemption flow each day. Larger flows
 			require manual settlement by the vault's Safe and may take longer to process.
@@ -47,11 +93,22 @@ The card is hidden unless GuardV0 enables a positive limit with its expected
 		letter-spacing: var(--ls-heading-xl);
 		color: var(--c-text);
 
+		:global(.tooltip) {
+			display: inline-block;
+		}
+
 		span {
 			margin-left: 0.25rem;
 			font: var(--f-ui-md-medium);
 			letter-spacing: var(--ls-ui-md);
 			color: var(--c-text-extra-light);
+		}
+
+		:global(.tooltip > .trigger > span) {
+			margin-left: 0;
+			font: inherit;
+			letter-spacing: inherit;
+			color: inherit;
 		}
 	}
 
@@ -60,5 +117,37 @@ The card is hidden unless GuardV0 enables a positive limit with its expected
 		color: var(--c-text-extra-light);
 		font: var(--f-ui-sm-medium);
 		letter-spacing: var(--ls-ui-sm);
+	}
+
+	.pending-flow-tooltip {
+		display: grid;
+		gap: 0.75rem;
+		min-width: 14rem;
+
+		p,
+		dl {
+			margin: 0;
+		}
+
+		dl {
+			display: grid;
+			gap: 0.5rem;
+		}
+
+		dl > div {
+			display: flex;
+			justify-content: space-between;
+			gap: 1rem;
+		}
+
+		dt {
+			color: var(--c-text-light);
+		}
+
+		dd {
+			margin: 0;
+			font-weight: 500;
+			color: var(--c-text);
+		}
 	}
 </style>

--- a/src/lib/trade-executor/components/LagoonGuardV0Flow.test.ts
+++ b/src/lib/trade-executor/components/LagoonGuardV0Flow.test.ts
@@ -10,11 +10,34 @@ const guard = {
 
 describe('LagoonGuardV0Flow', () => {
 	it('displays the daily automated settlement allowance', () => {
-		render(LagoonGuardV0Flow, { guard });
+		render(LagoonGuardV0Flow, {
+			guard,
+			treasury: {
+				pending_deposits: 1200,
+				pending_redemptions: 345.67
+			}
+		});
 
 		expect(screen.getByRole('heading', { name: 'Deposit and redemption flow' })).toBeInTheDocument();
 		expect(screen.getByText('$5,000')).toBeInTheDocument();
 		expect(screen.getByText('/24h')).toBeInTheDocument();
+		expect(screen.getByText('Pending deposits')).toBeInTheDocument();
+		expect(screen.getByText('$1,200')).toBeInTheDocument();
+		expect(screen.getByText('Pending redemptions')).toBeInTheDocument();
+		expect(screen.getByText('$346')).toBeInTheDocument();
+	});
+
+	it('displays pending treasury flow from the strategy state promise', async () => {
+		render(LagoonGuardV0Flow, {
+			guard,
+			treasuryPromise: Promise.resolve({
+				pending_deposits: 10_000,
+				pending_redemptions: 2500
+			})
+		});
+
+		expect(await screen.findByText('$10,000')).toBeInTheDocument();
+		expect(await screen.findByText('$2,500')).toBeInTheDocument();
 	});
 
 	it.each([

--- a/src/lib/trade-executor/schemas/state.test.ts
+++ b/src/lib/trade-executor/schemas/state.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest';
+import { syncSchema } from './state';
+
+describe('state schemas', () => {
+	it('parses pending treasury deposits and redemptions', () => {
+		const sync = syncSchema.parse({
+			treasury: {
+				pending_deposits: '123.45',
+				pending_redemptions: 67.89,
+				last_block_scanned: 123456
+			}
+		});
+
+		expect(sync.treasury?.pending_deposits).toBe(123.45);
+		expect(sync.treasury?.pending_redemptions).toBe(67.89);
+		expect(sync.treasury?.['last_block_scanned']).toBe(123456);
+	});
+});

--- a/src/lib/trade-executor/schemas/state.ts
+++ b/src/lib/trade-executor/schemas/state.ts
@@ -6,7 +6,7 @@
  *
  */
 import { z } from 'zod';
-import { count, unixTimestamp } from './utility-types';
+import { count, unixTimestamp, usDollarAmount } from './utility-types';
 import { portfolioSchema } from './portfolio';
 import { statisticsSchema } from './statistics';
 
@@ -16,6 +16,21 @@ export const backtestDataSchema = z.object({
 	decision_cycle_duration: z.string()
 });
 
+export const treasurySyncSchema = z
+	.object({
+		pending_deposits: usDollarAmount.nullish(),
+		pending_redemptions: usDollarAmount.nullish()
+	})
+	.passthrough();
+export type TreasurySync = z.infer<typeof treasurySyncSchema>;
+
+export const syncSchema = z
+	.object({
+		treasury: treasurySyncSchema.nullish()
+	})
+	.passthrough();
+export type Sync = z.infer<typeof syncSchema>;
+
 export const stateSchema = z.object({
 	created_at: unixTimestamp,
 	last_updated_at: unixTimestamp.nullish(),
@@ -24,10 +39,10 @@ export const stateSchema = z.object({
 	portfolio: portfolioSchema,
 	stats: statisticsSchema,
 	asset_blacklist: z.string().array(),
-	// skipping visualisation, uptime and sync types for now
+	sync: syncSchema.nullish(),
+	// skipping visualisation and uptime types for now
 	// visualisation: visualisation,
 	// uptime: uptime,
-	// sync: sync
 	backtest_data: backtestDataSchema.nullish()
 });
 export type State = z.infer<typeof stateSchema>;

--- a/src/routes/strategies/[strategy=apiStrategy]/+page.svelte
+++ b/src/routes/strategies/[strategy=apiStrategy]/+page.svelte
@@ -46,7 +46,10 @@ Strategy overview dashboard.
 	<StrategyPerformanceChart {strategy} />
 	<SummaryMetrics {keyMetrics} {backtestLink} hideTimeframes={strategy.hiddenElements.timeframes}>
 		{#if strategy.on_chain_data.asset_management_mode === 'lagoon'}
-			<LagoonGuardV0Flow guard={strategy.on_chain_data.smart_contracts.lagoon_guard_v0} />
+			<LagoonGuardV0Flow
+				guard={strategy.on_chain_data.smart_contracts.lagoon_guard_v0}
+				treasuryPromise={data.deferred.state.then((state) => state?.sync?.treasury)}
+			/>
 		{/if}
 	</SummaryMetrics>
 </div>


### PR DESCRIPTION
## Why

HyperAI state now exposes pending treasury deposits and redemptions. Investors need these values near the GuardV0 automated deposit and redemption flow capacity so they can understand how much treasury flow is already waiting for settlement.

## Lessons learnt

The trade-executor state parser was intentionally skipping most of `sync`, so backend state fields can exist without being available to typed frontend components. Keep new state-backed UI additions paired with narrow schema coverage for the exact fields being displayed.

## Summary

- Add typed parsing for `sync.treasury.pending_deposits` and `sync.treasury.pending_redemptions`, while preserving other treasury fields.
- Show pending deposits and redemptions in a tooltip on the GuardV0 deposit and redemption flow capacity number.
- Add focused unit coverage for treasury schema parsing and the tooltip, including the deferred state promise path.
- Add a changelog entry for the user-facing feature.