### PR TITLE
feat: reveal blacklisted vaults in listings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Weblog of stuff
 
+- Add a blacklisted-vault reveal control to vault listings (2026-08-17)
 - Unify CORE3 and Xerberus risk-rating card disclosures (2026-08-13)
 - Optionally export server-side APM traces and logs to SigNoz via OpenTelemetry (2026-08-12)
 - Refine vault risk summaries and transaction-status placement (2026-08-10)

--- a/docs/vault-listings.md
+++ b/docs/vault-listings.md
@@ -34,11 +34,11 @@ A successful response contains `vaults`, `nextOffset`, `hasMore`,
 private, no-store`. On `409`, the table refreshes the current URL through
 client navigation to obtain a fresh server-rendered first batch.
 
-After the default progressive rows have loaded, a listing with hidden
-blacklisted vaults shows a centred **Show X blacklisted vaults** control below
-the table. It fetches only the matching blacklisted rows, changes the displayed
-risk level to **Blacklisted**, and updates the URL without a document reload.
-Additional blacklisted rows continue loading in 50-row batches when needed.
+Once all default rows are visible, a listing with hidden blacklisted vaults
+shows a centred **Show X blacklisted vaults** control below the table. It fetches
+only the matching blacklisted rows, changes the displayed risk level to
+**Blacklisted**, and updates the URL without a document reload. Additional
+blacklisted rows continue loading in 50-row batches when needed.
 
 `/top-vaults/all-data` remains available for chart pages that genuinely need
 the complete export. Vault table pages must not use it after hydration.

--- a/docs/vault-listings.md
+++ b/docs/vault-listings.md
@@ -1,6 +1,6 @@
 # Vault listing pagination
 
-Vault table pages render their first 75 matching rows in the SvelteKit server
+Vault table pages render their first 125 matching rows in the SvelteKit server
 load. This makes the initial listing visible without downloading the complete
 vault export in the browser.
 
@@ -21,17 +21,24 @@ filters may narrow that definition but cannot change its base population.
 `GET /top-vaults/listing-data` returns the next 50 rows. It accepts the normal
 listing filter query parameters plus:
 
-| Parameter | Required         | Description                                                                                 |
-| --------- | ---------------- | ------------------------------------------------------------------------------------------- |
-| `listing` | No               | Listing key; defaults to `top`.                                                             |
-| `scope`   | Dynamic listings | Route-provided chain, protocol, stablecoin, or curator slug. Unknown values return no rows. |
-| `offset`  | No               | Non-negative number of rows already received; defaults to `0`.                              |
-| `version` | No               | Initial page `generated_at` timestamp. A changed export produces `409`.                     |
+| Parameter     | Required         | Description                                                                                 |
+| ------------- | ---------------- | ------------------------------------------------------------------------------------------- |
+| `listing`     | No               | Listing key; defaults to `top`.                                                             |
+| `scope`       | Dynamic listings | Route-provided chain, protocol, stablecoin, or curator slug. Unknown values return no rows. |
+| `offset`      | No               | Non-negative number of rows already received; defaults to `0`.                              |
+| `version`     | No               | Initial page `generated_at` timestamp. A changed export produces `409`.                     |
+| `blacklisted` | No               | Set to `1` to return only blacklisted rows that match the current listing filters.          |
 
-A successful response contains `vaults`, `nextOffset`, `hasMore`, and
-`generatedAt`. Responses use `Cache-Control: private, no-store`. On `409`, the
-table replaces its accumulated rows by navigating to the current URL again,
-which obtains a fresh server-rendered first batch.
+A successful response contains `vaults`, `nextOffset`, `hasMore`,
+`generatedAt`, and the full listing summary. Responses use `Cache-Control:
+private, no-store`. On `409`, the table refreshes the current URL through
+client navigation to obtain a fresh server-rendered first batch.
+
+After the default progressive rows have loaded, a listing with hidden
+blacklisted vaults shows a centred **Show X blacklisted vaults** control below
+the table. It fetches only the matching blacklisted rows, changes the displayed
+risk level to **Blacklisted**, and updates the URL without a document reload.
+Additional blacklisted rows continue loading in 50-row batches when needed.
 
 `/top-vaults/all-data` remains available for chart pages that genuinely need
 the complete export. Vault table pages must not use it after hydration.
@@ -40,7 +47,7 @@ the complete export. Vault table pages must not use it after hydration.
 
 The server sends compact full-result aggregates with the first row batch.
 Listing counts, TVL, weighted returns, and SEO item counts must use those
-aggregates, not the initial 75 rows. Charts that need every member receive a
+aggregates, not the initial 125 rows. Charts that need every member receive a
 separate, purpose-built payload rather than reusing table rows.
 
 Summary calculations use the same scope and filters as the listing. They omit

--- a/src/lib/server/top-vaults/listing.ts
+++ b/src/lib/server/top-vaults/listing.ts
@@ -16,9 +16,9 @@ import {
 	type VaultListingKey
 } from '$lib/top-vaults/listing/definitions';
 import { queryVaultListing } from '$lib/top-vaults/listing/query';
-import type { VaultListingOptions, VaultListingQuery } from '$lib/top-vaults/listing/query';
+import type { VaultListingOptions, VaultListingQuery, VaultListingResult } from '$lib/top-vaults/listing/query';
 import { parseVaultListingQuery } from '$lib/top-vaults/listing/state';
-import { INITIAL_VAULT_LISTING_LIMIT } from '$lib/top-vaults/listing/types';
+import { INITIAL_VAULT_LISTING_LIMIT, type VaultListingSummary } from '$lib/top-vaults/listing/types';
 import type { VaultInfo } from '$lib/top-vaults/schemas';
 
 async function resolveListingVaults(fetchFn: typeof fetch, vaults: VaultInfo[], key: VaultListingKey, scope?: string) {
@@ -42,6 +42,18 @@ async function resolveListingVaults(fetchFn: typeof fetch, vaults: VaultInfo[], 
 async function getListingOptions(options: VaultListingOptions, query: VaultListingQuery): Promise<VaultListingOptions> {
 	if (query.mr !== 'treasury') return options;
 	return { ...options, treasuryRate: await fetchLatestTreasuryRate().catch(() => null) };
+}
+
+/** Convert a complete query result into the compact listing metadata sent to the browser. */
+export function createVaultListingSummary(listing: VaultListingResult): VaultListingSummary {
+	return {
+		matchingCount: listing.vaults.length,
+		hiddenByTvl: listing.hiddenByTvl,
+		hiddenBlacklistedCount: listing.hiddenBlacklistedCount,
+		hiddenVaultNames: listing.hiddenVaults.slice(0, 2).map((vault) => vault.name),
+		totalTvl: listing.totalTvl,
+		avgTvlWeightedApy1M: listing.avgTvlWeightedApy1M
+	};
 }
 
 /**
@@ -69,14 +81,7 @@ export async function loadVaultListing(fetchFn: typeof fetch, url: URL, key: Vau
 			curators: {}
 		},
 		initialVaultListingHasMore: initialVaults.length < listing.vaults.length,
-		listingSummary: {
-			matchingCount: listing.vaults.length,
-			hiddenByTvl: listing.hiddenByTvl,
-			hiddenBlacklistedCount: listing.hiddenBlacklistedCount,
-			hiddenVaultNames: listing.hiddenVaults.slice(0, 2).map((vault) => vault.name),
-			totalTvl: listing.totalTvl,
-			avgTvlWeightedApy1M: listing.avgTvlWeightedApy1M
-		},
+		listingSummary: createVaultListingSummary(listing),
 		listingCurrencies:
 			key === 'international'
 				? [

--- a/src/lib/server/top-vaults/listing.ts
+++ b/src/lib/server/top-vaults/listing.ts
@@ -72,6 +72,7 @@ export async function loadVaultListing(fetchFn: typeof fetch, url: URL, key: Vau
 		listingSummary: {
 			matchingCount: listing.vaults.length,
 			hiddenByTvl: listing.hiddenByTvl,
+			hiddenBlacklistedCount: listing.hiddenBlacklistedCount,
 			hiddenVaultNames: listing.hiddenVaults.slice(0, 2).map((vault) => vault.name),
 			totalTvl: listing.totalTvl,
 			avgTvlWeightedApy1M: listing.avgTvlWeightedApy1M

--- a/src/lib/top-vaults/TopVaultsTable.svelte
+++ b/src/lib/top-vaults/TopVaultsTable.svelte
@@ -200,14 +200,15 @@ Whitelisted vaults are marked as Private, except tokenised funds, which are mark
 	let remoteLoading = $state(false);
 	let remoteOffset = $state(topVaults.vaults.length);
 	let revealedBlacklistedVaults = $state<VaultInfo[]>([]);
-	let currentListingSummary = $state<VaultListingSummary | undefined>(listingSummary);
+	let revealedListingSummary = $state<VaultListingSummary>();
 	$effect(() => {
 		accumulatedVaults = topVaults.vaults;
 		remoteOffset = topVaults.vaults.length;
 		remoteHasMore = progressive;
 	});
 	$effect(() => {
-		currentListingSummary = listingSummary;
+		listingSummary;
+		revealedListingSummary = undefined;
 	});
 
 	// --- Sort column registry (key → compareFn + default direction) ---
@@ -356,7 +357,7 @@ Whitelisted vaults are marked as Private, except tokenised funds, which are mark
 			const seen = new Set(accumulatedVaults.map((vault) => vault.id));
 			revealedBlacklistedVaults = next.vaults.filter((vault) => !seen.has(vault.id));
 			remoteHasMore = next.hasMore;
-			currentListingSummary = next.listingSummary;
+			revealedListingSummary = next.listingSummary;
 			riskOverride = blacklistedRiskIndex;
 			replaceState(targetUrl, {});
 		} finally {
@@ -555,7 +556,7 @@ Whitelisted vaults are marked as Private, except tokenised funds, which are mark
 	});
 	// The server summary also provides the hidden-blacklisted count when the
 	// unfiltered result fits in the initial batch (and is therefore not progressive).
-	let serverListingSummary = $derived(currentListingSummary);
+	let serverListingSummary = $derived(revealedListingSummary ?? listingSummary);
 	let blacklistedVaultsAreHidden = $derived(
 		!includeBlacklisted && !filterValue.startsWith('blacklist') && selectedRisk.maxValue < 999
 	);

--- a/src/lib/top-vaults/TopVaultsTable.svelte
+++ b/src/lib/top-vaults/TopVaultsTable.svelte
@@ -11,8 +11,7 @@ Whitelisted vaults are marked as Private, except tokenised funds, which are mark
 	import type { RiskRatingProvider } from './risk-rating-providers';
 	import type { ParamSchema } from '$lib/helpers/url-search-state';
 	import { onMount, untrack } from 'svelte';
-	import { SvelteURLSearchParams } from 'svelte/reactivity';
-	import { goto } from '$app/navigation';
+	import { goto, replaceState } from '$app/navigation';
 	import { page } from '$app/state';
 	import { inview } from 'svelte-inview';
 	import { resolve } from '$app/paths';
@@ -152,6 +151,13 @@ Whitelisted vaults are marked as Private, except tokenised funds, which are mark
 		listingSummary?: VaultListingSummary;
 	}
 
+	interface ListingDataResponse {
+		vaults: VaultInfo[];
+		nextOffset: number;
+		hasMore: boolean;
+		listingSummary: VaultListingSummary;
+	}
+
 	const emptyTopVaults: TopVaults = {
 		generated_at: new Date().toISOString(),
 		vaults: [],
@@ -193,10 +199,15 @@ Whitelisted vaults are marked as Private, except tokenised funds, which are mark
 	let remoteHasMore = $state(progressive);
 	let remoteLoading = $state(false);
 	let remoteOffset = $state(topVaults.vaults.length);
+	let revealedBlacklistedVaults = $state<VaultInfo[]>([]);
+	let currentListingSummary = $state<VaultListingSummary | undefined>(listingSummary);
 	$effect(() => {
 		accumulatedVaults = topVaults.vaults;
 		remoteOffset = topVaults.vaults.length;
 		remoteHasMore = progressive;
+	});
+	$effect(() => {
+		currentListingSummary = listingSummary;
 	});
 
 	// --- Sort column registry (key → compareFn + default direction) ---
@@ -307,13 +318,50 @@ Whitelisted vaults are marked as Private, except tokenised funds, which are mark
 	} as const satisfies ParamSchema;
 
 	let urlState = $derived(deserialiseSearchParams(page.url.searchParams, searchParamsSchema));
+	/** URL state changes shallowly while revealing hidden rows, without a page navigation. */
+	let riskOverride = $state<number | null>(null);
 
 	/** Update URL search params, merging overrides with current state */
-	function updateSearchParams(overrides: Partial<typeof urlState>) {
+	function getSearchUrl(overrides: Partial<typeof urlState>) {
 		const current = deserialiseSearchParams(page.url.searchParams, searchParamsSchema);
-		const updated = { ...current, ...overrides };
+		const updated = { ...current, ...(riskOverride == null ? {} : { risk: riskOverride }), ...overrides };
 		const queryString = serialiseSearchParams(updated, searchParamsSchema);
-		goto(resolve(`${page.url.pathname}?${queryString}`), { replaceState: true, noScroll: true, keepFocus: true });
+		return resolve(`${page.url.pathname}?${queryString}`);
+	}
+
+	function updateSearchParams(overrides: Partial<typeof urlState>) {
+		if ('risk' in overrides) riskOverride = null;
+		return goto(getSearchUrl(overrides), {
+			replaceState: true,
+			noScroll: true,
+			keepFocus: true
+		});
+	}
+
+	/** Reveal the hidden rows without reloading the listing page. */
+	async function showBlacklistedVaults() {
+		if (remoteLoading) return;
+
+		const targetUrl = getSearchUrl({ risk: blacklistedRiskIndex });
+		const targetSearchParams = new URL(targetUrl, page.url.origin).searchParams;
+		remoteLoading = true;
+		try {
+			const next = await fetchListingData(targetSearchParams, 0, true);
+			if (next == null) {
+				riskOverride = null;
+				await goto(targetUrl, { invalidateAll: true, replaceState: true, noScroll: true, keepFocus: true });
+				return;
+			}
+
+			const seen = new Set(accumulatedVaults.map((vault) => vault.id));
+			revealedBlacklistedVaults = next.vaults.filter((vault) => !seen.has(vault.id));
+			remoteHasMore = next.hasMore;
+			currentListingSummary = next.listingSummary;
+			riskOverride = blacklistedRiskIndex;
+			replaceState(targetUrl, {});
+		} finally {
+			remoteLoading = false;
+		}
 	}
 
 	// --- Filter state (derived from URL) ---
@@ -325,10 +373,10 @@ Whitelisted vaults are marked as Private, except tokenised funds, which are mark
 	let selectedAgeIndex = $derived(urlState.age);
 	let selectedAge = $derived(ageFilterOptions[selectedAgeIndex]);
 
-	let selectedRiskIndex = $derived(urlState.risk);
+	let selectedRiskIndex = $derived(riskOverride ?? urlState.risk);
 	let selectedRisk = $derived(riskFilterOptions[selectedRiskIndex]);
+	const blacklistedRiskIndex = riskFilterOptions.findIndex((option) => option.label === 'Blacklisted');
 	let riskDropdownOpen = $state(false);
-
 	let selectedDdKey = $derived(urlState.dd);
 	let selectedDdOption = $derived(ddFilterOptions.find((o) => o.key === selectedDdKey)!);
 	let ddDropdownOpen = $state(false);
@@ -479,7 +527,9 @@ Whitelisted vaults are marked as Private, except tokenised funds, which are mark
 
 	// Filter out blacklisted vaults unless explicitly included, searched for, or selected by risk level.
 	let baseVaults = $derived.by(() => {
-		const sourceVaults = progressive ? accumulatedVaults : topVaults.vaults;
+		const sourceVaults = progressive
+			? [...accumulatedVaults, ...revealedBlacklistedVaults]
+			: [...topVaults.vaults, ...revealedBlacklistedVaults];
 		if (includeBlacklisted || filterValue.startsWith('blacklist') || selectedRisk.maxValue >= 999) {
 			return sourceVaults;
 		}
@@ -503,7 +553,18 @@ Whitelisted vaults are marked as Private, except tokenised funds, which are mark
 		if (!filterTvl && !showFilters) return [];
 		return baseVaults.filter((v) => getVaultCurrentTvl(v) < getVaultTvlThreshold(v));
 	});
-	let serverListingSummary = $derived(progressive ? listingSummary : undefined);
+	// The server summary also provides the hidden-blacklisted count when the
+	// unfiltered result fits in the initial batch (and is therefore not progressive).
+	let serverListingSummary = $derived(currentListingSummary);
+	let blacklistedVaultsAreHidden = $derived(
+		!includeBlacklisted && !filterValue.startsWith('blacklist') && selectedRisk.maxValue < 999
+	);
+	let hiddenBlacklistedCount = $derived(
+		serverListingSummary?.hiddenBlacklistedCount ??
+			(blacklistedVaultsAreHidden
+				? (progressive ? accumulatedVaults : topVaults.vaults).filter(isBlacklisted).length
+				: 0)
+	);
 	let hiddenVaultNames = $derived(
 		serverListingSummary?.hiddenVaultNames ?? hiddenVaults.slice(0, 2).map((vault) => vault.name)
 	);
@@ -632,6 +693,24 @@ Whitelisted vaults are marked as Private, except tokenised funds, which are mark
 	let visibleVaults = $derived(progressive ? sortedVaults : sortedVaults.slice(0, maxVisibleRows));
 	let hasMoreRows = $derived(progressive ? remoteHasMore : maxVisibleRows < sortedVaults.length);
 
+	async function fetchListingData(
+		searchParams: URLSearchParams,
+		offset: number,
+		onlyBlacklisted = false
+	): Promise<ListingDataResponse | null> {
+		const params = new URLSearchParams(searchParams);
+		params.set('listing', listingKey);
+		if (listingScope) params.set('scope', listingScope);
+		params.set('offset', String(offset));
+		params.set('version', new Date(topVaults.generated_at).toISOString());
+		if (onlyBlacklisted) params.set('blacklisted', '1');
+
+		const response = await fetch(`/top-vaults/listing-data?${params}`);
+		if (response.status === 409) return null;
+		if (!response.ok) throw new Error(`Vault listing continuation failed: ${response.status}`);
+		return (await response.json()) as ListingDataResponse;
+	}
+
 	async function loadMore() {
 		if (!progressive) {
 			maxVisibleRows += VAULT_LISTING_PAGE_SIZE;
@@ -640,14 +719,14 @@ Whitelisted vaults are marked as Private, except tokenised funds, which are mark
 		if (remoteLoading || !remoteHasMore) return;
 		remoteLoading = true;
 		try {
-			const params = new SvelteURLSearchParams(page.url.searchParams);
-			params.set('listing', listingKey);
-			if (listingScope) params.set('scope', listingScope);
-			params.set('offset', String(remoteOffset));
-			params.set('version', new Date(topVaults.generated_at).toISOString());
-			const response = await fetch(`/top-vaults/listing-data?${params}`);
-			if (response.status === 409) {
-				await goto(resolve(`${page.url.pathname}${page.url.search}`), {
+			const loadingRevealedBlacklisted = riskOverride === blacklistedRiskIndex;
+			const searchParams = loadingRevealedBlacklisted
+				? new URL(getSearchUrl({}), page.url.origin).searchParams
+				: page.url.searchParams;
+			const offset = loadingRevealedBlacklisted ? revealedBlacklistedVaults.length : remoteOffset;
+			const next = await fetchListingData(searchParams, offset, loadingRevealedBlacklisted);
+			if (next == null) {
+				await goto(getSearchUrl({}), {
 					invalidateAll: true,
 					replaceState: true,
 					noScroll: true,
@@ -655,8 +734,15 @@ Whitelisted vaults are marked as Private, except tokenised funds, which are mark
 				});
 				return;
 			}
-			if (!response.ok) throw new Error(`Vault listing continuation failed: ${response.status}`);
-			const next = (await response.json()) as { vaults: VaultInfo[]; nextOffset: number; hasMore: boolean };
+			if (loadingRevealedBlacklisted) {
+				const seen = new Set([...accumulatedVaults, ...revealedBlacklistedVaults].map((vault) => vault.id));
+				revealedBlacklistedVaults = [
+					...revealedBlacklistedVaults,
+					...next.vaults.filter((vault) => !seen.has(vault.id))
+				];
+				remoteHasMore = next.hasMore;
+				return;
+			}
 			const seen = new Set(accumulatedVaults.map((vault) => vault.id));
 			accumulatedVaults = [...accumulatedVaults, ...next.vaults.filter((vault) => !seen.has(vault.id))];
 			remoteOffset = next.nextOffset;
@@ -1362,6 +1448,18 @@ Whitelisted vaults are marked as Private, except tokenised funds, which are mark
 			</tbody>
 		</table>
 	</div>
+
+	{#if hiddenBlacklistedCount > 0 && !remoteHasMore}
+		<button
+			class="show-blacklisted-vaults"
+			data-testid="show-blacklisted-vaults"
+			disabled={remoteLoading}
+			type="button"
+			onclick={showBlacklistedVaults}
+		>
+			Show {hiddenBlacklistedCount} blacklisted {hiddenBlacklistedCount === 1 ? 'vault' : 'vaults'}
+		</button>
+	{/if}
 </div>
 
 <style>
@@ -1669,6 +1767,18 @@ Whitelisted vaults are marked as Private, except tokenised funds, which are mark
 			@media (--viewport-xl-down) {
 				overflow-x: auto;
 			}
+		}
+
+		.show-blacklisted-vaults {
+			justify-self: center;
+			padding: 0;
+			border: 0;
+			background: transparent;
+			color: var(--c-text-extra-light);
+			font: var(--f-ui-sm-medium);
+			text-decoration: underline;
+			text-underline-offset: 0.15em;
+			cursor: pointer;
 		}
 
 		table {

--- a/src/lib/top-vaults/TopVaultsTable.test.ts
+++ b/src/lib/top-vaults/TopVaultsTable.test.ts
@@ -24,6 +24,33 @@ function getRenderedVaultNames() {
 }
 
 describe('TopVaultsTable risk rating column', () => {
+	it('offers to reveal blacklisted vaults through the Blacklisted risk filter', () => {
+		const safeVault = createTestVault('Safe vault', { risk: 'Low' });
+		const blacklistedVault = createTestVault('Blacklisted vault', { risk: 'Blacklisted' });
+
+		render(TopVaultsTable, {
+			props: {
+				topVaults: {
+					generated_at: '2026-07-30T11:30:40Z',
+					vaults: [safeVault, blacklistedVault],
+					core3_protocols: {},
+					curators: {}
+				},
+				listingSummary: {
+					matchingCount: 1,
+					hiddenByTvl: 0,
+					hiddenBlacklistedCount: 1,
+					hiddenVaultNames: [],
+					totalTvl: 100_000,
+					avgTvlWeightedApy1M: 0.1
+				}
+			}
+		});
+
+		expect(screen.getByRole('button', { name: 'Show 1 blacklisted vault' })).toBeInTheDocument();
+		expect(getRenderedVaultNames()).toEqual(['Safe vault']);
+	});
+
 	it('shows and sorts CORE3 ratings from lowest Probability of Loss first', () => {
 		const saferVault = createTestVault('Safer CORE3 vault', { protocol: 'Safer CORE3' });
 		const riskierVault = createTestVault('Riskier CORE3 vault', { protocol: 'Riskier CORE3' });

--- a/src/lib/top-vaults/TopVaultsTable.test.ts
+++ b/src/lib/top-vaults/TopVaultsTable.test.ts
@@ -24,7 +24,7 @@ function getRenderedVaultNames() {
 }
 
 describe('TopVaultsTable risk rating column', () => {
-	it('offers to reveal blacklisted vaults through the Blacklisted risk filter', () => {
+	it('shows the blacklisted-vault reveal control when the server summary reports hidden vaults', () => {
 		const safeVault = createTestVault('Safe vault', { risk: 'Low' });
 		const blacklistedVault = createTestVault('Blacklisted vault', { risk: 'Blacklisted' });
 

--- a/src/lib/top-vaults/listing/query.test.ts
+++ b/src/lib/top-vaults/listing/query.test.ts
@@ -44,6 +44,17 @@ describe('vault listing query', () => {
 
 		expect(result.vaults.map((vault) => vault.name)).toEqual(['Accepted']);
 		expect(result.hiddenByTvl).toBe(1);
+		expect(result.hiddenBlacklistedCount).toBe(1);
+	});
+
+	it('does not report blacklisted vaults as hidden once the Blacklisted risk filter is active', () => {
+		const blacklisted = createTestVault('Blacklisted', { current_nav: 100_000, risk: 'Blacklisted' });
+		const query = parseVaultListingQuery(new URLSearchParams('risk=0'), { tvl: '10k' });
+
+		const result = queryVaultListing([blacklisted], query, options);
+
+		expect(result.vaults.map((vault) => vault.name)).toEqual(['Blacklisted']);
+		expect(result.hiddenBlacklistedCount).toBe(0);
 	});
 
 	it('excludes blacklisted vaults from the listing summary by default', () => {

--- a/src/lib/top-vaults/listing/query.test.ts
+++ b/src/lib/top-vaults/listing/query.test.ts
@@ -47,6 +47,17 @@ describe('vault listing query', () => {
 		expect(result.hiddenBlacklistedCount).toBe(1);
 	});
 
+	it('counts only blacklisted vaults that the reveal action can display', () => {
+		const belowTvl = createTestVault('Below TVL', { current_nav: 9_999, risk: 'Blacklisted' });
+		const hiddenByAge = createTestVault('Too old', { current_nav: 100_000, years: 2, risk: 'Blacklisted' });
+		const revealable = createTestVault('Revealable', { current_nav: 100_000, years: 0.5, risk: 'Blacklisted' });
+		const query = parseVaultListingQuery(new URLSearchParams('age=2'), { tvl: '10k' });
+
+		const result = queryVaultListing([belowTvl, hiddenByAge, revealable], query, options);
+
+		expect(result.hiddenBlacklistedCount).toBe(1);
+	});
+
 	it('does not report blacklisted vaults as hidden once the Blacklisted risk filter is active', () => {
 		const blacklisted = createTestVault('Blacklisted', { current_nav: 100_000, risk: 'Blacklisted' });
 		const query = parseVaultListingQuery(new URLSearchParams('risk=0'), { tvl: '10k' });

--- a/src/lib/top-vaults/listing/query.ts
+++ b/src/lib/top-vaults/listing/query.ts
@@ -54,6 +54,7 @@ export interface VaultListingOptions {
 export interface VaultListingResult {
 	vaults: VaultInfo[];
 	hiddenByTvl: number;
+	hiddenBlacklistedCount: number;
 	hiddenVaults: VaultInfo[];
 	totalTvl: number;
 	avgTvlWeightedApy1M: number | null;
@@ -125,6 +126,8 @@ export function queryVaultListing(
 		(vault) =>
 			options.includeBlacklisted || query.q.startsWith('blacklist') || risk.maxValue >= 999 || !isBlacklisted(vault)
 	);
+	const blacklistedVaultsAreHidden =
+		!options.includeBlacklisted && !query.q.startsWith('blacklist') && risk.maxValue < 999;
 	const threshold = (vault: VaultInfo) =>
 		options.showFilters ? (tvl.chainOverrides?.[vault.chain_id] ?? tvl.value) : options.tvlThreshold;
 	const matchesWithoutTvl = base.filter((vault) => {
@@ -184,6 +187,7 @@ export function queryVaultListing(
 	return {
 		vaults: sortVaults(matches, query.sort, query.direction),
 		hiddenByTvl: hiddenVaults.length,
+		hiddenBlacklistedCount: blacklistedVaultsAreHidden ? vaults.filter(isBlacklisted).length : 0,
 		hiddenVaults,
 		totalTvl: calculateTotalTvl(statsWithUsdTvl, { maxTvlUsd: options.maxSummaryTvlUsd }),
 		avgTvlWeightedApy1M: calculateTvlWeightedApy(statsWithUsdTvl, {

--- a/src/lib/top-vaults/listing/query.ts
+++ b/src/lib/top-vaults/listing/query.ts
@@ -128,17 +128,18 @@ export function queryVaultListing(
 	);
 	const blacklistedVaultsAreHidden =
 		!options.includeBlacklisted && !query.q.startsWith('blacklist') && risk.maxValue < 999;
+	const blacklistedRisk = riskFilterOptions.find((item) => item.label === 'Blacklisted') ?? risk;
 	const threshold = (vault: VaultInfo) =>
 		options.showFilters ? (tvl.chainOverrides?.[vault.chain_id] ?? tvl.value) : options.tvlThreshold;
-	const matchesWithoutTvl = base.filter((vault) => {
+	const matchesFilters = (vault: VaultInfo, riskFilter = risk) => {
 		const years = vault.years ?? 0;
 		if (options.showFilters && ((age.value > 0 && years < age.value) || (age.maxAge < Infinity && years >= age.maxAge)))
 			return false;
-		if (options.showFilters && (risk.minValue > 0 || risk.maxValue < Infinity)) {
+		if (options.showFilters && (riskFilter.minValue > 0 || riskFilter.maxValue < Infinity)) {
 			if (
 				vault.risk_numeric != null
-					? vault.risk_numeric < risk.minValue || vault.risk_numeric > risk.maxValue
-					: !(risk.minValue === 0 && risk.maxValue >= 50)
+					? vault.risk_numeric < riskFilter.minValue || vault.risk_numeric > riskFilter.maxValue
+					: !(riskFilter.minValue === 0 && riskFilter.maxValue >= 50)
 			)
 				return false;
 		}
@@ -173,21 +174,23 @@ export function queryVaultListing(
 			.join(' ')
 			.toLowerCase();
 		return search.includes(query.q.trim().toLowerCase());
-	});
-	const hiddenVaults =
-		options.filterTvl || options.showFilters
-			? matchesWithoutTvl.filter((vault) => (getVaultCurrentTvlUsd(vault) ?? 0) < threshold(vault))
-			: [];
-	const matches =
-		options.filterTvl || options.showFilters
-			? matchesWithoutTvl.filter((vault) => (getVaultCurrentTvlUsd(vault) ?? 0) >= threshold(vault))
-			: matchesWithoutTvl;
+	};
+	const hasTvlFilter = options.filterTvl || options.showFilters;
+	const passesTvlFilter = (vault: VaultInfo) =>
+		!hasTvlFilter || (getVaultCurrentTvlUsd(vault) ?? 0) >= threshold(vault);
+	const matchesWithoutTvl = base.filter((vault) => matchesFilters(vault));
+	const hiddenVaults = hasTvlFilter ? matchesWithoutTvl.filter((vault) => !passesTvlFilter(vault)) : [];
+	const matches = matchesWithoutTvl.filter(passesTvlFilter);
+	const hiddenBlacklistedCount = blacklistedVaultsAreHidden
+		? vaults.filter((vault) => isBlacklisted(vault) && matchesFilters(vault, blacklistedRisk) && passesTvlFilter(vault))
+				.length
+		: 0;
 	const stats = options.includeBlacklistedInStats ? matches : matches.filter((vault) => !isBlacklisted(vault));
 	const statsWithUsdTvl = stats.map(withVaultCurrentTvlUsd);
 	return {
 		vaults: sortVaults(matches, query.sort, query.direction),
 		hiddenByTvl: hiddenVaults.length,
-		hiddenBlacklistedCount: blacklistedVaultsAreHidden ? vaults.filter(isBlacklisted).length : 0,
+		hiddenBlacklistedCount,
 		hiddenVaults,
 		totalTvl: calculateTotalTvl(statsWithUsdTvl, { maxTvlUsd: options.maxSummaryTvlUsd }),
 		avgTvlWeightedApy1M: calculateTvlWeightedApy(statsWithUsdTvl, {

--- a/src/lib/top-vaults/listing/types.ts
+++ b/src/lib/top-vaults/listing/types.ts
@@ -8,6 +8,8 @@ export const VAULT_LISTING_PAGE_SIZE = 50;
 export interface VaultListingSummary {
 	matchingCount: number;
 	hiddenByTvl: number;
+	/** Blacklisted vaults omitted from the default safety filter. */
+	hiddenBlacklistedCount: number;
 	hiddenVaultNames: string[];
 	totalTvl: number;
 	avgTvlWeightedApy1M: number | null;

--- a/src/lib/top-vaults/listing/types.ts
+++ b/src/lib/top-vaults/listing/types.ts
@@ -4,7 +4,7 @@ export const INITIAL_VAULT_LISTING_LIMIT = 125;
 /** Rows returned by each browser continuation request. */
 export const VAULT_LISTING_PAGE_SIZE = 50;
 
-/** Full-result values sent with the SSR batch, not repeated by continuations. */
+/** Full-result values sent with SSR batches and listing-data responses. */
 export interface VaultListingSummary {
 	matchingCount: number;
 	hiddenByTvl: number;

--- a/src/routes/top-vaults/listing-data/+server.ts
+++ b/src/routes/top-vaults/listing-data/+server.ts
@@ -2,6 +2,7 @@ import { json, error } from '@sveltejs/kit';
 import { getVaultListingDefinition, isVaultListingKey } from '$lib/top-vaults/listing/definitions';
 import { loadVaultListingContinuation } from '$lib/server/top-vaults/listing';
 import { VAULT_LISTING_PAGE_SIZE } from '$lib/top-vaults/listing/types';
+import { isBlacklisted } from '$lib/top-vaults/helpers';
 
 /** Return one globally sorted vault-listing continuation page. */
 export async function GET({ fetch, url }) {
@@ -20,13 +21,23 @@ export async function GET({ fetch, url }) {
 			{ status: 409, headers: { 'Cache-Control': 'private, no-store' } }
 		);
 	}
-	const vaults = listing.vaults.slice(offset, offset + VAULT_LISTING_PAGE_SIZE);
+	const onlyBlacklisted = url.searchParams.get('blacklisted') === '1';
+	const matchingVaults = onlyBlacklisted ? listing.vaults.filter(isBlacklisted) : listing.vaults;
+	const vaults = matchingVaults.slice(offset, offset + VAULT_LISTING_PAGE_SIZE);
 	return json(
 		{
 			vaults,
 			nextOffset: offset + vaults.length,
-			hasMore: offset + vaults.length < listing.vaults.length,
-			generatedAt
+			hasMore: offset + vaults.length < matchingVaults.length,
+			generatedAt,
+			listingSummary: {
+				matchingCount: listing.vaults.length,
+				hiddenByTvl: listing.hiddenByTvl,
+				hiddenBlacklistedCount: listing.hiddenBlacklistedCount,
+				hiddenVaultNames: listing.hiddenVaults.slice(0, 2).map((vault) => vault.name),
+				totalTvl: listing.totalTvl,
+				avgTvlWeightedApy1M: listing.avgTvlWeightedApy1M
+			}
 		},
 		{ headers: { 'Cache-Control': 'private, no-store' } }
 	);

--- a/src/routes/top-vaults/listing-data/+server.ts
+++ b/src/routes/top-vaults/listing-data/+server.ts
@@ -1,10 +1,10 @@
 import { json, error } from '@sveltejs/kit';
 import { getVaultListingDefinition, isVaultListingKey } from '$lib/top-vaults/listing/definitions';
-import { loadVaultListingContinuation } from '$lib/server/top-vaults/listing';
+import { createVaultListingSummary, loadVaultListingContinuation } from '$lib/server/top-vaults/listing';
 import { VAULT_LISTING_PAGE_SIZE } from '$lib/top-vaults/listing/types';
 import { isBlacklisted } from '$lib/top-vaults/helpers';
 
-/** Return one globally sorted vault-listing continuation page. */
+/** Return one globally sorted vault-listing continuation or blacklisted-reveal page. */
 export async function GET({ fetch, url }) {
 	const offset = Number(url.searchParams.get('offset') ?? '0');
 	if (!Number.isInteger(offset) || offset < 0) error(400, 'Invalid vault listing offset');
@@ -30,14 +30,7 @@ export async function GET({ fetch, url }) {
 			nextOffset: offset + vaults.length,
 			hasMore: offset + vaults.length < matchingVaults.length,
 			generatedAt,
-			listingSummary: {
-				matchingCount: listing.vaults.length,
-				hiddenByTvl: listing.hiddenByTvl,
-				hiddenBlacklistedCount: listing.hiddenBlacklistedCount,
-				hiddenVaultNames: listing.hiddenVaults.slice(0, 2).map((vault) => vault.name),
-				totalTvl: listing.totalTvl,
-				avgTvlWeightedApy1M: listing.avgTvlWeightedApy1M
-			}
+			listingSummary: createVaultListingSummary(listing)
 		},
 		{ headers: { 'Cache-Control': 'private, no-store' } }
 	);

--- a/tests/integration/vaults/index.test.ts
+++ b/tests/integration/vaults/index.test.ts
@@ -36,6 +36,20 @@ async function getVaultRow(page: import('@playwright/test').Page, name: string) 
 	return row;
 }
 
+/** Load every progressive batch so a control below the table is reachable. */
+async function loadAllVaultRows(page: import('@playwright/test').Page) {
+	for (let attempt = 0; attempt < 10; attempt++) {
+		const sentinel = page.getByTestId('load-more-sentinel');
+		if ((await sentinel.count()) === 0) return;
+
+		const rowCount = await page.locator('tbody tr.targetable').count();
+		await sentinel.scrollIntoViewIfNeeded();
+		await expect.poll(() => page.locator('tbody tr.targetable').count()).toBeGreaterThan(rowCount);
+	}
+
+	await expect(page.getByTestId('load-more-sentinel')).toHaveCount(0);
+}
+
 async function toggleReturnOption(page: import('@playwright/test').Page, label: string) {
 	await page.getByTestId('return-columns-menu').getByText(label, { exact: true }).click();
 }
@@ -243,6 +257,35 @@ test.describe('vault index page', () => {
 		await expect(page.getByTestId('top-vaults-meta')).toContainText('3 vaults out of');
 		await expect(page.getByTestId('top-vaults-meta')).toContainText('TVL $8M');
 		await expect(page.getByTestId('top-vaults-meta')).toContainText('Avg. return 20.00%');
+	});
+
+	test('reveals blacklisted vaults while preserving the scroll position', async ({ page }) => {
+		await page.setViewportSize({ width: 1280, height: 720 });
+		await page.goto('/vaults');
+		await loadAllVaultRows(page);
+
+		const revealButton = page.getByTestId('show-blacklisted-vaults');
+		await expect(revealButton).toHaveText(/Show \d+ blacklisted vaults?/);
+		await expect(page.getByTestId('top-vaults-meta')).toContainText('254 vaults');
+		await expect(page.locator('tbody tr.targetable')).toHaveCount(254);
+		await revealButton.scrollIntoViewIfNeeded();
+
+		const scrollBefore = await page.evaluate(() => window.scrollY);
+		expect(scrollBefore).toBeGreaterThan(0);
+		let documentNavigationUrl: string | undefined;
+		page.on('request', (request) => {
+			if (request.isNavigationRequest() && request.url().includes('risk=0')) {
+				documentNavigationUrl = request.url();
+			}
+		});
+		await revealButton.click();
+
+		await expect.poll(() => new URL(page.url()).searchParams.get('risk')).toBe('0');
+		await expect(page.getByTestId('show-blacklisted-vaults')).toHaveCount(0);
+		await expect(page.getByTestId('top-vaults-meta')).toContainText('255 vaults');
+		await expect(page.locator('tbody tr.targetable')).toHaveCount(255);
+		await expect.poll(() => page.evaluate(() => window.scrollY)).toBeGreaterThanOrEqual(scrollBefore - 200);
+		expect(documentNavigationUrl).toBeUndefined();
 	});
 
 	test('shows only whitelisted vaults', async ({ page }) => {


### PR DESCRIPTION
## Why

Blacklisted vaults are hidden by default, but visitors need a clear, contextual way to reveal them without losing their place in the listing.

## Lessons learnt

A full document navigation remounts the curator chart and other page assets, making a small table update feel slow. The progressive listing endpoint already has the server-cached data needed for an incremental reveal.

## Summary

- Add a centred control below fully loaded vault tables when blacklisted vaults have been hidden.
- Reveal blacklisted vault rows through a small background listing request and shallowly update the risk URL state.
- Preserve the reader's position and stream further hidden rows when necessary.
- Add Playwright integration coverage for revealing the vaults without a document navigation.
- Add the feature to the changelog.