### PR TITLE
feat: add permissioned vault filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Weblog of stuff
 
+- Add a permissioned-vault filter to vault listings (2026-08-25)
 - Show processed flow and reset time in the GuardV0 deposit tooltip (2026-08-20)
 - Add a blacklisted-vault reveal control to vault listings (2026-08-17)
 - Unify CORE3 and Xerberus risk-rating card disclosures (2026-08-13)

--- a/docs/vault-listings.md
+++ b/docs/vault-listings.md
@@ -16,6 +16,15 @@ Each listing has a fixed definition (`top`, `chain`, `protocol`,
 `stablecoin`, `curator`, `tokenised-funds`, and the special listings). URL
 filters may narrow that definition but cannot change its base population.
 
+### Permissioned vault filter
+
+The Filters panel labels the permissioned-vault control **Hide private**. It
+adds `private=1` to the URL and excludes every vault with a `whitelisted`
+deposit status. This includes tokenised funds: they are displayed as **Fund**
+in the table, but still require permission to deposit. The label refers to the
+deposit restriction, not the table's status text. It is not shown on the
+Whitelisted listing because every vault in that listing is permissioned.
+
 ## Continuation API
 
 `GET /top-vaults/listing-data` returns the next 50 rows. It accepts the normal

--- a/src/lib/top-vaults/TopVaultsPage.svelte
+++ b/src/lib/top-vaults/TopVaultsPage.svelte
@@ -55,10 +55,12 @@ Use `ratingProvider` to show a provider-specific risk rating column.
 		defaultAgeIndex?: number;
 		/** Default risk filter index (used to initialise the dropdown when showFilters is true) */
 		defaultRiskIndex?: number;
-		/** Default value for the "Hide unknown" filter (1 = hide, 0 = show) */
+		/** Default value for the "Hide unknown protocols" filter (1 = hide, 0 = show) */
 		defaultHideUnknown?: number;
-		/** Show the "Hide unknown" protocol filter checkbox */
+		/** Show the "Hide unknown protocols" filter checkbox */
 		showUnknownFilter?: boolean;
+		/** Show the "Hide private" permissioned-vault filter checkbox */
+		showPrivateFilter?: boolean;
 		/** Default monthly return filter key */
 		defaultMonthlyReturnKey?: string;
 		/** Default sort column key */
@@ -116,6 +118,7 @@ Use `ratingProvider` to show a provider-specific risk rating column.
 		defaultRiskIndex,
 		defaultHideUnknown,
 		showUnknownFilter,
+		showPrivateFilter,
 		defaultMonthlyReturnKey,
 		defaultSort,
 		defaultDirection,
@@ -269,6 +272,7 @@ Use `ratingProvider` to show a provider-specific risk rating column.
 					{defaultRiskIndex}
 					{defaultHideUnknown}
 					{showUnknownFilter}
+					{showPrivateFilter}
 					{defaultMonthlyReturnKey}
 					{defaultSort}
 					{defaultDirection}
@@ -303,6 +307,7 @@ Use `ratingProvider` to show a provider-specific risk rating column.
 					{defaultRiskIndex}
 					{defaultHideUnknown}
 					{showUnknownFilter}
+					{showPrivateFilter}
 					{defaultMonthlyReturnKey}
 					{defaultSort}
 					{defaultDirection}

--- a/src/lib/top-vaults/TopVaultsTable.svelte
+++ b/src/lib/top-vaults/TopVaultsTable.svelte
@@ -3,7 +3,8 @@
 Interactive vault listing with filters, sorting, and progressive row loading.
 
 Use `ratingProvider` to add its risk-rating column beside the vault name.
-Whitelisted vaults are marked as Private, except tokenised funds, which are marked as Fund.
+Permissioned vaults are marked as Private, except tokenised funds, which are marked as Fund.
+The Hide private filter excludes all permissioned vaults.
 -->
 <script lang="ts">
 	import type { Chain } from '$lib/helpers/chain';
@@ -63,6 +64,7 @@ Whitelisted vaults are marked as Private, except tokenised funds, which are mark
 		getVaultTvlNative,
 		hasSupportedProtocol,
 		isBlacklisted,
+		isPermissionedVault,
 		isVaultDepositCapped,
 		isGoodVaultStatus,
 		monthlyReturnFilterOptions,
