### PR TITLE
feat: show vault protocol and chain in search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Weblog of stuff
 
 - Show pending treasury deposits and redemptions in the GuardV0 deposit flow tooltip (2026-08-07)
+- Show vault protocol and chain names in desktop search suggestions (2026-08-07)
 - Show curator or protocol logos in chain-specific vault listings (2026-08-06)
 - Show HyperAI's GuardV0 automated deposit and redemption settlement limit (2026-08-05)
 - Add a whitelisted vault ranking for permissioned deposits (2026-08-03)

--- a/src/lib/search/components/Search.svelte
+++ b/src/lib/search/components/Search.svelte
@@ -8,6 +8,7 @@ underlying vault JSON index private.
 <script lang="ts">
 	import { onMount, tick } from 'svelte';
 	import { goto } from '$app/navigation';
+	import { resolve } from '$app/paths';
 	import { disableScroll } from '$lib/actions/scroll';
 	import { removeOnError } from '$lib/actions/image';
 	import { formatDollar, formatPercent, notFilledMarker } from '$lib/helpers/formatters';
@@ -154,7 +155,7 @@ underlying vault JSON index private.
 		}
 		if (event.key === 'Enter' && selectedIndex >= 0) {
 			event.preventDefault();
-			goto(results[selectedIndex].href);
+			goto(resolve(results[selectedIndex].href as `/vaults/${string}`));
 			closeSearchForNavigation();
 		}
 	}
@@ -162,7 +163,7 @@ underlying vault JSON index private.
 	function handleSubmit(event: SubmitEvent) {
 		if (selectedIndex >= 0) {
 			event.preventDefault();
-			goto(results[selectedIndex].href);
+			goto(resolve(results[selectedIndex].href as `/vaults/${string}`));
 		}
 		closeSearchForNavigation();
 	}
@@ -265,7 +266,7 @@ underlying vault JSON index private.
 									class:active={selectedIndex === index}
 									class:no-logo={!result.logoUrl}
 									data-entity-type={result.entityType}
-									href={result.href}
+									href={resolve(result.href as `/vaults/${string}`)}
 									role="option"
 									aria-selected={selectedIndex === index}
 									onpointerdown={(event) => event.preventDefault()}
@@ -281,6 +282,13 @@ underlying vault JSON index private.
 												<span class="entity-type-marker" aria-hidden="true"></span>
 												{searchEntityLabels[result.entityType]}
 											</span>
