### PR TITLE
fix: add frontend connectivity diagnostics

### DIFF
--- a/.env
+++ b/.env
@@ -41,14 +41,14 @@ TS_PUBLIC_VAULT_API_URL=https://tradingstrategy-store.trading-strategy.workers.d
 TS_PUBLIC_CREEM_CHECKOUT_URL=https://www.creem.io/test/payment/prod_2Kqof4QzSt5LoM3zmsbAq5
 
 # Defeault geo-blocked features:countries; this is reset to '{}' in .env.development
-TS_PUBLIC_GEO_BLOCK=`{
+TS_PUBLIC_GEO_BLOCK='{
 	"strategies:view": ["CU","IR","KP","RU","SY"],
 	"strategies:deposit": ["CU","IR","KP","RU","SY","US","UK"]
-}`
+}'
 
 # Latest ToS contracts per-chain
 # May be overridden on production (tos.json) to update without new release
-TS_PUBLIC_TOS_CONTRACTS=`{
+TS_PUBLIC_TOS_CONTRACTS='{
   "ethereum": {
     "address": "0xd63c1bE9D8B56CCcD6fd2Dd9F9c030c6a9916f5F",
     "version": 2,
@@ -73,7 +73,7 @@ TS_PUBLIC_TOS_CONTRACTS=`{
     "fileName": "2024-12-19.txt",
     "acceptanceMessage": "I agree on Terms of Service. I understand smart contract trading is risky and I may lose all of my deposits. \n\nThis Terms of Service version 1, dated 2024-12-19, was published at https://tradingstrategy.ai/tos/2024-12-19.txt"
   }
