### PR TITLE
fix: contain mobile navigation content

### DIFF
--- a/docs/tests.md
+++ b/docs/tests.md
@@ -75,7 +75,8 @@ closure after navigation to Pricing, and equivalent protocol/vault typeahead res
 `tests/integration/mobile-layout.test.ts` verifies that the home page, vault listing, and a representative
 vault detail page cannot be horizontally panned at a 375px mobile viewport. It checks document width, body
 width, and the actual horizontal scroll offset, while allowing intentionally scrollable elements such as the
-vault table. It also verifies that the two home-hero actions share the same width at that viewport.
+vault table. It also verifies that the two home-hero actions share the same width and that all three
+hero differentiators remain on one line at that viewport.
 
 #### Local secrets and `.env.local`
 

--- a/docs/tests.md
+++ b/docs/tests.md
@@ -68,9 +68,9 @@ pnpm run test:integration
 #### Responsive navigation coverage
 
 `tests/integration/navigation.test.ts` covers the shared header at desktop, tablet and narrow-mobile
-viewports. It verifies that the first compact-menu tap remains open after hydration, that the first
-tablet search-field focus survives hydration, menu closure after navigation to Pricing, and equivalent
-protocol/vault typeahead results.
+viewports. It verifies that the first compact-menu tap remains open after hydration, the open mobile
+drawer remains within the viewport, that the first tablet search-field focus survives hydration, menu
+closure after navigation to Pricing, and equivalent protocol/vault typeahead results.
 
 `tests/integration/mobile-layout.test.ts` verifies that the home page, vault listing, and a representative
 vault detail page cannot be horizontally panned at a 375px mobile viewport. It checks document width, body

--- a/docs/tests.md
+++ b/docs/tests.md
@@ -75,7 +75,7 @@ closure after navigation to Pricing, and equivalent protocol/vault typeahead res
 `tests/integration/mobile-layout.test.ts` verifies that the home page, vault listing, and a representative
 vault detail page cannot be horizontally panned at a 375px mobile viewport. It checks document width, body
 width, and the actual horizontal scroll offset, while allowing intentionally scrollable elements such as the
-vault table.
+vault table. It also verifies that the two home-hero actions share the same width at that viewport.
 
 #### Local secrets and `.env.local`
 

--- a/src/lib/components/Footer.svelte
+++ b/src/lib/components/Footer.svelte
@@ -99,6 +99,8 @@ Set `small` to use the compact spacing variant.
 
 <style>
 	footer {
+		min-width: 0;
+		max-width: 100%;
 		margin-block: 3.5rem;
 		padding-inline: 1.5rem;
 	}
@@ -128,6 +130,8 @@ Set `small` to use the compact spacing variant.
 
 		.link-group {
 			display: flex;
+			width: 100%;
+			max-width: 100%;
 			flex-wrap: wrap;
 			justify-content: center;
 			gap: inherit;
@@ -239,6 +243,7 @@ Set `small` to use the compact spacing variant.
 	}
 
 	.disclaimer {
+		overflow-wrap: anywhere;
 		text-align: center;
 		font: var(--f-ui-xs-roman);
 		letter-spacing: var(--f-ui-xs-spacing, normal);

--- a/src/lib/components/Footer.svelte
+++ b/src/lib/components/Footer.svelte
@@ -131,7 +131,6 @@ Set `small` to use the compact spacing variant.
 		.link-group {
 			display: flex;
 			width: 100%;
-			max-width: 100%;
 			flex-wrap: wrap;
 			justify-content: center;
 			gap: inherit;

--- a/src/lib/components/NavPanel.svelte
+++ b/src/lib/components/NavPanel.svelte
@@ -70,6 +70,7 @@ Responsive navigation drawer with optional search entry, primary links and site 
 		box-sizing: border-box;
 		width: 100%;
 		max-width: 420px;
+		min-width: 0;
 		padding: var(--space-md);
 		overflow-y: auto;
 		display: grid;

--- a/src/lib/components/NavPanel.svelte
+++ b/src/lib/components/NavPanel.svelte
@@ -70,7 +70,6 @@ Responsive navigation drawer with optional search entry, primary links and site 
 		box-sizing: border-box;
 		width: 100%;
 		max-width: 420px;
-		min-width: 0;
 		padding: var(--space-md);
 		overflow-y: auto;
 		display: grid;

--- a/src/routes/_components/HomeHeroBanner.svelte
+++ b/src/routes/_components/HomeHeroBanner.svelte
@@ -1,3 +1,7 @@
+<!--
+@component
+Promotes Trading Strategy vault discovery and managed strategies on the home page.
+-->
 <script lang="ts">
 	import { resolve } from '$app/paths';
 	import Button from '$lib/components/Button.svelte';
@@ -22,7 +26,7 @@
 
 				<div class="ctas">
 					<Button primaryHeroBanner size="lg" label="Earn with our vaults" href={resolve('/strategies')} />
-					<Button secondary size="lg" label="Explore vault data" href={resolve('/vaults')} />
+					<Button secondary size="lg" label="See top vaults" href={resolve('/vaults')} />
 				</div>
 
 				<div class="differentiators">
@@ -396,8 +400,15 @@
 		}
 
 		.ctas {
+			display: grid;
+			grid-template-columns: minmax(0, 1fr);
+			width: 100%;
 			margin-top: 0.5rem;
-			justify-content: flex-start;
+
+			:global(.button) {
+				width: 100%;
+				justify-content: center;
+			}
 		}
 	}
 

