### PR TITLE
fix: expand dusty position warning threshold

### DIFF
--- a/src/lib/trade-executor/models/position-info.test.ts
+++ b/src/lib/trade-executor/models/position-info.test.ts
@@ -184,11 +184,11 @@ describe('dust position warning', () => {
 		expect(createTradingPositionInfo(position).isDustPositionWarning).toBe(true);
 	});
 
-	test('detects a tiny residual quantity in final stats', () => {
+	test('detects a residual position valued at the $5 dust threshold', () => {
 		const position = tradingPositionSchema.parse({
 			...rawPosition,
 			closed_at: POSITION_OPEN_TS + 3 * HOUR,
-			last_token_price: 0.95
+			last_token_price: 5
 		});
 		const residualStats = [
 			positionStat({
@@ -200,8 +200,8 @@ describe('dust position warning', () => {
 			positionStat({
 				calculated_at: POSITION_OPEN_TS + 4 * HOUR,
 				last_valuation_at: POSITION_OPEN_TS + 4 * HOUR,
-				quantity: 1.0023875,
-				value: 0
+				quantity: 1,
+				value: 5
 			})
 		];
 

--- a/src/lib/trade-executor/models/position-info.ts
+++ b/src/lib/trade-executor/models/position-info.ts
@@ -13,7 +13,7 @@ import type { TimeBucket } from '$lib/schemas/utility';
 import { type TradeDirection, TradeDirections } from './trade-info';
 import { isNumber } from '$lib/helpers/formatters';
 
-const DUST_POSITION_VALUE_THRESHOLD_USD = 2;
+const DUST_POSITION_VALUE_THRESHOLD_USD = 5;
 const MIN_RESIDUAL_QUANTITY = 1e-12;
 
 export const createTradingPositionInfo = <T extends TradingPosition>(base: T, stats: PositionStatistics[] = []) => ({


### PR DESCRIPTION
## Why

Residual positions worth more than $2 can still be too small for their metrics to be meaningful. Raising the warning cutoff to $5 covers the current HyperAI residual position.

## Lessons learnt

The dust warning relies on a fixed USD cutoff, so the test suite should cover the inclusive boundary whenever that threshold changes.

## Summary

- Raise the dusty-position warning threshold from $2 to $5.
- Cover a residual position valued exactly at the new threshold.