### PR TITLE
fix: improve mobile vault layout

### DIFF
--- a/docs/tests.md
+++ b/docs/tests.md
@@ -72,6 +72,11 @@ viewports. It verifies that the first compact-menu tap remains open after hydrat
 tablet search-field focus survives hydration, menu closure after navigation to Pricing, and equivalent
 protocol/vault typeahead results.
 
+`tests/integration/mobile-layout.test.ts` verifies that the home page, vault listing, and a representative
+vault detail page cannot be horizontally panned at a 375px mobile viewport. It checks document width, body
+width, and the actual horizontal scroll offset, while allowing intentionally scrollable elements such as the
+vault table.
+
 #### Local secrets and `.env.local`
 
 For normal development, keep checked-in defaults in `.env` and place local-only secrets in

--- a/src/lib/components/Footer.svelte
+++ b/src/lib/components/Footer.svelte
@@ -128,6 +128,8 @@ Set `small` to use the compact spacing variant.
 
 		.link-group {
 			display: flex;
+			flex-wrap: wrap;
+			justify-content: center;
 			gap: inherit;
 		}
 

--- a/src/lib/top-vaults/VaultPriceChart.svelte
+++ b/src/lib/top-vaults/VaultPriceChart.svelte
@@ -396,6 +396,16 @@ so relative performance is comparable on a single axis.
 		.chart-title {
 			font: var(--f-heading-md-medium);
 			letter-spacing: var(--f-heading-md-spacing, normal);
+
+			@media (--viewport-sm-down) {
+				font: var(--f-ui-sm-roman);
+				letter-spacing: 0.1em;
+				text-transform: uppercase;
+
+				:global(.underline) {
+					border-bottom: 0;
+				}
+			}
 		}
 
 		:global([data-css-props]) {

--- a/src/routes/vaults/[vault=slug]/ChartWithFeaturedMetrics.svelte
+++ b/src/routes/vaults/[vault=slug]/ChartWithFeaturedMetrics.svelte
@@ -218,12 +218,27 @@ amounts in the denomination's native currency.
 				display: flex;
 				min-width: 0;
 				justify-content: space-between;
+
+				:global(.metric) {
+					flex: 1 1 0;
+					min-width: 0;
+				}
 			}
 		}
 
 		@media (--viewport-sm-down) {
 			.featured-metrics {
-				justify-content: space-evenly;
+				gap: 0.75rem;
+				padding-inline: 0;
+
+				:global(.metric.xl) {
+					--value-font: var(--f-heading-lg-medium);
+				}
+
+				:global(.metric .label),
+				:global(.metric .value) {
+					overflow-wrap: anywhere;
+				}
 			}
 		}
 	}

--- a/src/routes/vaults/[vault=slug]/VaultPageHeader.svelte
+++ b/src/routes/vaults/[vault=slug]/VaultPageHeader.svelte
@@ -36,7 +36,6 @@ Displays a vault's heading, external link, update action, and description.
 		// Unknown-protocol vaults fall back to the hostname of their external destination.
 		if (externalVaultUrl) return new URL(externalVaultUrl).host;
 	});
-	let hideCtaOnMobile = $derived(externalSiteName === 'Ostium');
 </script>
 
 <PageHeader>
@@ -47,7 +46,7 @@ Displays a vault's heading, external link, update action, and description.
 	{/snippet}
 
 	{#snippet cta()}
-		<span class="cta-actions" class:mobile-hidden={hideCtaOnMobile}>
+		<span class="cta-actions">
 			{#if externalVaultUrl}
 				<Button href={externalVaultUrl} target="_blank" rel="noreferrer">
 					{externalSiteName === 'Ostium' ? 'Open vault on Ostium' : `View on ${externalSiteName}`}
@@ -69,10 +68,8 @@ Displays a vault's heading, external link, update action, and description.
 		align-items: center;
 		gap: 0.75rem;
 
-		&.mobile-hidden {
-			@media (--viewport-sm-down) {
-				display: none;
-			}
+		@media (--viewport-sm-down) {
+			display: none;
 		}
 	}
 
@@ -91,5 +88,9 @@ Displays a vault's heading, external link, update action, and description.
 		flex-wrap: wrap;
 		gap: 0.25em;
 		align-items: center;
+
+		@media (--viewport-sm-down) {
+			font: var(--f-h2-medium);
+		}
 	}
 </style>

--- a/src/routes/vaults/[vault=slug]/VaultRankings.svelte
+++ b/src/routes/vaults/[vault=slug]/VaultRankings.svelte
@@ -1,3 +1,7 @@
+<!--
+@component
+Shows a vault's overall, chain, and protocol return rankings.
+-->
 <script lang="ts">
 	import type { Chain } from '$lib/helpers/chain';
 	import type { VaultInfo } from '$lib/top-vaults/schemas';
@@ -72,6 +76,12 @@
 			font: var(--f-ui-md-roman);
 		}
 