--- a/src/routes/_components/HomeHeroBanner.svelte
+++ b/src/routes/_components/HomeHeroBanner.svelte
@@ -22,7 +22,7 @@ Promotes Trading Strategy vault discovery and managed strategies on the home pag
 
 		<div class="content">
 			<div class="text">
-				<p>Compare and allocate across 3000+ risk-scored vaults using professional metrics and strategies.</p>
+				<p>Compare and allocate across 3000+ vaults using professional performance and risk metrics.</p>
 
 				<div class="ctas">
 					<Button primaryHeroBanner size="lg" label="Earn with our vaults" href={resolve('/strategies')} />

--- a/src/routes/_components/HomeHeroBanner.svelte
+++ b/src/routes/_components/HomeHeroBanner.svelte
@@ -329,10 +329,8 @@ Promotes Trading Strategy vault discovery and managed strategies on the home pag
 		padding-top: 0.15rem;
 
 		@media (--viewport-sm-down) {
-			flex-wrap: nowrap;
-			gap: 0.25rem 0.5rem;
-			font: var(--f-ui-xxs-medium, 500 11px/16px var(--ff-ui));
-			letter-spacing: normal;
+			font: var(--f-ui-sm-medium);
+			letter-spacing: var(--f-ui-sm-spacing);
 		}
 	}
 
@@ -430,7 +428,15 @@ Promotes Trading Strategy vault discovery and managed strategies on the home pag
 		}
 
 		.differentiators {
-			gap: 0.5rem 0.875rem;
+			flex-wrap: nowrap;
+			gap: 0.25rem 0.5rem;
+			font: var(--f-ui-xs-medium);
+			font-size: 11px;
+			letter-spacing: normal;
+
+			:global(.trigger) {
+				white-space: nowrap;
+			}
 		}
 	}
 </style>

--- a/src/routes/_components/HomeHeroBanner.svelte
+++ b/src/routes/_components/HomeHeroBanner.svelte
@@ -329,8 +329,10 @@ Promotes Trading Strategy vault discovery and managed strategies on the home pag
 		padding-top: 0.15rem;
 
 		@media (--viewport-sm-down) {
-			font: var(--f-ui-sm-medium);
-			letter-spacing: var(--f-ui-sm-spacing);
+			flex-wrap: nowrap;
+			gap: 0.25rem 0.5rem;
+			font: var(--f-ui-xxs-medium, 500 11px/16px var(--ff-ui));
+			letter-spacing: normal;
 		}
 	}
 

--- a/tests/integration/mobile-layout.test.ts
+++ b/tests/integration/mobile-layout.test.ts
@@ -46,4 +46,22 @@ test.describe('mobile layout', () => {
 		expect(strategyAction!.x).toBeGreaterThanOrEqual(0);
 		expect(strategyAction!.x + strategyAction!.width).toBeLessThanOrEqual(mobileViewport.width);
 	});
+
+	test('home hero differentiators fit on one line', async ({ page }) => {
+		await page.setViewportSize(mobileViewport);
+		await page.goto('/', { waitUntil: 'networkidle' });
+
+		const differentiators = page.getByTestId('home-hero-banner').locator('.differentiators');
+		const bounds = await differentiators.locator('.tooltip').evaluateAll((items) =>
+			items.map((item) => {
+				const { top, right } = item.getBoundingClientRect();
+				return { top, right };
+			})
+		);
+		const container = await differentiators.boundingBox();
+
+		expect(container).not.toBeNull();
+		expect(new Set(bounds.map(({ top }) => Math.round(top))).size).toBe(1);
+		expect(bounds.at(-1)!.right).toBeLessThanOrEqual(container!.x + container!.width);
+	});
 });

--- a/tests/integration/mobile-layout.test.ts
+++ b/tests/integration/mobile-layout.test.ts
@@ -29,4 +29,21 @@ test.describe('mobile layout', () => {
 			await expectNoHorizontalPageScroll(page);
 		});
 	}