@@ -93,7 +95,18 @@ Whitelisted vaults are marked as Private, except tokenised funds, which are mark
 
 	const allVaultsPath = resolve('/vaults/all');
 	const filtersOpenStorageKey = 'top-vaults-filters-open';
-	const filterSearchParamKeys = ['tvl', 'age', 'risk', 'q', 'closed', 'unknown', 'dd', 'mr', 'returns'] as const;
+	const filterSearchParamKeys = [
+		'tvl',
+		'age',
+		'risk',
+		'q',
+		'closed',
+		'unknown',
+		'private',
+		'dd',
+		'mr',
+		'returns'
+	] as const;
 
 	/** Return whether the URL explicitly contains a vault-table filtering parameter. */
 	function hasFilterSearchParams(searchParams: URLSearchParams) {
@@ -122,10 +135,12 @@ Whitelisted vaults are marked as Private, except tokenised funds, which are mark
 		defaultAgeIndex?: number;
 		/** Default risk filter index (used to initialise the dropdown when showFilters is true) */
 		defaultRiskIndex?: number;
-		/** Default value for the "Hide unknown" filter (1 = hide, 0 = show) */
+		/** Default value for the "Hide unknown protocols" filter (1 = hide, 0 = show) */
 		defaultHideUnknown?: number;
-		/** Show the "Hide unknown" protocol filter checkbox */
+		/** Show the "Hide unknown protocols" filter checkbox */
 		showUnknownFilter?: boolean;
+		/** Show the "Hide private" permissioned-vault filter checkbox */
+		showPrivateFilter?: boolean;
 		/** Default monthly return filter key */
 		defaultMonthlyReturnKey?: string;
 		/** Default sort column key */
@@ -181,6 +196,7 @@ Whitelisted vaults are marked as Private, except tokenised funds, which are mark
 		defaultRiskIndex = 1,
 		defaultHideUnknown = 1,
 		showUnknownFilter = true,
+		showPrivateFilter = true,
 		defaultMonthlyReturnKey = 'any',
 		defaultSort,
 		defaultDirection,
@@ -309,6 +325,7 @@ Whitelisted vaults are marked as Private, except tokenised funds, which are mark
 		q: { type: 'string', defaultValue: '' },
 		closed: { type: 'number', defaultValue: 0 },
 		unknown: { type: 'number', defaultValue: defaultHideUnknown },
+		private: { type: 'number', defaultValue: 0 },
 		dd: { type: 'string', defaultValue: 'any', options: ddFilterOptions.map((o) => o.key) },
 		mr: {
 			type: 'string',
@@ -391,6 +408,7 @@ Whitelisted vaults are marked as Private, except tokenised funds, which are mark
 
 	let hideClosed = $derived(urlState.closed === 1);
 	let hideUnknown = $derived(showUnknownFilter && urlState.unknown === 1);
+	let hidePrivate = $derived(urlState.private === 1);
 	let returnsDropdownOpen = $state(false);
 	let filtersOpen = $state(hasFilterSearchParams(page.url.searchParams));
 	let hasLoadedFilterPreference = false;
@@ -628,6 +646,9 @@ Whitelisted vaults are marked as Private, except tokenised funds, which are mark
 
 			// Hide unknown protocol filter (checkbox-driven)
 			if (hideUnknown && !hasSupportedProtocol(v)) return false;
+
+			// Hide private vault filter (checkbox-driven)
+			if (hidePrivate && isPermissionedVault(v)) return false;
 
 			const vaultCompareStr = [
 				v.chain_id,
@@ -1064,7 +1085,7 @@ Whitelisted vaults are marked as Private, except tokenised funds, which are mark
 								<div class="filter-group">
 									<Tooltip>
 										<label class="checkbox-filter" slot="trigger">
-											<span class="filter-label filter-label-hint">Hide unknown</span>
+											<span class="filter-label filter-label-hint">Hide unknown protocols</span>
 											<input
 												type="checkbox"
 												checked={hideUnknown}
@@ -1074,6 +1095,22 @@ Whitelisted vaults are marked as Private, except tokenised funds, which are mark
 										<svelte:fragment slot="popup">
 											Don't show vaults whose protocol has not been identified yet
 										</svelte:fragment>
+									</Tooltip>
+								</div>
+							{/if}
+
+							{#if showPrivateFilter}
+								<div class="filter-group">
+									<Tooltip>
+										<label class="checkbox-filter" slot="trigger">
+											<span class="filter-label filter-label-hint">Hide private</span>
+											<input
+												type="checkbox"
+												checked={hidePrivate}
+												onchange={() => updateSearchParams({ private: hidePrivate ? 0 : 1 })}
+											/>
+										</label>
+										<svelte:fragment slot="popup">Hide vaults that require permission to deposit</svelte:fragment>
 									</Tooltip>
 								</div>
 							{/if}
@@ -1295,7 +1332,7 @@ Whitelisted vaults are marked as Private, except tokenised funds, which are mark
 					{@const chain = getChain(vault.chain_id)}
 					{@const blacklisted = isBlacklisted(vault)}
 					{@const badStatus = !isGoodVaultStatus(vault)}
-					{@const isPrivate = vault.whitelist?.status === 'whitelisted'}
+					{@const isPrivate = isPermissionedVault(vault)}
 					{@const isTokenisedFund = vault.flags.includes('tokenised_fund')}
 					{@const isCapped = isVaultDepositCapped(vault)}
 					{@const depositStatusLabel = isTokenisedFund ? 'Fund' : 'Private'}

--- a/src/lib/top-vaults/helpers.test.ts
+++ b/src/lib/top-vaults/helpers.test.ts
@@ -2,6 +2,7 @@ import { describe, test, expect } from 'vitest';
 import {
 	CORE3_METHODOLOGY_URL,
 	isBlacklisted,
+	isPermissionedVault,
 	isEligibleFrontpageVault,
 	hasSupportedProtocol,
 	getProtocolDisplayName,
@@ -98,6 +99,18 @@ describe('isBlacklisted', () => {
 		const vault = createTestVault('Test vault');
 		expect(vault.risk_numeric).toBeNull();
 		expect(isBlacklisted(vault)).toBe(false);
+	});
+});
+
+describe('isPermissionedVault', () => {
+	test('returns true only for vaults that require deposit permission', () => {
+		expect(
+			isPermissionedVault(createTestVault('Permissioned', { whitelist: { status: 'whitelisted', notes: null } }))
+		).toBe(true);
+		expect(
+			isPermissionedVault(createTestVault('Public', { whitelist: { status: 'permissionless', notes: null } }))
+		).toBe(false);
+		expect(isPermissionedVault(createTestVault('Unknown'))).toBe(false);
 	});
 });
 

--- a/src/lib/top-vaults/helpers.ts
+++ b/src/lib/top-vaults/helpers.ts
@@ -224,6 +224,11 @@ export function isBlacklisted(vault: Pick<VaultInfo, 'risk_numeric'> & Partial<P
 	return vault.risk_numeric === 999 || vault.risk?.toLowerCase() === 'blacklisted';
 }
 
+/** Whether the vault requires permission before deposits can be made. */
+export function isPermissionedVault(vault: Pick<VaultInfo, 'whitelist'>) {
+	return vault.whitelist?.status === 'whitelisted';
+}
+
 const unsupportedProtocolNames = ['<protocol not yet identified>', '<unknown erc-7450>'] as const;
 const unsupportedProtocolSlugs = new Set([
 	...unsupportedProtocolNames.map((protocol) => slugify(protocol)),

--- a/src/lib/top-vaults/listing/definitions.ts
+++ b/src/lib/top-vaults/listing/definitions.ts
@@ -5,7 +5,13 @@
  * that a URL can only narrow its declared listing population.
  */
 import { getChainsBySlug } from '$lib/helpers/chain';
-import { DEFAULT_TVL_KEY, MAX_SUMMARY_TVL_USD, isBlacklisted, isUnknownVaultProtocol } from '../helpers';
+import {
+	DEFAULT_TVL_KEY,
+	MAX_SUMMARY_TVL_USD,
+	isBlacklisted,
+	isPermissionedVault,
+	isUnknownVaultProtocol
+} from '../helpers';
 import type { VaultInfo } from '../schemas';
 import type { VaultListingOptions } from './query';
 import type { VaultListingQueryDefaults } from './state';
@@ -129,7 +135,7 @@ export function filterVaultListingScope(vaults: VaultInfo[], key: VaultListingKe
 		case 'blacklisted':
 			return vaults.filter(isBlacklisted);
 		case 'whitelisted':
-			return vaults.filter((vault) => vault.whitelist?.status === 'whitelisted');
+			return vaults.filter(isPermissionedVault);
 		case 'chain': {
 			if (!scope) return [];
 			const chainIds = new Set(getChainsBySlug(scope).map((chain) => chain.id));

--- a/src/lib/top-vaults/listing/query.test.ts
+++ b/src/lib/top-vaults/listing/query.test.ts
@@ -109,6 +109,24 @@ describe('vault listing query', () => {
 		expect(query.tvl).toBe('10k');
 	});
 
+	it('hides permissioned vaults when requested', () => {
+		const publicVault = createTestVault('Public', { current_nav: 100_000 });
+		const privateVault = createTestVault('Private', {
+			current_nav: 100_000,
+			whitelist: { status: 'whitelisted', notes: null }
+		});
+		const privateFund = createTestVault('Private fund', {
+			current_nav: 100_000,
+			flags: ['tokenised_fund'],
+			whitelist: { status: 'whitelisted', notes: null }
+		});
+		const query = parseVaultListingQuery(new URLSearchParams('private=1'), { tvl: '10k' });
+
+		expect(
+			queryVaultListing([publicVault, privateVault, privateFund], query, options).vaults.map((vault) => vault.name)
+		).toEqual(['Public']);
+	});
+
 	it('keeps a blacklisted definition scoped to blacklisted vaults', () => {
 		const safe = createTestVault('Safe', { current_nav: 100_000 });
 		const blacklisted = createTestVault('Blacklisted', { current_nav: 100_000, risk: 'Blacklisted' });

--- a/src/lib/top-vaults/listing/query.ts
+++ b/src/lib/top-vaults/listing/query.ts
@@ -18,6 +18,7 @@ import {
 	getVaultProtocolDisplayName,
 	hasSupportedProtocol,
 	isBlacklisted,
+	isPermissionedVault,
 	monthlyReturnFilterOptions,
 	rankVaultsBy,
 	riskFilterOptions,
@@ -37,6 +38,7 @@ export interface VaultListingQuery {
 	q: string;
 	closed: boolean;
 	unknown: boolean;
+	private: boolean;
 	sort: string;
 	direction: VaultSortDirection;
 }
@@ -162,6 +164,7 @@ export function queryVaultListing(
 		}
 		if (query.closed && vault.deposit_closed_reason != null) return false;
 		if (query.unknown && !hasSupportedProtocol(vault)) return false;
+		if (query.private && isPermissionedVault(vault)) return false;
 		const search = [
 			vault.chain_id,
 			getChainDisplayName(vault.chain_id),

--- a/src/lib/top-vaults/listing/state.ts
+++ b/src/lib/top-vaults/listing/state.ts
@@ -67,6 +67,7 @@ export function parseVaultListingQuery(
 		q: (params.get('q') ?? '').slice(0, 100),
 		closed: params.get('closed') === '1',
 		unknown: params.get('unknown') == null ? (defaults.unknown ?? true) : params.get('unknown') === '1',
+		private: params.get('private') === '1',
 		sort: sortKeys.has(sort) ? sort : (defaults.sort ?? DEFAULT_RETURN_COLUMN_IDS[0]),
 		direction: direction === 'asc' || direction === 'desc' ? direction : (defaults.direction ?? 'desc')
 	};

--- a/src/routes/vaults/[vault=slug]/+page.svelte
+++ b/src/routes/vaults/[vault=slug]/+page.svelte
@@ -31,6 +31,7 @@ Vault detail page with performance, protocol, private-deposit, and third-party r
 		getVaultProtocolDisplayName,
 		hasSupportedProtocol,
 		isBlacklisted,
+		isPermissionedVault,
 		isVaultDepositCapped,
 		isVaultTvlDownMoreThan95Percent
 	} from '$lib/top-vaults/helpers';
@@ -48,7 +49,7 @@ Vault detail page with performance, protocol, private-deposit, and third-party r
 	let showBlacklistedAlert = $derived(blacklisted && !notesDuplicateMorphoFlags);
 	let showNotes = $derived(vault.notes != null && !notesDuplicateMorphoFlags);
 	let isTokenisedFund = $derived(vault.flags.includes('tokenised_fund'));
-	let isPrivate = $derived(vault.whitelist?.status === 'whitelisted');
+	let isPrivate = $derived(isPermissionedVault(vault));
 	let isCapped = $derived(isVaultDepositCapped(vault));
 	let showTvlWarning = $derived(isVaultTvlDownMoreThan95Percent(vault));
 	let showLongDurationWarning = $derived(vault.flags.includes('long_duration'));

--- a/src/routes/vaults/[vault=slug]/VaultTransactionStatus.svelte
+++ b/src/routes/vaults/[vault=slug]/VaultTransactionStatus.svelte
@@ -10,7 +10,7 @@ Displays vault deposit and redemption availability when either operation is rest
 -->
 <script lang="ts">
 	import MetricsBox from '$lib/components/MetricsBox.svelte';
-	import { isGoodVaultStatus, isVaultDepositCapped } from '$lib/top-vaults/helpers';
+	import { isGoodVaultStatus, isPermissionedVault, isVaultDepositCapped } from '$lib/top-vaults/helpers';
 	import type { VaultInfo } from '$lib/top-vaults/schemas';
 
 	interface Props {
@@ -19,7 +19,7 @@ Displays vault deposit and redemption availability when either operation is rest
 
 	let { vault }: Props = $props();
 
-	let isPrivate = $derived(vault.whitelist?.status === 'whitelisted');
+	let isPrivate = $derived(isPermissionedVault(vault));
 	let isCapped = $derived(isVaultDepositCapped(vault));
 	let depositStatus = $derived(
 		isPrivate

--- a/src/routes/vaults/whitelisted/+page.svelte
+++ b/src/routes/vaults/whitelisted/+page.svelte
@@ -54,6 +54,7 @@ Whitelisted vault listing for permissioned deposits.
 	defaultTvlKey="any"
 	defaultRiskIndex={1}
 	defaultHideUnknown={0}
+	showPrivateFilter={false}
 	defaultSort="tvl"
 	defaultDirection="desc"
 />

--- a/tests/integration/vaults/index.test.ts
+++ b/tests/integration/vaults/index.test.ts
@@ -141,6 +141,8 @@ test.describe('vault index page', () => {
 
 		await expect(primaryFilters.getByText('Technical risk', { exact: true })).toBeVisible();
 		await expect(primaryFilters.getByText('Hide undepositable', { exact: true })).toBeVisible();
+		await expect(primaryFilters.getByText('Hide unknown protocols', { exact: true })).toBeVisible();
+		await expect(primaryFilters.getByText('Hide private', { exact: true })).toBeVisible();
 		await expect(primaryFilters.getByTestId('vault-search')).toHaveCount(0);
 		await expect(page.locator('.filters-content').getByText('Min TVL')).toBeVisible();
 		await expect(page.locator('.filters-content').getByText('Age', { exact: true })).toBeVisible();
@@ -443,6 +445,24 @@ test.describe('vault index page', () => {
 		await toggleReturnOption(page, 'Six months annualised');
 
 		await expect(page).toHaveURL(/returns=1m-ann%2C3m-ann%2C6m-ann/);
+	});
+
+	test('hides all permissioned vaults when the private filter is selected', async ({ page }) => {
+		await page.goto('/vaults/all?q=Private');
+		await openFilters(page);
+
+		const privateFilter = page.getByText('Hide private', { exact: true }).locator('..').locator('input');
+		await privateFilter.check();
+
+		await expect(page).toHaveURL(/private=1/);
+		await expect(page.locator('tbody tr.targetable')).toHaveCount(0);
+	});
+
+	test('does not offer the private filter on the whitelisted-vault listing', async ({ page }) => {
+		await page.goto('/vaults/whitelisted');
+		await openFilters(page);
+
+		await expect(page.getByText('Hide private', { exact: true })).toHaveCount(0);
 	});
 
 	test('shows limited data tooltips for partial 3M and 1Y returns', async ({ page }) => {


### PR DESCRIPTION
## Why

Vault listings need a clear way to remove permissioned investment options while retaining stable shared URLs and pagination.

## Lessons learnt

“Private” is a UI label: tokenised funds with a whitelisted deposit status are also permissioned, while the Whitelisted listing must not offer a control that would hide its entire population.

## Summary

- Rename the unknown-protocol filter and add Hide private with clear deposit-permission wording.
- Apply `private=1` consistently to browser, server, and pagination queries via a shared predicate.
- Document the URL behaviour, add coverage, and hide the control on the Whitelisted listing.