### PR TITLE
perf: persist strategies page cache

### DIFF
--- a/.claude/plans/strategies-page-filesystem-cache.md
+++ b/.claude/plans/strategies-page-filesystem-cache.md
@@ -1,0 +1,188 @@
+# Strategies page filesystem cache plan
+
+## Goal
+
+Cache every data dependency needed to render `/strategies` for 30 minutes, persist the cache across frontend container restarts, and refresh it in the background every 20 minutes. A warm or stale filesystem entry must let the page render without waiting for executor metadata, top-vault, share-price, or admin TVL requests.
+
+Keep the existing security behaviour: the public page must only receive live strategies, the admin page may receive unpublished strategies and TVL data, and the route must not gain shared HTTP caching because its output depends on admin state and IP-country blocking.
+
+## Current behaviour and constraints
+
+- `src/routes/strategies/+page.server.ts` fetches API strategy metadata, YAML strategy enrichment, and admin TVL data during each server load.
+- API metadata uses `getCachedStrategies`, an in-process SWR cache with a 60-second TTL. Its first request after a process restart waits for all executor metadata requests.
+- YAML strategies fetch the top-vault feed and relative `/vaults/:id/metrics` endpoints. A background job outside a SvelteKit request cannot safely reuse this code with bare `globalThis.fetch`, because the relative metrics URLs require SvelteKit's request-aware `event.fetch`.
+- The custom adapter-node entry point is `scripts/server.js`. It can run a process-local timer after Express starts listening.
+- The production Compose service currently mounts `./data` at `/app/data` read-only. It has no writable persistent cache volume.
+- Strategy data contains `Date` objects. Plain `JSON.parse(JSON.stringify(data))` would silently turn them into strings, so the persistent format needs an explicit codec and validation.
+- The working tree already contains a separate `/strategies` payload optimisation. Preserve those changes and run role-specific sorting and tile compaction before writing or returning page variants.
+
+## Cache contract
+
+Create a server-only strategies page cache module, for example `src/lib/strategies/page-cache.server.ts`, with these constants:
+
+- Fresh TTL: 30 minutes.
+- Scheduled refresh interval: 20 minutes.
+- Cache format version: an integer incremented when the persisted shape changes.
+- Default development cache directory: a gitignored local cache directory outside `static/` and any other web-served tree.
+- Production cache directory: supplied by `TS_PRIVATE_STRATEGIES_CACHE_DIR`, set to `/app/cache/strategies` in Compose.
+
+Persist one versioned snapshot containing both already-prepared variants:
+
+```ts
+type StrategiesPageCacheSnapshot = {
+	version: number;
+	updatedAt: Date;
+	public: {
+		strategies: StrategyInfo[];
+	};
+	admin: {
+		strategies: StrategyInfo[];
+		tvlData?: PerformanceData;
+	};
+};
+```
+
+Build both variants from a single refresh operation:
+
+1. Fetch all API strategy metadata directly, bypassing the old request-triggered 60-second cache.
+2. Fetch and enrich all configured YAML strategies once using top-vault data and share-price returns.
+3. Fetch admin TVL data in parallel with the other independent sources.
+4. Derive the public variant by filtering API and YAML strategies to `live` tags.
+5. Derive the admin variant from all fetched strategies.
+6. Sort each variant and apply the existing chart-range/tile-payload compaction independently, since the public and admin strategy sets can have different ranges.
+7. Mark the snapshot successful only after all required strategy sources are complete. Treat TVL as optional, matching current behaviour.
+
+Use `devalue` or an equivalently explicit codec so `Date` and `undefined` values survive persistence. Validate the envelope, version, timestamps, role variants, and strategy data after decoding. A corrupt or incompatible file is a cache miss, never trusted data.
+
+Expose a narrow API:
+
+- `getStrategiesPageData(fetch, admin)`: load the disk snapshot into memory once, return the appropriate fresh variant, and await a credential-neutral refresh only when no valid snapshot exists.
+- `refreshStrategiesPageData(fetch)`: force an upstream refresh even when the current snapshot is younger than 30 minutes; used by the 20-minute scheduler.
+- `getStrategiesPageCacheStatus()`: return timestamps, age, refresh state, source (`memory`, `filesystem`, or `upstream`), and last refresh error for private diagnostics. Never expose the bearer token or filesystem path in page data.
+
+All cache-building fetches must be credential-neutral. Wrap the supplied SvelteKit fetch so it resolves relative URLs but explicitly omits credentials and strips `cookie`, `authorization`, and request-specific forwarding headers. Do not allow `locals.admin`, visitor cookies, IP-country, or other request state to influence a snapshot. The same wrapper is used for a rare no-snapshot request fallback and for the internal scheduled refresh.
+
+Freshness and failure semantics:
+
+- Age under 30 minutes: serve immediately.
+- Age at or over 30 minutes: serve stale immediately and record that refresh is overdue; do not detach request-scoped work after returning a visitor response. The internal scheduler remains the normal refresh trigger.
+- Scheduled refresh: force refresh every 20 minutes so a healthy cache normally never reaches the 30-minute stale boundary.
+- Upstream refresh failure: retain and serve the last good snapshot, record/log the error, and retry at the next scheduled interval or an explicit internal refresh.
+- No valid snapshot anywhere: the first request must await one credential-neutral upstream refresh, preserving the current cold-start fallback without persisting visitor identity.
+- Never replace a good snapshot with a partial or failed refresh.
+
+Keep one in-process snapshot in front of the file to avoid filesystem reads on normal requests. Write a uniquely named temporary file in the cache directory, flush/close it, and atomically rename it over the final path. Clean abandoned temporary files on startup, ignoring cleanup failures. Use single-flight refresh protection in-process. Document that the Compose deployment has one frontend process; if multiple writers are introduced later, add an inter-process lock or move the cache to R2/Redis rather than relying only on atomic rename.
+
+If the configured directory cannot be created or written, log a clear startup warning and degrade to the same in-memory cache semantics rather than crashing the frontend. The persistent-cache status must report this degraded mode.
+
+## Background refresh process
+
+Add a protected SvelteKit endpoint such as `POST /_internal/cache/strategies/refresh` that:
+
+- Rejects other methods.
+- Requires a per-process bearer token.
+- Calls `refreshStrategiesPageData(event.fetch)`, ensuring existing relative internal fetches and `handleFetch` behaviour continue to work.
+- Returns concise status and timing JSON, without returning cached strategy contents.
+- Sets `cache-control: private, no-store`.
+
+Update `scripts/server.js` to:
+
+1. Generate a random internal refresh token before dynamically importing `build/handler.js`, and expose it only through a private process environment variable read by the endpoint.
+2. Start Express as today.
+3. Trigger the protected local endpoint once after the server begins listening.
+4. Trigger it every 20 minutes with `setInterval` and `timer.unref()`.
+5. Prevent overlapping refresh calls. Keep the endpoint request open until the refresh completes; bound individual upstream operations and the overall refresh below a documented maximum, then give the scheduler's local HTTP request a comfortably larger timeout (for example, a 10-minute refresh budget and a 15-minute caller timeout). Do not abort a healthy refresh merely because it is slower than an ordinary page request.
+6. Log success duration/cache timestamp and failures, without crashing or blocking the HTTP server.
+
+This keeps the scheduler in the long-lived adapter-node process while the refresh itself runs inside a normal SvelteKit request context. The random token avoids adding a deployment-managed secret and prevents a public caller from forcing expensive refreshes.
+
+The internal route still passes through the application's global server hooks, which is desirable for tracing. It is not nested below the geo-blocked strategies layout and therefore must not depend on geo or admin locals. Configure the local request's host/origin consistently with adapter-node's production settings so relative `event.fetch` URLs resolve to the same local server. Cover the actual built handler and hook chain in the container test rather than assuming unit-level endpoint tests are sufficient.
+
+## Remove the 60-second cache from the page path
+
+- Stop `/strategies` from using the current 60-second `getCachedStrategies` wrapper; its complete page snapshot uses the requested 30-minute TTL.
+- Ensure the page-cache refresher performs a true upstream refresh by calling the uncached strategy fetch operation. Simply calling an SWR wrapper from the 20-minute timer can re-persist old data while resetting the file timestamp.
+- Leave the homepage, sitemap, and TVL endpoint on their current cache policy unless a separate product decision explicitly opts them into 30-minute freshness. Increasing the shared wrapper globally would silently change those consumers and is not required to satisfy the `/strategies` page cache.
+- Update page cache-age diagnostics and comments so `/strategies` no longer reports or implies the 60-second cache.
+
+## Docker and Compose changes
+
+Update `Dockerfile` to create the runtime cache directory with permissions suitable for the runtime user. Keep the directory separate from immutable application code and the read-only vault dataset. Because an existing named volume can retain older ownership, check writability at application startup and degrade to memory-only caching with an explicit warning rather than failing the container.
+
+Update `docker-compose.yml`:
+
+```yaml
+services:
+  frontend:
+    volumes:
+      - ./data:/app/data:ro
+      - strategies-cache:/app/cache
+    environment:
+      - TS_PRIVATE_STRATEGIES_CACHE_DIR=/app/cache/strategies
+
+volumes:
+  strategies-cache:
+```
+
+The named volume persists across normal image/container replacement on the same Docker host. Document that `docker compose down -v` deliberately deletes it and that it is not a cross-host distributed cache.
+
+Ensure all runtime modules needed by the cache codec and file writer remain available after `pnpm prune --prod`. In particular, keep `devalue` in `dependencies`, not `devDependencies`. If the scheduler is extracted from `scripts/server.js`, explicitly copy the added runtime script in the Dockerfile.
+
+## Route integration
+
+Refactor `src/routes/strategies/+page.server.ts` so its load function only:
+
+1. Reads `locals.admin`.
+2. Calls `getStrategiesPageData(fetch, Boolean(admin))`.
+3. Returns the already-prepared role variant.
+
+Do not set public page response cache headers. Keep geo-blocking in the existing strategies layout. Do not persist passwords, cookies, IP-country values, request headers, or other per-request information in the filesystem snapshot.
+
+## Observability and documentation
+
+- Log structured refresh start, success, failure, duration, source count, snapshot age, and cache path. Do not log full strategy payloads or the bearer token.
+- Extend the existing hidden freshness diagnostics with safe filesystem snapshot fields such as `updatedAt`, age, source, last successful background refresh, and a sanitised last-error summary. Never serialise the cache path or refresh token to a public page.
+- Update `docs/cache-freshness-diagnostics.md` from 60 seconds to 30 minutes and describe the 20-minute scheduled refresh and stale-on-error behaviour.
+- Add a short operational note covering the Compose volume, manual cache removal, expected startup behaviour, and how to invoke the protected refresh from inside the container for diagnostics without exposing its token.
+
+## Tests and verification
+
+Add focused unit tests with an injectable cache directory, clock, fetch implementation, and scheduler callback:
+
+- Cold cache fetches upstream, prepares public/admin variants, preserves `Date` values, and atomically writes a versioned snapshot.
+- A fresh file snapshot is loaded after simulated process restart without upstream requests.
+- Public data excludes unpublished strategies while admin data includes them and receives TVL data.
+- A scheduled force refresh at 20 minutes updates the snapshot even though its 30-minute TTL has not expired.
+- Concurrent page requests and a scheduler tick share one refresh promise.
+- A stale snapshot is returned immediately without starting visitor-scoped detached work; the scheduled internal refresh updates it.
+- Refresh fetches omit cookies and authorisation, and admin/non-admin visitor requests cannot change the generated shared snapshot.
+- Failed or partial refreshes leave the last good file and memory snapshot unchanged.
+- Corrupt, truncated, or wrong-version files are ignored safely and replaced after a successful refresh.
+- Atomic write tests confirm readers see either the old complete snapshot or the new complete snapshot, not a partial file.
+- The internal endpoint rejects missing/incorrect tokens, accepts the server token, does not expose data, and uses `private, no-store`.
+- The scheduler starts once, runs immediately and every 20 minutes, does not overlap, catches errors, gives refreshes enough time to finish, and does not keep shutdown alive.
+- SIGTERM during a refresh can leave only an ignorable uniquely named temporary file; the next start removes abandoned temporary files and continues using the last complete snapshot.
+
+Run:
+
+- Focused Vitest tests for the page cache, codec, endpoint, and scheduler.
+- Existing strategy sorting/chart compaction tests.
+- The strategies integration test with mock APIs.
+- ESLint and Prettier on changed files.
+- `pnpm run check`, reporting unrelated baseline diagnostics separately if they remain.
+- `docker compose config` and a production image build.
+- A container smoke test that verifies `/app/cache/strategies` is writable and that a token-authenticated refresh succeeds through the built handler, real hook chain, and production host/origin settings before creating the snapshot in the named volume.
+- A degraded-mode container test (or focused filesystem test) showing an unwritable cache path logs a warning and continues with memory-only caching.
+
+Finally, use Playwright against the Tailscale-exposed development server to verify public and admin variants still render correctly. Measure three scenarios: cold with no file, process restart with a persisted file, and scheduled refresh while serving the last good snapshot. Record TTFB, FCP/LCP, document transfer size, cache source, snapshot age, and upstream request counts.
+
+## Acceptance criteria
+
+- `/strategies` uses a 30-minute persistent cache for all page data and no longer depends on a 60-second page-data cache.
+- A successful refresh runs every 20 minutes without blocking page requests.
+- A normal container replacement serves the persisted snapshot before upstream requests finish.
+- Public/admin separation and geo-blocking behaviour are unchanged.
+- Refresh failures never destroy or replace the last good snapshot.
+- The cache file is versioned, validated, and atomically replaced.
+- The writable named volume is separate from `/app/data:ro` and documented as single-host persistence.
+- Focused tests, container smoke checks, and before/after performance measurements demonstrate the behaviour.

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ node_modules
 /build
 /.svelte-kit
 /.svelte-kit-test
