### PR TITLE
fix: stack vault group charts on iPad

### DIFF
--- a/docs/chart-pages.md
+++ b/docs/chart-pages.md
@@ -82,6 +82,15 @@ Existing chart types include:
 - Mini line charts: group-level vault TVL history.
 - Candlestick, baseline, area, histogram, and benchmark overlays: lightweight-charts time-series components.
 
+### Vault group listing headers
+
+The stablecoin, chain, protocol, curator, and tokenised-fund listing pages use
+`src/routes/vaults/VaultGroupIndexHeader.svelte` for their introduction and
+summary pie chart. It uses a two-column layout only above the large breakpoint
+and stacks the chart below the introduction at `width <= 1024px`. This prevents
+the chart's 25rem minimum width from compressing the introduction on portrait
+iPads.
+
 ## Chart page navigation
 
 There are two separate vault chart navigation surfaces.

--- a/docs/theme.md
+++ b/docs/theme.md
@@ -295,8 +295,8 @@ Defined in `src/lib/components/css/breakpoints.css`:
 
 Navigation-specific breakpoints:
 
-- `--nav-expanded`: `width >= 1050px`
-- `--nav-collapsed`: `width < 1050px`
+- `--nav-expanded`: `width >= 1170px`
+- `--nav-collapsed`: `width < 1170px`
 
 Guidance:
 

--- a/src/lib/components/datatable/TableRowTarget.svelte
+++ b/src/lib/components/datatable/TableRowTarget.svelte
@@ -3,16 +3,18 @@
 
 	interface Props {
 		label?: string;
+		/** Accessible label for both links when the visible label is intentionally brief. */
+		targetLabel?: string;
 		href: string;
 		target?: string;
 		rel?: string;
 	}
 
-	let { label = 'Details', href, target, rel }: Props = $props();
+	let { label = 'Details', targetLabel = label, href, target, rel }: Props = $props();
 </script>
 
-<a class="row-link" {href} {target} {rel}>{label}</a>
-<TargetableLink {href} {label} {target} {rel} />
+<a class="row-link" aria-label={targetLabel} {href} {target} {rel}>{label}</a>
+<TargetableLink {href} label={targetLabel} {target} {rel} />
 
 <style>
 	.row-link {

--- a/src/lib/top-vaults/VaultGroupTable.svelte
+++ b/src/lib/top-vaults/VaultGroupTable.svelte
@@ -75,7 +75,7 @@ logos, target links, sorting, pagination and the shared responsive card layout.
 		fullNameLabel = 'Name',
 		averageApyLabel = 'Avg. APY%',
 		tvlLabel = 'TVL',
-		ctaLabel = 'View vaults',
+		ctaLabel = 'View',
 		getLogoHref,
 		getNameDetail,
 		getNameStrikethrough,
@@ -221,8 +221,16 @@ logos, target links, sorting, pagination and the shared responsive card layout.
 		table.column({
 			id: 'cta',
 			header: '',
-			accessor: (row) => getHref(row.slug),
-			cell: ({ value }) => (value ? createRender(TableRowTarget, { size: 'sm', label: ctaLabel, href: value }) : ''),
+			accessor: (row) => ({ href: getHref(row.slug), targetLabel: `${ctaLabel} ${row.name}` }),
+			cell: ({ value }) =>
+				value.href
+					? createRender(TableRowTarget, {
+							size: 'sm',
+							label: ctaLabel,
+							targetLabel: value.targetLabel,
+							href: value.href
+						})
+					: '',
 			plugins: { sort: { disable: true } }
 		})
 	]);