+
+	test('home hero actions have equal widths', async ({ page }) => {
+		await page.setViewportSize(mobileViewport);
+		await page.goto('/', { waitUntil: 'networkidle' });
+
+		const actions = page.getByTestId('home-hero-banner').getByRole('link');
+		const [strategyAction, vaultAction] = await Promise.all([
+			actions.nth(0).boundingBox(),
+			actions.nth(1).boundingBox()
+		]);
+
+		expect(strategyAction).not.toBeNull();
+		expect(vaultAction).not.toBeNull();
+		expect(strategyAction!.width).toBeCloseTo(vaultAction!.width, 0);
+		expect(strategyAction!.x).toBeGreaterThanOrEqual(0);
+		expect(strategyAction!.x + strategyAction!.width).toBeLessThanOrEqual(mobileViewport.width);
+	});
 });

--- a/tests/integration/mobile-layout.test.ts
+++ b/tests/integration/mobile-layout.test.ts
@@ -52,16 +52,18 @@ test.describe('mobile layout', () => {
 		await page.goto('/', { waitUntil: 'networkidle' });
 
 		const differentiators = page.getByTestId('home-hero-banner').locator('.differentiators');
-		const bounds = await differentiators.locator('.tooltip').evaluateAll((items) =>
+		const bounds = await differentiators.locator('.tooltip .trigger').evaluateAll((items) =>
 			items.map((item) => {
-				const { top, right } = item.getBoundingClientRect();
-				return { top, right };
+				const { height, right, top } = item.getBoundingClientRect();
+				return { height, right, top };
 			})
 		);
 		const container = await differentiators.boundingBox();
 
 		expect(container).not.toBeNull();
+		expect(bounds).toHaveLength(3);
 		expect(new Set(bounds.map(({ top }) => Math.round(top))).size).toBe(1);
+		expect(bounds.every(({ height }) => height <= 16)).toBe(true);
 		expect(bounds.at(-1)!.right).toBeLessThanOrEqual(container!.x + container!.width);
 	});
 });

--- a/tests/integration/navigation.test.ts
+++ b/tests/integration/navigation.test.ts
@@ -19,6 +19,27 @@ test('opens compact navigation on the first tap after page load', async ({ page 
 	expect(bounds!.width).toBeCloseTo(1024, 0);
 });
 
+test('keeps the mobile navigation within the viewport', async ({ page }) => {
+	await page.setViewportSize({ width: 375, height: 667 });
+	await page.goto('/pricing', { waitUntil: 'networkidle' });
+	await page.getByTestId('navigation-toggle').click();
+
+	const dimensions = await page.getByRole('navigation', { name: 'Mobile navigation' }).evaluate((navigation) => {
+		window.scrollTo({ left: document.documentElement.scrollWidth, top: 0 });
+
+		return {
+			viewportWidth: window.innerWidth,
+			navigationWidth: navigation.scrollWidth,
+			documentWidth: document.documentElement.scrollWidth,
+			horizontalOffset: window.scrollX
+		};
+	});
+
+	expect(dimensions.navigationWidth).toBeLessThanOrEqual(dimensions.viewportWidth);
+	expect(dimensions.documentWidth).toBeLessThanOrEqual(dimensions.viewportWidth);
+	expect(dimensions.horizontalOffset).toBe(0);
+});
+
 test('keeps the first tablet search tap focused through hydration', async ({ page }) => {
 	await page.setViewportSize({ width: 1024, height: 768 });
 	await page.goto('/pricing', { waitUntil: 'commit' });

--- a/tests/integration/navigation.test.ts
+++ b/tests/integration/navigation.test.ts
@@ -24,7 +24,10 @@ test('keeps the mobile navigation within the viewport', async ({ page }) => {
 	await page.goto('/pricing', { waitUntil: 'networkidle' });
 	await page.getByTestId('navigation-toggle').click();
 
-	const dimensions = await page.getByRole('navigation', { name: 'Mobile navigation' }).evaluate((navigation) => {
+	const navigation = page.getByRole('navigation', { name: 'Mobile navigation' });
+	await expect(page.getByRole('checkbox', { name: 'Hide navigation panel' })).toBeChecked();
+
+	const dimensions = await navigation.evaluate((navigation) => {
 		window.scrollTo({ left: document.documentElement.scrollWidth, top: 0 });
 
 		return {


### PR DESCRIPTION
## Why

The compact mobile navigation could let its footer content exceed the viewport width, and the home-page hero actions had unequal widths on narrow screens.

## Lessons learnt

A flex group only wraps predictably when its available width is explicitly constrained, particularly when it appears inside a grid-based navigation drawer. Mobile CTA rows should use an explicit shared grid track when equal action widths are part of the design.

## Summary

- Constrain the mobile drawer footer, social-link group, and disclaimer to the available width.
- Make the home-hero actions equal-width on mobile, keep differentiators on one line, and rename the vault-discovery action.
- Add Playwright coverage for mobile navigation overflow, hero action widths, and differentiator layout.
- Document the expanded responsive-navigation and mobile-layout coverage.