### PR TITLE
feat: refine vault detail information layout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Weblog of stuff
 
+- Improve vault detail card layouts and disclosure controls (2026-08-10)
 - Show curator or protocol logos in chain-specific vault listings (2026-08-06)
 - Show HyperAI's GuardV0 automated deposit and redemption settlement limit (2026-08-05)
 - Add a whitelisted vault ranking for permissioned deposits (2026-08-03)

--- a/src/lib/components/MetricsBox.svelte
+++ b/src/lib/components/MetricsBox.svelte
@@ -4,13 +4,14 @@
 	interface Props {
 		title?: string;
 		class?: string;
+		fill?: boolean;
 		children: Snippet;
 	}
 
-	let { title, class: classes, children }: Props = $props();
+	let { title, class: classes, fill = false, children }: Props = $props();
 </script>
 
-<div class={['metrics-box', classes]}>
+<div class={['metrics-box', fill && 'fill', classes]}>
 	{#if title}
 		<h2>{title}</h2>
 	{/if}
@@ -37,6 +38,10 @@
 			@media (--viewport-sm-down) {
 				font-size: 0.875rem;
 			}
+		}
+
+		&.fill {
+			grid-template-rows: 1fr;
 		}
 	}
 </style>

--- a/src/lib/top-vaults/Core3Ratings.svelte
+++ b/src/lib/top-vaults/Core3Ratings.svelte
@@ -116,133 +116,151 @@ page); omit it on the protocol page itself to render the name as plain text.
 				{:else}
 					The rating applies to all vaults on this protocol.
 				{/if}
