### PR TITLE
fix: clarify closed vault filter

### DIFF
--- a/src/lib/top-vaults/TopVaultsTable.svelte
+++ b/src/lib/top-vaults/TopVaultsTable.svelte
@@ -1068,7 +1068,7 @@ The Hide private filter excludes all permissioned vaults.
 							<div class="filter-group">
 								<Tooltip>
 									<label class="checkbox-filter" slot="trigger">
-										<span class="filter-label filter-label-hint">Hide undepositable</span>
+										<span class="filter-label filter-label-hint">Hide currently closed</span>
 										<input
 											type="checkbox"
 											checked={hideClosed}

--- a/tests/integration/vaults/index.test.ts
+++ b/tests/integration/vaults/index.test.ts
@@ -140,7 +140,7 @@ test.describe('vault index page', () => {
 		await openFilters(page);
 
 		await expect(primaryFilters.getByText('Technical risk', { exact: true })).toBeVisible();
-		await expect(primaryFilters.getByText('Hide undepositable', { exact: true })).toBeVisible();
+		await expect(primaryFilters.getByText('Hide currently closed', { exact: true })).toBeVisible();
 		await expect(primaryFilters.getByText('Hide unknown protocols', { exact: true })).toBeVisible();
 		await expect(primaryFilters.getByText('Hide private', { exact: true })).toBeVisible();
 		await expect(primaryFilters.getByTestId('vault-search')).toHaveCount(0);


### PR DESCRIPTION
## Why

The previous label used unfamiliar terminology, making it less clear that the filter concerns whether a vault is currently accepting deposits.

## Lessons learnt

A concise state-based label works with the existing tooltip to explain both the current condition and its effect.

## Summary

- Rename the filter to Hide currently closed.
- Update the vault-listing integration expectation.