+/.cache
 /package
 /data
 *.local

--- a/Dockerfile
+++ b/Dockerfile
@@ -38,6 +38,10 @@ COPY --from=builder /app/build ./build
 COPY --from=builder /app/scripts/server.js ./scripts/server.js
 COPY --from=builder /app/scripts/check-connectivity.mjs ./scripts/check-connectivity.mjs
 
+# Named Compose volumes are mounted here at runtime. Keep it distinct from the
+# read-only /app/data dataset mount.
+RUN mkdir -p /app/cache/strategies
+
 EXPOSE 3000
 
 # See if increase libuv thread pool size makes performance better

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,6 +21,7 @@ services:
       - 'host.docker.internal:host-gateway'
     volumes:
       - ./data:/app/data:ro
+      - strategies-cache:/app/cache
     environment:
       # Public SvelteKit env vars
       - TS_PUBLIC_SITE_MODE
@@ -58,6 +59,7 @@ services:
       - TS_PRIVATE_MAILERLITE_API_KEY
       - TS_PRIVATE_MAILERLITE_GROUPS
       - TS_PRIVATE_TURNSTILE_SECRET_KEY
+      - TS_PRIVATE_STRATEGIES_CACHE_DIR=/app/cache/strategies
       # Required for node adapter; see:
       # https://svelte.dev/docs/kit/adapter-node#Environment-variables-ORIGIN-PROTOCOL_HEADER-HOST_HEADER-and-PORT_HEADER
       - FRONTEND_PROTOCOL_HEADER
