### PR TITLE
feat: refine vault detail information layout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Weblog of stuff
 
 - Let vault information cards fill the available desktop row space (2026-08-10)
+- Add a details disclosure to Xerberus risk rating cards (2026-08-10)
 - Improve vault detail card layouts and disclosure controls (2026-08-10)
 - Show pending treasury deposits and redemptions in the GuardV0 deposit flow tooltip (2026-08-07)
 - Show vault protocol and chain names in desktop search suggestions (2026-08-07)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Weblog of stuff
 
+- Refine vault risk summaries and transaction-status placement (2026-08-10)
 - Centre content-sized vault information card actions (2026-08-10)
 - Consolidate vault notifications beneath the page heading (2026-08-10)
 - Let vault information cards fill the available desktop row space (2026-08-10)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Weblog of stuff
 
+- Consolidate vault notifications beneath the page heading (2026-08-10)
 - Let vault information cards fill the available desktop row space (2026-08-10)
 - Add a details disclosure to Xerberus risk rating cards (2026-08-10)
 - Improve vault detail card layouts and disclosure controls (2026-08-10)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Weblog of stuff
 
+- Centre content-sized vault information card actions (2026-08-10)
 - Consolidate vault notifications beneath the page heading (2026-08-10)
 - Let vault information cards fill the available desktop row space (2026-08-10)
 - Add a details disclosure to Xerberus risk rating cards (2026-08-10)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Weblog of stuff
 
+- Let vault information cards fill the available desktop row space (2026-08-10)
 - Improve vault detail card layouts and disclosure controls (2026-08-10)
 - Show pending treasury deposits and redemptions in the GuardV0 deposit flow tooltip (2026-08-07)
 - Show vault protocol and chain names in desktop search suggestions (2026-08-07)

--- a/docs/vault-data-source.md
+++ b/docs/vault-data-source.md
@@ -67,6 +67,14 @@ The frontend treats unrecognised source values as `unknown`, and preserves optio
 
 Other reasons, including high utilisation or permissioning, remain their source-provided status rather than being inferred as a cap.
 
+#### Detail-page risk summaries
+
+The vault detail page's **Other metrics** card shows one third-party provider result when it is available. A vault-level or protocol-level Xerberus assessment takes precedence and is shown as **Xerberus risk**. Its score is displayed as `score / 100`; higher scores indicate a stronger rating (lower estimated risk), so it is not a Probability of Loss percentage. The score tooltip states whether Xerberus assessed the vault directly or its underlying protocol.
+
+When no Xerberus assessment is available, the card uses the resolved CORE3 protocol rating as **CORE3 risk**. CORE3 uses credit-style labels from AA (lowest Probability of Loss) to D (highest). If neither provider has data, the card falls back to the frontend's protocol technical-risk classification.
+
+The full Xerberus and CORE3 cards remain below the vault-information cards. Transaction availability is shown after those provider cards so restrictions and their corresponding risk context remain together.
+
 ### Vault prices parquet
 
 **Code:** `src/lib/top-vaults/vault-prices-parquet.ts` → `ensureVaultPricesParquet()`

--- a/src/lib/top-vaults/XerberusRisk.svelte
+++ b/src/lib/top-vaults/XerberusRisk.svelte
@@ -20,6 +20,7 @@ mistake protocol coverage for a vault-specific assessment.
 	import type { XerberusVault } from './schemas';
 	import type { XerberusProtocolScore } from '$lib/xerberus/protocol-scores';
 	import IconQuestionCircle from '~icons/local/question-circle';