-				{#if reportUrl}
-					<!-- eslint-disable-next-line svelte/no-navigation-without-resolve -->
-					<a href={reportUrl} target="_blank" rel="noreferrer">View full rating on the CORE3 website</a>.
-				{/if}
 			</p>
 
-			<div class="columns">
-				<table class="data">
-					<tbody>
-						{#if core3.pol?.score != null}
-							<tr>
-								<th>
-									<Tooltip>
-										<!-- eslint-disable-next-line svelte/no-navigation-without-resolve -->
-										<a slot="trigger" class="metric-link" href={CORE3_METHODOLOGY_URL} target="_blank" rel="noreferrer">
-											Probability of Loss
-											<IconQuestionCircle />
-										</a>
-										<svelte:fragment slot="popup">
-											<p>
-												CORE3's Probability of Loss (PoL) estimates how likely users or token holders are to suffer a
-												financially material loss, excluding market price moves.
-											</p>
-											<p>
-												The scale runs 0–100 — lower is better — and maps to a letter grade from AA (lowest risk) down
-												to D.
-											</p>
-											<p>
-												It is a weighted aggregate of risk categories
-												{#if categoryScores.length}(this protocol's sub-scores in brackets){/if}:
-											</p>
-											<ul>
-												{#each methodologyWeights as { key, label, weight } (key)}
-													<li>{label} — {weight}%{categoryScoreSuffix(key)}</li>
-												{/each}
-												<li>Dependency — 15% (coming soon)</li>
-											</ul>
-											<p>
-												The total is then scaled by 1.0–1.3× for factors such as protocol longevity, past incidents and
-												category leadership.
+			<details class="rating-details">
+				<summary>
+					View details
+					<IconChevronDown />
+				</summary>
+
+				<div class="rating-details-content">
+					<div class="columns">
+						<table class="data">
+							<tbody>
+								{#if core3.pol?.score != null}
+									<tr>
+										<th>
+											<Tooltip>
 												<!-- eslint-disable-next-line svelte/no-navigation-without-resolve -->
-												<a href={CORE3_METHODOLOGY_URL} target="_blank" rel="noreferrer">Read CORE3 methodology</a>.
-											</p>
-										</svelte:fragment>
-									</Tooltip>
-								</th>
-								<td>{formatNumber(core3.pol.score, 2, 2)}</td>
-							</tr>
-						{/if}
-						{#if core3.pol?.confidence}
-							<tr>
-								<th>Confidence</th>
-								<td>{core3.pol.confidence}</td>
-							</tr>
-						{/if}
-						{#if core3.rank != null}
-							<tr>
-								<th>
-									<Tooltip>
-										<!-- eslint-disable-next-line svelte/no-navigation-without-resolve -->
-										<a slot="trigger" class="metric-link" href={rankingUrl} target="_blank" rel="noreferrer">
-											CORE3 rank
-											<IconQuestionCircle />
-										</a>
-										<svelte:fragment slot="popup">
-											Where this protocol ranks among all DeFi protocols rated by CORE3, ordered by risk (1 = best).
-											Opens the CORE3 ranking page.
-										</svelte:fragment>
-									</Tooltip>
-								</th>
-								<td>#{core3.rank}</td>
-							</tr>
-						{/if}
-					</tbody>
-				</table>
+												<a
+													slot="trigger"
+													class="metric-link"
+													href={CORE3_METHODOLOGY_URL}
+													target="_blank"
+													rel="noreferrer"
+												>
+													Probability of Loss
+													<IconQuestionCircle />
+												</a>
+												<svelte:fragment slot="popup">
+													<p>
+														CORE3's Probability of Loss (PoL) estimates how likely users or token holders are to suffer
+														a financially material loss, excluding market price moves.
+													</p>
+													<p>
+														The scale runs 0–100 — lower is better — and maps to a letter grade from AA (lowest risk)
+														down to D.
+													</p>
+													<p>
+														It is a weighted aggregate of risk categories
+														{#if categoryScores.length}(this protocol's sub-scores in brackets){/if}:
+													</p>
+													<ul>
+														{#each methodologyWeights as { key, label, weight } (key)}
+															<li>{label} — {weight}%{categoryScoreSuffix(key)}</li>
+														{/each}
+														<li>Dependency — 15% (coming soon)</li>
+													</ul>
+													<p>
+														The total is then scaled by 1.0–1.3× for factors such as protocol longevity, past incidents
+														and category leadership.
+														<!-- eslint-disable-next-line svelte/no-navigation-without-resolve -->
+														<a href={CORE3_METHODOLOGY_URL} target="_blank" rel="noreferrer">Read CORE3 methodology</a>.
+													</p>
+												</svelte:fragment>
+											</Tooltip>
+										</th>
+										<td>{formatNumber(core3.pol.score, 2, 2)}</td>
+									</tr>
+								{/if}
+								{#if core3.pol?.confidence}
+									<tr>
+										<th>Confidence</th>
+										<td>{core3.pol.confidence}</td>
+									</tr>
+								{/if}
+								{#if core3.rank != null}
+									<tr>
+										<th>
+											<Tooltip>
+												<!-- eslint-disable-next-line svelte/no-navigation-without-resolve -->
+												<a slot="trigger" class="metric-link" href={rankingUrl} target="_blank" rel="noreferrer">
+													CORE3 rank
+													<IconQuestionCircle />
+												</a>
+												<svelte:fragment slot="popup">
+													Where this protocol ranks among all DeFi protocols rated by CORE3, ordered by risk (1 = best).
+													Opens the CORE3 ranking page.
+												</svelte:fragment>
+											</Tooltip>
+										</th>
+										<td>#{core3.rank}</td>
+									</tr>
+								{/if}
+							</tbody>
+						</table>
 
-				<table class="data">
-					<tbody>
-						{#if dataCoverage != null}
-							<tr>
-								<th>Data coverage</th>
-								<td>{formatNumber(dataCoverage, 1, 1)}%</td>
-							</tr>
-						{/if}
-						{#if core3.category?.name}
-							<tr>
-								<th>Category</th>
-								<td>{core3.category.name}</td>
-							</tr>
-						{/if}
-						{#if marketCap}
-							<tr>
-								<th>Market cap</th>
-								<td>{formatDollar(marketCap, 1, 1, { notation: 'compact' })}</td>
-							</tr>
-						{/if}
-					</tbody>
-				</table>
-			</div>
+						<table class="data">
+							<tbody>
+								{#if dataCoverage != null}
+									<tr>
+										<th>Data coverage</th>
+										<td>{formatNumber(dataCoverage, 1, 1)}%</td>
+									</tr>
+								{/if}
+								{#if core3.category?.name}
+									<tr>
+										<th>Category</th>
+										<td>{core3.category.name}</td>
+									</tr>
+								{/if}
+								{#if marketCap}
+									<tr>
+										<th>Market cap</th>
+										<td>{formatDollar(marketCap, 1, 1, { notation: 'compact' })}</td>
+									</tr>
+								{/if}
+							</tbody>
+						</table>
+					</div>
 
-			{#if categoryScores.length}
-				<section class="scorecard">
-					<h3>Risk score by category</h3>
-					<p class="scorecard-note">Sub-scores run 0–100 — lower is better.</p>
-					<ul class="scores">
-						{#each categoryScores as cat (cat.key)}
-							<li>
-								<span class="label">{cat.label}</span>
-								<span class="value">{formatNumber(cat.score, 0, 0)}</span>
-								<span
-									class="meter"
-									data-tone={cat.tone}
-									role="meter"
-									aria-valuemin="0"
-									aria-valuemax="100"
-									aria-valuenow={cat.score}
-									aria-label="{cat.label} risk score {formatNumber(cat.score, 0, 0)} out of 100"
-								>
-									{#each meterDotIndices as i (i)}
-										<span class="dot" style="--frac: {Math.min(Math.max(cat.score / 10 - i, 0), 1)}"></span>
-									{/each}
-								</span>
-							</li>
-						{/each}
-					</ul>
-				</section>
-			{/if}
+					{#if categoryScores.length}
+						<section class="scorecard">
+							<h3>Risk score by category</h3>
+							<p class="scorecard-note">Sub-scores run 0–100 — lower is better.</p>
+							<ul class="scores">
+								{#each categoryScores as cat (cat.key)}
+									<li>
+										<span class="label">{cat.label}</span>
+										<span class="value">{formatNumber(cat.score, 0, 0)}</span>
+										<span
+											class="meter"
+											data-tone={cat.tone}
+											role="meter"
+											aria-valuemin="0"
+											aria-valuemax="100"
+											aria-valuenow={cat.score}
+											aria-label="{cat.label} risk score {formatNumber(cat.score, 0, 0)} out of 100"
+										>
+											{#each meterDotIndices as i (i)}
+												<span class="dot" style="--frac: {Math.min(Math.max(cat.score / 10 - i, 0), 1)}"></span>
+											{/each}
+										</span>
+									</li>
+								{/each}
+							</ul>
+						</section>
+					{/if}
+
+					{#if reportUrl}
+						<!-- eslint-disable-next-line svelte/no-navigation-without-resolve -->
+						<a class="full-rating-link" href={reportUrl} target="_blank" rel="noreferrer"
+							>View full rating on the CORE3 website</a
+						>
+					{/if}
+				</div>
+			</details>
 		</div>
 	{/if}
 </MetricsBox>
@@ -357,6 +375,45 @@ page); omit it on the protocol page itself to render the name as plain text.
 			font-weight: 500;
 			color: var(--c-text-light);
 		}
+	}
+
+	.full-rating-link,
+	.rating-details summary {
+		width: fit-content;
+		font: var(--f-ui-md-medium);
+		color: var(--c-text-light);
+		text-decoration: underline;
+	}
+
+	.rating-details {
+		border-top: 1px solid var(--c-box-3);
+		padding-top: 1.25rem;
+
+		summary {
+			display: flex;
+			align-items: center;
+			gap: 0.25rem;
+			cursor: pointer;
+			list-style: none;
+
+			&::-webkit-details-marker {
+				display: none;
+			}
+
+			:global(.icon) {
+				transition: rotate 0.15s ease;
+			}
+		}
+
+		&[open] summary :global(.icon) {
+			rotate: 180deg;
+		}
+	}
+
+	.rating-details-content {
+		display: grid;
+		gap: 1.25rem;
+		padding-top: 1.25rem;
 	}
 
 	.columns {

--- a/src/routes/vaults/[vault=slug]/+page.svelte
+++ b/src/routes/vaults/[vault=slug]/+page.svelte
@@ -135,27 +135,21 @@ Vault detail page with performance, protocol, private-deposit, and third-party r
 
 		<VaultMetrics {vault} {stablecoinMetadata} />
 
-		{#if vault.description}
-			<MetricsBox class="description" title="About the vault">
-				<Markdown content={vault.description} />
-			</MetricsBox>
-		{/if}
+		<div class="vault-information">
+			{#if vault.description}
+				<MetricsBox class="description" title="About the vault">
+					<Markdown content={vault.description} />
+				</MetricsBox>
+			{/if}
 
-		{#if showNotes && vault.notes}
-			<MetricsBox class="notes" title="Notes">
-				<Markdown content={vault.notes} />
-			</MetricsBox>
-		{/if}
+			{#if curatorMetadata}
+				<VaultCuratorInfo {vault} curator={curatorMetadata} />
+			{/if}
 
-		{#if curatorMetadata}
-			<VaultCuratorInfo {vault} curator={curatorMetadata} />
-		{/if}
-
-		{#if protocolMetadata}
-			<VaultProtocolInfo {vault} {protocolMetadata} />
-		{/if}
-
-		<VaultPeriodicMetrics {vault} {chain} />
+			{#if protocolMetadata}
+				<VaultProtocolInfo {vault} {protocolMetadata} />
+			{/if}
+		</div>
 
 		{#if vault.xerberus}
 			<XerberusRisk xerberus={vault.xerberus} />
@@ -169,6 +163,14 @@ Vault detail page with performance, protocol, private-deposit, and third-party r
 				context="vault"
 			/>
 		{/if}
+
+		{#if showNotes && vault.notes}
+			<MetricsBox class="notes" title="Notes">
+				<Markdown content={vault.notes} />
+			</MetricsBox>
+		{/if}
+
+		<VaultPeriodicMetrics {vault} {chain} />
 
 		<VaultTechnicalDetailsTable {vault} {chain} {stablecoinMetadata} {generated_at} />
 	</Section>
@@ -206,6 +208,15 @@ Vault detail page with performance, protocol, private-deposit, and third-party r
 	.notification-stack {
 		display: grid;
 		gap: var(--space-md);
+	}
+
+	.vault-information {
+		display: grid;
+		gap: var(--gap);
+
+		@media (--viewport-lg-up) {
+			grid-template-columns: repeat(3, minmax(0, 1fr));
+		}
 	}
 
 	:global(:is(.description, .notes)) {

--- a/src/routes/vaults/[vault=slug]/VaultCuratorInfo.svelte
+++ b/src/routes/vaults/[vault=slug]/VaultCuratorInfo.svelte
@@ -29,13 +29,15 @@ curator.
 	let assetType = $derived(vault.flags.includes('tokenised_fund') ? 'tokenised fund' : 'vault');
 </script>
 
-<MetricsBox>
+<MetricsBox fill>
 	<div class="curator-info">
-		{#if curatorLogoUrl}
-			<img src={curatorLogoUrl} alt={curator.name} class="curator-logo" />
-		{/if}
 		<div class="content">
-			<h2>Curated by {curator.name}</h2>
+			<div class="heading">
+				{#if curatorLogoUrl}
+					<img src={curatorLogoUrl} alt={curator.name} class="curator-logo" />
+				{/if}
+				<h2>Curated by {curator.name}</h2>
+			</div>
 			<p class="description">
 				This {assetType} is curated by <a href={curatorPageUrl}>{curator.name}</a>.
 			</p>
@@ -51,24 +53,10 @@ curator.
 
 <style>
 	.curator-info {
-		display: grid;
-		grid-template-columns: 1fr auto;
+		display: flex;
+		flex-direction: column;
 		gap: 1rem;
-		align-items: center;
-
-		&:has(.curator-logo) {
-			grid-template-columns: auto 1fr auto;
-		}
-
-		@media (--viewport-sm-down) {
-			.content {
-				grid-column: span 2;
-			}
-
-			:global(.view-all-btn) {
-				grid-area: 2 / span 3;
-			}
-		}
+		height: 100%;
 
 		.curator-logo {
 			max-width: 9rem;
@@ -80,6 +68,12 @@ curator.
 			display: grid;
 			gap: 0.625rem;
 			min-width: 0;
+
+			.heading {
+				display: flex;
+				gap: 1rem;
+				align-items: start;
+			}
 
 			h2 {
 				margin: 0;
@@ -93,6 +87,11 @@ curator.
 					font-size: 0.875rem;
 				}
 			}
+		}
+
+		:global(.view-all-btn) {
+			--button-width: 100%;
+			margin-top: auto;
 		}
 
 		.description {

--- a/src/routes/vaults/[vault=slug]/VaultMetrics.svelte
+++ b/src/routes/vaults/[vault=slug]/VaultMetrics.svelte
@@ -290,7 +290,7 @@ Displays supplementary vault information, including transaction status, performa
 		</div>
 	</MetricsBox>
 
-	<MetricsBox class="performance" title="Returns and fees">
+	<MetricsBox class="performance" title="Performance and fees">
 		<div class="table-scroll">
 			<table class="vault-metrics-table">
 				<thead>

--- a/src/routes/vaults/[vault=slug]/VaultPeriodicMetrics.svelte
+++ b/src/routes/vaults/[vault=slug]/VaultPeriodicMetrics.svelte
@@ -71,7 +71,7 @@ Performance metrics table for a vault across multiple lookback periods.
 		label: string | (() => string);
 		field: keyof PeriodMetrics;
 		formatter: (value: unknown) => string;
-		hidden?: boolean; // hidden until expanded (double-click)
+		hidden?: boolean; // hidden until expanded
 		excluded?: boolean; // permanently excluded from display
 	};
 
@@ -79,7 +79,7 @@ Performance metrics table for a vault across multiple lookback periods.
 		return typeof row.label === 'function' ? row.label() : row.label;
 	}
 
-	// Expanded state - toggled on double-click
+	// Expanded state - toggled by the View all control
 	let expanded = $state(false);
 
 	// Row definitions in display order
@@ -131,35 +131,41 @@ Performance metrics table for a vault across multiple lookback periods.
 		{
 			label: '<a href="/glossary/volatility">Volatility</a>',
 			field: 'volatility',
-			formatter: (v) => formatPercent(v as number | null)
+			formatter: (v) => formatPercent(v as number | null),
+			hidden: true
 		},
 		{
 			label: '<a href="/glossary/total-value-locked-tvl">TVL</a> low',
 			field: 'tvl_low',
-			formatter: (v) => formatDollar(v as number | null)
+			formatter: (v) => formatDollar(v as number | null),
+			hidden: true
 		},
 		{
 			label: '<a href="/glossary/total-value-locked-tvl">TVL</a> high',
 			field: 'tvl_high',
-			formatter: (v) => formatDollar(v as number | null)
+			formatter: (v) => formatDollar(v as number | null),
+			hidden: true
 		},
 		{
 			label: () => `Share price start (${vault.denomination})`,
 			field: 'share_price_start',
-			formatter: (v) => formatNumber(v as number | null, 4, 6)
+			formatter: (v) => formatNumber(v as number | null, 4, 6),
+			hidden: true
 		},
 		{
 			label: () => `Share price end (${vault.denomination})`,
 			field: 'share_price_end',
-			formatter: (v) => formatNumber(v as number | null, 4, 6)
+			formatter: (v) => formatNumber(v as number | null, 4, 6),
+			hidden: true
 		},
 		{
 			label: 'Period data availability',
 			field: 'daily_samples',
-			formatter: formatDays
+			formatter: formatDays,
+			hidden: true
 		},
-		{ label: 'Period start', field: 'period_start_at', formatter: formatDate },
-		{ label: 'Period end', field: 'period_end_at', formatter: formatDate },
+		{ label: 'Period start', field: 'period_start_at', formatter: formatDate, hidden: true },
+		{ label: 'Period end', field: 'period_end_at', formatter: formatDate, hidden: true },
 		{
 			label: 'Raw samples',
 			field: 'raw_samples',
@@ -197,9 +203,8 @@ Performance metrics table for a vault across multiple lookback periods.
 </script>
 
 {#if vault.period_results?.length}
-	<!-- svelte-ignore a11y_no_static_element_interactions -->
-	<div class="periodic-metrics" ondblclick={() => (expanded = !expanded)}>
-		<MetricsBox title="Performance metrics">
+	<div class="periodic-metrics">
+		<MetricsBox title="Returns and period details">
 			<div class="table-wrapper">
 				<table class="period-table">
 					<thead>
@@ -241,6 +246,9 @@ Performance metrics table for a vault across multiple lookback periods.
 					</tbody>
 				</table>
 			</div>
+			<button class="view-all" type="button" onclick={() => (expanded = !expanded)} aria-expanded={expanded}>
+				{expanded ? 'View less' : 'View all'}
+			</button>
 		</MetricsBox>
 	</div>
 {/if}
@@ -248,6 +256,21 @@ Performance metrics table for a vault across multiple lookback periods.
 <style>
 	.table-wrapper {
 		overflow-x: auto;
+	}
+
+	.view-all {
+		margin-top: 1rem;
+		padding: 0;
+		border: 0;
+		background: none;
+		color: var(--c-text-light);
+		font: var(--f-ui-md-medium);
+		text-decoration: underline;
+		cursor: pointer;
+
+		&:hover {
+			color: var(--c-text);
+		}
 	}
 
 	.period-table {

--- a/src/routes/vaults/[vault=slug]/VaultProtocolInfo.svelte
+++ b/src/routes/vaults/[vault=slug]/VaultProtocolInfo.svelte
@@ -21,16 +21,18 @@
 	let assetType = $derived(vault.flags.includes('tokenised_fund') ? 'tokenised fund' : 'vault');
 </script>
 
-<MetricsBox>
+<MetricsBox fill>
 	<div class="protocol-info">
-		{#if protocolMetadata.logos.light}
-			{@const protocolLogoUrl = getVaultProtocolLogoUrl(protocolMetadata.slug)}
-			{#if protocolLogoUrl}
-				<img src={protocolLogoUrl} alt={protocolMetadata.name} class="protocol-logo" />
-			{/if}
-		{/if}
 		<div class="content">
-			<h2>Running on {protocolMetadata.name} protocol</h2>
+			<div class="heading">
+				{#if protocolMetadata.logos.light}
+					{@const protocolLogoUrl = getVaultProtocolLogoUrl(protocolMetadata.slug)}
+					{#if protocolLogoUrl}
+						<img src={protocolLogoUrl} alt={protocolMetadata.name} class="protocol-logo" />
+					{/if}
+				{/if}
+				<h2>Running on {protocolMetadata.name} protocol</h2>
+			</div>
 			<p class="description">
 				This {assetType} is running on <a href={protocolPageUrl}>{protocolMetadata.name}</a>:
 			</p>
@@ -44,24 +46,10 @@
 
 <style>
 	.protocol-info {
-		display: grid;
-		grid-template-columns: 1fr auto;
+		display: flex;
+		flex-direction: column;
 		gap: 1rem;
-		align-items: center;
-
-		&:has(.protocol-logo) {
-			grid-template-columns: auto 1fr auto;
-		}
-
-		@media (--viewport-sm-down) {
-			.content {
-				grid-column: span 2;
-			}
-
-			:global(.view-all-btn) {
-				grid-area: 2 / span 3;
-			}
-		}
+		height: 100%;
 
 		.protocol-logo {
 			height: 3rem;
@@ -71,6 +59,13 @@
 		.content {
 			display: grid;
 			gap: 0.625rem;
+			min-width: 0;
+
+			.heading {
+				display: flex;
+				gap: 1rem;
+				align-items: start;
+			}
 
 			h2 {
 				margin: 0;
@@ -84,6 +79,11 @@
 					font-size: 0.875rem;
 				}
 			}
+		}
+
+		:global(.view-all-btn) {
+			--button-width: 100%;
+			margin-top: auto;
 		}
 
 		.description {

--- a/tests/integration/strategies/yaml-strategy.test.ts
+++ b/tests/integration/strategies/yaml-strategy.test.ts
@@ -63,7 +63,9 @@ test.describe('YAML-configured strategy', () => {
 		await expect(page.getByText('Returns and period details')).toBeVisible();
 		await expect(page.getByRole('columnheader', { name: 'Month', exact: true })).toBeVisible();
 		await expect(page.getByRole('columnheader', { name: '3 months' })).toBeVisible();
-		const periodTable = page.locator('.period-table');
+		const periodicMetrics = page.locator('.periodic-metrics');
+		await periodicMetrics.getByRole('button', { name: 'View all' }).click();
+		const periodTable = periodicMetrics.locator('.period-table');
 		await expect(periodTable).toContainText('Period data availability');
 		await expect(periodTable).toContainText('30 days');
 		await expect(periodTable).toContainText('90 days');

--- a/tests/integration/strategies/yaml-strategy.test.ts
+++ b/tests/integration/strategies/yaml-strategy.test.ts
@@ -60,7 +60,7 @@ test.describe('YAML-configured strategy', () => {
 		const response = await page.goto(`${BASE}/performance`);
 		expect(response?.status()).toBe(200);
 
-		await expect(page.getByText('Performance metrics')).toBeVisible();
+		await expect(page.getByText('Returns and period details')).toBeVisible();
 		await expect(page.getByRole('columnheader', { name: 'Month', exact: true })).toBeVisible();
 		await expect(page.getByRole('columnheader', { name: '3 months' })).toBeVisible();
 		const periodTable = page.locator('.period-table');


### PR DESCRIPTION
## Why

Improve the vault detail page hierarchy so the supporting information, risk data and extended metrics are easier to scan on every viewport.

## Lessons learnt

Reusable information cards need a fill layout variant when actions must remain aligned at the bottom of equally sized grid cards.

## Summary

- Arrange vault, curator and protocol information cards in a responsive desktop grid.
- Improve card logo and action placement.
- Add clear expandable controls for period and CORE3 rating details.
- Reorder standalone risk cards above notes and refine section labels.