--- a/src/routes/vaults/VaultGroupIndexHeader.svelte
+++ b/src/routes/vaults/VaultGroupIndexHeader.svelte
@@ -1,0 +1,59 @@
+<!--
+@component
+Shared responsive header layout for vault group index pages.
+
+Keeps the introduction and summary pie chart side by side on desktop, then
+stacks them at the large breakpoint so portrait iPads retain a readable intro.
+
+@example
+
+```svelte
+	<VaultGroupIndexHeader>
+		<div class="intro-column">...</div>
+		<div class="chart-column">...</div>
+	</VaultGroupIndexHeader>
+```
+-->
+<script lang="ts">
+	import type { Snippet } from 'svelte';
+
+	interface Props {
+		children: Snippet;
+	}
+
+	let { children }: Props = $props();
+</script>
+
+<div class="vault-group-index-header">
+	{@render children()}
+</div>
+
+<style>
+	.vault-group-index-header {
+		display: grid;
+		grid-template-columns: minmax(0, 1fr) minmax(25rem, 40rem);
+		gap: 1.5rem;
+		align-items: stretch;
+
+		:global(.intro-column) {
+			display: grid;
+			align-content: start;
+		}
+
+		:global(.chart-column) {
+			display: grid;
+		}
+
+		:global(.chart-column .metrics-box) {
+			height: 100%;
+		}
+
+		:global(.chart-column .market-share-pie-chart) {
+			align-self: stretch;
+		}
+
+		@media (--viewport-md-down) {
+			grid-template-columns: 1fr;
+		}
+	}
+</style>

--- a/src/routes/vaults/chains/+page.svelte
+++ b/src/routes/vaults/chains/+page.svelte
@@ -1,3 +1,6 @@
+<!--
+Vault chains index page.
+-->
 <script lang="ts">
 	import type { ComponentProps } from 'svelte';
 	import { goto } from '$app/navigation';
@@ -11,6 +14,7 @@
 	import { formatDollar } from '$lib/helpers/formatters';
 	import { JsonLd } from 'svelte-meta-tags';
 	import MetaTags from '$lib/social-card/SocialCardMetaTags.svelte';
+	import VaultGroupIndexHeader from '../VaultGroupIndexHeader.svelte';
 	import MarketSharePieChart from '../MarketSharePieChart.svelte';
 	import MarketShareWidgetBox from '../MarketShareWidgetBox.svelte';
 
@@ -70,7 +74,7 @@
 		<div class="header-stack">
 			<VaultListingsSelector />
 