@@ -76,3 +78,7 @@ services:
       # headers only needed if the collector requires an ingestion key. See docs/monitoring.md
       - OTEL_EXPORTER_OTLP_ENDPOINT
       - OTEL_EXPORTER_OTLP_HEADERS
+
+volumes:
+  # Single-host persistent cache. `docker compose down -v` deliberately removes it.
+  strategies-cache:

--- a/docs/cache-freshness-diagnostics.md
+++ b/docs/cache-freshness-diagnostics.md
@@ -18,21 +18,52 @@ If those sources are refreshed at different times, the homepage and detail page 
 ### Homepage
 
 - `/` HTML edge cache: 30 minutes
-  - Defined in [src/routes/+page.ts](/Users/moo/code/frontend/src/routes/+page.ts)
+  - Defined in [src/routes/+page.ts](../src/routes/+page.ts)
 - API executor metadata SWR cache: 60 seconds
-  - Defined in [src/lib/trade-executor/client/strategy-info.ts](/Users/moo/code/frontend/src/lib/trade-executor/client/strategy-info.ts)
+  - Defined in [src/lib/trade-executor/client/strategy-info.ts](../src/lib/trade-executor/client/strategy-info.ts)
 - YAML tile share-price SWR cache: 3600 seconds
-  - Defined in [src/lib/strategies/yaml/share-price.ts](/Users/moo/code/frontend/src/lib/strategies/yaml/share-price.ts)
+  - Defined in [src/lib/strategies/yaml/share-price.ts](../src/lib/strategies/yaml/share-price.ts)
 - Top vaults upstream feed timestamp:
   - Read from `generated_at` in the top-vaults payload
 
 ### YAML strategy overview page
 
 - Vault summary metrics come from the top-vaults feed
-  - Loaded in [src/routes/strategies/[strategy=yamlStrategy]/+layout.ts](/Users/moo/code/frontend/src/routes/strategies/[strategy=yamlStrategy]/+layout.ts)
+  - Loaded in [src/routes/strategies/[strategy=yamlStrategy]/+layout.ts](../src/routes/strategies/[strategy=yamlStrategy]/+layout.ts)
 - The chart fetches `/vaults/:id/metrics` client-side after hydration
-  - Implemented in [src/lib/top-vaults/VaultPriceChart.svelte](/Users/moo/code/frontend/src/lib/top-vaults/VaultPriceChart.svelte)
+  - Implemented in [src/lib/top-vaults/VaultPriceChart.svelte](../src/lib/top-vaults/VaultPriceChart.svelte)
 - The frontend app code does not add SWR caching to this chart request
