### PR TITLE
Rename DEX spot data page

### DIFF
--- a/src/routes/trading-view/backtesting/+page.svelte
+++ b/src/routes/trading-view/backtesting/+page.svelte
@@ -67,7 +67,7 @@
 </script>
 
 <svelte:head>
-	<title>Historical DEX trading data</title>
+	<title>DEX spot data</title>
 	<meta name="description" content="Download price, OHLCV and liquidity backtesting data" />
 </svelte:head>
 
@@ -75,7 +75,7 @@
 
 <main class="backtesting-page">
 	<Section tag="header">
-		<HeroBanner title="Historical DEX trading data">
+		<HeroBanner title="DEX spot data">
 			{#snippet subtitle()}
 				<p>
 					The following datasets are available for historical DEX trading data.
@@ -93,6 +93,13 @@
 				</p>
 			{/snippet}
 		</HeroBanner>
+	</Section>
+
+	<Section>
+		<Alert size="md" status="info" title="Looking for vaults data?">
+			Download vault metadata and historical vault price datasets for research and analysis.
+			<Button slot="cta" size="sm" label="View vault datasets" href="/vaults/datasets" />
+		</Alert>
 	</Section>
 
 	<Section>

--- a/src/routes/vaults/api/+page.svelte
+++ b/src/routes/vaults/api/+page.svelte
@@ -71,7 +71,7 @@
 			<Button slot="cta" label="Download vault data" />
 		</ContentCard>
 
-		<ContentCard title="Backtesting" href="/trading-view/backtesting">
+		<ContentCard title="DEX spot data" href="/trading-view/backtesting">
 			<IconBacktesting slot="icon" />
 			<p>
 				Download historical OHLCV data for backtesting your trading algorithms. Liquidity information is available for


### PR DESCRIPTION
## Why

Make the DEX spot datasets easier to find and distinguish them from vault datasets.

## Lessons learnt

Use the API catalogue and historical DEX data page together when changing the public data navigation.

## Summary

- Rename the Backtesting card and its destination page to DEX spot data.
- Add a vault datasets cross-link callout on the DEX spot data page.