+		@media (--viewport-sm-down) {
+			grid-template-columns: auto minmax(0, 1fr);
+			gap: 0.5rem;
+			font: var(--f-ui-sm-roman);
+		}
+
 		ul {
 			display: flex;
 			flex-wrap: wrap;
@@ -79,10 +89,18 @@
 			list-style: none;
 			padding: 0;
 
+			@media (--viewport-sm-down) {
+				gap: 0.5rem 1rem;
+			}
+
 			li {
 				display: flex;
 				gap: 0.5ex;
 				color: var(--c-text-extra-light);
+
+				@media (--viewport-sm-down) {
+					gap: 0.25ex;
+				}
 			}
 
 			.rank {

--- a/tests/integration/mobile-layout.test.ts
+++ b/tests/integration/mobile-layout.test.ts
@@ -1,0 +1,32 @@
+import { expect, test, type Page } from '@playwright/test';
+
+const mobileViewport = { width: 375, height: 667 };
+
+/** Assert that a page cannot be panned horizontally outside its mobile viewport. */
+async function expectNoHorizontalPageScroll(page: Page) {
+	const dimensions = await page.evaluate(() => {
+		window.scrollTo({ left: document.documentElement.scrollWidth, top: 0 });
+
+		return {
+			viewportWidth: window.innerWidth,
+			documentWidth: document.documentElement.scrollWidth,
+			bodyWidth: document.body.scrollWidth,
+			horizontalOffset: window.scrollX
+		};
+	});
+
+	expect(dimensions.documentWidth).toBeLessThanOrEqual(dimensions.viewportWidth);
+	expect(dimensions.bodyWidth).toBeLessThanOrEqual(dimensions.viewportWidth);
+	expect(dimensions.horizontalOffset).toBe(0);
+}
+
+test.describe('mobile layout', () => {
+	for (const path of ['/', '/vaults', '/vaults/return-leader-alpha']) {
+		test(`${path} does not allow horizontal page scrolling`, async ({ page }) => {
+			await page.setViewportSize(mobileViewport);
+			await page.goto(path, { waitUntil: 'networkidle' });
+
+			await expectNoHorizontalPageScroll(page);
+		});
+	}
+});

--- a/tests/integration/vaults/index.test.ts
+++ b/tests/integration/vaults/index.test.ts
@@ -456,16 +456,11 @@ test.describe('vault index page', () => {
 		await expect(page.locator('.notes')).toHaveCount(0);
 	});
 
-	test('shows the external vault link in the mobile detail header', async ({ page }) => {
+	test('hides detail header actions on mobile', async ({ page }) => {
 		await page.setViewportSize({ width: 390, height: 844 });
 		await page.goto('/vaults/morpho-flagged-blacklisted-vault');
 
-		const externalVaultLink = page.getByRole('link', { name: 'View on Morpho' });
-		await expect(externalVaultLink).toBeVisible();
-		await expect(externalVaultLink).toHaveAttribute(
-			'href',
-			'https://app.euler.finance/earn/0xc3415c9231dad88f8146107372143f6dae042967?network=arbitrum'
-		);
+		await expect(page.locator('.cta-actions')).toBeHidden();
 	});
 
 	test('explains the tokenised fund structure when deposits may be disabled on a vault detail page', async ({


### PR DESCRIPTION
## Why

Mobile vault pages could be panned horizontally because the footer social links overflowed, and detail-page content was too wide or visually inconsistent on narrow screens.

## Lessons learnt

Page-level horizontal overflow can originate from a shared component outside the visible viewport. Test the document scroll width and actual horizontal offset, while allowing intentional inner scrolling such as the vault table.

## Summary

- Wrap footer social links so they remain within narrow viewports.
- Refine mobile vault detail headings, actions, rankings, featured metrics, and share-price chart labels.
- Add and document mobile horizontal-scroll integration coverage for the home and vault-listing pages.