+	import IconChevronDown from '~icons/local/chevron-down';
 
 	interface Props {
 		xerberus: XerberusVault | XerberusProtocolScore;
@@ -48,50 +49,58 @@ mistake protocol coverage for a vault-specific assessment.
 			<h2>Xerberus risk rating</h2>
 		</header>
 
-		<table class="data" class:protocol={context === 'protocol'}>
-			<tbody>
-				<tr>
-					<th>
-						<Tooltip>
-							<span slot="trigger" class="metric-label">
-								Xerberus score
-								<IconQuestionCircle />
-							</span>
-							<svelte:fragment slot="popup">
-								The Xerberus assessment uses a 0–100 scale. Higher scores represent a stronger rating.
-							</svelte:fragment>
-						</Tooltip>
-					</th>
-					<td>{formatNumber(score, 0, 0)} / 100</td>
-				</tr>
-				{#if context !== 'protocol'}
-					<tr>
-						<th>Assessment level</th>
-						<td>{assessmentLabel}</td>
-					</tr>
-					<tr>
-						<th>Rated entity</th>
-						<td>{xerberus.name}</td>
-					</tr>
-				{/if}
-			</tbody>
-		</table>
+		{#if context !== 'protocol'}
+			<p class="intro">{assessmentDescription}</p>
+		{/if}
 
-		<footer class="footer">
-			{#if context !== 'protocol'}
-				<p>{assessmentDescription}</p>
-			{/if}
-			{#if reportUrl}
-				<!-- eslint-disable-next-line svelte/no-navigation-without-resolve -->
-				<a href={reportUrl} target="_blank" rel="noreferrer" class:protocol-link={context === 'protocol'}>
-					{#if context === 'protocol'}
-						<span>View this protocol on Xerberus</span> to understand the protocol risk score.
-					{:else}
-						View this {isPoolAssessment ? 'vault' : 'protocol'} rating on Xerberus
-					{/if}
-				</a>
-			{/if}
-		</footer>
+		<details class="rating-details">
+			<summary>
+				View details
+				<IconChevronDown />
+			</summary>
+
+			<div class="rating-details-content">
+				<table class="data" class:protocol={context === 'protocol'}>
+					<tbody>
+						<tr>
+							<th>
+								<Tooltip>
+									<span slot="trigger" class="metric-label">
+										Xerberus score
+										<IconQuestionCircle />
+									</span>
+									<svelte:fragment slot="popup">
+										The Xerberus assessment uses a 0–100 scale. Higher scores represent a stronger rating.
+									</svelte:fragment>
+								</Tooltip>
+							</th>
+							<td>{formatNumber(score, 0, 0)} / 100</td>
+						</tr>
+						{#if context !== 'protocol'}
+							<tr>
+								<th>Assessment level</th>
+								<td>{assessmentLabel}</td>
+							</tr>
+							<tr>
+								<th>Rated entity</th>
+								<td>{xerberus.name}</td>
+							</tr>
+						{/if}
+					</tbody>
+				</table>
+
+				{#if reportUrl}
+					<!-- eslint-disable-next-line svelte/no-navigation-without-resolve -->
+					<a href={reportUrl} target="_blank" rel="noreferrer" class:protocol-link={context === 'protocol'}>
+						{#if context === 'protocol'}
+							<span>View this protocol on Xerberus</span> to understand the protocol risk score.
+						{:else}
+							View this {isPoolAssessment ? 'vault' : 'protocol'} rating on Xerberus
+						{/if}
+					</a>
+				{/if}
+			</div>
+		</details>
 	</div>
 </MetricsBox>
 
@@ -139,28 +148,18 @@ mistake protocol coverage for a vault-specific assessment.
 		color: color-mix(in srgb, var(--c-text), var(--c-link) 80%);
 	}
 
-	.footer {
-		border-top: 1px solid var(--c-box-3);
-		padding-top: 1.25rem;
-		display: grid;
-		gap: 0.5rem;
-
-		p {
-			margin: 0;
-		}
-
-		a {
-			justify-self: start;
-		}
-	}
-
-	.footer p,
-	.footer a {
+	.intro,
+	.rating-details a {
 		font: var(--f-ui-md-roman);
 		color: var(--c-text-extra-light);
 	}
 
-	.footer a {
+	.intro {
+		margin: 0;
+	}
+
+	.rating-details a {
+		justify-self: start;
 		text-decoration: underline;
 		font-weight: 500;
 		color: var(--c-text-light);
@@ -172,6 +171,41 @@ mistake protocol coverage for a vault-specific assessment.
 				text-decoration: underline;
 			}
 		}
+	}
+
+	.rating-details {
+		border-top: 1px solid var(--c-box-3);
+		padding-top: 1.25rem;
+
+		summary {
+			display: flex;
+			align-items: center;
+			gap: 0.25rem;
+			width: fit-content;
+			cursor: pointer;
+			list-style: none;
+			font: var(--f-ui-md-medium);
+			color: var(--c-text-light);
+			text-decoration: underline;
+
+			&::-webkit-details-marker {
+				display: none;
+			}
+
+			:global(.icon) {
+				transition: rotate 0.15s ease;
+			}
+		}
+
+		&[open] summary :global(.icon) {
+			rotate: 180deg;
+		}
+	}
+
+	.rating-details-content {
+		display: grid;
+		gap: 1.25rem;
+		padding-top: 1.25rem;
 	}
 
 	table.data {

--- a/src/routes/vaults/[vault=slug]/+page.svelte
+++ b/src/routes/vaults/[vault=slug]/+page.svelte
@@ -30,7 +30,8 @@ Vault detail page with performance, protocol, private-deposit, and third-party r
 		getVaultProtocolDisplayName,
 		hasSupportedProtocol,
 		isBlacklisted,
-		isVaultDepositCapped
+		isVaultDepositCapped,
+		isVaultTvlDownMoreThan95Percent
 	} from '$lib/top-vaults/helpers';
 	import { getCuratorSocialLogoUrl } from '$lib/social-card/helpers';
 	import { getVaultProtocolLogoUrl } from '$lib/vault-protocol/helpers.js';
@@ -48,6 +49,8 @@ Vault detail page with performance, protocol, private-deposit, and third-party r
 	let isTokenisedFund = $derived(vault.flags.includes('tokenised_fund'));
 	let isPrivate = $derived(vault.whitelist?.status === 'whitelisted');
 	let isCapped = $derived(isVaultDepositCapped(vault));
+	let showTvlWarning = $derived(isVaultTvlDownMoreThan95Percent(vault));
+	let showLongDurationWarning = $derived(vault.flags.includes('long_duration'));
 	let depositMayBeDisabled = $derived(vault.deposit_closed_reason != null);
 	let redemptionMayBeDisabled = $derived(vault.redemption_closed_reason != null);
 	let operationWarning = $derived(
@@ -76,8 +79,10 @@ Vault detail page with performance, protocol, private-deposit, and third-party r
 		<VaultListingsSelector />
 	</Section>
 
-	{#if operationWarning || isPrivate || morphoFlags.length > 0}
-		<Section padding="md">
+	<VaultPageHeader {vault} />
+
+	<Section padding="md" --section-gap="var(--gap)">
+		{#if operationWarning || isPrivate || morphoFlags.length > 0 || showTvlWarning || showLongDurationWarning || showBlacklistedAlert || !hasSupportedProtocol(vault)}
 			<div class="notification-stack">
 				{#if isTokenisedFund && (operationWarning || isPrivate)}
 					<Alert size="md" status="info">
@@ -96,33 +101,43 @@ Vault detail page with performance, protocol, private-deposit, and third-party r
 					>
 				{/if}
 
+				{#if showTvlWarning}
+					<Alert size="md" status="warning">
+						The value in this vault is down more than 95% of its peak. The vault is likely abandoned or facing issues.
+					</Alert>
+				{/if}
+
+				{#if showLongDurationWarning}
+					<Alert size="md" status="error">
+						This vault may have especially long duration redemption periods. Make sure you check the redemptions before
+						depositing.
+					</Alert>
+				{/if}
+
 				{#if morphoFlags.length > 0}
 					<Alert size="md" status={morphoAlertStatus} title="Morpho has flagged this vault">
 						{morphoFlags.join(', ')}
 					</Alert>
 				{/if}
+
+				{#if showBlacklistedAlert}
+					<Alert size="md" title="Blacklisted">
+						{vault.notes ?? 'Unknown reason'}
+					</Alert>
+				{/if}
+
+				{#if !hasSupportedProtocol(vault)}
+					<Alert size="md" status="warning" title="Protocol not supported">
+						<div>
+							This protocol is not supported yet. Contact us on Discord for information about how to include new
+							protocols.
+						</div>
+						<Button slot="cta" size="sm" label="Join Discord" href={discordUrl} target="_blank" rel="noreferrer">
+							<IconDiscord slot="icon" />
+						</Button>
+					</Alert>
+				{/if}
 			</div>
-		</Section>
-	{/if}
-
-	<VaultPageHeader {vault} />
-
-	<Section padding="md" --section-gap="var(--gap)">
-		{#if showBlacklistedAlert}
-			<Alert size="md" title="Blacklisted">
-				{vault.notes ?? 'Unknown reason'}
-			</Alert>
-		{/if}
-
-		{#if !hasSupportedProtocol(vault)}
-			<Alert size="md" status="warning" title="Protocol not supported">
-				<div>
-					This protocol is not supported yet. Contact us on Discord for information about how to include new protocols.
-				</div>
-				<Button slot="cta" size="sm" label="Join Discord" href={discordUrl} target="_blank" rel="noreferrer">
-					<IconDiscord slot="icon" />
-				</Button>
-			</Alert>
 		{/if}
 
 		<VaultRankings {vault} {chain} {protocolMetadata} />

--- a/src/routes/vaults/[vault=slug]/+page.svelte
+++ b/src/routes/vaults/[vault=slug]/+page.svelte
@@ -215,7 +215,7 @@ Vault detail page with performance, protocol, private-deposit, and third-party r
 		gap: var(--gap);
 
 		@media (--viewport-lg-up) {
-			grid-template-columns: repeat(3, minmax(0, 1fr));
+			grid-template-columns: repeat(auto-fit, minmax(15rem, 1fr));
 		}
 	}
 

--- a/src/routes/vaults/[vault=slug]/+page.svelte
+++ b/src/routes/vaults/[vault=slug]/+page.svelte
@@ -22,6 +22,7 @@ Vault detail page with performance, protocol, private-deposit, and third-party r
 	import VaultCuratorInfo from './VaultCuratorInfo.svelte';
 	import VaultProtocolInfo from './VaultProtocolInfo.svelte';
 	import VaultRankings from './VaultRankings.svelte';
+	import VaultTransactionStatus from './VaultTransactionStatus.svelte';
 	import Core3Ratings from '$lib/top-vaults/Core3Ratings.svelte';
 	import XerberusRisk from '$lib/top-vaults/XerberusRisk.svelte';
 	import IconDiscord from '~icons/local/discord';
@@ -51,6 +52,7 @@ Vault detail page with performance, protocol, private-deposit, and third-party r
 	let isCapped = $derived(isVaultDepositCapped(vault));
 	let showTvlWarning = $derived(isVaultTvlDownMoreThan95Percent(vault));
 	let showLongDurationWarning = $derived(vault.flags.includes('long_duration'));
+	let hasUnsupportedProtocol = $derived(!hasSupportedProtocol(vault));
 	let depositMayBeDisabled = $derived(vault.deposit_closed_reason != null);
 	let redemptionMayBeDisabled = $derived(vault.redemption_closed_reason != null);
 	let operationWarning = $derived(
@@ -65,6 +67,15 @@ Vault detail page with performance, protocol, private-deposit, and third-party r
 					: redemptionMayBeDisabled
 						? 'Withdrawals may be disabled for this vault'
 						: undefined
+	);
+	let hasNotifications = $derived(
+		operationWarning != null ||
+			isPrivate ||
+			morphoFlags.length > 0 ||
+			showTvlWarning ||
+			showLongDurationWarning ||
+			showBlacklistedAlert ||
+			hasUnsupportedProtocol
 	);
 	let chartLogoUrl = $derived(
 		getCuratorSocialLogoUrl(curatorMetadata) ??
@@ -82,7 +93,7 @@ Vault detail page with performance, protocol, private-deposit, and third-party r
 	<VaultPageHeader {vault} />
 
 	<Section padding="md" --section-gap="var(--gap)">
-		{#if operationWarning || isPrivate || morphoFlags.length > 0 || showTvlWarning || showLongDurationWarning || showBlacklistedAlert || !hasSupportedProtocol(vault)}
+		{#if hasNotifications}
 			<div class="notification-stack">
 				{#if isTokenisedFund && (operationWarning || isPrivate)}
 					<Alert size="md" status="info">
@@ -126,7 +137,7 @@ Vault detail page with performance, protocol, private-deposit, and third-party r
 					</Alert>
 				{/if}
 
-				{#if !hasSupportedProtocol(vault)}
+				{#if hasUnsupportedProtocol}
 					<Alert size="md" status="warning" title="Protocol not supported">
 						<div>
 							This protocol is not supported yet. Contact us on Discord for information about how to include new
@@ -148,7 +159,7 @@ Vault detail page with performance, protocol, private-deposit, and third-party r
 		<VaultUtilisationChart {vault} />
 		-->
 
-		<VaultMetrics {vault} {stablecoinMetadata} />
+		<VaultMetrics {vault} {stablecoinMetadata} {core3} />
 
 		<div class="vault-information">
 			{#if vault.description}
@@ -178,6 +189,8 @@ Vault detail page with performance, protocol, private-deposit, and third-party r
 				context="vault"
 			/>
 		{/if}
+
+		<VaultTransactionStatus {vault} />
 
 		{#if showNotes && vault.notes}
 			<MetricsBox class="notes" title="Notes">

--- a/src/routes/vaults/[vault=slug]/VaultCuratorInfo.svelte
+++ b/src/routes/vaults/[vault=slug]/VaultCuratorInfo.svelte
@@ -90,7 +90,7 @@ curator.
 		}
 
 		:global(.view-all-btn) {
-			--button-width: 100%;
+			align-self: center;
 			margin-top: auto;
 		}
 

--- a/src/routes/vaults/[vault=slug]/VaultMetrics.svelte
+++ b/src/routes/vaults/[vault=slug]/VaultMetrics.svelte
@@ -1,16 +1,17 @@
 <!--
 @component
-Displays supplementary vault information, including transaction status, performance, fees, and risk metrics.
+Displays supplementary vault information, performance, fees, and risk metrics.
 -->
 <script lang="ts">
-	import type { VaultInfo } from '$lib/top-vaults/schemas';
+	import type { Core3Protocol, VaultInfo } from '$lib/top-vaults/schemas';
 	import MetricsBox from '$lib/components/MetricsBox.svelte';
 	import Tooltip from '$lib/components/Tooltip.svelte';
+	import Core3RiskCell from '$lib/top-vaults/Core3RiskCell.svelte';
 	import Risk from '$lib/top-vaults/Risk.svelte';
 	import Metric from './Metric.svelte';
 	import { resolve } from '$app/paths';
 	import IconWarningFilled from '~icons/local/warning-filled';
-	import { getFormattedLockup, isGoodVaultStatus, isVaultDepositCapped } from '$lib/top-vaults/helpers';
+	import { getFormattedLockup } from '$lib/top-vaults/helpers';
 	import { formatNumber, formatPercent, formatPercentProfit } from '$lib/helpers/formatters';
 	import { getChainDisplayName } from '$lib/helpers/chain';
 	import {
@@ -23,6 +24,7 @@ Displays supplementary vault information, including transaction status, performa
 	interface Props {
 		vault: VaultInfo;
 		stablecoinMetadata?: StablecoinMetadata | null;
+		core3?: Core3Protocol | null;
 	}
 
 	const LIMITED_HISTORY_CHAINS = [9999, 9998, 9997, 9995];
@@ -34,23 +36,9 @@ Displays supplementary vault information, including transaction status, performa
 	const INTERNALISED_FEE_DISCLAIMER =
 		'Internalised fees are reflected in the share price. One-time deposit and withdrawal fees may still affect net returns.';
 
-	let { vault, stablecoinMetadata = null }: Props = $props();
+	let { vault, stablecoinMetadata = null, core3 = null }: Props = $props();
 
 	let hasLimitedHistory = $derived(LIMITED_HISTORY_CHAINS.includes(vault.chain_id));
-	let isPrivate = $derived(vault.whitelist?.status === 'whitelisted');
-	let isCapped = $derived(isVaultDepositCapped(vault));
-	let depositStatus = $derived(
-		isPrivate
-			? isCapped
-				? 'Private — Capped'
-				: vault.deposit_closed_reason
-					? `Private — ${vault.deposit_closed_reason}`
-					: 'Private'
-			: isCapped
-				? 'Capped'
-				: vault.deposit_closed_reason
-	);
-	let showTransactionStatus = $derived(isPrivate || !isGoodVaultStatus(vault));
 	let hasNetFeeInformation = $derived(vault.net_fees?.fee_mode != null);
 	let hasInternalisedFees = $derived(
 		vault.fee_internalised === true ||
@@ -66,18 +54,6 @@ Displays supplementary vault information, including transaction status, performa
 	);
 	let denominationLogoUrl = $derived(getVaultDenominationLogoUrl(vault, denominationSlug));
 	let denominationHref = $derived(stablecoinMetadata ? getStablecoinDetailsHref(denominationSlug) : undefined);
-
-	function getDaysUntil(dateString: string | null): number | null {
-		if (!dateString) return null;
-		const targetDate = new Date(dateString);
-		const now = new Date();
-		const diffMs = targetDate.getTime() - now.getTime();
-		const diffDays = Math.floor(diffMs / (1000 * 60 * 60 * 24));
-		return diffDays;
-	}
-
-	let depositDaysLeft = $derived(getDaysUntil(vault.deposit_next_open));
-	let redemptionDaysLeft = $derived(getDaysUntil(vault.redemption_next_open));
 
 	let lifetimeMaxDrawdown = $derived(
 		vault.period_results?.find((p) => p.period.toLowerCase() === 'lifetime')?.max_drawdown ?? null
@@ -188,36 +164,6 @@ Displays supplementary vault information, including transaction status, performa
 </script>
 
 <div class="additional-metrics">
-	{#if showTransactionStatus}
-		<MetricsBox class="transaction-status" title="Transaction status">
-			<div class="status-grid">
-				<div class="status-item">
-					<span class="status-label">Deposits</span>
-					{#if depositStatus}
-						<span class={['status-value', isPrivate ? 'private' : 'closed']}>{depositStatus}</span>
-						{#if depositDaysLeft !== null && depositDaysLeft >= 0}
-							<span class="status-next-open">Opens in {depositDaysLeft} {depositDaysLeft === 1 ? 'day' : 'days'}</span>
-						{/if}
-					{:else}
-						<span class="status-value open">Open</span>
-					{/if}
-				</div>
-				<div class="status-item">
-					<span class="status-label">Redemptions</span>
-					{#if vault.redemption_closed_reason}
-						<span class="status-value closed">{vault.redemption_closed_reason}</span>
-						{#if redemptionDaysLeft !== null && redemptionDaysLeft >= 0}
-							<span class="status-next-open"
-								>Opens in {redemptionDaysLeft} {redemptionDaysLeft === 1 ? 'day' : 'days'}</span
-							>
-						{/if}
-					{:else}
-						<span class="status-value open">Open</span>
-					{/if}
-				</div>
-			</div>
-		</MetricsBox>
-	{/if}
 	<MetricsBox class="other-metrics" title="Other metrics">
 		<div class="metrics-inner">
 			<div class="mobile">
@@ -259,11 +205,28 @@ Displays supplementary vault information, including transaction status, performa
 				{formatPercent(lifetimeMaxDrawdown)}
 			</Metric>
 
-			<Metric label="Protocol Technical Risk">
-				<a class="risk-link" href={resolve('/blog/announcing-vault-technical-risk-framework-beta')}>
-					<Risk risk={vault.risk} />
-				</a>
-			</Metric>
+			{#if vault.xerberus}
+				<Metric label="Xerberus risk">
+					<Tooltip>
+						<span slot="trigger" class="xerberus-score">{formatNumber(vault.xerberus.score, 0)} / 100</span>
+						<svelte:fragment slot="popup">
+							Xerberus scored this {vault.xerberus.entity_type === 'pool'
+								? 'vault directly'
+								: 'vault’s underlying protocol'} on a 0–100 scale. Higher scores indicate lower estimated risk.
+						</svelte:fragment>
+					</Tooltip>
+				</Metric>
+			{:else if core3?.pol?.rating}
+				<Metric label="CORE3 risk">
+					<Core3RiskCell rating={core3.pol.rating} />
+				</Metric>
+			{:else}
+				<Metric label="Protocol Technical Risk">
+					<a class="risk-link" href={resolve('/blog/announcing-vault-technical-risk-framework-beta')}>
+						<Risk risk={vault.risk} />
+					</a>
+				</Metric>
+			{/if}
 
 			<Metric label="Lockup period">
 				{getFormattedLockup(vault)}
@@ -445,55 +408,21 @@ Displays supplementary vault information, including transaction status, performa
 		@media (--viewport-lg-up) {
 			grid-template-columns: 1fr 1fr;
 
-			:global(:is(.other-metrics, .transaction-status, .performance)) {
+			:global(:is(.other-metrics, .performance)) {
 				grid-column: span 2;
 			}
 		}
 
-		.status-grid {
-			display: flex;
-			flex-wrap: wrap;
-			gap: var(--gap);
-		}
-
-		.status-item {
-			display: flex;
-			flex-direction: column;
-			gap: 0.25rem;
-		}
-
-		.status-label {
-			font: var(--f-ui-sm-medium);
-			color: var(--c-text-light);
-		}
-
-		.status-value {
-			font: var(--f-ui-md-medium);
-
-			&.open {
-				color: var(--c-success);
-			}
-
-			&.closed {
-				color: var(--c-error);
-			}
-
-			&.private {
-				color: var(--c-bearish);
-			}
-		}
-
-		.status-next-open {
-			font: var(--f-ui-sm-roman);
-			color: var(--c-text-light);
-			margin-top: 0.25rem;
-		}
-
 		.metrics-inner {
-			display: flex;
-			flex-wrap: wrap;
-			justify-content: space-between;
-			gap: var(--gap);
+			display: grid;
+			grid-template-columns: repeat(2, minmax(0, 1fr));
+			gap: 1.5rem 1rem;
+
+			@media (--viewport-md-up) {
+				grid-template-columns: repeat(auto-fit, minmax(9rem, 1fr));
+				column-gap: 2rem;
+				max-width: 80rem;
+			}
 		}
 
 		.vault-metrics-table {
@@ -637,6 +566,7 @@ Displays supplementary vault information, including transaction status, performa
 		}
 
 		.risk-link,
+		.xerberus-score,
 		a.denomination-link,
 		.glossary-link {
 			text-decoration: underline;

--- a/src/routes/vaults/[vault=slug]/VaultMetrics.test.ts
+++ b/src/routes/vaults/[vault=slug]/VaultMetrics.test.ts
@@ -1,7 +1,7 @@
 import { cleanup, render, screen, within } from '@testing-library/svelte';
 import { afterEach, describe, expect, test } from 'vitest';
 import { createTestVault } from '$lib/top-vaults/test-utils';
-import type { PeriodMetrics } from '$lib/top-vaults/schemas';
+import type { Core3Protocol, PeriodMetrics } from '$lib/top-vaults/schemas';
 import VaultMetrics from './VaultMetrics.svelte';
 
 const MISSING_FEE_TOOLTIP = 'The fee information is not available onchain. Net returns cannot be calculated.';
@@ -51,6 +51,59 @@ function createPeriodMetrics(
 }
 
 describe('VaultMetrics', () => {
+	test('shows a Xerberus score in preference to a CORE3 rating', () => {
+		const vault = createTestVault('Xerberus-rated vault', {
+			xerberus: {
+				score: 81,
+				score_scale: '0–100',
+				entity_type: 'protocol',
+				entity_id: 'xerberus-protocol',
+				name: 'Xerberus protocol',
+				protocol_slug: 'xerberus-protocol',
+				report_url: 'https://app.xerberus.io/protocol/dendrogram/xerberus-protocol',
+				fetched_at: '2026-08-10T00:00:00Z'
+			}
+		});
+		const core3: Core3Protocol = {
+			slug: 'xerberus-protocol',
+			name: 'Xerberus protocol',
+			pol: { score: 20, rating: 'BB', confidence: null }
+		};
+
+		render(VaultMetrics, { props: { vault, core3 } });
+
+		expect(screen.getByText('Xerberus risk')).toBeInTheDocument();
+		expect(screen.getByText('81 / 100')).toBeInTheDocument();
+		expect(
+			screen.getByText(
+				'Xerberus scored this vault’s underlying protocol on a 0–100 scale. Higher scores indicate lower estimated risk.'
+			)
+		).toBeInTheDocument();
+		expect(screen.queryByText('CORE3 risk')).not.toBeInTheDocument();
+	});
+
+	test('shows the CORE3 rating when Xerberus is unavailable', () => {
+		const core3: Core3Protocol = {
+			slug: 'core3-protocol',
+			name: 'CORE3 protocol',
+			pol: { score: 20, rating: 'BB', confidence: null }
+		};
+
+		render(VaultMetrics, { props: { vault: createTestVault('CORE3-rated vault'), core3 } });
+
+		expect(screen.getByText('CORE3 risk')).toBeInTheDocument();
+		expect(screen.getByText('BB')).toBeInTheDocument();
+		expect(screen.queryByText('Protocol Technical Risk')).not.toBeInTheDocument();
+		expect(screen.queryByText('View more')).not.toBeInTheDocument();
+	});
+
+	test('falls back to the protocol technical risk when no provider rating is available', () => {
+		render(VaultMetrics, { props: { vault: createTestVault('Unrated vault', { risk: 'Low' }) } });
+
+		expect(screen.getByText('Protocol Technical Risk')).toBeInTheDocument();
+		expect(screen.getByText('Low')).toBeInTheDocument();
+	});
+
 	test('shows no data tooltips when fee information and net returns are missing', () => {
 		const vault = createTestVault('No fee data vault', {
 			one_month_cagr: 0.12,
@@ -199,18 +252,5 @@ describe('VaultMetrics', () => {
 
 		expect(screen.getAllByText(INTERNALISED_FEE_TOOLTIP)).toHaveLength(6);
 		expect(screen.getByText(INTERNALISED_FEE_DISCLAIMER)).toBeInTheDocument();
-	});
-
-	test('shows private instead of open for deposits that need whitelisting', () => {
-		const vault = createTestVault('Private vault', {
-			whitelist: { status: 'whitelisted', notes: null }
-		});
-
-		render(VaultMetrics, { props: { vault } });
-
-		expect(screen.getByText('Transaction status')).toBeInTheDocument();
-		const deposits = screen.getByText('Deposits').parentElement;
-		expect(deposits).toContainElement(screen.getByText('Private'));
-		expect(deposits).not.toHaveTextContent('Open');
 	});
 });

--- a/src/routes/vaults/[vault=slug]/VaultPageHeader.svelte
+++ b/src/routes/vaults/[vault=slug]/VaultPageHeader.svelte
@@ -1,18 +1,13 @@
 <!--
 @component
-Displays a vault's heading, external link, update action, and important operational warnings.
+Displays a vault's heading, external link, update action, and description.
 -->
 <script lang="ts">
 	import type { VaultInfo } from '$lib/top-vaults/schemas';
-	import Alert from '$lib/components/Alert.svelte';
 	import Button from '$lib/components/Button.svelte';
 	import PageHeader from '$lib/components/PageHeader.svelte';
 	import UpdateInfoButton from '$lib/top-vaults/UpdateInfoButton.svelte';
-	import {
-		getVaultProtocolDisplayName,
-		hasSupportedProtocol,
-		isVaultTvlDownMoreThan95Percent
-	} from '$lib/top-vaults/helpers';
+	import { getVaultProtocolDisplayName, hasSupportedProtocol } from '$lib/top-vaults/helpers';
 
 	interface Props {
 		vault: VaultInfo;
@@ -35,7 +30,6 @@ Displays a vault's heading, external link, update action, and important operatio
 		if (vault.link) return new URL(vault.link).host;
 	});
 	let hideCtaOnMobile = $derived(externalSiteName === 'Ostium');
-	let showTvlWarning = $derived(isVaultTvlDownMoreThan95Percent(vault));
 </script>
 
 <PageHeader>
@@ -56,23 +50,6 @@ Displays a vault's heading, external link, update action, and important operatio
 		</span>
 	{/snippet}
 </PageHeader>
-
-{#if showTvlWarning}
-	<div class="vault-tvl-warning ds-container">
-		<Alert size="md" status="warning">
-			The value in this vault is down more than 95% of its peak. The vault is likely abandoned or facing issues.
-		</Alert>
-	</div>
-{/if}
-
-{#if vault.flags.includes('long_duration')}
-	<div class="long-duration-warning ds-container">
-		<Alert size="md" status="error">
-			This vault may have especially long duration redemption periods. Make sure you check the redemptions before
-			depositing.
-		</Alert>
-	</div>
-{/if}
 
 {#if vault.short_description}
 	<p class="vault-description ds-container">{vault.short_description}</p>
@@ -100,14 +77,6 @@ Displays a vault's heading, external link, update action, and important operatio
 		@media (--viewport-md-up) {
 			margin-top: 1rem;
 		}
-	}
-
-	.vault-tvl-warning {
-		margin-top: var(--space-md);
-	}
-
-	.long-duration-warning {
-		margin-top: var(--space-md);
 	}
 
 	.page-title {

--- a/src/routes/vaults/[vault=slug]/VaultProtocolInfo.svelte
+++ b/src/routes/vaults/[vault=slug]/VaultProtocolInfo.svelte
@@ -82,7 +82,7 @@
 		}
 
 		:global(.view-all-btn) {
-			--button-width: 100%;
+			align-self: center;
 			margin-top: auto;
 		}
 

--- a/src/routes/vaults/[vault=slug]/VaultTransactionStatus.svelte
+++ b/src/routes/vaults/[vault=slug]/VaultTransactionStatus.svelte
@@ -1,0 +1,118 @@
+<!--
+@component
+Displays vault deposit and redemption availability when either operation is restricted.
+
+@example
+
+```svelte
+	<VaultTransactionStatus {vault} />
+```
+-->
+<script lang="ts">
+	import MetricsBox from '$lib/components/MetricsBox.svelte';
+	import { isGoodVaultStatus, isVaultDepositCapped } from '$lib/top-vaults/helpers';
+	import type { VaultInfo } from '$lib/top-vaults/schemas';
+
+	interface Props {
+		vault: VaultInfo;
+	}
+
+	let { vault }: Props = $props();
+
+	let isPrivate = $derived(vault.whitelist?.status === 'whitelisted');
+	let isCapped = $derived(isVaultDepositCapped(vault));
+	let depositStatus = $derived(
+		isPrivate
+			? isCapped
+				? 'Private — Capped'
+				: vault.deposit_closed_reason
+					? `Private — ${vault.deposit_closed_reason}`
+					: 'Private'
+			: isCapped
+				? 'Capped'
+				: vault.deposit_closed_reason
+	);
+	let showTransactionStatus = $derived(isPrivate || !isGoodVaultStatus(vault));
+
+	function getDaysUntil(dateString: string | null): number | null {
+		if (!dateString) return null;
+		const targetDate = new Date(dateString);
+		const diffMs = targetDate.getTime() - Date.now();
+		return Math.floor(diffMs / (1000 * 60 * 60 * 24));
+	}
+
+	let depositDaysLeft = $derived(getDaysUntil(vault.deposit_next_open));
+	let redemptionDaysLeft = $derived(getDaysUntil(vault.redemption_next_open));
+</script>
+
+{#if showTransactionStatus}
+	<MetricsBox class="transaction-status" title="Transaction status">
+		<div class="status-grid">
+			<div class="status-item">
+				<span class="status-label">Deposits</span>
+				{#if depositStatus}
+					<span class={['status-value', isPrivate ? 'private' : 'closed']}>{depositStatus}</span>
+					{#if depositDaysLeft !== null && depositDaysLeft >= 0}
+						<span class="status-next-open">Opens in {depositDaysLeft} {depositDaysLeft === 1 ? 'day' : 'days'}</span>
+					{/if}
+				{:else}
+					<span class="status-value open">Open</span>
+				{/if}
+			</div>
+			<div class="status-item">
+				<span class="status-label">Redemptions</span>
+				{#if vault.redemption_closed_reason}
+					<span class="status-value closed">{vault.redemption_closed_reason}</span>
+					{#if redemptionDaysLeft !== null && redemptionDaysLeft >= 0}
+						<span class="status-next-open"
+							>Opens in {redemptionDaysLeft} {redemptionDaysLeft === 1 ? 'day' : 'days'}</span
+						>
+					{/if}
+				{:else}
+					<span class="status-value open">Open</span>
+				{/if}
+			</div>
+		</div>
+	</MetricsBox>
+{/if}
+
+<style>
+	.status-grid {
+		display: flex;
+		flex-wrap: wrap;
+		gap: var(--gap);
+	}
+
+	.status-item {
+		display: flex;
+		flex-direction: column;
+		gap: 0.25rem;
+	}
+
+	.status-label {
+		font: var(--f-ui-sm-medium);
+		color: var(--c-text-light);
+	}
+
+	.status-value {
+		font: var(--f-ui-md-medium);
+
+		&.open {
+			color: var(--c-success);
+		}
+
+		&.closed {
+			color: var(--c-error);
+		}
+
+		&.private {
+			color: var(--c-bearish);
+		}
+	}
+
+	.status-next-open {
+		margin-top: 0.25rem;
+		font: var(--f-ui-sm-roman);
+		color: var(--c-text-light);
+	}
+</style>

--- a/src/routes/vaults/[vault=slug]/VaultTransactionStatus.test.ts
+++ b/src/routes/vaults/[vault=slug]/VaultTransactionStatus.test.ts
@@ -1,0 +1,25 @@
+import { render, screen } from '@testing-library/svelte';
+import { describe, expect, test } from 'vitest';
+import { createTestVault } from '$lib/top-vaults/test-utils';
+import VaultTransactionStatus from './VaultTransactionStatus.svelte';
+
+describe('VaultTransactionStatus', () => {
+	test('does not render for a healthy public vault', () => {
+		render(VaultTransactionStatus, { props: { vault: createTestVault('Healthy public vault') } });
+
+		expect(screen.queryByText('Transaction status')).not.toBeInTheDocument();
+	});
+
+	test('shows private instead of open for deposits that need whitelisting', () => {
+		const vault = createTestVault('Private vault', {
+			whitelist: { status: 'whitelisted', notes: null }
+		});
+
+		render(VaultTransactionStatus, { props: { vault } });
+
+		expect(screen.getByText('Transaction status')).toBeInTheDocument();
+		const deposits = screen.getByText('Deposits').parentElement;
+		expect(deposits).toContainElement(screen.getByText('Private'));
+		expect(deposits).not.toHaveTextContent('Open');
+	});
+});


### PR DESCRIPTION
## Why

Vault-detail information cards should use the available desktop space without sacrificing the established tablet and mobile layout. Related operational alerts, provider risk summaries, and transaction restrictions should appear where their context is clearest. Condensed third-party risk data must retain its provider, scope, and score semantics.

## Lessons learnt

Auto-fitting desktop grid tracks let incomplete card sets fill a row, but small screens need explicit column sizing to avoid layout flips around common viewport widths. Risk scores should never be condensed into bare numbers: their scale, direction, and whether they assess a vault or its protocol need to remain available in the UI.

## Summary

- Make the vault information grid automatically fit its rendered cards, including equal two-card desktop rows.
- Centre content-sized curator and protocol actions at the bottom of their cards.
- Add a View details fold to Xerberus risk ratings, with the external report link at the bottom of expanded details.
- Consolidate all vault alerts into one stack immediately below the vault heading.
- Use a compact, responsive Other metrics grid with stable mobile columns.
- Prefer Xerberus risk summaries over CORE3, otherwise show the CORE3 grade or technical-risk fallback.
- Display Xerberus summaries as a scoped score out of 100 with higher-is-better guidance.
- Place transaction status after the full provider risk cards.
- Document vault detail risk-summary precedence and scoring semantics.