### PR TITLE
fix: omit GMX vault TVL decline warning

### DIFF
--- a/src/lib/top-vaults/helpers.test.ts
+++ b/src/lib/top-vaults/helpers.test.ts
@@ -30,6 +30,7 @@ import {
 	getVaultPeakTvlUsd,
 	getVaultTvlNative,
 	isVaultTvlDownMoreThan95Percent,
+	shouldShowVaultTvlDownMoreThan95PercentWarning,
 	getXerberusScoreBand,
 	getXerberusScoreColour,
 	isNonUsdDenominatedVault,
@@ -566,6 +567,24 @@ describe('isVaultTvlDownMoreThan95Percent', () => {
 		expect(isVaultTvlDownMoreThan95Percent(createTestVault('Zero peak vault', { current_nav: 0, peak_nav: 0 }))).toBe(
 			false
 		);
+	});
+});
+
+describe('shouldShowVaultTvlDownMoreThan95PercentWarning', () => {
+	test('does not show the warning for GMX vaults', () => {
+		const vault = createTestVault('GMX vault', {
+			protocol: 'GMX',
+			current_nav: 4_999,
+			peak_nav: 100_000
+		});
+
+		expect(shouldShowVaultTvlDownMoreThan95PercentWarning(vault)).toBe(false);
+	});
+
+	test('shows the warning for other vaults with the same TVL decline', () => {
+		const vault = createTestVault('Collapsed vault', { current_nav: 4_999, peak_nav: 100_000 });
+
+		expect(shouldShowVaultTvlDownMoreThan95PercentWarning(vault)).toBe(true);
 	});
 });
 

--- a/src/lib/top-vaults/helpers.ts
+++ b/src/lib/top-vaults/helpers.ts
@@ -575,6 +575,16 @@ export function isVaultTvlDownMoreThan95Percent(vault: Pick<VaultInfo, 'current_
 	);
 }
 
+/**
+ * Whether to show the historical TVL decline warning on a vault detail page.
+ * The warning does not apply to GMX vaults.
+ */
+export function shouldShowVaultTvlDownMoreThan95PercentWarning(
+	vault: Pick<VaultInfo, 'current_nav' | 'peak_nav' | 'protocol_slug'>
+): boolean {
+	return vault.protocol_slug !== 'gmx' && isVaultTvlDownMoreThan95Percent(vault);
+}
+
 const DEFAULT_DETAIL_RISK_FILTER = riskFilterOptions[1];
 
 /**

--- a/src/routes/vaults/[vault=slug]/+page.svelte
+++ b/src/routes/vaults/[vault=slug]/+page.svelte
@@ -32,7 +32,7 @@ Vault detail page with performance, protocol, private-deposit, and third-party r
 		hasSupportedProtocol,
 		isBlacklisted,
 		isVaultDepositCapped,
-		isVaultTvlDownMoreThan95Percent
+		shouldShowVaultTvlDownMoreThan95PercentWarning
 	} from '$lib/top-vaults/helpers';
 	import { getCuratorSocialLogoUrl } from '$lib/social-card/helpers';
 	import { getVaultProtocolLogoUrl } from '$lib/vault-protocol/helpers.js';
@@ -50,7 +50,7 @@ Vault detail page with performance, protocol, private-deposit, and third-party r
 	let isTokenisedFund = $derived(vault.flags.includes('tokenised_fund'));
 	let isPrivate = $derived(vault.whitelist?.status === 'whitelisted');
 	let isCapped = $derived(isVaultDepositCapped(vault));
-	let showTvlWarning = $derived(isVaultTvlDownMoreThan95Percent(vault));
+	let showTvlWarning = $derived(shouldShowVaultTvlDownMoreThan95PercentWarning(vault));
 	let showLongDurationWarning = $derived(vault.flags.includes('long_duration'));
 	let hasUnsupportedProtocol = $derived(!hasSupportedProtocol(vault));
 	let depositMayBeDisabled = $derived(vault.deposit_closed_reason != null);


### PR DESCRIPTION
## Why

GMX vaults can appear more than 95% below their historical TVL peak, but this warning is not applicable to them.

## Lessons learnt

Keep protocol-specific warning exceptions separate from the underlying TVL decline calculation.

## Summary

- Exclude GMX vaults from the historical TVL decline warning.
- Add coverage for GMX and non-GMX vaults.