+
+### Strategies listing page
+
+- `/strategies` uses a versioned filesystem snapshot for its complete public
+  and admin listing payloads. The admin variant additionally includes TVL
+  data; the public variant never receives it.
+- A snapshot has a 30-minute freshness target and the adapter-node process
+  refreshes it every 20 minutes through a protected local endpoint. The page
+  deliberately serves the last known-good snapshot while a refresh fails; it
+  does not start request-scoped background work for visitors.
+- A successful snapshot is retained when the top-vault source cannot be
+  refreshed. Individual executor metadata failures retain the listing's
+  existing disconnected-tile behaviour. When the snapshot is older than 30
+  minutes, visitors still receive it until the next scheduled refresh succeeds.
+- In Compose, the snapshot lives in the `strategies-cache` named volume at
+  `/app/cache/strategies`, separate from the read-only `/app/data` mount. It
+  persists ordinary container replacement on one Docker host; `docker compose
+down -v` intentionally removes it.
+- The cache automatically falls back to in-memory operation with a warning if
+  the configured directory is not writable. It never stores visitor cookies,
+  authorisation headers, IP-country data, or the scheduler token.
+- Vite development and preview servers do not run the adapter-node scheduler.
+  Their local `.cache/strategies` snapshot is therefore refreshed only after it
+  is removed or the server starts without a snapshot; use production Compose
+  for scheduled-refresh verification.
+
+For operational diagnostics, inspect the container log entries prefixed
+`[strategies-cache]`. The scheduler generates a per-process bearer token and
+uses it only for its loopback `POST /_internal/cache/strategies/refresh`
+request; do not treat that bearer-protected endpoint as a public cache-control
+API.
 
 ## Hidden diagnostics in page source
 
@@ -41,7 +72,7 @@ To make freshness visible without changing the UI, pages now render hidden debug
 - Homepage: `data-debug-freshness="home-page"`
 - YAML strategy pages: `data-debug-freshness="yaml-strategy:<slug>"`
 
-These markers are rendered by [src/lib/components/DebugFreshnessData.svelte](/Users/moo/code/frontend/src/lib/components/DebugFreshnessData.svelte) as hidden `<pre>` elements so they are:
+These markers are rendered by [src/lib/components/DebugFreshnessData.svelte](../src/lib/components/DebugFreshnessData.svelte) as hidden `<pre>` elements so they are:
 
 - visible in page source
 - inspectable in DevTools
@@ -114,4 +145,4 @@ The most common explanation is not a rendering bug but a freshness gap between:
 
 ## Related docs
 
-- [docs/cache-invalidation.md](/Users/moo/code/frontend/docs/cache-invalidation.md)
+- [Cache invalidation](cache-invalidation.md)

--- a/scripts/server.js
+++ b/scripts/server.js
@@ -2,10 +2,19 @@
  * Express.js based SvelteKit server-side renderer.
  */
 
-// Check your SvelteKit build/handler.js file
-// location based on your SvelteKit installation
-import { handler } from '../build/handler.js';
+import { randomBytes } from 'node:crypto';
 import express from 'express';
+
+const refreshIntervalMilliseconds = 20 * 60 * 1000;
+const refreshRequestTimeoutMilliseconds = 15 * 60 * 1000;
+
+// This secret exists only inside this adapter-node process. It lets the local
+// scheduler use a regular SvelteKit request without exposing a public trigger.
+process.env.TS_PRIVATE_STRATEGIES_REFRESH_TOKEN = randomBytes(32).toString('base64url');
+
+// Import after creating the token: $env/dynamic/private is read when the built
+// SvelteKit handler loads the protected refresh endpoint.
+const { handler } = await import('../build/handler.js');
 
 // web-top-node request tracking removed — no longer needed
 // import { Tracker, TrackerServer, createTrackerMiddleware } from '@trading-strategy-ai/web-top-node';
