### PR TITLE
chore: archive ichi and opencz strategies

### DIFF
--- a/strategies/ichi-hyperliquid.yaml
+++ b/strategies/ichi-hyperliquid.yaml
@@ -16,6 +16,7 @@ chain_id: 9999
 # See https://github.com/tradingstrategy-ai/trade-executor/blob/c27b0895eabf9b9cd190afec21c5f53f626a1a3c/tradeexecutor/strategy/tag.py#L6
 tags:
   - live
+  - archived
 # How far up in the listing page we displays this
 sort_priority: 0
 # Show on front page

--- a/strategies/opencz.yaml
+++ b/strategies/opencz.yaml
@@ -16,6 +16,7 @@ chain_id: 9999
 # See https://github.com/tradingstrategy-ai/trade-executor/blob/c27b0895eabf9b9cd190afec21c5f53f626a1a3c/tradeexecutor/strategy/tag.py#L6
 tags:
   - live
+  - archived
 # How far up in the listing page we displays this
 sort_priority: 0
 # Show on front page


### PR DESCRIPTION
## Why

Both the Ichimoku trend-follower and OpenCZ strategies should no longer appear
among the current strategies, but they still need to stay publicly reachable
for anyone holding a position or following their history.

## Lessons learnt

- The tag string is `archived`, not `archive` — it matches trade-executor's
  `tag.py` and the `archiveStatus` filter in `src/routes/strategies/+page.svelte`.
- Archiving a YAML strategy is a pure YAML change. Tags flow straight through
  `src/lib/strategies/yaml/schema.ts` → `adapter.ts` → `StrategyInfo`, so the
  existing listing filter picks them up with no code change.
- Keep the `live` tag when archiving. Two places gate on it: the public snapshot
  filter in `src/lib/strategies/page-cache.server.ts` and the detail-page
  authorisation check in `[strategy=yamlStrategy]/+layout.server.ts`. Dropping
  `live` de-lists the strategy and 401s its page for non-admins, which is not
  the same thing as archiving it.
- There is no visual "archived" badge anywhere — the tag only drives the
  segmented filter on the listing page.
- The strategies listing is served from a disk snapshot with a 30 minute TTL,
  so the change will not be visible immediately after deploy.

## Summary

- Added the `archived` tag alongside `live` in `strategies/ichi-hyperliquid.yaml`
- Added the `archived` tag alongside `live` in `strategies/opencz.yaml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)