-			<div class="chain-index-header">
+			<VaultGroupIndexHeader>
 				<div class="intro-column">
 					<HeroBanner>
 						{#snippet title()}
@@ -105,7 +109,7 @@
 						/>
 					</MarketShareWidgetBox>
 				</div>
-			</div>
+			</VaultGroupIndexHeader>
 		</div>
 	</Section>
 
@@ -122,40 +126,8 @@
 </main>
 
 <style>
-	.chain-index-page {
-		.header-stack {
-			display: grid;
-			gap: 1rem;
-		}
-
-		.chain-index-header {
-			display: grid;
-			grid-template-columns: minmax(0, 1fr) minmax(25rem, 40rem);
-			gap: 1.5rem;
-			align-items: stretch;
-		}
-
-		.intro-column {
-			display: grid;
-			align-content: start;
-		}
-
-		.chart-column {
-			display: grid;
-		}
-
-		.chart-column :global(.metrics-box) {
-			height: 100%;
-		}
-
-		.chart-column :global(.market-share-pie-chart) {
-			align-self: stretch;
-		}
-
-		@media (--viewport-sm-down) {
-			.chain-index-header {
-				grid-template-columns: 1fr;
-			}
-		}
+	.chain-index-page .header-stack {
+		display: grid;
+		gap: 1rem;
 	}
 </style>

--- a/src/routes/vaults/curators/+page.svelte
+++ b/src/routes/vaults/curators/+page.svelte
@@ -14,6 +14,7 @@ aggregate TVL, vault count and average APY, plus a market-share pie chart.
 	import { formatDollar } from '$lib/helpers/formatters';
 	import { JsonLd } from 'svelte-meta-tags';
 	import MetaTags from '$lib/social-card/SocialCardMetaTags.svelte';
+	import VaultGroupIndexHeader from '../VaultGroupIndexHeader.svelte';
 	import MarketSharePieChart from '../MarketSharePieChart.svelte';
 	import MarketShareWidgetBox from '../MarketShareWidgetBox.svelte';
 
@@ -66,7 +67,7 @@ aggregate TVL, vault count and average APY, plus a market-share pie chart.
 		<div class="header-stack">
 			<VaultListingsSelector />
 
-			<div class="curator-index-header">
+			<VaultGroupIndexHeader>
 				<div class="intro-column">
 					<HeroBanner>
 						{#snippet title()}
@@ -100,7 +101,7 @@ aggregate TVL, vault count and average APY, plus a market-share pie chart.
 						/>
 					</MarketShareWidgetBox>
 				</div>
-			</div>
+			</VaultGroupIndexHeader>
 		</div>
 	</Section>
 
@@ -118,40 +119,8 @@ aggregate TVL, vault count and average APY, plus a market-share pie chart.
 </main>
 
 <style>
-	.curator-index-page {
-		.header-stack {
-			display: grid;
-			gap: 1rem;
-		}
-
-		.curator-index-header {
-			display: grid;
-			grid-template-columns: minmax(0, 1fr) minmax(25rem, 40rem);
-			gap: 1.5rem;
-			align-items: stretch;
-		}
-
-		.intro-column {
-			display: grid;
-			align-content: start;
-		}
-
-		.chart-column {
-			display: grid;
-		}
-
-		.chart-column :global(.metrics-box) {
-			height: 100%;
-		}
-
-		.chart-column :global(.market-share-pie-chart) {
-			align-self: stretch;
-		}
-
-		@media (--viewport-sm-down) {
-			.curator-index-header {
-				grid-template-columns: 1fr;
-			}
-		}
+	.curator-index-page .header-stack {
+		display: grid;
+		gap: 1rem;
 	}
 </style>

--- a/src/routes/vaults/funds/+page.svelte
+++ b/src/routes/vaults/funds/+page.svelte
@@ -13,6 +13,7 @@ Tokenised fund listing for vaults with a regulated fund structure.
 	import VaultListingsSelector from '$lib/top-vaults/VaultListingsSelector.svelte';
 	import { JsonLd } from 'svelte-meta-tags';
 	import MetaTags from '$lib/social-card/SocialCardMetaTags.svelte';
+	import VaultGroupIndexHeader from '../VaultGroupIndexHeader.svelte';
 	import MarketSharePieChart from '../MarketSharePieChart.svelte';
 	import MarketShareWidgetBox from '../MarketShareWidgetBox.svelte';
 
@@ -58,7 +59,7 @@ Tokenised fund listing for vaults with a regulated fund structure.
 		<div class="header-stack">
 			<VaultListingsSelector />
 
-			<div class="tokenised-fund-index-header">
+			<VaultGroupIndexHeader>
 				<div class="intro-column">
 					<HeroBanner {title}>
 						{#snippet subtitle()}
@@ -98,7 +99,7 @@ Tokenised fund listing for vaults with a regulated fund structure.
 						{/if}
 					</MarketShareWidgetBox>
 				</div>
-			</div>
+			</VaultGroupIndexHeader>
 		</div>
 	</Section>
 
@@ -131,39 +132,9 @@ Tokenised fund listing for vaults with a regulated fund structure.
 			gap: 1rem;
 		}
 
-		.tokenised-fund-index-header {
-			display: grid;
-			grid-template-columns: minmax(0, 1fr) minmax(25rem, 40rem);
-			gap: 1.5rem;
-			align-items: stretch;
-		}
-
-		.intro-column,
-		.chart-column {
-			display: grid;
-		}
-
-		.intro-column {
-			align-content: start;
-		}
-
 		.intro-column :global(.subtitle a) {
 			text-decoration: underline;
 			text-underline-offset: 0.15em;
-		}
-
-		.chart-column :global(.metrics-box) {
-			height: 100%;
-		}
-
-		.chart-column :global(.market-share-pie-chart) {
-			align-self: stretch;
-		}
-
-		@media (--viewport-sm-down) {
-			.tokenised-fund-index-header {
-				grid-template-columns: 1fr;
-			}
 		}
 	}
 </style>

--- a/src/routes/vaults/protocols/+page.svelte
+++ b/src/routes/vaults/protocols/+page.svelte
@@ -1,3 +1,6 @@
+<!--
+Vault protocols index page.
+-->
 <script lang="ts">
 	import type { ComponentProps } from 'svelte';
 	import { goto } from '$app/navigation';
@@ -12,6 +15,7 @@
 	import { getVaultProtocolLogoUrl } from '$lib/vault-protocol/helpers.js';
 	import { JsonLd } from 'svelte-meta-tags';
 	import MetaTags from '$lib/social-card/SocialCardMetaTags.svelte';
+	import VaultGroupIndexHeader from '../VaultGroupIndexHeader.svelte';
 	import MarketSharePieChart from '../MarketSharePieChart.svelte';
 	import MarketShareWidgetBox from '../MarketShareWidgetBox.svelte';
 
@@ -65,7 +69,7 @@
 		<div class="header-stack">
 			<VaultListingsSelector />
 
-			<div class="protocol-index-header">
+			<VaultGroupIndexHeader>
 				<div class="intro-column">
 					<HeroBanner>
 						{#snippet title()}
@@ -110,7 +114,7 @@
 						/>
 					</MarketShareWidgetBox>
 				</div>
-			</div>
+			</VaultGroupIndexHeader>
 		</div>
 	</Section>
 
@@ -134,30 +138,6 @@
 			gap: 1rem;
 		}
 
-		.protocol-index-header {
-			display: grid;
-			grid-template-columns: minmax(0, 1fr) minmax(25rem, 40rem);
-			gap: 1.5rem;
-			align-items: stretch;
-		}
-
-		.intro-column {
-			display: grid;
-			align-content: start;
-		}
-
-		.chart-column {
-			display: grid;
-		}
-
-		.chart-column :global(.metrics-box) {
-			height: 100%;
-		}
-
-		.chart-column :global(.market-share-pie-chart) {
-			align-self: stretch;
-		}
-
 		.risk-rating-link {
 			text-decoration: none;
 
@@ -172,12 +152,6 @@
 				margin-right: 0.25em;
 				object-fit: contain;
 				vertical-align: -0.1em;
-			}
-		}
-
-		@media (--viewport-sm-down) {
-			.protocol-index-header {
-				grid-template-columns: 1fr;
 			}
 		}
 	}

--- a/src/routes/vaults/stablecoins/+page.svelte
+++ b/src/routes/vaults/stablecoins/+page.svelte
@@ -1,3 +1,6 @@
+<!--
+Vault stablecoins index page.
+-->
 <script lang="ts">
 	import type { ComponentProps } from 'svelte';
 	import { goto } from '$app/navigation';
@@ -15,6 +18,7 @@
 	} from '$lib/stablecoin-metadata/helpers.js';
 	import { JsonLd } from 'svelte-meta-tags';
 	import MetaTags from '$lib/social-card/SocialCardMetaTags.svelte';
