### PR TITLE
fix: override migrated Fira vault destination

### DIFF
--- a/src/routes/vaults/[vault=slug]/VaultPageHeader.svelte
+++ b/src/routes/vaults/[vault=slug]/VaultPageHeader.svelte
@@ -21,18 +21,25 @@ Displays a vault's heading, external link, update action, and important operatio
 	let { vault }: Props = $props();
 
 	const FIRA_HOSTNAME = 'app.fira.money';
+	const FIRA_VAULT_SLUG = 'vi-usdc-qa-g';
+	const FIRA_VAULT_URL = 'https://app.fira.money/market/busd0-usd0?type=variable';
+
+	// The public top-vaults feed temporarily still provides the retired Euler Earn URL for this vault.
+	// Keep this override local to the outbound CTA, rather than changing the vault's Euler protocol classification.
+	// Remove it when the feed permanently serves FIRA_VAULT_URL for FIRA_VAULT_SLUG.
+	let externalVaultUrl = $derived(vault.vault_slug === FIRA_VAULT_SLUG ? FIRA_VAULT_URL : vault.link);
 
 	let externalSiteName = $derived.by(() => {
 		// Fira hosts the live market UI for a migrated Euler vault.
 		// The vault must remain categorised as Euler, so do not change its protocol metadata.
 		// This presentation-only exception makes the call to action describe where it actually goes.
-		if (vault.link && new URL(vault.link).hostname === FIRA_HOSTNAME) return 'Fira';
+		if (externalVaultUrl && new URL(externalVaultUrl).hostname === FIRA_HOSTNAME) return 'Fira';
 
 		// Other supported vaults continue to use their protocol name in the call to action.
 		if (hasSupportedProtocol(vault)) return getVaultProtocolDisplayName(vault);
 
 		// Unknown-protocol vaults fall back to the hostname of their external destination.
-		if (vault.link) return new URL(vault.link).host;
+		if (externalVaultUrl) return new URL(externalVaultUrl).host;
 	});
 	let hideCtaOnMobile = $derived(externalSiteName === 'Ostium');
 	let showTvlWarning = $derived(isVaultTvlDownMoreThan95Percent(vault));
@@ -47,8 +54,8 @@ Displays a vault's heading, external link, update action, and important operatio
 
 	{#snippet cta()}
 		<span class="cta-actions" class:mobile-hidden={hideCtaOnMobile}>
-			{#if vault.link}
-				<Button href={vault.link} target="_blank" rel="noreferrer">
+			{#if externalVaultUrl}
+				<Button href={externalVaultUrl} target="_blank" rel="noreferrer">
 					{externalSiteName === 'Ostium' ? 'Open vault on Ostium' : `View on ${externalSiteName}`}
 				</Button>
 			{/if}

--- a/src/routes/vaults/[vault=slug]/VaultPageHeader.test.ts
+++ b/src/routes/vaults/[vault=slug]/VaultPageHeader.test.ts
@@ -1,0 +1,19 @@
+import { render, screen } from '@testing-library/svelte';
+import { expect, test } from 'vitest';
+import { createTestVault } from '$lib/top-vaults/test-utils';
+import VaultPageHeader from './VaultPageHeader.svelte';
+
+test('uses Fira for the migrated Euler vault while preserving its protocol metadata', () => {
+	const vault = createTestVault('vi-usdc-qa-g', {
+		protocol: 'Euler',
+		protocol_slug: 'euler',
+		link: 'https://app.euler.finance/earn/0xd80C3E98c9093b41645c07c2B6D956136F89559b?network=146'
+	});
+
+	render(VaultPageHeader, { props: { vault } });
+
+	expect(screen.getByRole('link', { name: 'View on Fira' })).toHaveAttribute(
+		'href',
+		'https://app.fira.money/market/busd0-usd0?type=variable'
+	);
+});


### PR DESCRIPTION
## Why

The live top-vaults feed still supplies a retired Euler Earn URL for `vi-usdc-qa-g`, so a hostname-only Fira label override cannot take effect after deployment.

## Lessons learnt

A presentation override that depends on refreshed source data cannot correct a stale destination. A temporary CTA-level URL override is needed until the data feed is updated.

## Summary

- Override the migrated vault CTA with its verified Fira market URL.
- Keep the vault categorised under Euler.
- Add a component test for the Fira label and destination.