### PR TITLE
fix: clarify vault filter section

### DIFF
--- a/src/lib/top-vaults/TopVaultsTable.svelte
+++ b/src/lib/top-vaults/TopVaultsTable.svelte
@@ -1141,7 +1141,7 @@ The Private checkbox in the Hide vaults group excludes all permissioned vaults.
 								role="group"
 								aria-labelledby="filter-group-performance-heading"
 							>
-								<h3 class="filter-section-heading" id="filter-group-performance-heading">Performance</h3>
+								<h3 class="filter-section-heading" id="filter-group-performance-heading">Performance and risk</h3>
 								<div class="filter-group">
 									<Tooltip>
 										<span class="filter-label filter-label-hint" slot="trigger">Technical risk</span>

--- a/tests/integration/vaults/index.test.ts
+++ b/tests/integration/vaults/index.test.ts
@@ -71,7 +71,7 @@ async function expectFilterControls(page: import('@playwright/test').Page) {
 	for (const [name, group] of [
 		['Display', displayGroup],
 		['Hide vaults', hideGroup],
-		['Performance', performanceGroup]
+		['Performance and risk', performanceGroup]
 	] as const) {
 		await expect(group).toHaveAccessibleName(name);
 		await expect(group.getByRole('heading', { name })).toBeVisible();


### PR DESCRIPTION
## Why

The filter group includes both performance metrics and a technical-risk control, so its heading should describe the full scope.

## Lessons learnt

Section headings should cover every control within their accessible group.

## Summary

- Rename the vault Filters section from Performance to Performance and risk.
- Update the integration assertion for the accessible section name.