### PR TITLE
fix: unify offchain USD denomination

### DIFF
--- a/docs/chart-pages.md
+++ b/docs/chart-pages.md
@@ -38,6 +38,8 @@ The common data sources are:
 - `+page.server.ts` for pages that can prepare their data during server rendering.
 - Vault detail metrics endpoints such as `/vaults/[vault]/metrics` for time-series data.
 
+Before this dataset reaches chart payload builders, raw USD and Kinexys accounting denominations are normalised to the single `USD (offchain)` / `usd-offchain` group. Charts must use this normalised metadata and must not add provider-specific off-chain USD series.
+
 Current cached chart-data endpoints include:
 
 - `core3-risk/chart-data/+server.ts`

--- a/docs/vault-data-source.md
+++ b/docs/vault-data-source.md
@@ -6,7 +6,7 @@ The frontend consumes two server-side vault datasets and one external reference 
 
 | Dataset              | Source                                | Local cache path                        | Used by                                                  |
 | -------------------- | ------------------------------------- | --------------------------------------- | -------------------------------------------------------- |
-| Top vaults JSON      | R2: `top_vaults_by_chain.json`        | In-memory (SWR cache)                   | Vault listings, landing page, vault detail pages         |
+| Top vaults JSON      | R2: `top_vaults_by_chain.json`        | In-memory (1-hour TTL)                  | Vault listings, landing page, vault detail pages         |
 | Vault prices parquet | R2: `cleaned-vault-prices-1h.parquet` | `data/cleaned-vault-prices-1h.parquet`  | Share price chart, TVL charts, historical TVL aggregates |
 | Treasury benchmark   | FRED CSV: `DTB3` series               | `~/.cache/ts-frontend/fred-DTB3-*.json` | US 3M T-bill benchmark line on non-perp vault charts     |
 
@@ -44,7 +44,11 @@ If R2 credentials are unavailable, each dataset can be configured with a direct 
 2. If R2 fails or is not configured → fall back to `TS_PRIVATE_TOP_VAULTS_URL`
 3. If neither is available → throws error
 
-The response is parsed, validated against the Zod schema, and cached in memory with SWR (stale-while-revalidate) via `src/lib/top-vaults/cache.ts`.
+The response is parsed, validated against the Zod schema, normalised for frontend presentation, and cached in memory for one hour via `src/lib/top-vaults/cache.ts`. When the cache expires, the next request waits for a fresh export; there is no stale-while-revalidate behaviour.
+
+#### Off-chain USD denomination
+
+The frontend presents every raw `USD` accounting denomination as `USD (offchain)` with the `usd-offchain` slug. This includes Kinexys vaults, whose source data can instead expose a USDC settlement-token address. The normalisation happens in `src/lib/top-vaults/client.ts` before any page, listing, or chart consumes the dataset. It groups all off-chain USD accounting balances together and prevents them from being presented as an on-chain stablecoin token.
 
 #### Whitelist status
 
@@ -137,7 +141,7 @@ The datasets listing page (`src/routes/vaults/datasets/+page.server.ts`) require
 R2 bucket (vaults-pro-data)
 ├── top_vaults_by_chain.json
 │   └─→ server-config.ts (R2 SDK, URL fallback)
-│       ─→ cache.ts (SWR in-memory) ─→ page loaders
+│       ─→ client.ts (presentation normalisation) ─→ cache.ts (1-hour in-memory) ─→ page loaders
 │
 └── cleaned-vault-prices-1h.parquet
     └─→ vault-prices-parquet.ts (URL if set, else R2 SDK)

--- a/src/lib/stablecoin-metadata/helpers.test.ts
+++ b/src/lib/stablecoin-metadata/helpers.test.ts
@@ -7,9 +7,7 @@ import {
 	getStablecoinDetailsHref,
 	getStablecoinLogoUrl,
 	getStablecoinNativeRate,
-	getVaultDenominationLogoUrl,
 	isStablecoinDepegged,
-	isMidasRawUsdVault,
 	OFFCHAIN_USD_SHORT_DESCRIPTION,
 	resolveStablecoinSlug
 } from './helpers';
