### PR TITLE
fix: improve vault rankings copy and layout

### DIFF
--- a/src/lib/top-vaults/return-columns.ts
+++ b/src/lib/top-vaults/return-columns.ts
@@ -177,18 +177,18 @@ function getPeriodValues(vault: VaultInfo, period: '6m' | '1y', type: 'ann' | 'a
 export const returnColumnDefinitions = [
 	{
 		id: '1m-ann',
-		label: 'One month annualised',
-		shortLabel: '1M ann.',
-		headerLabel: '1M<br/>return ann.',
+		label: '30 days annualised',
+		shortLabel: '30 days ann.',
+		headerLabel: '30 days<br/>return ann.',
 		sortDirection: 'desc',
 		showAnnualisedTooltip: true,
 		getValues: (vault) => getTopLevelValues(vault, 'one_month_cagr_net', 'one_month_cagr')
 	},
 	{
 		id: '1m-abs',
-		label: 'One month absolute',
-		shortLabel: '1M abs',
-		headerLabel: '1M<br/>return abs.',
+		label: '30 days absolute',
+		shortLabel: '30 days abs',
+		headerLabel: '30 days<br/>return abs.',
 		sortDirection: 'desc',
 		showAnnualisedTooltip: false,
 		getValues: (vault) => getTopLevelValues(vault, 'one_month_returns_net', 'one_month_returns')

--- a/src/lib/top-vaults/return-columns.ts
+++ b/src/lib/top-vaults/return-columns.ts
@@ -177,18 +177,18 @@ function getPeriodValues(vault: VaultInfo, period: '6m' | '1y', type: 'ann' | 'a
 export const returnColumnDefinitions = [
 	{
 		id: '1m-ann',
-		label: '30 days annualised',
-		shortLabel: '30 days ann.',
-		headerLabel: '30 days<br/>return ann.',
+		label: 'One month annualised',
+		shortLabel: '1M ann.',
+		headerLabel: '1M<br/>return ann.',
 		sortDirection: 'desc',
 		showAnnualisedTooltip: true,
 		getValues: (vault) => getTopLevelValues(vault, 'one_month_cagr_net', 'one_month_cagr')
 	},
 	{
 		id: '1m-abs',
-		label: '30 days absolute',
-		shortLabel: '30 days abs',
-		headerLabel: '30 days<br/>return abs.',
+		label: 'One month absolute',
+		shortLabel: '1M abs',
+		headerLabel: '1M<br/>return abs.',
 		sortDirection: 'desc',
 		showAnnualisedTooltip: false,
 		getValues: (vault) => getTopLevelValues(vault, 'one_month_returns_net', 'one_month_returns')

--- a/src/lib/top-vaults/vault-sort-description.ts
+++ b/src/lib/top-vaults/vault-sort-description.ts
@@ -1,0 +1,43 @@
+import { DEFAULT_RETURN_COLUMN_IDS, canonicaliseReturnSortKey, type ReturnColumnId } from './return-columns';
+
+const returnSortDescriptions: Record<ReturnColumnId, string> = {
+	'1m-ann': '30-day returns',
+	'1m-abs': '30-day absolute returns',
+	'3m-ann': 'three-month annualised returns',
+	'3m-abs': 'three-month absolute returns',
+	'6m-ann': 'six-month annualised returns',
+	'6m-abs': 'six-month absolute returns',
+	'1y-ann': 'one-year annualised returns',
+	'1y-abs': 'one-year absolute returns',
+	'lifetime-ann': 'lifetime annualised returns',
+	'lifetime-abs': 'lifetime absolute returns'
+};
+
+const tableSortDescriptions: Record<string, string> = {
+	chain: 'blockchain',
+	vault: 'vault name',
+	provider_risk_rating: 'risk rating',
+	three_months_sharpe: 'three-month Sharpe ratio',
+	three_months_volatility: 'three-month volatility',
+	max_dd: 'maximum drawdown',
+	denomination: 'denomination',
+	tvl: 'total value locked',
+	age: 'age',
+	fees: 'fees',
+	lockup: 'deposit delay',
+	risk: 'protocol technical risk'
+};
+
+/**
+ * Return the human-readable metric currently used to rank a vault table.
+ *
+ * @param sort - Sort key encoded in the vault-listing URL.
+ */
+export function getVaultSortDescription(sort: string | null): string {
+	const canonicalReturnSort = sort && canonicaliseReturnSortKey(sort);
+	if (canonicalReturnSort) {
+		return returnSortDescriptions[canonicalReturnSort];
+	}
+
+	return tableSortDescriptions[sort ?? ''] ?? returnSortDescriptions[DEFAULT_RETURN_COLUMN_IDS[0]];
+}

--- a/src/routes/vaults/+page.svelte
+++ b/src/routes/vaults/+page.svelte
@@ -46,6 +46,6 @@ Top stablecoin vault listing page.
 	listingKey={data.listingKey}
 	listingSummary={data.listingSummary}
 	title="Top DeFi stablecoin vaults"
-	subtitle="The best-performing stablecoin vaults. Ranked by 1M returns. Other ranking criteria available in Filters."
+	subtitle="The best-performing stablecoin vaults. Ranked by 30-day returns. Other ranking criteria available in Filters."
 	showFilters
 />

--- a/src/routes/vaults/+page.svelte
+++ b/src/routes/vaults/+page.svelte
@@ -4,6 +4,7 @@ Top stablecoin vault listing page.
 <script lang="ts">
 	import { page } from '$app/state';
 	import TopVaultsPage from '$lib/top-vaults/TopVaultsPage.svelte';
+	import { getVaultSortDescription } from '$lib/top-vaults/vault-sort-description';
 	import { JsonLd } from 'svelte-meta-tags';
 	import MetaTags from '$lib/social-card/SocialCardMetaTags.svelte';
 
@@ -13,6 +14,10 @@ Top stablecoin vault listing page.
 	const title = 'Top DeFi stablecoin vaults';
 	const description = 'Vaults rankings with the highest yield and the lowest risk.';
 	let pageUrl = $derived(new URL(page.url.pathname, page.url.origin).href);
+	let rankingDescription = $derived(getVaultSortDescription(page.url.searchParams.get('sort')));
+	let subtitle = $derived(
+		`The best-performing stablecoin vaults. Ranked by ${rankingDescription}. Table headers and filters offer more criteria.`
+	);
 </script>
 
 <MetaTags
@@ -46,6 +51,6 @@ Top stablecoin vault listing page.
 	listingKey={data.listingKey}
 	listingSummary={data.listingSummary}
 	title="Top DeFi stablecoin vaults"
-	subtitle="The best-performing stablecoin vaults. Ranked by 30-day returns. Other ranking criteria available in Filters."
+	{subtitle}
 	showFilters
 />

--- a/src/routes/vaults/+page.svelte
+++ b/src/routes/vaults/+page.svelte
@@ -46,6 +46,6 @@ Top stablecoin vault listing page.
 	listingKey={data.listingKey}
 	listingSummary={data.listingSummary}
 	title="Top DeFi stablecoin vaults"
-	subtitle="The best-performing stablecoin vaults. Ranked by 1M returns. Use filters for other criteria."
+	subtitle="The best-performing stablecoin vaults. Ranked by 1M returns. Other ranking criteria available in Filters."
 	showFilters
 />

--- a/src/routes/vaults/+page.svelte
+++ b/src/routes/vaults/+page.svelte
@@ -1,3 +1,6 @@
+<!--
+Top stablecoin vault listing page.
+-->
 <script lang="ts">
 	import { page } from '$app/state';
 	import TopVaultsPage from '$lib/top-vaults/TopVaultsPage.svelte';
@@ -43,6 +46,6 @@
 	listingKey={data.listingKey}
 	listingSummary={data.listingSummary}
 	title="Top DeFi stablecoin vaults"
-	subtitle="The best performing DeFi stablecoin vaults across all blockchains"
+	subtitle="The best-performing stablecoin vaults. Ranked by 1M returns. Use filters for other criteria."
 	showFilters
 />

--- a/src/routes/vaults/+page.svelte
+++ b/src/routes/vaults/+page.svelte
@@ -11,7 +11,7 @@ Top stablecoin vault listing page.
 	let { data } = $props();
 	let topVaults = $derived(data.initialTopVaults);
 
-	const title = 'Top DeFi stablecoin vaults';
+	const title = 'Top stablecoin vaults';
 	const description = 'Vaults rankings with the highest yield and the lowest risk.';
 	let pageUrl = $derived(new URL(page.url.pathname, page.url.origin).href);
 	let rankingDescription = $derived(getVaultSortDescription(page.url.searchParams.get('sort')));
@@ -50,7 +50,7 @@ Top stablecoin vault listing page.
 	progressive={data.initialVaultListingHasMore}
 	listingKey={data.listingKey}
 	listingSummary={data.listingSummary}
-	title="Top DeFi stablecoin vaults"
+	{title}
 	{subtitle}
 	showFilters
 />

--- a/src/routes/vaults/[vault=slug]/VaultCuratorInfo.svelte
+++ b/src/routes/vaults/[vault=slug]/VaultCuratorInfo.svelte
@@ -90,7 +90,7 @@ curator.
 		}
 
 		:global(.view-all-btn) {
-			align-self: center;
+			--button-width: 100%;
 			margin-top: auto;
 		}
 

--- a/src/routes/vaults/[vault=slug]/VaultCuratorInfo.svelte
+++ b/src/routes/vaults/[vault=slug]/VaultCuratorInfo.svelte
@@ -29,15 +29,13 @@ curator.
 	let assetType = $derived(vault.flags.includes('tokenised_fund') ? 'tokenised fund' : 'vault');
 </script>
 
-<MetricsBox fill>
+<MetricsBox>
 	<div class="curator-info">
+		{#if curatorLogoUrl}
+			<img src={curatorLogoUrl} alt={curator.name} class="curator-logo" />
+		{/if}
 		<div class="content">
-			<div class="heading">
-				{#if curatorLogoUrl}
-					<img src={curatorLogoUrl} alt={curator.name} class="curator-logo" />
-				{/if}
-				<h2>Curated by {curator.name}</h2>
-			</div>
+			<h2>Curated by {curator.name}</h2>
 			<p class="description">
 				This {assetType} is curated by <a href={curatorPageUrl}>{curator.name}</a>.
 			</p>
@@ -53,10 +51,24 @@ curator.
 
 <style>
 	.curator-info {
-		display: flex;
-		flex-direction: column;
+		display: grid;
+		grid-template-columns: 1fr auto;
 		gap: 1rem;
-		height: 100%;
+		align-items: center;
+
+		&:has(.curator-logo) {
+			grid-template-columns: auto 1fr auto;
+		}
+
+		@media (--viewport-sm-down) {
+			.content {
+				grid-column: span 2;
+			}
+
+			:global(.view-all-btn) {
+				grid-area: 2 / span 3;
+			}
+		}
 
 		.curator-logo {
 			max-width: 9rem;
@@ -68,12 +80,6 @@ curator.
 			display: grid;
 			gap: 0.625rem;
 			min-width: 0;
-
-			.heading {
-				display: flex;
-				gap: 1rem;
-				align-items: start;
-			}
 
 			h2 {
 				margin: 0;
@@ -87,11 +93,6 @@ curator.
 					font-size: 0.875rem;
 				}
 			}
-		}
-
-		:global(.view-all-btn) {
-			--button-width: 100%;
-			margin-top: auto;
 		}
 
 		.description {

--- a/src/routes/vaults/[vault=slug]/VaultProtocolInfo.svelte
+++ b/src/routes/vaults/[vault=slug]/VaultProtocolInfo.svelte
@@ -21,18 +21,16 @@
 	let assetType = $derived(vault.flags.includes('tokenised_fund') ? 'tokenised fund' : 'vault');
 </script>
 
-<MetricsBox fill>
+<MetricsBox>
 	<div class="protocol-info">
+		{#if protocolMetadata.logos.light}
+			{@const protocolLogoUrl = getVaultProtocolLogoUrl(protocolMetadata.slug)}
+			{#if protocolLogoUrl}
+				<img src={protocolLogoUrl} alt={protocolMetadata.name} class="protocol-logo" />
+			{/if}
+		{/if}
 		<div class="content">
-			<div class="heading">
-				{#if protocolMetadata.logos.light}
-					{@const protocolLogoUrl = getVaultProtocolLogoUrl(protocolMetadata.slug)}
-					{#if protocolLogoUrl}
-						<img src={protocolLogoUrl} alt={protocolMetadata.name} class="protocol-logo" />
-					{/if}
-				{/if}
-				<h2>Running on {protocolMetadata.name} protocol</h2>
-			</div>
+			<h2>Running on {protocolMetadata.name} protocol</h2>
 			<p class="description">
 				This {assetType} is running on <a href={protocolPageUrl}>{protocolMetadata.name}</a>:
 			</p>
@@ -46,10 +44,24 @@
 
 <style>
 	.protocol-info {
-		display: flex;
-		flex-direction: column;
+		display: grid;
+		grid-template-columns: 1fr auto;
 		gap: 1rem;
-		height: 100%;
+		align-items: center;
+
+		&:has(.protocol-logo) {
+			grid-template-columns: auto 1fr auto;
+		}
+
+		@media (--viewport-sm-down) {
+			.content {
+				grid-column: span 2;
+			}
+
+			:global(.view-all-btn) {
+				grid-area: 2 / span 3;
+			}
+		}
 
 		.protocol-logo {
 			height: 3rem;
@@ -60,12 +72,6 @@
 			display: grid;
 			gap: 0.625rem;
 			min-width: 0;
-
-			.heading {
-				display: flex;
-				gap: 1rem;
-				align-items: start;
-			}
 
 			h2 {
 				margin: 0;
@@ -79,11 +85,6 @@
 					font-size: 0.875rem;
 				}
 			}
-		}
-
-		:global(.view-all-btn) {
-			--button-width: 100%;
-			margin-top: auto;
 		}
 
 		.description {

--- a/src/routes/vaults/[vault=slug]/VaultProtocolInfo.svelte
+++ b/src/routes/vaults/[vault=slug]/VaultProtocolInfo.svelte
@@ -82,7 +82,7 @@
 		}
 
 		:global(.view-all-btn) {
-			align-self: center;
+			--button-width: 100%;
 			margin-top: auto;
 		}
 

--- a/tests/integration/vaults/index.test.ts
+++ b/tests/integration/vaults/index.test.ts
@@ -99,6 +99,12 @@ test.describe('vault index page', () => {
 		await expect(header).toContainText(/Lifetime\s*return abs\./);
 	});
 
+	test('describes the default return ranking', async ({ page }) => {
+		await expect(page.locator('.hero-banner .subtitle')).toHaveText(
+			'The best-performing stablecoin vaults. Ranked by 1M returns. Use filters for other criteria.'
+		);
+	});
+
 	test('shows lifetime data tooltip on the lifetime return cell', async ({ page }) => {
 		const row = await getVaultRow(page, 'Trading Strategy ICHIv3 LS 2');
 

--- a/tests/integration/vaults/index.test.ts
+++ b/tests/integration/vaults/index.test.ts
@@ -101,7 +101,7 @@ test.describe('vault index page', () => {
 
 	test('describes the default return ranking', async ({ page }) => {
 		await expect(page.locator('.hero-banner .subtitle')).toHaveText(
-			'The best-performing stablecoin vaults. Ranked by 1M returns. Use filters for other criteria.'
+			'The best-performing stablecoin vaults. Ranked by 1M returns. Other ranking criteria available in Filters.'
 		);
 	});
 

--- a/tests/integration/vaults/index.test.ts
+++ b/tests/integration/vaults/index.test.ts
@@ -94,14 +94,14 @@ test.describe('vault index page', () => {
 
 	test('shows the default return columns', async ({ page }) => {
 		const header = page.locator('thead');
-		await expect(header).toContainText(/1M\s*return ann\./);
+		await expect(header).toContainText(/30 days\s*return ann\./);
 		await expect(header).toContainText(/3M\s*return ann\./);
 		await expect(header).toContainText(/Lifetime\s*return abs\./);
 	});
 
 	test('describes the default return ranking', async ({ page }) => {
 		await expect(page.locator('.hero-banner .subtitle')).toHaveText(
-			'The best-performing stablecoin vaults. Ranked by 1M returns. Other ranking criteria available in Filters.'
+			'The best-performing stablecoin vaults. Ranked by 30-day returns. Other ranking criteria available in Filters.'
 		);
 	});
 

--- a/tests/integration/vaults/index.test.ts
+++ b/tests/integration/vaults/index.test.ts
@@ -94,7 +94,7 @@ test.describe('vault index page', () => {
 
 	test('shows the default return columns', async ({ page }) => {
 		const header = page.locator('thead');
-		await expect(header).toContainText(/30 days\s*return ann\./);
+		await expect(header).toContainText(/1M\s*return ann\./);
 		await expect(header).toContainText(/3M\s*return ann\./);
 		await expect(header).toContainText(/Lifetime\s*return abs\./);
 	});

--- a/tests/integration/vaults/index.test.ts
+++ b/tests/integration/vaults/index.test.ts
@@ -93,6 +93,8 @@ test.describe('vault index page', () => {
 	});
 
 	test('shows the default return columns', async ({ page }) => {
+		await expect(page.getByRole('heading', { name: 'Top stablecoin vaults' })).toBeVisible();
+
 		const header = page.locator('thead');
 		await expect(header).toContainText(/1M\s*return ann\./);
 		await expect(header).toContainText(/3M\s*return ann\./);

--- a/tests/integration/vaults/index.test.ts
+++ b/tests/integration/vaults/index.test.ts
@@ -101,7 +101,16 @@ test.describe('vault index page', () => {
 
 	test('describes the default return ranking', async ({ page }) => {
 		await expect(page.locator('.hero-banner .subtitle')).toHaveText(
-			'The best-performing stablecoin vaults. Ranked by 30-day returns. Other ranking criteria available in Filters.'
+			'The best-performing stablecoin vaults. Ranked by 30-day returns. Table headers and filters offer more criteria.'
+		);
+	});
+
+	test('updates the ranking description when the table sort changes', async ({ page }) => {
+		await page.locator('th.tvl button').click();
+
+		await expect(page).toHaveURL(/sort=tvl/);
+		await expect(page.locator('.hero-banner .subtitle')).toHaveText(
+			'The best-performing stablecoin vaults. Ranked by total value locked. Table headers and filters offer more criteria.'
 		);
 	});
 


### PR DESCRIPTION
## Why

The vault listing subtitle did not identify the active ranking criterion, which made it misleading after a user sorted the table by a different column. Its heading was unnecessarily verbose, and vault protocol and curator actions had regressed from their original desktop position.

## Lessons learnt

Derive user-facing ranking copy from the same URL sort state as the table so navigation, links, and interactive sorting remain consistent. When restoring a visual regression, trace the full layout change with blame rather than reverting a single downstream declaration.

## Summary

- Simplify the vault listing heading and clarify its ranking subtitle.
- Show the active ranking criterion in the subtitle, updating it when table sorting changes.
- Keep concise 1M labels in the table while using 30-day wording in the description.
- Restore the original desktop grid layout for vault protocol and curator actions.
- Add integration coverage for the vault listing heading and ranking descriptions.