-}`
+}'
 
 ###############################################################
 #

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,6 +36,7 @@ COPY --from=builder /app/package.json ./package.json
 COPY --from=builder /app/node_modules ./node_modules
 COPY --from=builder /app/build ./build
 COPY --from=builder /app/scripts/server.js ./scripts/server.js
+COPY --from=builder /app/scripts/check-connectivity.mjs ./scripts/check-connectivity.mjs
 
 EXPOSE 3000
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,8 @@
 version: '3.9'
 services:
   frontend:
+    # Check every configured dependency without starting the web server:
+    # docker compose run --rm frontend node scripts/check-connectivity.mjs
     image: 'ghcr.io/tradingstrategy-ai/frontend:${TS_PUBLIC_FRONTEND_VERSION_TAG}'
     ports:
       # The production server has :80 port bind by Caddy.
@@ -42,6 +44,7 @@ services:
       - TS_PUBLIC_VAULT_SPARKLINES_URL
       - TS_PUBLIC_VAULT_API_URL
       - TS_PUBLIC_STABLECOIN_METADATA_URL
+      - TS_PUBLIC_SAMPLE_DATA_URL
       - TS_PUBLIC_CREEM_CHECKOUT_URL
       # Private (secret) SvelteKit env vars
       - TS_PRIVATE_ADMIN_PW
@@ -50,6 +53,7 @@ services:
       - TS_PRIVATE_R2_SECRET_ACCESS_KEY
       - TS_PRIVATE_R2_BUCKET_NAME
       - TS_PRIVATE_TOP_VAULTS_URL
+      - TS_PRIVATE_VAULT_PRICES_PARQUET_URL
       - TS_PRIVATE_MAILERLITE_URL
       - TS_PRIVATE_MAILERLITE_API_KEY
       - TS_PRIVATE_MAILERLITE_GROUPS
@@ -65,3 +69,6 @@ services:
       - DD_VERSION=${TS_PUBLIC_FRONTEND_VERSION_TAG}
       - DD_TRACE_AGENT_URL
       - DD_DOGSTATSD_URL
+      # Temporarily set DIAGNOSE=1, recreate the service, then inspect its logs:
+      # docker compose up -d --force-recreate frontend && docker compose logs -f frontend
+      - DIAGNOSE

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -121,6 +121,58 @@ docker-compose logs
 
 Then visit the [diagnostics page](https://tradingstrategy.ai/diagnostics) to see the version tag has been updated.
 
+### Checking production connectivity
+
+Before restarting the service, or when the front page fails to render, run the
+connectivity checker in the same Compose service and with the same environment:
+
+```shell
+docker compose run --rm frontend node scripts/check-connectivity.mjs
+```
+
+The command probes every configured upstream without printing credentials. It
+checks the frontend's required configuration, backend and strategy executors,
+the top-vaults source, reference-rate feeds, and configured optional services
+such as Ghost, R2-backed metadata, MailerLite, Sentry, RPC endpoints and
+Datadog. It exits with status 1 when a configured probe fails; `SKIP` means an
+optional feature has deliberately not been configured.
+
+Run it after loading the production secrets and before restarting the service:
+
+```shell
+source ~/secrets.env
+docker compose run --rm frontend node scripts/check-connectivity.mjs
+```
+
+### Diagnosing a hanging page request
+
+To log each server-side upstream request with its start, completion, failure and
+duration, temporarily enable the `DIAGNOSE` environment variable and recreate
+the frontend:
+
+```shell
+export DIAGNOSE=1
+docker compose up -d --force-recreate frontend
+docker compose logs -f frontend
+```
+
+The logs are prefixed with `[DIAGNOSE]` and redact query strings and URL
+credentials. A `start` line without a later `done` or `failed` line identifies
+the upstream request that is hanging. Request the affected page while following
+the logs, for example:
+
+```shell
+curl --fail --silent --show-error http://127.0.0.1:${FRONTEND_PORT:-3000}/ > /dev/null
+```
+
+Disable tracing and recreate the service after investigation, as this mode logs
+every server-side upstream request:
+
+```shell
+unset DIAGNOSE
+docker compose up -d --force-recreate frontend
+```
+
 ## Local containers
 
 ### Creating PAT to access Github container registry

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "dev": "vite dev",
     "build": "vite build",
     "build:test": "vite build --mode test",
+    "check:connectivity": "node scripts/check-connectivity.mjs",
     "preview": "vite preview",
     "benchmark:historical-tvl-chain": "node scripts/benchmark-historical-tvl-chain.mjs",
     "prepare": "svelte-kit sync || echo ''",

--- a/scripts/check-connectivity.mjs
+++ b/scripts/check-connectivity.mjs
@@ -1,0 +1,470 @@
+#!/usr/bin/env node
+
+/**
+ * Check the external services used by the production frontend.
+ *
+ * This intentionally reads only process.env so it can run in the production
+ * image with exactly the same configuration as the SvelteKit server:
+ *
+ *   docker compose run --rm frontend node scripts/check-connectivity.mjs
+ *
+ * Secrets are used only for authenticated requests and are never printed.
+ */
+import dgram from 'node:dgram';
+import { stat } from 'node:fs/promises';
+
+const timeoutMs = Number.parseInt(process.env.CONNECTIVITY_TIMEOUT_MS ?? '10000', 10);
+const results = [];
+let topVaults;
+
+function configured(name) {
+	const value = process.env[name]?.trim();
+	return value || undefined;
+}
+
+function displayUrl(value) {
+	try {
+		const url = new URL(value);
+		return `${url.protocol}//${url.host}${url.pathname}`;
+	} catch {
+		return '<invalid URL>';
+	}
+}
+
+function joinUrl(base, path) {
+	return new URL(path.replace(/^\//, ''), `${base.replace(/\/$/, '')}/`).toString();
+}
+
+function requiredEnvironment(names) {
+	return names.every((name) => configured(name));
+}
+
+function record(name, severity, state, detail) {
+	results.push({ name, severity, state, detail });
+}
+
+async function check(name, severity, callback) {
+	try {
+		const detail = await callback();
+		record(name, severity, 'PASS', detail);
+		return detail;
+	} catch (error) {
+		record(name, severity, 'FAIL', error instanceof Error ? error.message : String(error));
+		return undefined;
+	}
+}
+
+function skip(name, severity, detail) {
+	record(name, severity, 'SKIP', detail);
+}
+
+async function request(url, options = {}) {
+	const response = await fetch(url, {
+		redirect: 'manual',
+		...options,
+		signal: AbortSignal.timeout(timeoutMs),
+		headers: {
+			'User-Agent': 'trading-strategy-frontend-connectivity-check/1.0',
+			...options.headers
+		}
+	});
+	return response;
+}
+
+async function expectResponse(url, { acceptedStatuses, ...options } = {}) {
+	const response = await request(url, options);
+	const accepted = acceptedStatuses ? acceptedStatuses.includes(response.status) : response.ok;
+
+	if (!accepted) {
+		throw new Error(`${displayUrl(url)} returned HTTP ${response.status}`);
+	}
+
+	return response;
+}
+
+async function readJson(response, label) {
+	try {
+		return await response.json();
+	} catch {
+		throw new Error(`${label} returned invalid JSON`);
+	}
+}
+
+function parseStrategies() {
+	const source = configured('TS_PUBLIC_STRATEGIES');
+	if (!source) throw new Error('TS_PUBLIC_STRATEGIES is not configured');
+
+	let strategies;
+	try {
+		strategies = JSON.parse(source);
+	} catch {
+		throw new Error('TS_PUBLIC_STRATEGIES is not valid JSON');
+	}
+
+	if (!Array.isArray(strategies)) throw new Error('TS_PUBLIC_STRATEGIES must be a JSON array');
+
+	for (const strategy of strategies) {
+		if (!strategy || typeof strategy.id !== 'string' || typeof strategy.url !== 'string') {
+			throw new Error('Every strategy needs string id and url fields');
+		}
+		try {
+			new URL(strategy.url);
+		} catch {
+			throw new Error(`Strategy ${strategy.id} has an invalid URL`);
+		}
+	}
+
+	return strategies;
+}
+
+async function loadTopVaults() {
+	const r2Environment = [
+		'TS_PRIVATE_R2_ACCOUNT_ID',
+		'TS_PRIVATE_R2_ACCESS_KEY_ID',
+		'TS_PRIVATE_R2_SECRET_ACCESS_KEY',
+		'TS_PRIVATE_R2_BUCKET_NAME'
+	];
+
+	let data;
+	if (requiredEnvironment(r2Environment)) {
+		const { GetObjectCommand, S3Client } = await import('@aws-sdk/client-s3');
+		const client = new S3Client({
+			region: 'auto',
+			endpoint: `https://${configured('TS_PRIVATE_R2_ACCOUNT_ID')}.r2.cloudflarestorage.com`,
+			credentials: {
+				accessKeyId: configured('TS_PRIVATE_R2_ACCESS_KEY_ID'),
+				secretAccessKey: configured('TS_PRIVATE_R2_SECRET_ACCESS_KEY')
+			}
+		});
+		const response = await client.send(
+			new GetObjectCommand({
+				Bucket: configured('TS_PRIVATE_R2_BUCKET_NAME'),
+				Key: 'top_vaults_by_chain.json'
+			})
+		);
+		if (!response.Body) throw new Error('R2 returned an empty top-vaults object');
+		try {
+			data = JSON.parse(await response.Body.transformToString());
+		} catch {
+			throw new Error('R2 top-vaults object is not valid JSON');
+		}
+	} else {
+		const source = configured('TS_PRIVATE_TOP_VAULTS_URL');
+		if (!source) {
+			throw new Error('Neither complete R2 credentials nor TS_PRIVATE_TOP_VAULTS_URL is configured');
+		}
+		const response = await expectResponse(source);
+		data = await readJson(response, 'Top-vaults fallback');
+	}
+
+	if (!data || !Array.isArray(data.vaults) || data.vaults.length === 0) {
+		throw new Error('Top-vaults data has no vaults array');
+	}
+	return data;
+}
+
+async function sendDogStatsdDatagram(url) {
+	let parsed;
+	try {
+		parsed = new URL(url);
+	} catch {
+		throw new Error('DD_DOGSTATSD_URL is not a valid URL');
+	}
+	if (parsed.protocol !== 'udp:' || !parsed.hostname || !parsed.port) {
+		throw new Error('Only udp://host:port DD_DOGSTATSD_URL values can be checked');
+	}
+
+	const socket = dgram.createSocket('udp4');
+	try {
+		await new Promise((resolve, reject) => {
+			const timer = setTimeout(() => reject(new Error('UDP connection timed out')), timeoutMs);
+			socket.once('error', reject);
+			socket.connect(Number(parsed.port), parsed.hostname, () => {
+				clearTimeout(timer);
+				resolve();
+			});
+		});
+		await new Promise((resolve, reject) =>
+			socket.send('frontend.connectivity_check:1|c', (error) => (error ? reject(error) : resolve()))
+		);
+	} finally {
+		socket.close();
+	}
+}
+
+function printResults() {
+	const width = Math.max(...results.map((result) => result.name.length), 7);
+	console.log('\nFrontend connectivity report');
+	console.log(`Timeout per HTTP check: ${timeoutMs} ms\n`);
+
+	for (const result of results) {
+		console.log(
+			`${result.state.padEnd(4)} ${result.severity.padEnd(8)} ${result.name.padEnd(width)}  ${result.detail}`
+		);
+	}
+
+	const failures = results.filter((result) => result.state === 'FAIL');
+	const skipped = results.filter((result) => result.state === 'SKIP');
+	console.log(
+		`\n${failures.length === 0 ? 'ALL CONFIGURED SERVICES ARE REACHABLE' : `${failures.length} CHECK(S) FAILED`}`
+	);
+	if (skipped.length) console.log(`${skipped.length} optional check(s) skipped because they are not configured.`);
+	if (failures.length) process.exitCode = 1;
+}
+
+async function main() {
+	const backendUrl = configured('TS_PUBLIC_BACKEND_INTERNAL_URL') ?? configured('TS_PUBLIC_BACKEND_URL');
+	let strategies = [];
+
+	await check('Runtime configuration', 'REQUIRED', async () => {
+		const siteMode = configured('TS_PUBLIC_SITE_MODE') ?? 'local';
+		if (!['local', 'staging', 'production'].includes(siteMode)) {
+			throw new Error(`TS_PUBLIC_SITE_MODE has unsupported value ${siteMode}`);
+		}
+		if (!configured('TS_PUBLIC_BACKEND_URL')) throw new Error('TS_PUBLIC_BACKEND_URL is not configured');
+		if (!configured('FRONTEND_PROTOCOL_HEADER') || !configured('FRONTEND_HOST_HEADER')) {
+			throw new Error('FRONTEND_PROTOCOL_HEADER and FRONTEND_HOST_HEADER are required by adapter-node');
+		}
+		strategies = parseStrategies();
+		return `${strategies.length} strategy configuration(s), mode ${siteMode}`;
+	});
+
+	if (backendUrl) {
+		await check('Backend API', 'REQUIRED', async () => {
+			const response = await expectResponse(backendUrl, {
+				acceptedStatuses: [200, 201, 202, 204, 301, 302, 307, 308, 400, 401, 403, 404, 405]
+			});
+			return `${displayUrl(backendUrl)} responded HTTP ${response.status}`;
+		});
+	} else {
+		record('Backend API', 'REQUIRED', 'FAIL', 'No backend URL configured');
+	}
+
+	for (const strategy of strategies) {
+		await check(`Strategy ${strategy.id}`, 'REQUIRED', async () => {
+			const metadataUrl = joinUrl(strategy.url, 'metadata');
+			const response = await expectResponse(metadataUrl);
+			const metadata = await readJson(response, `Strategy ${strategy.id} metadata`);
+			if (!metadata || typeof metadata !== 'object') throw new Error('Metadata is not an object');
+			return `${displayUrl(metadataUrl)} responded HTTP ${response.status}`;
+		});
+	}
+
+	await check('Top-vaults source', 'REQUIRED', async () => {
+		const data = await loadTopVaults();
+		topVaults = data;
+		return `${data.vaults.length} vaults loaded via ${
+			requiredEnvironment([
+				'TS_PRIVATE_R2_ACCOUNT_ID',
+				'TS_PRIVATE_R2_ACCESS_KEY_ID',
+				'TS_PRIVATE_R2_SECRET_ACCESS_KEY',
+				'TS_PRIVATE_R2_BUCKET_NAME'
+			])
+				? 'R2'
+				: 'the fallback URL'
+		}`;
+	});
+
+	await check('Vault-price cache', 'OPTIONAL', async () => {
+		const cache = await stat('data/cleaned-vault-prices-1h.parquet');
+		if (cache.size === 0) throw new Error('data/cleaned-vault-prices-1h.parquet is empty');
+		return `data/cleaned-vault-prices-1h.parquet is ${Math.round(cache.size / 1024 / 1024)} MiB`;
+	});
+
+	await check('FRED reference rate', 'OPTIONAL', async () => {
+		const response = await expectResponse('https://fred.stlouisfed.org/graph/fredgraph.csv?id=SNDR', {
+			headers: { 'User-Agent': 'Mozilla/5.0 (X11; Linux x86_64; rv:133.0) Gecko/20100101 Firefox/133.0' }
+		});
+		const text = await response.text();
+		if (!text.split('\n', 1)[0].toLowerCase().includes('observation_date')) {
+			throw new Error('FRED response is not a CSV series');
+		}
+		return 'SNDR CSV retrieved';
+	});
+
+	await check('US Treasury rates', 'OPTIONAL', async () => {
+		const response = await expectResponse(
+			'https://api.fiscaldata.treasury.gov/services/api/fiscal_service/v2/accounting/od/avg_interest_rates?sort=-record_date&page%5Bsize%5D=1&filter=security_desc:eq:Treasury%20Notes'
+		);
+		const data = await readJson(response, 'US Treasury rates');
+		if (!Array.isArray(data.data) || data.data.length === 0) throw new Error('Treasury response has no rate data');
+		return 'latest Treasury note rate retrieved';
+	});
+
+	const ghostUrl = configured('TS_PUBLIC_GHOST_API_URL');
+	const ghostKey = configured('TS_PUBLIC_GHOST_CONTENT_API_KEY');
+	if (ghostUrl || ghostKey) {
+		if (!ghostUrl || !ghostKey) {
+			record('Ghost content API', 'OPTIONAL', 'FAIL', 'Both Ghost URL and content API key are required');
+		} else {
+			await check('Ghost content API', 'OPTIONAL', async () => {
+				const url = new URL(joinUrl(ghostUrl, 'ghost/api/content/posts/'));
+				url.searchParams.set('limit', '1');
+				url.searchParams.set('key', ghostKey);
+				const response = await expectResponse(url);
+				const data = await readJson(response, 'Ghost content API');
+				if (!Array.isArray(data.posts)) throw new Error('Ghost response has no posts array');
+				return `${displayUrl(ghostUrl)} returned ${data.posts.length} post(s)`;
+			});
+		}
+	} else {
+		skip('Ghost content API', 'OPTIONAL', 'Not configured');
+	}
+
+	const stablecoinUrl = configured('TS_PUBLIC_STABLECOIN_METADATA_URL');
+	if (stablecoinUrl) {
+		await check('Stablecoin metadata', 'OPTIONAL', async () => {
+			const response = await expectResponse(joinUrl(stablecoinUrl, 'index.json'));
+			const data = await readJson(response, 'Stablecoin metadata');
+			if (!Array.isArray(data)) throw new Error('Metadata index is not an array');
+			return `${displayUrl(stablecoinUrl)} returned ${data.length} entries`;
+		});
+	} else {
+		skip('Stablecoin metadata', 'OPTIONAL', 'Not configured');
+	}
+
+	const protocolUrl = configured('TS_PUBLIC_VAULT_PROTOCOL_METADATA_URL');
+	const sampleVault = topVaults?.vaults.find((vault) => vault.protocol_slug && vault.id);
+	if (protocolUrl && sampleVault) {
+		await check('Vault protocol metadata', 'OPTIONAL', async () => {
+			const url = joinUrl(protocolUrl, `${sampleVault.protocol_slug}/metadata.json`);
+			const response = await expectResponse(url);
+			const data = await readJson(response, 'Vault protocol metadata');
+			if (!data || typeof data !== 'object') throw new Error('Protocol metadata is not an object');
+			return `${displayUrl(url)} responded HTTP ${response.status}`;
+		});
+	} else {
+		skip('Vault protocol metadata', 'OPTIONAL', protocolUrl ? 'Top-vaults source unavailable' : 'Not configured');
+	}
+
+	const sparklinesUrl = configured('TS_PUBLIC_VAULT_SPARKLINES_URL');
+	if (sparklinesUrl && sampleVault) {
+		await check('Vault sparklines', 'OPTIONAL', async () => {
+			const url = joinUrl(sparklinesUrl, `sparkline-90d-${sampleVault.id}.svg`);
+			const response = await expectResponse(url);
+			const text = await response.text();
+			if (!text.includes('<svg')) throw new Error('Sparkline response is not SVG');
+			return `${displayUrl(url)} responded HTTP ${response.status}`;
+		});
+	} else {
+		skip('Vault sparklines', 'OPTIONAL', sparklinesUrl ? 'Top-vaults source unavailable' : 'Not configured');
+	}
+
+	const sampleDataUrl = configured('TS_PUBLIC_SAMPLE_DATA_URL') ?? 'https://vault-protocol-metadata.tradingstrategy.ai';
+	await check('Public sample data CDN', 'OPTIONAL', async () => {
+		const url = joinUrl(sampleDataUrl, 'vault-metadata.sample.json');
+		const response = await expectResponse(url, { method: 'HEAD' });
+		return `${displayUrl(url)} responded HTTP ${response.status}`;
+	});
+
+	const vaultApiUrl = configured('TS_PUBLIC_VAULT_API_URL');
+	if (vaultApiUrl) {
+		await check('Vault data API', 'OPTIONAL', async () => {
+			const url = joinUrl(vaultApiUrl, 'files/top_vaults_by_chain.json');
+			const response = await expectResponse(url, { acceptedStatuses: [200, 401, 403] });
+			return `${displayUrl(url)} responded HTTP ${response.status}${response.status === 401 || response.status === 403 ? ' (authentication enforced)' : ''}`;
+		});
+	} else {
+		skip('Vault data API', 'OPTIONAL', 'Not configured');
+	}
+
+	const mailerLiteUrl = configured('TS_PRIVATE_MAILERLITE_URL');
+	const mailerLiteKey = configured('TS_PRIVATE_MAILERLITE_API_KEY');
+	if (mailerLiteUrl || mailerLiteKey) {
+		if (!mailerLiteUrl || !mailerLiteKey) {
+			record('MailerLite API', 'OPTIONAL', 'FAIL', 'Both MailerLite URL and API key are required');
+		} else {
+			await check('MailerLite API', 'OPTIONAL', async () => {
+				const url = joinUrl(mailerLiteUrl, 'api/subscribers?limit=1');
+				const response = await expectResponse(url, { headers: { Authorization: `Bearer ${mailerLiteKey}` } });
+				return `${displayUrl(url)} responded HTTP ${response.status}`;
+			});
+		}
+	} else {
+		skip('MailerLite API', 'OPTIONAL', 'Not configured');
+	}
+
+	const sentryDsn = configured('TS_PUBLIC_SENTRY_DSN');
+	if (sentryDsn) {
+		await check('Sentry ingestion host', 'OPTIONAL', async () => {
+			const dsn = new URL(sentryDsn);
+			const response = await expectResponse(dsn.origin, {
+				acceptedStatuses: [200, 301, 302, 307, 308, 400, 401, 403, 404, 405]
+			});
+			return `${dsn.origin} responded HTTP ${response.status}`;
+		});
+	} else {
+		skip('Sentry ingestion host', 'OPTIONAL', 'Not configured');
+	}
+
+	const turnstileKey = configured('TS_PUBLIC_TURNSTILE_SITE_KEY');
+	if (turnstileKey) {
+		await check('Cloudflare Turnstile', 'OPTIONAL', async () => {
+			const response = await expectResponse('https://challenges.cloudflare.com/turnstile/v0/api.js');
+			return `widget script responded HTTP ${response.status}`;
+		});
+	} else {
+		skip('Cloudflare Turnstile', 'OPTIONAL', 'Not configured');
+	}
+
+	const rpcSource = configured('TS_PUBLIC_RPC_URLS');
+	if (rpcSource) {
+		let rpcUrls;
+		try {
+			rpcUrls = JSON.parse(rpcSource);
+		} catch {
+			record('Blockchain RPC configuration', 'OPTIONAL', 'FAIL', 'TS_PUBLIC_RPC_URLS is not valid JSON');
+		}
+		if (rpcUrls && typeof rpcUrls === 'object' && !Array.isArray(rpcUrls)) {
+			for (const [chainId, rpcUrl] of Object.entries(rpcUrls)) {
+				await check(`Blockchain RPC ${chainId}`, 'OPTIONAL', async () => {
+					if (typeof rpcUrl !== 'string') throw new Error('RPC URL is not a string');
+					const response = await expectResponse(rpcUrl, {
+						method: 'POST',
+						headers: { 'Content-Type': 'application/json' },
+						body: JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'eth_chainId', params: [] })
+					});
+					const data = await readJson(response, `Blockchain RPC ${chainId}`);
+					if (typeof data.result !== 'string') throw new Error('eth_chainId returned no result');
+					return `${displayUrl(rpcUrl)} returned chain ID ${data.result}`;
+				});
+			}
+		}
+	} else {
+		skip('Blockchain RPCs', 'OPTIONAL', 'Not configured');
+	}
+
+	const datadogProduction = configured('DD_ENV') === 'prod';
+	const traceAgentUrl = configured('DD_TRACE_AGENT_URL');
+	if (traceAgentUrl) {
+		await check('Datadog trace agent', 'OPTIONAL', async () => {
+			const url = joinUrl(traceAgentUrl, 'info');
+			const response = await expectResponse(url);
+			return `${displayUrl(url)} responded HTTP ${response.status}`;
+		});
+	} else {
+		if (datadogProduction) {
+			record('Datadog trace agent', 'OPTIONAL', 'FAIL', 'DD_TRACE_AGENT_URL is not configured');
+		} else {
+			skip('Datadog trace agent', 'OPTIONAL', 'DD_TRACE_AGENT_URL is not configured');
+		}
+	}
+
+	const dogstatsdUrl = configured('DD_DOGSTATSD_URL');
+	if (dogstatsdUrl) {
+		await check('Datadog DogStatsD', 'OPTIONAL', async () => {
+			await sendDogStatsdDatagram(dogstatsdUrl);
+			return 'UDP datagram sent (UDP delivery cannot be acknowledged)';
+		});
+	} else {
+		if (datadogProduction) {
+			record('Datadog DogStatsD', 'OPTIONAL', 'FAIL', 'DD_DOGSTATSD_URL is not configured');
+		} else {
+			skip('Datadog DogStatsD', 'OPTIONAL', 'DD_DOGSTATSD_URL is not configured');
+		}
+	}
+
+	printResults();
+}
+
+await main();

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -5,6 +5,7 @@ import { env } from '$env/dynamic/private';
 import { backendUrl, backendInternalUrl, sentryDsn, siteMode, strategyMicrosite, version } from '$lib/config';
 import { countryCodeSchema } from '$lib/helpers/geo';
 import { parseDate } from '$lib/helpers/date';