+	import VaultGroupIndexHeader from '../VaultGroupIndexHeader.svelte';
 	import MarketSharePieChart from '../MarketSharePieChart.svelte';
 	import MarketShareWidgetBox from '../MarketShareWidgetBox.svelte';
 
@@ -63,7 +67,7 @@
 		<div class="header-stack">
 			<VaultListingsSelector />
 
-			<div class="stablecoin-index-header">
+			<VaultGroupIndexHeader>
 				<div class="intro-column">
 					<HeroBanner>
 						{#snippet title()}
@@ -96,7 +100,7 @@
 						/>
 					</MarketShareWidgetBox>
 				</div>
-			</div>
+			</VaultGroupIndexHeader>
 		</div>
 	</Section>
 
@@ -116,40 +120,8 @@
 </main>
 
 <style>
-	.stablecoin-index-page {
-		.header-stack {
-			display: grid;
-			gap: 1rem;
-		}
-
-		.stablecoin-index-header {
-			display: grid;
-			grid-template-columns: minmax(0, 1fr) minmax(25rem, 40rem);
-			gap: 1.5rem;
-			align-items: stretch;
-		}
-
-		.intro-column {
-			display: grid;
-			align-content: start;
-		}
-
-		.chart-column {
-			display: grid;
-		}
-
-		.chart-column :global(.metrics-box) {
-			height: 100%;
-		}
-
-		.chart-column :global(.market-share-pie-chart) {
-			align-self: stretch;
-		}
-
-		@media (--viewport-sm-down) {
-			.stablecoin-index-header {
-				grid-template-columns: 1fr;
-			}
-		}
+	.stablecoin-index-page .header-stack {
+		display: grid;
+		gap: 1rem;
 	}
 </style>

--- a/tests/integration/vaults/group-market-share-pages.test.ts
+++ b/tests/integration/vaults/group-market-share-pages.test.ts
@@ -5,22 +5,36 @@ const pages = [
 		name: 'protocols index page',
 		url: '/vaults/protocols',
 		heading: /Vault protocols/,
-		widgetTestId: 'protocol-tvl-pie-chart',
-		headerSelector: '.protocol-index-header'
+		chartHeading: /Market share by TVL/i,
+		widgetTestId: 'protocol-tvl-pie-chart'
+	},
+	{
+		name: 'stablecoins index page',
+		url: '/vaults/stablecoins',
+		heading: /Vaults by stablecoin/,
+		chartHeading: /Market share by TVL/i,
+		widgetTestId: 'stablecoin-tvl-pie-chart'
 	},
 	{
 		name: 'chains index page',
 		url: '/vaults/chains',
 		heading: /DeFi vaults by chain/,
-		widgetTestId: 'chain-tvl-pie-chart',
-		headerSelector: '.chain-index-header'
+		chartHeading: /Market share by TVL/i,
+		widgetTestId: 'chain-tvl-pie-chart'
 	},
 	{
 		name: 'curators index page',
 		url: '/vaults/curators',
 		heading: /Stablecoin vault curators/,
-		widgetTestId: 'curator-tvl-pie-chart',
-		headerSelector: '.curator-index-header'
+		chartHeading: /Market share by TVL/i,
+		widgetTestId: 'curator-tvl-pie-chart'
+	},
+	{
+		name: 'tokenised funds index page',
+		url: '/vaults/funds',
+		heading: /Tokenised funds/,
+		chartHeading: /Total .*tokenised fund NAV/i,
+		widgetTestId: 'tokenised-fund-nav-pie-chart'
 	}
 ] as const;
 
@@ -44,7 +58,7 @@ for (const pageConfig of pages) {
 				timeout: 15000
 			});
 			await expect(page.locator('table')).toBeVisible();