@@ -39,7 +48,42 @@ app.use((req, res, next) => {
 // Install SvelteKit server-side renderer
 app.use(handler);
 
+let refreshInFlight = false;
+
+async function refreshStrategiesCache() {
+	if (refreshInFlight) {
+		console.warn('[strategies-cache] Scheduled refresh skipped because another refresh is still running.');
+		return;
+	}
+
+	refreshInFlight = true;
+	const startedAt = performance.now();
+	try {
+		const response = await fetch('http://127.0.0.1:3000/_internal/cache/strategies/refresh', {
+			method: 'POST',
+			headers: { authorization: `Bearer ${process.env.TS_PRIVATE_STRATEGIES_REFRESH_TOKEN}` },
+			signal: AbortSignal.timeout(refreshRequestTimeoutMilliseconds)
+		});
+		if (!response.ok) throw new Error(`HTTP ${response.status}: ${await response.text()}`);
+		const result = await response.json();
+		console.log(
+			`[strategies-cache] Scheduled refresh completed in ${Math.round(performance.now() - startedAt)}ms`,
+			result.cache
+		);
+	} catch (error) {
+		const summary = error instanceof Error ? `${error.name}: ${error.message}` : 'Unknown error';
+		console.error(
+			`[strategies-cache] Scheduled refresh failed after ${Math.round(performance.now() - startedAt)}ms (${summary}).`
+		);
+	} finally {
+		refreshInFlight = false;
+	}
+}
+
 // Start web server
 app.listen(3000, () => {
 	console.log('Listening on port 3000');
+	void refreshStrategiesCache();
+	const refreshTimer = setInterval(() => void refreshStrategiesCache(), refreshIntervalMilliseconds);
+	refreshTimer.unref();
 });

--- a/src/lib/strategies/page-cache.server.test.ts
+++ b/src/lib/strategies/page-cache.server.test.ts
@@ -1,0 +1,68 @@
+import { mkdtemp, readFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { beforeEach, afterEach, describe, expect, it, vi } from 'vitest';
+import type { StrategyInfo } from 'trade-executor/models/strategy-info';
+
+const mocks = vi.hoisted(() => ({ getAllStrategies: vi.fn() }));
+
+vi.mock('trade-executor/client/strategy-info', () => ({ getAllStrategies: mocks.getAllStrategies }));
+vi.mock('$lib/strategies/yaml/loader', () => ({ yamlStrategies: new Map() }));
+vi.mock('$lib/top-vaults/client', () => ({ fetchTopVaults: vi.fn() }));
+vi.mock('$lib/helpers/public-api', () => ({ fetchPublicApi: async () => ({}) }));
+
+import {
+	getStrategiesPageData,
+	resetStrategiesPageCacheForTests,
+	STRATEGIES_PAGE_CACHE_TTL_MS
+} from './page-cache.server';
+
+let directory: string;
+
+function strategy(id: string, tags: string[]): StrategyInfo {
+	return { id, name: id, tags, sort_priority: 1, useSharePrice: false, connected: true } as StrategyInfo;
+}
+
+beforeEach(async () => {
+	directory = await mkdtemp(join(tmpdir(), 'strategies-page-cache-'));
+	resetStrategiesPageCacheForTests(directory);
+	mocks.getAllStrategies.mockReset();
+	mocks.getAllStrategies.mockResolvedValue([strategy('live', ['live']), strategy('hidden', ['archived'])]);
+});
+
+afterEach(async () => {
+	resetStrategiesPageCacheForTests();
+	await rm(directory, { recursive: true, force: true });
+});
+
+describe('strategies page filesystem cache', () => {
+	it('persists separate public and admin snapshots for 30 minutes', async () => {
+		const fetch = vi.fn() as unknown as Fetch;
+		const publicData = await getStrategiesPageData(fetch, false);
+		const adminData = await getStrategiesPageData(fetch, true);
+
+		expect(publicData.strategies.map((item) => item.id)).toEqual(['live']);
+		expect(adminData.strategies.map((item) => item.id)).toEqual(expect.arrayContaining(['live', 'hidden']));
+		expect(mocks.getAllStrategies).toHaveBeenCalledOnce();
+		expect(await readFile(join(directory, 'strategies-page.devalue'), 'utf8')).toContain('live');
+		expect(STRATEGIES_PAGE_CACHE_TTL_MS).toBe(30 * 60 * 1000);
+	});
+
+	it('loads a persisted snapshot after a simulated process restart', async () => {
+		const fetch = vi.fn() as unknown as Fetch;
+		await getStrategiesPageData(fetch, false);
+		resetStrategiesPageCacheForTests(directory);
+		mocks.getAllStrategies.mockRejectedValue(new Error('The persisted snapshot should avoid this request'));
+
+		const data = await getStrategiesPageData(fetch, false);
+		expect(data.strategies.map((item) => item.id)).toEqual(['live']);
+		expect(mocks.getAllStrategies).toHaveBeenCalledOnce();
+	});
+
+	it('keeps disconnected strategies renderable in a cold snapshot', async () => {
+		mocks.getAllStrategies.mockResolvedValue([{ ...strategy('offline', ['live']), connected: false }]);
+
+		const data = await getStrategiesPageData(vi.fn() as unknown as Fetch, false);
+		expect(data.strategies.map((item) => item.id)).toEqual(['offline']);
+	});
+});

--- a/src/lib/strategies/page-cache.server.ts
+++ b/src/lib/strategies/page-cache.server.ts
@@ -1,0 +1,271 @@
+/**
+ * Persistent, server-only cache for the complete strategies listing payload.
+ *
+ * The cache deliberately stores separately prepared public and admin variants:
+ * a request's cookies or role must never influence the shared snapshot.
+ */
+import { mkdir, open, readdir, readFile, rename, unlink } from 'node:fs/promises';
+import { join } from 'node:path';
+import { env } from '$env/dynamic/private';
+import { parse, stringify } from 'devalue';
+import type { StrategyInfo } from 'trade-executor/models/strategy-info';
+import type { PerformanceData } from 'trade-executor/schemas/utility-types.js';
+import { fetchPublicApi } from '$lib/helpers/public-api';
+import { yamlStrategies } from '$lib/strategies/yaml/loader';
+import { compareStrategiesForFrontend } from '$lib/strategies/sort';
+import { toListingStrategy } from '$lib/strategies/yaml/adapter';
+import { fetchSharePriceReturns90d } from '$lib/strategies/yaml/share-price';
+import { fetchTopVaults } from '$lib/top-vaults/client';
+import { getAllStrategies } from 'trade-executor/client/strategy-info';
+import { compactStrategyTileChartData, getStrategyChartDateRange } from 'trade-executor/helpers/chart';
+
+export const STRATEGIES_PAGE_CACHE_TTL_MS = 30 * 60 * 1000;
+const CACHE_VERSION = 1;
+const CACHE_FILE_NAME = 'strategies-page.devalue';
+
+type StrategiesVariant = {
+	strategies: StrategyInfo[];
+	tvlData?: PerformanceData;
+};
+
+type StrategiesPageCacheSnapshot = {
+	version: number;
+	updatedAt: Date;
+	public: StrategiesVariant;
+	admin: StrategiesVariant;
+};
+
+let cacheDirectory = env.TS_PRIVATE_STRATEGIES_CACHE_DIR ?? join(process.cwd(), '.cache', 'strategies');
+let snapshot: StrategiesPageCacheSnapshot | undefined;
+let initialisePromise: Promise<void> | undefined;
+let persistentCacheAvailable = true;
+let refreshPromise: Promise<StrategiesPageCacheSnapshot> | undefined;
+let cacheSource: 'empty' | 'memory' | 'filesystem' | 'upstream' = 'empty';
+let lastRefreshAt: Date | undefined;
+let lastRefreshError: string | undefined;
+
+function cacheFilePath() {
+	return join(cacheDirectory, CACHE_FILE_NAME);
+}
+
+function safeError(error: unknown) {
+	const message = error instanceof Error ? `${error.name}: ${error.message}` : 'Unknown cache refresh error';
+	return message.slice(0, 300);
+}
+
+function isStrategyList(value: unknown): value is StrategyInfo[] {
+	return (
+		Array.isArray(value) &&
+		value.every(
+			(strategy) =>
+				Boolean(strategy) && typeof strategy === 'object' && typeof (strategy as { id?: unknown }).id === 'string'
+		)
+	);
+}
+
+function isSnapshot(value: unknown): value is StrategiesPageCacheSnapshot {
+	if (!value || typeof value !== 'object') return false;
+	const candidate = value as Partial<StrategiesPageCacheSnapshot>;
+	const publicVariant = candidate.public;
+	const adminVariant = candidate.admin;
+	if (!publicVariant || !adminVariant) return false;
+
+	return (
+		candidate.version === CACHE_VERSION &&
+		candidate.updatedAt instanceof Date &&
+		!Number.isNaN(candidate.updatedAt.valueOf()) &&
+		isStrategyList(publicVariant.strategies) &&
+		isStrategyList(adminVariant.strategies)
+	);
+}
+
+function initialiseCache() {
+	if (initialisePromise) return initialisePromise;
+
+	initialisePromise = (async () => {
+		try {
+			await mkdir(cacheDirectory, { recursive: true });
+			const files = await readdir(cacheDirectory);
+			await Promise.all(
+				files
+					.filter((file) => file.startsWith(`${CACHE_FILE_NAME}.tmp-`))
+					.map((file) => unlink(join(cacheDirectory, file)).catch(() => undefined))
+			);
+		} catch (error) {
+			persistentCacheAvailable = false;
+			console.warn(`[strategies-cache] Persistent cache unavailable; using memory only (${safeError(error)}).`);
+			return;
+		}
+
+		try {
+			const decoded = parse(await readFile(cacheFilePath(), 'utf8'));
+			if (!isSnapshot(decoded)) {
+				console.warn('[strategies-cache] Ignoring an invalid or incompatible cache snapshot.');
+				return;
+			}
+			snapshot = decoded;
+			cacheSource = 'filesystem';
+			lastRefreshAt = decoded.updatedAt;
+		} catch (error) {
+			const code = (error as NodeJS.ErrnoException).code;
+			if (code !== 'ENOENT') console.warn(`[strategies-cache] Could not read cache snapshot (${safeError(error)}).`);
+		}
+	})();
+
+	return initialisePromise;
+}
+
+async function writeSnapshot(nextSnapshot: StrategiesPageCacheSnapshot) {
+	if (!persistentCacheAvailable) return;
+	const destination = cacheFilePath();
+	const temporary = `${destination}.tmp-${process.pid}-${crypto.randomUUID()}`;
+	let file: Awaited<ReturnType<typeof open>> | undefined;
+
+	try {
+		file = await open(temporary, 'w', 0o600);
+		await file.writeFile(stringify(nextSnapshot), 'utf8');
+		await file.sync();
+		await file.close();
+		file = undefined;
+		await rename(temporary, destination);
+	} catch (error) {
+		await file?.close().catch(() => undefined);
+		await unlink(temporary).catch(() => undefined);
+		console.warn(`[strategies-cache] Could not persist snapshot; retrying on the next refresh (${safeError(error)}).`);
+	}
+}
+
+/**
+ * Preserve SvelteKit's request-aware relative URL handling while preventing a
+ * visitor's credentials, location headers, or role from entering the snapshot.
+ */
+function createCredentialNeutralFetch(fetch: Fetch): Fetch {
+	return (async (input: RequestInfo | URL, init?: RequestInit) => {
+		const requestHeaders = input instanceof Request ? input.headers : undefined;
+		const headers = new Headers(requestHeaders);
+		new Headers(init?.headers).forEach((value, key) => headers.set(key, value));
+		for (const header of [
+			'authorization',
+			'cookie',
+			'cf-ipcountry',
+			'x-forwarded-for',
+			'x-forwarded-host',
+			'x-forwarded-proto',
+			'x-real-ip'
+		]) {
+			headers.delete(header);
+		}
+
+		return fetch(input as RequestInfo, { ...init, credentials: 'omit', headers });
+	}) as Fetch;
+}
+
+async function fetchTvlData(fetch: Fetch) {
+	try {
+		const data = await fetchPublicApi<{ strategies_tvl?: PerformanceData }>(fetch, 'impressive-numbers');
+		return data.strategies_tvl;
+	} catch (error) {
+		console.warn(`[strategies-cache] Rendering admin data without TVL (${safeError(error)}).`);
+		return undefined;
+	}
+}
+
+async function getYamlStrategies(fetch: Fetch): Promise<StrategyInfo[]> {
+	const configs = [...yamlStrategies.values()];
+	if (!configs.length) return [];
+
+	const topVaults = await fetchTopVaults(fetch);
+	return Promise.all(
+		configs.map(async (config) => {
+			const vault = topVaults.vaults.find((candidate) => candidate.address === config.vault_address);
+			const returns = vault ? await fetchSharePriceReturns90d(fetch, vault.id) : undefined;
+			return toListingStrategy(config, vault, returns);
+		})
+	);
+}
+
+function prepareStrategies(strategies: StrategyInfo[]) {
+	const sorted = [...strategies].sort(compareStrategiesForFrontend);
+	const [startAt] = getStrategyChartDateRange(sorted);
+	return sorted.map((strategy) => compactStrategyTileChartData(strategy, startAt));
+}
+
+async function buildSnapshot(fetch: Fetch): Promise<StrategiesPageCacheSnapshot> {
+	const neutralFetch = createCredentialNeutralFetch(fetch);
+	const [apiStrategies, yamlStrategiesList, tvlData] = await Promise.all([
+		getAllStrategies(neutralFetch),
+		getYamlStrategies(neutralFetch),
+		fetchTvlData(neutralFetch)
+	]);
+	const liveOnly = (strategy: StrategyInfo) => strategy.tags?.includes('live');
+
+	return {
+		version: CACHE_VERSION,
+		updatedAt: new Date(),
+		public: {
+			strategies: prepareStrategies([...apiStrategies.filter(liveOnly), ...yamlStrategiesList.filter(liveOnly)])
+		},
+		admin: { strategies: prepareStrategies([...apiStrategies, ...yamlStrategiesList]), tvlData }
+	};
+}
+
+/** Force an upstream refresh while retaining the last known-good snapshot on failure. */
+export async function refreshStrategiesPageData(fetch: Fetch): Promise<StrategiesPageCacheSnapshot> {
+	await initialiseCache();
+	if (refreshPromise) return refreshPromise;
+
+	refreshPromise = (async () => {
+		try {
+			const nextSnapshot = await buildSnapshot(fetch);
+			await writeSnapshot(nextSnapshot);
+			snapshot = nextSnapshot;
+			cacheSource = 'upstream';
+			lastRefreshAt = nextSnapshot.updatedAt;
+			lastRefreshError = undefined;
+			return nextSnapshot;
+		} catch (error) {
+			lastRefreshError = safeError(error);
+			console.error(`[strategies-cache] Refresh failed; keeping the last good snapshot (${lastRefreshError}).`);
+			throw error;
+		} finally {
+			refreshPromise = undefined;
+		}
+	})();
+
+	return refreshPromise;
+}
+
+/** Return the prepared role-specific data, refreshing only if no valid snapshot exists. */
+export async function getStrategiesPageData(fetch: Fetch, admin: boolean): Promise<StrategiesVariant> {
+	await initialiseCache();
+	if (!snapshot) await refreshStrategiesPageData(fetch);
+	if (!snapshot) throw new Error('Strategies page cache refresh did not produce a snapshot.');
+	return admin ? snapshot.admin : snapshot.public;
+}
+
+/** Safe state for protected diagnostics and refresh responses. */
+export function getStrategiesPageCacheStatus() {
+	const ageMs = snapshot ? Math.max(0, Date.now() - snapshot.updatedAt.valueOf()) : undefined;
+	return {
+		updatedAt: snapshot?.updatedAt.toISOString(),
+		ageSeconds: ageMs === undefined ? undefined : Math.floor(ageMs / 1000),
+		fresh: ageMs !== undefined && ageMs < STRATEGIES_PAGE_CACHE_TTL_MS,
+		refreshing: Boolean(refreshPromise),
+		source: cacheSource,
+		persistent: persistentCacheAvailable,
+		lastRefreshAt: lastRefreshAt?.toISOString(),
+		lastRefreshError
+	};
+}
+
+/** Test-only reset hook; not imported by application routes. */
+export function resetStrategiesPageCacheForTests(directory?: string) {
+	cacheDirectory = directory ?? env.TS_PRIVATE_STRATEGIES_CACHE_DIR ?? join(process.cwd(), '.cache', 'strategies');
+	snapshot = undefined;
+	initialisePromise = undefined;
+	persistentCacheAvailable = true;
+	refreshPromise = undefined;
+	cacheSource = 'empty';
+	lastRefreshAt = undefined;
+	lastRefreshError = undefined;
+}

--- a/src/lib/strategies/yaml/share-price.ts
+++ b/src/lib/strategies/yaml/share-price.ts
@@ -11,7 +11,10 @@ const NINETY_DAYS_SECONDS = 90 * 24 * 60 * 60;
  * Fetch share price data for a vault and convert to 90-day relative returns.
  * Returns [timestamp, relativeReturn][] suitable for share_price_returns_90_days.
  */
-async function fetchSharePriceReturns90d(fetch: Fetch, vaultId: string): Promise<[number, number][] | undefined> {
+export async function fetchSharePriceReturns90d(
+	fetch: Fetch,
+	vaultId: string
+): Promise<[number, number][] | undefined> {
 	try {
 		const resp = await fetch(`/vaults/${vaultId}/metrics`);
 		if (!resp.ok) return undefined;

--- a/src/lib/trade-executor/helpers/chart.test.ts
+++ b/src/lib/trade-executor/helpers/chart.test.ts
@@ -38,4 +38,20 @@ describe('compactStrategyTileChartData', () => {
 		]);
 		expect(compacted.summary_statistics?.share_price_returns_90_days).toBeUndefined();
 	});
+
+	it('keeps one carry-in sample when limiting the visible chart range', () => {
+		const strategy = makeStrategy(true);
+		strategy.summary_statistics!.share_price_returns_90_days = [
+			[Date.UTC(2026, 0, 1, 16) / 1000, 0.1],
+			[Date.UTC(2026, 0, 2, 16) / 1000, 0.2],
+			[Date.UTC(2026, 0, 3, 16) / 1000, 0.3]
+		];
+
+		const compacted = compactStrategyTileChartData(strategy, new Date(Date.UTC(2026, 0, 3)));
+
+		expect(compacted.summary_statistics?.share_price_returns_90_days).toEqual([
+			[Date.UTC(2026, 0, 2) / 1000, 0.2],
+			[Date.UTC(2026, 0, 3) / 1000, 0.3]
+		]);
+	});
 });

--- a/src/lib/trade-executor/helpers/chart.ts
+++ b/src/lib/trade-executor/helpers/chart.ts
@@ -26,9 +26,11 @@ export function getStrategyChartDateRange(strategies: StrategyInfo[]): [Date, Da
  * Keep only the chart series used by a strategy tile at daily resolution.
  *
  * @param strategy Strategy data that will be serialised for a tile
+ * @param startAt Optional visible chart start. One preceding sample is retained
+ *   to preserve the series value at the start of the range.
  * @returns Strategy data without the unused chart series
  */
-export function compactStrategyTileChartData(strategy: StrategyInfo): StrategyInfo {
+export function compactStrategyTileChartData(strategy: StrategyInfo, startAt?: Date): StrategyInfo {
 	const summary = strategy.summary_statistics;
 	if (!summary) return strategy;
 
@@ -39,13 +41,19 @@ export function compactStrategyTileChartData(strategy: StrategyInfo): StrategyIn
 		? 'compounding_unrealised_trading_profitability'
 		: 'share_price_returns_90_days';
 	const selectedSeries = summary[selectedKey];
+	const startAtTimestamp = startAt ? startAt.valueOf() / 1000 : undefined;
+	const firstVisibleIndex = startAtTimestamp
+		? selectedSeries?.findIndex(([timestamp]) => timestamp >= startAtTimestamp)
+		: undefined;
+	const visibleSeries =
+		firstVisibleIndex && firstVisibleIndex > 0 ? selectedSeries?.slice(firstVisibleIndex - 1) : selectedSeries;
 
 	return {
 		...strategy,
 		summary_statistics: {
 			...summary,
 			[discardedKey]: undefined,
-			[selectedKey]: selectedSeries ? downsampleDailySeries(selectedSeries) : undefined
+			[selectedKey]: visibleSeries ? downsampleDailySeries(visibleSeries) : undefined
 		}
 	};
 }

--- a/src/routes/+page.server.ts
+++ b/src/routes/+page.server.ts
@@ -40,7 +40,9 @@ export async function load({ fetch }) {
 			Promise.all([fetchLatestFredValue('SNDR'), fetchLatestTreasuryRate()])
 		]);
 
-		const frontpageStrategies = strategies.filter((s) => s.frontpage).map(compactStrategyTileChartData);
+		const frontpageStrategies = strategies
+			.filter((s) => s.frontpage)
+			.map((strategy) => compactStrategyTileChartData(strategy));
 		const yamlTileFreshness: {
 			strategyId: string;
 			vaultId: string | null;

--- a/src/routes/_internal/cache/strategies/refresh/+server.ts
+++ b/src/routes/_internal/cache/strategies/refresh/+server.ts
@@ -1,0 +1,33 @@
+/** Protected local trigger for the adapter-node strategies cache scheduler. */
+import { timingSafeEqual } from 'node:crypto';
+import { json, type RequestHandler } from '@sveltejs/kit';
+import { env } from '$env/dynamic/private';
+import { getStrategiesPageCacheStatus, refreshStrategiesPageData } from '$lib/strategies/page-cache.server';
+
+function tokenMatches(request: Request) {
+	const token = env.TS_PRIVATE_STRATEGIES_REFRESH_TOKEN;
+	const supplied = request.headers.get('authorization')?.replace(/^Bearer\s+/i, '');
+	if (!token || !supplied) return false;
+	const encoder = new TextEncoder();
+	const expectedBuffer = encoder.encode(token);
+	const suppliedBuffer = encoder.encode(supplied);
+	return expectedBuffer.length === suppliedBuffer.length && timingSafeEqual(expectedBuffer, suppliedBuffer);
+}
+
+export const POST: RequestHandler = async ({ request, fetch }) => {
+	const headers = { 'cache-control': 'private, no-store' };
+	if (!tokenMatches(request)) {
+		return json({ error: 'Unauthorised' }, { status: 401, headers });
+	}
+
+	const startedAt = performance.now();
+	try {
+		await refreshStrategiesPageData(fetch);
+		return json(
+			{ durationMs: Math.round(performance.now() - startedAt), cache: getStrategiesPageCacheStatus() },
+			{ headers }
+		);
+	} catch {
+		return json({ error: 'Refresh failed', cache: getStrategiesPageCacheStatus() }, { status: 503, headers });
+	}
+};

--- a/src/routes/strategies/+page.server.ts
+++ b/src/routes/strategies/+page.server.ts
@@ -1,69 +1,11 @@
 /**
- * Using a server-only load function to serve cached strategies
+ * Serve the prepared, role-specific strategies page snapshot.
  *
- * NOTE: do NOT add HTTP caching to this route, since it renders
- * different content based on admin role and IP country
+ * Do not add HTTP caching: the rendered response still depends on admin role
+ * and the strategies layout's IP-country behaviour.
  */
-import type { StrategyInfo } from 'trade-executor/models/strategy-info';
-import type { PerformanceData } from 'trade-executor/schemas/utility-types.js';
-import { getCachedStrategies } from 'trade-executor/client/strategy-info';
-import { fetchPublicApi } from '$lib/helpers/public-api';
-import { yamlStrategies } from '$lib/strategies/yaml/loader';
-import { compareStrategiesForFrontend } from '$lib/strategies/sort';
-import { toListingStrategy } from '$lib/strategies/yaml/adapter';
-import { fetchTopVaults } from '$lib/top-vaults/client';
-import { getCachedSharePriceReturns } from '$lib/strategies/yaml/share-price';
-
-async function fetchTvlData() {
-	try {
-		const tvlData = await fetchPublicApi<{ strategies_tvl?: PerformanceData }>(fetch, 'impressive-numbers');
-		return tvlData.strategies_tvl;
-	} catch (e) {
-		console.error('Request failed; rendering page without TVL data.');
-		console.error(e);
-	}
-}
-
-async function getYamlStrategies(fetch: Fetch, admin: boolean): Promise<StrategyInfo[]> {
-	if (yamlStrategies.size === 0) return [];
-
-	const configs = [...yamlStrategies.values()];
-	const filtered = admin ? configs : configs.filter((c) => c.tags.includes('live'));
-	if (filtered.length === 0) return [];
-
-	try {
-		const topVaults = await fetchTopVaults(fetch);
-		return Promise.all(
-			filtered.map(async (config) => {
-				const vault = topVaults.vaults.find((v) => v.address === config.vault_address);
-				const sharePriceReturns = vault ? await getCachedSharePriceReturns(fetch, vault.id) : undefined;
-				return toListingStrategy(config, vault, sharePriceReturns);
-			})
-		);
-	} catch (e) {
-		console.error('Failed to fetch vault data for YAML strategies:', e);
-		return filtered.map((config) => toListingStrategy(config));
-	}
-}
+import { getStrategiesPageData } from '$lib/strategies/page-cache.server';
 
 export async function load({ fetch, locals }) {
-	const { admin } = locals;
-
-	// return all strategies for admins, "live" strategies for non-admins
-	const apiStrategies = getCachedStrategies(fetch).then((strategies) => {
-		return admin ? strategies : strategies.filter((s) => s.tags?.includes('live'));
-	});
-
-	const yamlStrategyList = getYamlStrategies(fetch, !!admin);
-
-	// return TVL data for admins only
-	const tvlData = admin ? fetchTvlData() : undefined;
-
-	const allStrategies = [...(await apiStrategies), ...(await yamlStrategyList)];
-	allStrategies.sort(compareStrategiesForFrontend);
-
-	return {
-		strategies: allStrategies,
-		tvlData: await tvlData
-	};
+	return getStrategiesPageData(fetch, Boolean(locals.admin));
 }


### PR DESCRIPTION
## Why

The strategies listing waited for executor metadata and YAML vault enrichment after every process restart, and it serialised substantially more chart data than tiles display.

## Lessons learnt

A shared SSR snapshot must be credential-neutral and role-specific. Persistent refresh failures must keep the previous complete snapshot rather than silently replacing it with disconnected executor data.

## Summary

- Persist separate public and admin `/strategies` snapshots for 30 minutes and refresh them every 20 minutes from adapter-node.
- Add a protected loopback refresh endpoint, atomic cache writes, degraded memory-only mode, Docker named-volume support, and focused tests.
- Compact tile chart payloads to the visible 90-day range and document cache operations.