+											{#if result.protocolName && result.chainName}
+												<span class="vault-context" title={`${result.protocolName} · ${result.chainName}`}>
+													<span>{result.protocolName}</span>
+													<span aria-hidden="true">·</span>
+													<span>{result.chainName}</span>
+												</span>
+											{/if}
 											{#if address}<span>· {address}</span>{/if}
 										</span>
 									</span>
@@ -306,8 +314,10 @@ underlying vault JSON index private.
 			</div>
 
 			{#if hasQuery}
-				<a class="show-all" href={`/search?q=${encodeURIComponent(query.trim())}`} onclick={closeSearchForNavigation}
-					>Show all results</a
+				<a
+					class="show-all"
+					href={resolve(`/search?q=${encodeURIComponent(query.trim())}` as '/search')}
+					onclick={closeSearchForNavigation}>Show all results</a
 				>
 			{/if}
 		</div>
@@ -427,6 +437,7 @@ underlying vault JSON index private.
 		display: grid;
 		min-width: 0;
 		gap: 0.125rem;
+		container-type: inline-size;
 	}
 	.result-main strong {
 		overflow: hidden;
@@ -441,12 +452,16 @@ underlying vault JSON index private.
 		display: flex;
 		align-items: center;
 		gap: 0.35rem;
+		min-width: 0;
+		overflow: hidden;
 		color: var(--c-text-extra-light);
 		font: var(--f-ui-xs-medium);
 		text-transform: capitalize;
+		white-space: nowrap;
 	}
 	.entity-type {
 		display: inline-flex;
+		flex: 0 0 auto;
 		align-items: center;
 		gap: 0.35rem;
 		color: var(--entity-colour);
@@ -457,6 +472,16 @@ underlying vault JSON index private.
 		height: 0.5rem;
 		border-radius: 0.125rem;
 		background: currentColor;
+	}
+	.vault-context {
+		display: none;
+		min-width: 0;
+		overflow: hidden;
+	}
+	.vault-context span:not([aria-hidden]) {
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
 	}
 	.result-sparkline {
 		justify-items: end;
@@ -613,6 +638,13 @@ underlying vault JSON index private.
 	}
 
 	@media (--nav-expanded) {
+		@container (min-width: 18rem) {
+			.vault-context {
+				display: inline-flex;
+				align-items: center;
+				gap: 0.35rem;
+			}
+		}
 		.result-sparkline {
 			display: block;
 			width: 7rem;

--- a/src/lib/search/entities.ts
+++ b/src/lib/search/entities.ts
@@ -41,6 +41,10 @@ export interface SearchResult {
 	vaultId: string | null;
 	/** Full vault contract address; null for non-vault entities. */
 	address: string | null;
+	/** Human-readable vault protocol name; null for non-vault entities. */
+	protocolName: string | null;
+	/** Human-readable vault chain name; null for non-vault entities. */
+	chainName: string | null;
 	averageApy1m: number | null;
 	latestTvl: number | null;
 	href: string;

--- a/src/lib/search/vault-search.server.ts
+++ b/src/lib/search/vault-search.server.ts
@@ -1,5 +1,5 @@
 import { getLogoUrl } from '$lib/helpers/assets';
-import { getChain } from '$lib/helpers/chain';
+import { getChain, getChainDisplayName } from '$lib/helpers/chain';
 import { fetchStablecoinMetadataIndex } from '$lib/stablecoin-metadata/client';
 import {
 	buildStablecoinMetadataLookup,
@@ -13,6 +13,7 @@ import {
 	getCurrencyUsdRates,
 	getMonthlyReturn,
 	getProtocolDisplayName,
+	getVaultProtocolDisplayName,
 	getVaultCurrentTvlUsd,
 	isBlacklisted,
 	isUnknownVaultProtocol,
@@ -127,6 +128,8 @@ function buildIndex(topVaults: TopVaults, stablecoins: StablecoinMetadata[]): In
 						: 'vault',
 				vaultId: vault.id,
 				address: vault.address,
+				protocolName: getVaultProtocolDisplayName(vault),
+				chainName: getChainDisplayName(vault.chain_id),
 				averageApy1m: getMonthlyReturn(vault),
 				latestTvl: getVaultCurrentTvlUsd(vault),
 				href: `/vaults/${vault.vault_slug}`,
@@ -182,6 +185,8 @@ function buildIndex(topVaults: TopVaults, stablecoins: StablecoinMetadata[]): In
 				entityType: 'curator',
 				vaultId: null,
 				address: null,
+				protocolName: null,
+				chainName: null,
 				...getGroupMetrics(groupVaults),
 				href: `/vaults/curators/${slug}`,
 				logoUrl: logos?.generic ?? logos?.light ?? logos?.dark ?? null
@@ -201,6 +206,8 @@ function buildIndex(topVaults: TopVaults, stablecoins: StablecoinMetadata[]): In
 				entityType: 'protocol',
 				vaultId: null,
 				address: null,
+				protocolName: null,
+				chainName: null,
 				...getGroupMetrics(groupVaults),
 				href: `/vaults/protocols/${slug}`,
 				logoUrl: getVaultProtocolLogoUrl(slug) ?? null
@@ -224,6 +231,8 @@ function buildIndex(topVaults: TopVaults, stablecoins: StablecoinMetadata[]): In
 				entityType: 'stablecoin',
 				vaultId: null,
 				address: null,
+				protocolName: null,
+				chainName: null,
 				...getGroupMetrics(groupVaults),
 				href: `/vaults/stablecoins/${slug}`,
 				logoUrl: getStablecoinLogoUrl(slug) ?? null
@@ -243,6 +252,8 @@ function buildIndex(topVaults: TopVaults, stablecoins: StablecoinMetadata[]): In
 				entityType: 'chain',
 				vaultId: null,
 				address: null,
+				protocolName: null,
+				chainName: null,
 				...getGroupMetrics(groupVaults),
 				href: `/vaults/chains/${slug}`,
 				logoUrl: getLogoUrl('blockchain', slug) ?? null

--- a/tests/integration/navigation.test.ts
+++ b/tests/integration/navigation.test.ts
@@ -116,6 +116,12 @@ test('renders equivalent, colour-coded protocol and vault typeahead results on d
 		await expect(vault).toBeVisible();
 		await expect(vault).not.toContainText('3M price');
 		await expect(vault.locator('.logo-slot img')).toHaveAttribute('src', '/brand-mark-100x100.png');
+		const vaultContext = vault.locator('.vault-context');
+		if (name === 'desktop') {
+			await expect(vaultContext).toHaveAttribute('title', /.+ · .+/);
+		} else {
+			await expect(vaultContext).not.toBeVisible();
+		}
 
 		if (name === 'mobile') {
 			const dialog = await page.getByRole('dialog', { name: 'Search' }).boundingBox();


### PR DESCRIPTION
## Why

Desktop search results need enough context to distinguish otherwise similar vault names without making compact search layouts harder to scan.

## Lessons learnt

Search suggestions should carry display-ready protocol and chain names from the server index. Container queries keep optional metadata constrained by the actual result-row space, while the navigation breakpoint keeps tablet and mobile results compact.

## Summary

- Add protocol and chain names to vault search suggestion data.
- Display the names beside the Vault badge only in sufficiently wide desktop results.
- Cover desktop, tablet, and mobile visibility with responsive Playwright integration coverage.
- Record the visible change in the changelog.