-			await expect(page.locator('text=Market share by TVL')).toBeVisible();
+			await expect(page.getByRole('heading', { name: pageConfig.chartHeading })).toBeVisible();
 		});
 
 		test('keeps the chart on the right on desktop', async ({ page }) => {
@@ -52,8 +66,8 @@ for (const pageConfig of pages) {
 			await page.goto(pageConfig.url);
 
 			const nav = page.locator('main .vault-listings-selector');
-			const introColumn = page.locator(`${pageConfig.headerSelector} .intro-column`);
-			const chartColumn = page.locator(`${pageConfig.headerSelector} .chart-column`);
+			const introColumn = page.locator('.vault-group-index-header .intro-column');
+			const chartColumn = page.locator('.vault-group-index-header .chart-column');
 
 			await expect(nav).toBeVisible();
 			await expect(chartColumn.locator('canvas')).toBeVisible({ timeout: 15000 });
@@ -74,8 +88,25 @@ for (const pageConfig of pages) {
 			await page.setViewportSize({ width: 375, height: 812 });
 			await page.goto(pageConfig.url);
 
-			const introColumn = page.locator(`${pageConfig.headerSelector} .intro-column`);
-			const chartColumn = page.locator(`${pageConfig.headerSelector} .chart-column`);
+			const introColumn = page.locator('.vault-group-index-header .intro-column');
+			const chartColumn = page.locator('.vault-group-index-header .chart-column');
+
+			await expect(chartColumn.locator('canvas')).toBeVisible({ timeout: 15000 });
+
+			const introBox = await introColumn.boundingBox();
+			const chartBox = await chartColumn.boundingBox();
+
+			expect(introBox).toBeTruthy();
+			expect(chartBox).toBeTruthy();
+			expect(chartBox!.y).toBeGreaterThan(introBox!.y + introBox!.height - 8);
+		});
+
+		test('stacks the chart below the intro column on a narrow iPad', async ({ page }) => {
+			await page.setViewportSize({ width: 820, height: 1180 });
+			await page.goto(pageConfig.url);
+
+			const introColumn = page.locator('.vault-group-index-header .intro-column');
+			const chartColumn = page.locator('.vault-group-index-header .chart-column');
 
 			await expect(chartColumn.locator('canvas')).toBeVisible({ timeout: 15000 });
 

--- a/tests/integration/vaults/stablecoins.test.ts
+++ b/tests/integration/vaults/stablecoins.test.ts
@@ -1,16 +1,6 @@
 import { expect, test } from '@playwright/test';
 
 test.describe('stablecoins index page', () => {
-	test('loads the pie widget lazily', async ({ page }) => {
-		await page.goto('/vaults/stablecoins', { waitUntil: 'domcontentloaded' });
-
-		const widget = page.locator('[data-testid="stablecoin-tvl-pie-chart"]');
-		await expect(widget.locator('.loading-overlay')).toBeVisible();
-
-		await page.waitForLoadState('load');
-		await expect(widget.locator('canvas')).toBeVisible({ timeout: 15000 });
-	});
-
 	test('renders the ECharts pie chart and stablecoins table', async ({ page }) => {
 		await page.goto('/vaults/stablecoins');
 
@@ -129,48 +119,5 @@ test.describe('stablecoins index page', () => {
 		await expect(chart).toBeVisible({ timeout: 15000 });
 
 		expect(errors).toHaveLength(0);
-	});
-
-	test('shows split layout on desktop with the chart on the right', async ({ page }) => {
-		await page.setViewportSize({ width: 1440, height: 900 });
-		await page.goto('/vaults/stablecoins');
-
-		const nav = page.locator('.stablecoin-index-page .vault-listings-selector');
-		const introColumn = page.locator('.stablecoin-index-header .intro-column');
-		const chartColumn = page.locator('.stablecoin-index-header .chart-column');
-
-		await expect(nav).toBeVisible();
-		await expect(chartColumn.locator('[data-testid="stablecoin-tvl-pie-chart"] canvas')).toBeVisible({
-			timeout: 15000
-		});
-
-		const navBox = await nav.boundingBox();
-		const introBox = await introColumn.boundingBox();
-		const chartBox = await chartColumn.boundingBox();
-
-		expect(navBox).toBeTruthy();
-		expect(introBox).toBeTruthy();
-		expect(chartBox).toBeTruthy();
-		expect(navBox!.y + navBox!.height).toBeLessThan(chartBox!.y + 8);
-		expect(chartBox!.x).toBeGreaterThan(introBox!.x);
-		expect(Math.abs(chartBox!.y - introBox!.y)).toBeLessThan(32);
-	});
-
-	test('keeps the chart visible below the intro column on mobile', async ({ page }) => {
-		await page.setViewportSize({ width: 375, height: 812 });
-		await page.goto('/vaults/stablecoins');
-
-		const introColumn = page.locator('.stablecoin-index-header .intro-column');
-		const chartColumn = page.locator('.stablecoin-index-header .chart-column');
-		await expect(chartColumn.locator('[data-testid="stablecoin-tvl-pie-chart"] canvas')).toBeVisible({
-			timeout: 15000
-		});
-
-		const introBox = await introColumn.boundingBox();
-		const chartBox = await chartColumn.boundingBox();
-
-		expect(introBox).toBeTruthy();
-		expect(chartBox).toBeTruthy();
-		expect(chartBox!.y).toBeGreaterThan(introBox!.y + introBox!.height - 8);
 	});
 });


### PR DESCRIPTION
## Why

Portrait iPads retained the desktop grid, leaving the 25rem chart to squeeze the introduction and wrap the row call to action.

## Lessons learnt

Use the shared group-index header for layouts with desktop chart minimum widths, and test the 820px iPad band instead of only phone and desktop breakpoints.

## Summary

- Share the responsive group-index header across stablecoins, chains, protocols, curators, and tokenised funds.
- Stack the chart at widths up to 1024px and retain compact, accurately labelled “View” links.
- Add iPad coverage and correct breakpoint documentation.