### PR TITLE
fix: label Fira-hosted Euler vault link

### DIFF
--- a/src/routes/vaults/[vault=slug]/VaultPageHeader.svelte
+++ b/src/routes/vaults/[vault=slug]/VaultPageHeader.svelte
@@ -20,8 +20,18 @@ Displays a vault's heading, external link, update action, and important operatio
 
 	let { vault }: Props = $props();
 
+	const FIRA_HOSTNAME = 'app.fira.money';
+
 	let externalSiteName = $derived.by(() => {
+		// Fira hosts the live market UI for a migrated Euler vault.
+		// The vault must remain categorised as Euler, so do not change its protocol metadata.
+		// This presentation-only exception makes the call to action describe where it actually goes.
+		if (vault.link && new URL(vault.link).hostname === FIRA_HOSTNAME) return 'Fira';
+
+		// Other supported vaults continue to use their protocol name in the call to action.
 		if (hasSupportedProtocol(vault)) return getVaultProtocolDisplayName(vault);
+
+		// Unknown-protocol vaults fall back to the hostname of their external destination.
 		if (vault.link) return new URL(vault.link).host;
 	});
 	let hideCtaOnMobile = $derived(externalSiteName === 'Ostium');


### PR DESCRIPTION
## Why

A migrated Euler vault can link to Fira while its CTA continues to use the Euler protocol label, making the destination misleading.

## Lessons learnt

A vault protocol classification and its external market destination can differ after a migration; CTA copy must account for the destination when that happens.

## Summary

- Detect Fira-hosted vault links in the vault-page header.
- Show “View on Fira” while retaining Euler as the vault protocol.
- Document the narrowly scoped presentation exception inline.