@@ -80,18 +78,6 @@ describe('stablecoin metadata helpers', () => {
 		expect(getStablecoinDetailsHref('usd-offchain')).toBeUndefined();
 		expect(getStablecoinDetailsHref('usdc')).toBe('/vaults/stablecoins/usdc');
 		expect(OFFCHAIN_USD_SHORT_DESCRIPTION).toBe('U.S. Dollars in the banking system without onchain transparency');
-	});
-
-	test('uses the US flag only for Midas vaults denominated in raw USD', () => {
-		expect(isMidasRawUsdVault({ protocol_slug: 'midas', denomination: 'USD' })).toBe(true);
-		expect(isMidasRawUsdVault({ protocol_slug: 'midas', denomination: 'USDT' })).toBe(false);
-		expect(getVaultDenominationLogoUrl({ protocol_slug: 'midas', denomination: 'USD' }, 'usd')).toBe('/flags/us.svg');
-		expect(getVaultDenominationLogoUrl({ protocol_slug: 'midas', denomination: 'USDT' }, 'usdt')).not.toBe(
-			'/flags/us.svg'
-		);
-		expect(getVaultDenominationLogoUrl({ protocol_slug: 'morpho', denomination: 'USD' }, 'usd')).not.toBe(
-			'/flags/us.svg'
-		);
 	});
 
 	test('appends symbol to display name when missing', () => {

--- a/src/lib/stablecoin-metadata/helpers.ts
+++ b/src/lib/stablecoin-metadata/helpers.ts
@@ -4,6 +4,7 @@ import { slugify } from '$lib/helpers/slugify';
 import type { StablecoinMetadata } from './schemas';
 
 export const STABLECOIN_DEPEG_RATE_THRESHOLD = 0.9;
+export const OFFCHAIN_USD_DENOMINATION = 'USD (offchain)';
 export const OFFCHAIN_USD_STABLECOIN_SLUG = 'usd-offchain';
 export const OFFCHAIN_USD_SHORT_DESCRIPTION = 'U.S. Dollars in the banking system without onchain transparency';
 const OFFCHAIN_USD_LOGO_URL = '/flags/us.svg';
@@ -144,38 +145,6 @@ export function getStablecoinDetailsHref(slug: string | null | undefined): strin
 	if (!trimmedSlug || trimmedSlug === OFFCHAIN_USD_STABLECOIN_SLUG) return undefined;
 
 	return `/vaults/stablecoins/${trimmedSlug}`;
-}
-
-/**
- * Whether a vault is denominated in Midas' raw USD accounting currency.
- *
- * This is distinct from tokenised stablecoins such as USDT, even though their
- * metadata can expose a USD symbol alias.
- *
- * @param vault vault denomination fields
- */
-export function isMidasRawUsdVault(vault: { protocol_slug?: string | null; denomination?: string | null }): boolean {
-	return vault.protocol_slug === 'midas' && vault.denomination?.trim().toLowerCase() === 'usd';
-}
-
-/**
- * Return the denomination logo for a vault.
- *
- * Midas reports certain vaults as raw USD rather than an on-chain token. These
- * use the US flag; tokenised denominations such as USDT retain their own logos.
- *
- * @param vault vault denomination fields
- * @param slug resolved stablecoin denomination slug
- */
-export function getVaultDenominationLogoUrl(
-	vault: { protocol_slug?: string | null; denomination?: string | null },
-	slug: string | null | undefined
-): string | undefined {
-	if (isMidasRawUsdVault(vault)) {
-		return OFFCHAIN_USD_LOGO_URL;
-	}
-
-	return slug ? getStablecoinLogoUrl(slug) : undefined;
 }
 
 /**

--- a/src/lib/top-vaults/client.ts
+++ b/src/lib/top-vaults/client.ts
@@ -1,7 +1,7 @@
 import { error } from '@sveltejs/kit';
 import { fetchTopVaultsRaw } from './server-config';
 import { type TopVaults, topVaultsSchema } from './schemas';
-import { normaliseKinexysVaultDenomination, normaliseVaultProtocolDisplayName } from './helpers';
+import { normaliseOffchainUsdVaultDenomination, normaliseVaultProtocolDisplayName } from './helpers';
 
 function getSafeErrorSummary(errorValue: unknown): string {
 	if (errorValue instanceof Error) {
@@ -17,7 +17,9 @@ export async function fetchTopVaults(fetch: Fetch): Promise<TopVaults> {
 
 		return {
 			...data,
-			vaults: data.vaults.map((vault) => normaliseVaultProtocolDisplayName(normaliseKinexysVaultDenomination(vault)))
+			vaults: data.vaults.map((vault) =>
+				normaliseVaultProtocolDisplayName(normaliseOffchainUsdVaultDenomination(vault))
+			)
 		};
 	} catch (e) {
 		if (e && typeof e === 'object' && 'status' in e) throw e;

--- a/src/lib/top-vaults/helpers.test.ts
+++ b/src/lib/top-vaults/helpers.test.ts
@@ -33,7 +33,7 @@ import {
 	getXerberusScoreBand,
 	getXerberusScoreColour,
 	isNonUsdDenominatedVault,
-	normaliseKinexysVaultDenomination,
+	normaliseOffchainUsdVaultDenomination,
 	normaliseVaultProtocolDisplayName,
 	withVaultCurrentTvlUsd,
 	withVaultDenominationTokenRate,
@@ -117,7 +117,7 @@ describe('Xerberus protocol score helpers', () => {
 	});
 });
 
-describe('normaliseKinexysVaultDenomination', () => {
+describe('normaliseOffchainUsdVaultDenomination', () => {
 	test('uses off-chain USD dollars for Kinexys vault denomination', () => {
 		const vault = createTestVault('JPMorgan OnChain Liquidity-Token Money Market Fund', {
 			protocol: 'Kinexys',
@@ -128,7 +128,7 @@ describe('normaliseKinexysVaultDenomination', () => {
 			denomination_token_rate: createDenominationTokenRate({ usd_rate: 0.999897 })
 		});
 
-		const normalised = normaliseKinexysVaultDenomination(vault);
+		const normalised = normaliseOffchainUsdVaultDenomination(vault);
 
 		expect(normalised.denomination).toBe('USD (offchain)');
 		expect(normalised.normalised_denomination).toBe('USD (offchain)');
@@ -137,10 +137,25 @@ describe('normaliseKinexysVaultDenomination', () => {
 		expect(normalised.denomination_token_rate).toBeNull();
 	});
 
-	test('does not change non-Kinexys vaults', () => {
-		const vault = createTestVault('Aave USDC', { protocol: 'Aave V3' });
+	test('uses the same denomination for all raw USD vaults', () => {
+		const vault = createTestVault('USD-denominated money market fund', {
+			protocol: 'Securitize',
+			denomination: 'USD',
+			normalised_denomination: 'USD',
+			denomination_slug: 'usd'
+		});
 
-		expect(normaliseKinexysVaultDenomination(vault)).toBe(vault);
+		const normalised = normaliseOffchainUsdVaultDenomination(vault);
+
+		expect(normalised.denomination).toBe('USD (offchain)');
+		expect(normalised.normalised_denomination).toBe('USD (offchain)');
+		expect(normalised.denomination_slug).toBe('usd-offchain');
+	});
+
+	test('does not change tokenised USD denominations', () => {
+		const vault = createTestVault('Aave USDC', { protocol: 'Aave V3', denomination: 'USDC' });
+
+		expect(normaliseOffchainUsdVaultDenomination(vault)).toBe(vault);
 	});
 });
 

--- a/src/lib/top-vaults/helpers.ts
+++ b/src/lib/top-vaults/helpers.ts
@@ -6,6 +6,7 @@ import { vaultSparklinesUrl } from '$lib/config';
 import { capitalize, isNumber } from '$lib/helpers/formatters';
 import { getChain } from '$lib/helpers/chain';
 import { slugify } from '$lib/helpers/slugify';
+import { OFFCHAIN_USD_DENOMINATION, OFFCHAIN_USD_STABLECOIN_SLUG } from '$lib/stablecoin-metadata/helpers';
 
 /**
  * Strip a full vault object to only the fields needed for listing/summary views.
@@ -20,25 +21,29 @@ export function slimVault(vault: Record<string, unknown>): SlimVaultInfo {
 
 const HYPERCORE_CHAIN_ID = 9999;
 const KINEXYS_PROTOCOL_SLUG = 'kinexys';
-const KINEXYS_DENOMINATION = 'USD (offchain)';
-const KINEXYS_DENOMINATION_SLUG = 'usd-offchain';
 export const UNKNOWN_VAULT_PROTOCOL_DISPLAY_NAME = 'Unknown vault protocol';
 /** Canonical group used for vaults whose underlying protocol is unidentified or unsupported. */
 export const UNKNOWN_VAULT_PROTOCOL_SLUG = 'unknown';
 const UNKNOWN_VAULT_PROTOCOL_SLUGS = new Set(['erc-4626']);
 
 /**
- * Kinexys vault balances are denominated in off-chain USD dollars, even when
- * the scanner reports the settlement token address as USDC.
+ * Raw USD and Kinexys vault balances are denominated in off-chain USD dollars,
+ * not in an on-chain stablecoin. Normalise them to one shared denomination so
+ * they are presented consistently in every vault view and chart.
+ *
+ * @param vault vault whose denomination may need normalising
  */
-export function normaliseKinexysVaultDenomination(vault: VaultInfo): VaultInfo {
-	if (vault.protocol_slug !== KINEXYS_PROTOCOL_SLUG) return vault;
+export function normaliseOffchainUsdVaultDenomination(vault: VaultInfo): VaultInfo {
+	// All off-chain USD accounting denominations must use this one shared presentation.
+	const isOffchainUsd =
+		vault.protocol_slug === KINEXYS_PROTOCOL_SLUG || vault.denomination.trim().toLowerCase() === 'usd';
+	if (!isOffchainUsd) return vault;
 
 	return {
 		...vault,
-		denomination: KINEXYS_DENOMINATION,
-		normalised_denomination: KINEXYS_DENOMINATION,
-		denomination_slug: KINEXYS_DENOMINATION_SLUG,
+		denomination: OFFCHAIN_USD_DENOMINATION,
+		normalised_denomination: OFFCHAIN_USD_DENOMINATION,
+		denomination_slug: OFFCHAIN_USD_STABLECOIN_SLUG,
 		denomination_token_address: null,
 		denomination_token_rate: null
 	};

--- a/src/routes/vaults/[vault=slug]/+page.server.ts
+++ b/src/routes/vaults/[vault=slug]/+page.server.ts
@@ -3,7 +3,7 @@ import { fetchStablecoinMetadataIndex } from '$lib/stablecoin-metadata/client';
 import {
 	buildStablecoinMetadataLookup,
 	findStablecoinMetadata,
-	isMidasRawUsdVault
+	OFFCHAIN_USD_STABLECOIN_SLUG
 } from '$lib/stablecoin-metadata/helpers';
 import { getCachedTopVaults } from '$lib/top-vaults/cache';
 import {
@@ -39,14 +39,15 @@ export async function load({ params, fetch }) {
 		fetchStablecoinMetadataIndex(fetch)
 	]);
 	const stablecoinMetadataLookup = buildStablecoinMetadataLookup(stablecoinMetadataIndex);
-	const stablecoinMetadata = isMidasRawUsdVault(vault)
-		? undefined
-		: findStablecoinMetadata(
-				stablecoinMetadataLookup,
-				vault.denomination_slug,
-				vault.denomination,
-				vault.normalised_denomination
-			);
+	const stablecoinMetadata =
+		vault.denomination_slug === OFFCHAIN_USD_STABLECOIN_SLUG
+			? undefined
+			: findStablecoinMetadata(
+					stablecoinMetadataLookup,
+					vault.denomination_slug,
+					vault.denomination,
+					vault.normalised_denomination
+				);
 	const vaultWithRates = withVaultDenominationTokenRate(
 		vault,
 		stablecoinMetadata,

--- a/src/routes/vaults/[vault=slug]/VaultMetrics.svelte
+++ b/src/routes/vaults/[vault=slug]/VaultMetrics.svelte
@@ -16,7 +16,7 @@ Displays supplementary vault information, performance, fees, and risk metrics.
 	import { getChainDisplayName } from '$lib/helpers/chain';
 	import {
 		getStablecoinDetailsHref,
-		getVaultDenominationLogoUrl,
+		getStablecoinLogoUrl,
 		resolveStablecoinSlug
 	} from '$lib/stablecoin-metadata/helpers';
 	import type { StablecoinMetadata } from '$lib/stablecoin-metadata/schemas';
@@ -52,7 +52,7 @@ Displays supplementary vault information, performance, fees, and risk metrics.
 			name: vault.normalised_denomination
 		})
 	);
-	let denominationLogoUrl = $derived(getVaultDenominationLogoUrl(vault, denominationSlug));
+	let denominationLogoUrl = $derived(denominationSlug ? getStablecoinLogoUrl(denominationSlug) : undefined);
 	let denominationHref = $derived(stablecoinMetadata ? getStablecoinDetailsHref(denominationSlug) : undefined);
 
 	let lifetimeMaxDrawdown = $derived(

--- a/src/routes/vaults/[vault=slug]/VaultTechnicalDetailsTable.svelte
+++ b/src/routes/vaults/[vault=slug]/VaultTechnicalDetailsTable.svelte
@@ -23,7 +23,7 @@ Includes the source whitelist status and any source-provided whitelist notes.
 	} from '$lib/top-vaults/helpers';
 	import {
 		getStablecoinDetailsHref,
-		getVaultDenominationLogoUrl,
+		getStablecoinLogoUrl,
 		resolveStablecoinSlug
 	} from '$lib/stablecoin-metadata/helpers';
 	import type { StablecoinMetadata } from '$lib/stablecoin-metadata/schemas';
@@ -61,7 +61,7 @@ Includes the source whitelist status and any source-provided whitelist notes.
 	let showNativeTvlRows = $derived(denominationCurrency != null && denominationCurrency !== 'usd');
 	let lifetimePeriod = $derived(vault.period_results?.find((p) => p.period.toLowerCase() === 'lifetime') ?? null);
 	let denominationPageSlug = $derived(denominationSlug ?? vault.denomination_slug);
-	let denominationLogoUrl = $derived(getVaultDenominationLogoUrl(vault, denominationSlug));
+	let denominationLogoUrl = $derived(denominationSlug ? getStablecoinLogoUrl(denominationSlug) : undefined);
 	let denominationHref = $derived(stablecoinMetadata ? getStablecoinDetailsHref(denominationSlug) : undefined);
 	let showExchangeRateRow = $derived(vault.protocol_slug !== 'kinexys');
 	let mobileOstiumHref = $derived(

--- a/src/routes/vaults/historical-tvl-stablecoin/+page.svelte
+++ b/src/routes/vaults/historical-tvl-stablecoin/+page.svelte
@@ -22,7 +22,7 @@ Historical vault TVL by stablecoin page with a server-side aggregated weekly sta
 
 	const title = 'Historical vault TVL by stablecoin';
 	const description = 'Explore how stablecoin vault TVL has evolved across different stablecoins over time.';
-	const chartDataVersion = 'daily-short-history-v1';
+	const chartDataVersion = 'offchain-usd-v2';
 	let pageUrl = $derived(new URL(page.url.pathname, page.url.origin).href);
 
 	onMount(() => {

--- a/src/routes/vaults/historical-tvl-stablecoin/chart-data/+server.ts
+++ b/src/routes/vaults/historical-tvl-stablecoin/chart-data/+server.ts
@@ -16,7 +16,7 @@ import { getCachedTopVaults } from '$lib/top-vaults/cache';
 const compress = promisify(brotliCompress);
 
 const CACHE_TTL_MS = HISTORICAL_TVL_CACHE_TTL_SECONDS * 1000;
-const CACHE_VERSION = 'historical-tvl-stablecoin-daily-short-history-v1';
+const CACHE_VERSION = 'historical-tvl-stablecoin-offchain-usd-v2';
 
 let cache: { json: string; br: Uint8Array; expires: number; version: string } | null = null;
 


### PR DESCRIPTION
## Why

Raw USD accounting denominations and Kinexys balances both represent off-chain USD, but appeared as separate groups in vault views and historical TVL charts.

## Lessons learnt

Normalise denominations at the top-vault data boundary so all listings, detail pages, search results, and chart payloads consume the same presentation data.

## Summary

- Group raw USD and Kinexys balances under `USD (offchain)` / `usd-offchain`.
- Remove legacy provider-specific denomination presentation helpers.
- Refresh the historical stablecoin TVL cache key and document the canonical denomination rule.