+import { diagnoseFetch } from '$lib/diagnostics/server';
 
 const defaultColorMode = 'dark';
 
@@ -26,7 +27,7 @@ export async function handleFetch({ request, fetch }) {
 	if (backendInternalUrl && request.url.startsWith(backendUrl)) {
 		request = new Request(request.url.replace(backendUrl, backendInternalUrl), request);
 	}
-	return fetch(request);
+	return diagnoseFetch(request, fetch);
 }
 
 export const handleError = Sentry.handleErrorWithSentry((async ({ error }) => {
@@ -137,7 +138,7 @@ const handleIpCountry: Handle = async ({ event, resolve }) => {
 	if (ipCountry) {
 		try {
 			event.locals.ipCountry = countryCodeSchema.parse(ipCountry);
-		} catch (e) {
+		} catch {
 			console.warn(`Invalid CF-IPCountry: ${ipCountry}`);
 		}
 	}

--- a/src/lib/diagnostics/server.ts
+++ b/src/lib/diagnostics/server.ts
@@ -1,0 +1,68 @@
+/**
+ * Opt-in, server-side timing logs for tracking blocked upstream requests.
+ *
+ * Set `DIAGNOSE=1` in the frontend container to emit these logs. Keep this
+ * disabled during normal operation: each server-side fetch produces a log line.
+ */
+import { env } from '$env/dynamic/private';
+
+function isDiagnoseEnabled(): boolean {
+	return env.DIAGNOSE === '1' || env.DIAGNOSE === 'true';
+}
+
+function elapsedMilliseconds(startedAt: number): string {
+	return `${Math.round(performance.now() - startedAt)}ms`;
+}
+
+/**
+ * Run an operation with opt-in start, completion and failure timing logs.
+ *
+ * @param label A safe description that contains no credentials.
+ * @param operation The asynchronous operation to trace.
+ */
+export async function diagnose<T>(label: string, operation: () => Promise<T>): Promise<T> {
+	if (!isDiagnoseEnabled()) return operation();
+
+	const startedAt = performance.now();
+	console.log(`[DIAGNOSE] start ${label}`);
+
+	try {
+		const result = await operation();
+		console.log(`[DIAGNOSE] done ${label} in ${elapsedMilliseconds(startedAt)}`);
+		return result;
+	} catch (error) {
+		const errorName = error instanceof Error ? error.name : 'UnknownError';
+		console.log(`[DIAGNOSE] failed ${label} in ${elapsedMilliseconds(startedAt)} (${errorName})`);
+		throw error;
+	}
+}
+
+/**
+ * Log a SvelteKit server-side request without exposing credentials in its URL.
+ *
+ * @param request The outgoing request.
+ * @param fetchFn SvelteKit's server-side fetch function.
+ */
+export async function diagnoseFetch(request: Request, fetchFn: typeof fetch): Promise<Response> {
+	if (!isDiagnoseEnabled()) return fetchFn(request);
+
+	const url = new URL(request.url);
+	url.username = '';
+	url.password = '';
+	url.search = '';
+	url.hash = '';
+	const label = `HTTP ${request.method} ${url.toString()}`;
+
+	const startedAt = performance.now();
+	console.log(`[DIAGNOSE] start ${label}`);
+
+	try {
+		const response = await fetchFn(request);
+		console.log(`[DIAGNOSE] done ${label} HTTP ${response.status} in ${elapsedMilliseconds(startedAt)}`);
+		return response;
+	} catch (error) {
+		const errorName = error instanceof Error ? error.name : 'UnknownError';
+		console.log(`[DIAGNOSE] failed ${label} in ${elapsedMilliseconds(startedAt)} (${errorName})`);
+		throw error;
+	}
+}

--- a/src/lib/r2/client.ts
+++ b/src/lib/r2/client.ts
@@ -9,6 +9,7 @@
  */
 import { env } from '$env/dynamic/private';
 import { S3Client, GetObjectCommand, HeadObjectCommand } from '@aws-sdk/client-s3';
+import { diagnose } from '$lib/diagnostics/server';
 
 function createClient(): S3Client | undefined {
 	const accountId = env.TS_PRIVATE_R2_ACCOUNT_ID;
@@ -60,7 +61,7 @@ export async function getR2Object(key: string) {
 	if (!client || !bucket) return null;
 
 	const command = new GetObjectCommand({ Bucket: bucket, Key: key });
-	const response = await client.send(command);
+	const response = await diagnose(`R2 GET ${key}`, () => client.send(command));
 
 	return {
 		body: response.Body,
@@ -84,7 +85,7 @@ export async function headR2Object(key: string) {
 	if (!client || !bucket) return null;
 
 	const command = new HeadObjectCommand({ Bucket: bucket, Key: key });
-	const response = await client.send(command);
+	const response = await diagnose(`R2 HEAD ${key}`, () => client.send(command));
 
 	return {
 		contentLength: response.ContentLength ?? null,

--- a/src/lib/reference-rates.ts
+++ b/src/lib/reference-rates.ts
@@ -10,6 +10,7 @@
  *    restarts and transient API failures (e.g. FRED rate-limiting)
  */
 import swrCache from '$lib/swrCache';
+import { diagnose } from '$lib/diagnostics/server';
 import {
 	FRED_CSV_BASE,
 	FRED_TIMEOUT,
@@ -33,10 +34,12 @@ const TWO_DAYS = 2 * ONE_DAY_S;
 async function fetchFredCsvLatest(seriesId: string): Promise<number | null> {
 	const cacheKey = `fred-${seriesId}`;
 	try {
-		const resp = await fetch(`${FRED_CSV_BASE}?id=${encodeURIComponent(seriesId)}`, {
-			signal: AbortSignal.timeout(FRED_TIMEOUT),
-			headers: { 'User-Agent': randomUserAgent() }
-		});
+		const resp = await diagnose(`FRED ${seriesId}`, () =>
+			fetch(`${FRED_CSV_BASE}?id=${encodeURIComponent(seriesId)}`, {
+				signal: AbortSignal.timeout(FRED_TIMEOUT),
+				headers: { 'User-Agent': randomUserAgent() }
+			})
+		);
 		if (!resp.ok) return readJsonFileCache<number>(cacheKey);
 		const text = await resp.text();
 		const lines = text.trim().split('\n');
@@ -68,10 +71,12 @@ const TREASURY_RATES_URL =
 async function fetchTreasuryNoteRate(): Promise<number | null> {
 	const cacheKey = 'treasury-note-rate';
 	try {
-		const resp = await fetch(TREASURY_RATES_URL, {
-			signal: AbortSignal.timeout(FRED_TIMEOUT),
-			headers: { 'User-Agent': randomUserAgent() }
-		});
+		const resp = await diagnose('US Treasury reference rate', () =>
+			fetch(TREASURY_RATES_URL, {
+				signal: AbortSignal.timeout(FRED_TIMEOUT),
+				headers: { 'User-Agent': randomUserAgent() }
+			})
+		);
 		if (!resp.ok) return readJsonFileCache<number>(cacheKey);
 		const json = await resp.json();
 		const rate = parseFloat(json.data?.[0]?.avg_interest_rate_amt);

--- a/src/routes/+page.server.ts
+++ b/src/routes/+page.server.ts
@@ -15,6 +15,7 @@ import {
 import { getCachedSharePriceReturns } from '$lib/strategies/yaml/share-price';
 import { compactStrategyTileChartData } from 'trade-executor/helpers/chart';
 import { fetchLatestFredValue, fetchLatestTreasuryRate } from '$lib/reference-rates';
+import { diagnose } from '$lib/diagnostics/server';
 
 const HOME_PAGE_EDGE_CACHE_TTL_SECONDS = 30 * 60;
 const FRONT_PAGE_VAULT_COUNT = 5;
@@ -29,113 +30,115 @@ function getAgeSeconds(dateValue: Date | string | null | undefined) {
 }
 
 export async function load({ fetch }) {
-	const [strategies, topVaultsResult, ratesResult] = await Promise.all([
-		getCachedStrategies(fetch),
-		fetchTopVaults(fetch).catch((e) => {
-			console.error('Failed to fetch top vaults:', e);
-			return undefined;
-		}),
-		Promise.all([fetchLatestFredValue('SNDR'), fetchLatestTreasuryRate()])
-	]);
+	return diagnose('Front page SSR load', async () => {
+		const [strategies, topVaultsResult, ratesResult] = await Promise.all([
+			getCachedStrategies(fetch),
+			fetchTopVaults(fetch).catch((e) => {
+				console.error('Failed to fetch top vaults:', e);
+				return undefined;
+			}),
+			Promise.all([fetchLatestFredValue('SNDR'), fetchLatestTreasuryRate()])
+		]);
 
-	const frontpageStrategies = strategies.filter((s) => s.frontpage).map(compactStrategyTileChartData);
-	const yamlTileFreshness: {
-		strategyId: string;
-		vaultId: string | null;
-		sharePriceCacheAgeSeconds: number | null;
-		sharePriceCacheTtlSeconds: number;
-		sharePriceSeriesEndAt: string | null;
-	}[] = [];
+		const frontpageStrategies = strategies.filter((s) => s.frontpage).map(compactStrategyTileChartData);
+		const yamlTileFreshness: {
+			strategyId: string;
+			vaultId: string | null;
+			sharePriceCacheAgeSeconds: number | null;
+			sharePriceCacheTtlSeconds: number;
+			sharePriceSeriesEndAt: string | null;
+		}[] = [];
 
-	// Add YAML strategies with frontpage flag
-	const yamlFrontpage = [...yamlStrategies.values()].filter((c) => c.frontpage);
-	if (yamlFrontpage.length > 0 && topVaultsResult) {
-		try {
-			for (const config of yamlFrontpage) {
-				const vault = topVaultsResult.vaults.find((v) => v.address === config.vault_address);
-				const sharePriceReturns = vault ? await getCachedSharePriceReturns(fetch, vault.id) : undefined;
-				yamlTileFreshness.push({
-					strategyId: config.slug,
-					vaultId: vault?.id ?? null,
-					sharePriceCacheAgeSeconds: vault ? getCachedSharePriceReturns.getAge(fetch, vault.id) : null,
-					sharePriceCacheTtlSeconds: getCachedSharePriceReturns.ttl,
-					sharePriceSeriesEndAt: sharePriceReturns?.length
-						? new Date(sharePriceReturns.at(-1)![0] * 1000).toISOString()
-						: null
-				});
-				frontpageStrategies.push(toListingStrategy(config, vault, sharePriceReturns));
+		// Add YAML strategies with frontpage flag
+		const yamlFrontpage = [...yamlStrategies.values()].filter((c) => c.frontpage);
+		if (yamlFrontpage.length > 0 && topVaultsResult) {
+			try {
+				for (const config of yamlFrontpage) {
+					const vault = topVaultsResult.vaults.find((v) => v.address === config.vault_address);
+					const sharePriceReturns = vault ? await getCachedSharePriceReturns(fetch, vault.id) : undefined;
+					yamlTileFreshness.push({
+						strategyId: config.slug,
+						vaultId: vault?.id ?? null,
+						sharePriceCacheAgeSeconds: vault ? getCachedSharePriceReturns.getAge(fetch, vault.id) : null,
+						sharePriceCacheTtlSeconds: getCachedSharePriceReturns.ttl,
+						sharePriceSeriesEndAt: sharePriceReturns?.length
+							? new Date(sharePriceReturns.at(-1)![0] * 1000).toISOString()
+							: null
+					});
+					frontpageStrategies.push(toListingStrategy(config, vault, sharePriceReturns));
+				}
+			} catch (e) {
+				console.error('Failed to fetch vault data for frontpage YAML strategies:', e);
+				for (const config of yamlFrontpage) {
+					frontpageStrategies.push(toListingStrategy(config));
+				}
 			}
-		} catch (e) {
-			console.error('Failed to fetch vault data for frontpage YAML strategies:', e);
+		} else if (yamlFrontpage.length > 0) {
 			for (const config of yamlFrontpage) {
 				frontpageStrategies.push(toListingStrategy(config));
 			}
 		}
-	} else if (yamlFrontpage.length > 0) {
-		for (const config of yamlFrontpage) {
-			frontpageStrategies.push(toListingStrategy(config));
+
+		frontpageStrategies.sort(compareStrategiesForFrontpage);
+
+		const [savingsRate, treasuryRate] = ratesResult;
+
+		let topVaults: { generated_at: Date | string; vaults: SlimVaultInfo[]; aggregates: VaultAggregates } | undefined;
+
+		if (topVaultsResult) {
+			const allSlim = topVaultsResult.vaults.map(slimVault);
+			const baseVaults = allSlim.filter((v) => isEligibleFrontpageVault(v) && meetsMinTvl(v));
+			const rankedVaults = baseVaults
+				.filter(meetsDefaultTvl)
+				.sort(rankVaultsBy(['three_months_cagr', 'three_months_cagr_net']))
+				.reverse();
+
+			const totalTvl = calculateTotalTvl(baseVaults);
+			const rankedTvl = calculateTotalTvl(rankedVaults);
+			const weightedAvgApy =
+				rankedTvl > 0
+					? rankedVaults.reduce((acc, v) => {
+							const weight = (v.current_nav ?? 0) / rankedTvl;
+							return acc + weight * (v.three_months_cagr_net ?? v.three_months_cagr ?? 0);
+						}, 0)
+					: 0;
+
+			topVaults = {
+				generated_at: topVaultsResult.generated_at,
+				// TopVaults renders five cards. Avoid serialising the unused 25 vaults
+				// into the initial HTML response.
+				vaults: rankedVaults.slice(0, FRONT_PAGE_VAULT_COUNT),
+				aggregates: {
+					totalTvl,
+					weightedAvgApy,
+					rankedVaultCount: rankedVaults.length
+				}
+			};
 		}
-	}
 
-	frontpageStrategies.sort(compareStrategiesForFrontpage);
-
-	const [savingsRate, treasuryRate] = ratesResult;
-
-	let topVaults: { generated_at: Date | string; vaults: SlimVaultInfo[]; aggregates: VaultAggregates } | undefined;
-
-	if (topVaultsResult) {
-		const allSlim = topVaultsResult.vaults.map(slimVault);
-		const baseVaults = allSlim.filter((v) => isEligibleFrontpageVault(v) && meetsMinTvl(v));
-		const rankedVaults = baseVaults
-			.filter(meetsDefaultTvl)
-			.sort(rankVaultsBy(['three_months_cagr', 'three_months_cagr_net']))
-			.reverse();
-
-		const totalTvl = calculateTotalTvl(baseVaults);
-		const rankedTvl = calculateTotalTvl(rankedVaults);
-		const weightedAvgApy =
-			rankedTvl > 0
-				? rankedVaults.reduce((acc, v) => {
-						const weight = (v.current_nav ?? 0) / rankedTvl;
-						return acc + weight * (v.three_months_cagr_net ?? v.three_months_cagr ?? 0);
-					}, 0)
-				: 0;
-
-		topVaults = {
-			generated_at: topVaultsResult.generated_at,
-			// TopVaults renders five cards. Avoid serialising the unused 25 vaults
-			// into the initial HTML response.
-			vaults: rankedVaults.slice(0, FRONT_PAGE_VAULT_COUNT),
-			aggregates: {
-				totalTvl,
-				weightedAvgApy,
-				rankedVaultCount: rankedVaults.length
-			}
-		};
-	}
-
-	return {
-		debugFreshness: {
-			renderedAt: new Date().toISOString(),
-			httpEdgeCacheTtlSeconds: HOME_PAGE_EDGE_CACHE_TTL_SECONDS,
-			apiStrategiesCache: {
-				ttlSeconds: getCachedStrategies.ttl,
-				ageSeconds: getCachedStrategies.getAge(fetch)
+		return {
+			debugFreshness: {
+				renderedAt: new Date().toISOString(),
+				httpEdgeCacheTtlSeconds: HOME_PAGE_EDGE_CACHE_TTL_SECONDS,
+				apiStrategiesCache: {
+					ttlSeconds: getCachedStrategies.ttl,
+					ageSeconds: getCachedStrategies.getAge(fetch)
+				},
+				topVaultsFeed: topVaultsResult
+					? {
+							generatedAt: new Date(topVaultsResult.generated_at).toISOString(),
+							ageSeconds: getAgeSeconds(topVaultsResult.generated_at)
+						}
+					: null,
+				yamlTileSharePriceCache: {
+					ttlSeconds: getCachedSharePriceReturns.ttl,
+					strategies: yamlTileFreshness
+				}
 			},
-			topVaultsFeed: topVaultsResult
-				? {
-						generatedAt: new Date(topVaultsResult.generated_at).toISOString(),
-						ageSeconds: getAgeSeconds(topVaultsResult.generated_at)
-					}
-				: null,
-			yamlTileSharePriceCache: {
-				ttlSeconds: getCachedSharePriceReturns.ttl,
-				strategies: yamlTileFreshness
-			}
-		},
-		strategies: frontpageStrategies,
-		savingsRate,
-		treasuryRate,
-		topVaults
-	};
+			strategies: frontpageStrategies,
+			savingsRate,
+			treasuryRate,
+			topVaults
+		};
+	});
 }


### PR DESCRIPTION
## Why

Production front-page failures need a direct way to identify unavailable or hanging upstream dependencies.

## Lessons learnt

Compose parses its tracked environment file before starting a one-off command, so its multiline values must use Compose-compatible quoting.

## Summary

- add a production-image connectivity checker for configured frontend dependencies
- add opt-in DIAGNOSE request timing logs and Compose wiring
- document the production investigation workflow