### PR TITLE
feat: filter AMM pools from vault listings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Weblog of stuff
 
+- Add an AMM filter to vault listings and pool terminology on detail pages (2026-08-27)
 - Reorganise vault filters into responsive groups and add volatility filtering (2026-08-27)
 - Add a permissioned-vault filter to vault listings (2026-08-25)
 - Show processed flow and reset time in the GuardV0 deposit tooltip (2026-08-20)

--- a/docs/vault-listings.md
+++ b/docs/vault-listings.md
@@ -26,6 +26,17 @@ deposit. The label refers to the deposit restriction, not the table's status
 text. It is not shown on the Whitelisted listing because every vault in that
 listing is permissioned.
 
+### AMM filter
+
+The **AMM** checkbox in the **Hide vaults** group excludes records with the
+`amm_pool_like` feature. These are AMM pools and AMM-like vaults with direct
+exposure to underlying assets. It is enabled by default on filterable listings,
+except protocol listings, where it is disabled so a protocol page includes all
+of that protocol's pools by default. The default does not need a URL parameter;
+unchecking the control adds `amm=0` to show AMM pools. `amm=1` makes the
+default hiding explicit. The filter uses the exported feature classification,
+not a protocol-name allowlist.
+
 ### Volatility filter
 
 The **Volatility** control filters the annualised three-month volatility value.

--- a/docs/vault-listings.md
+++ b/docs/vault-listings.md
@@ -30,8 +30,8 @@ listing is permissioned.
 
 The **AMM** checkbox in the **Hide vaults** group excludes records with the
 `amm_pool_like` feature. These are AMM pools and AMM-like vaults with direct
-exposure to underlying assets. It is enabled by default on filterable listings,
-except protocol listings, where it is disabled so a protocol page includes all
+exposure to underlying assets. It is enabled by default on all listings, except
+protocol listings, where it is disabled so a protocol page includes all
 of that protocol's pools by default. The default does not need a URL parameter;
 unchecking the control adds `amm=0` to show AMM pools. `amm=1` makes the
 default hiding explicit. The filter uses the exported feature classification,

--- a/src/lib/top-vaults/TopVaultsPage.svelte
+++ b/src/lib/top-vaults/TopVaultsPage.svelte
@@ -13,6 +13,7 @@ Use `ratingProvider` to show a provider-specific risk rating column.
 	import type { StablecoinMetadata } from '$lib/stablecoin-metadata/schemas';
 	import type { CuratorInfo } from './schemas';
 	import type { VaultListingSummary } from './listing/types';
+	import type { VaultListingKey } from './listing/definitions';
 	import Alert from '$lib/components/Alert.svelte';
 	import HeroBanner from '$lib/components/HeroBanner.svelte';
 	import Section from '$lib/components/Section.svelte';
@@ -92,7 +93,7 @@ Use `ratingProvider` to show a provider-specific risk rating column.
 		ratingProvider?: RiskRatingProvider;
 		/** Whether rows are fetched in pages from the server. */
 		progressive?: boolean;
-		listingKey?: string;
+		listingKey?: VaultListingKey;
 		listingScope?: string;
 		listingSummary?: VaultListingSummary;
 	}

--- a/src/lib/top-vaults/TopVaultsTable.svelte
+++ b/src/lib/top-vaults/TopVaultsTable.svelte
@@ -5,6 +5,7 @@ Interactive vault listing with filters, sorting, and progressive row loading.
 Use `ratingProvider` to add its risk-rating column beside the vault name.
 Permissioned vaults are marked as Private, except tokenised funds, which are marked as Fund.
 The Private checkbox in the Hide vaults group excludes all permissioned vaults.
+The AMM checkbox hides AMM pools and AMM-like vaults on listings with Filters.
 -->
 <script lang="ts">
 	import type { Chain } from '$lib/helpers/chain';
@@ -63,6 +64,7 @@ The Private checkbox in the Hide vaults group excludes all permissioned vaults.
 		getVaultPeakTvlUsd,
 		getVaultTvlNative,
 		hasSupportedProtocol,
+		isAmmPoolLikeVault,
 		isBlacklisted,
 		isPermissionedVault,
 		isVaultDepositCapped,
@@ -93,6 +95,7 @@ The Private checkbox in the Hide vaults group excludes all permissioned vaults.
 		type ReturnColumnId
 	} from './return-columns';
 	import { sortVaults } from './listing/query';
+	import { getVaultListingDefaults, type VaultListingKey } from './listing/definitions';
 	import { INITIAL_VAULT_LISTING_LIMIT, VAULT_LISTING_PAGE_SIZE, type VaultListingSummary } from './listing/types';
 
 	const allVaultsPath = resolve('/vaults/all');
@@ -104,6 +107,7 @@ The Private checkbox in the Hide vaults group excludes all permissioned vaults.
 		'q',
 		'closed',
 		'unknown',
+		'amm',
 		'private',
 		'dd',
 		'vol',
@@ -168,7 +172,7 @@ The Private checkbox in the Hide vaults group excludes all permissioned vaults.
 		ratingProvider?: RiskRatingProvider;
 		/** Whether rows are fetched in pages from the server. */
 		progressive?: boolean;
-		listingKey?: string;
+		listingKey?: VaultListingKey;
 		listingScope?: string;
 		listingSummary?: VaultListingSummary;
 	}
@@ -218,6 +222,7 @@ The Private checkbox in the Hide vaults group excludes all permissioned vaults.
 		listingScope,
 		listingSummary
 	}: Props = $props();
+	const defaultHideAmm = untrack(() => ((getVaultListingDefaults(listingKey, listingScope).amm ?? true) ? 1 : 0));
 	let accumulatedVaults = $state<VaultInfo[]>(topVaults.vaults);
 	let remoteHasMore = $state(progressive);
 	let remoteLoading = $state(false);
@@ -328,6 +333,7 @@ The Private checkbox in the Hide vaults group excludes all permissioned vaults.
 		q: { type: 'string', defaultValue: '' },
 		closed: { type: 'number', defaultValue: 0 },
 		unknown: { type: 'number', defaultValue: defaultHideUnknown },
+		amm: { type: 'number', defaultValue: defaultHideAmm },
 		private: { type: 'number', defaultValue: 0 },
 		dd: { type: 'string', defaultValue: 'any', options: ddFilterOptions.map((o) => o.key) },
 		vol: { type: 'string', defaultValue: 'any', options: volatilityFilterOptions.map((o) => o.key) },
@@ -415,6 +421,7 @@ The Private checkbox in the Hide vaults group excludes all permissioned vaults.
 
 	let hideClosed = $derived(urlState.closed === 1);
 	let hideUnknown = $derived(showUnknownFilter && urlState.unknown === 1);
+	let hideAmm = $derived(showFilters && urlState.amm === 1);
 	let hidePrivate = $derived(urlState.private === 1);
 	let returnsDropdownOpen = $state(false);
 	let filtersOpen = $state(hasFilterSearchParams(page.url.searchParams));
@@ -657,6 +664,9 @@ The Private checkbox in the Hide vaults group excludes all permissioned vaults.
 
 			// Hide unknown protocol filter (checkbox-driven)
 			if (hideUnknown && !hasSupportedProtocol(v)) return false;
+
+			// Hide AMM pool filter (checkbox-driven)
+			if (hideAmm && isAmmPoolLikeVault(v)) return false;
 
 			// Hide private vault filter (checkbox-driven)
 			if (hidePrivate && isPermissionedVault(v)) return false;
@@ -1117,6 +1127,22 @@ The Private checkbox in the Hide vaults group excludes all permissioned vaults.
 										</Tooltip>
 									</div>
 								{/if}
+
+								<div class="filter-group">
+									<Tooltip>
+										<label class="checkbox-filter" slot="trigger">
+											<input
+												type="checkbox"
+												checked={hideAmm}
+												onchange={() => updateSearchParams({ amm: hideAmm ? 0 : 1 })}
+											/>
+											<span class="filter-label filter-label-hint">AMM</span>
+										</label>
+										<svelte:fragment slot="popup">
+											Hide AMM pools and AMM-like vaults with direct exposure to underlying assets
+										</svelte:fragment>
+									</Tooltip>
+								</div>
 
 								{#if showPrivateFilter}
 									<div class="filter-group">

--- a/src/lib/top-vaults/TopVaultsTable.svelte
+++ b/src/lib/top-vaults/TopVaultsTable.svelte
@@ -1139,7 +1139,8 @@ The AMM checkbox hides AMM pools and AMM-like vaults on listings with Filters.
 											<span class="filter-label filter-label-hint">AMM</span>
 										</label>
 										<svelte:fragment slot="popup">
-											Hide AMM pools and AMM-like vaults with direct exposure to underlying assets
+											<p>Hide AMM pools and AMM-like vaults with direct exposure to underlying assets.</p>
+											<a href={resolve('/glossary/amm')}>What is AMM?</a>
 										</svelte:fragment>
 									</Tooltip>
 								</div>

--- a/src/lib/top-vaults/TopVaultsTable.svelte
+++ b/src/lib/top-vaults/TopVaultsTable.svelte
@@ -66,6 +66,7 @@ The AMM checkbox hides AMM pools and AMM-like vaults on listings with Filters.
 		hasSupportedProtocol,
 		isAmmPoolLikeVault,
 		isBlacklisted,
+		isPoolProtocol,
 		isPermissionedVault,
 		isVaultDepositCapped,
 		isGoodVaultStatus,
@@ -223,6 +224,8 @@ The AMM checkbox hides AMM pools and AMM-like vaults on listings with Filters.
 		listingSummary
 	}: Props = $props();
 	const defaultHideAmm = untrack(() => ((getVaultListingDefaults(listingKey, listingScope).amm ?? true) ? 1 : 0));
+	let listingAssetType = $derived(listingKey === 'protocol' && isPoolProtocol(listingScope) ? 'pool' : 'vault');
+	let listingAssetTypePlural = $derived(`${listingAssetType}s`);
 	let accumulatedVaults = $state<VaultInfo[]>(topVaults.vaults);
 	let remoteHasMore = $state(progressive);
 	let remoteLoading = $state(false);
@@ -979,7 +982,8 @@ The AMM checkbox hides AMM pools and AMM-like vaults on listings with Filters.
 		<div class="table-stats" class:hidden={loading} data-testid="top-vaults-meta">
 			<Tooltip>
 				<svelte:fragment slot="trigger"
-					>{matchingVaultCount} vaults{#if totalVaultCount > matchingVaultCount}
+					>{matchingVaultCount}
+					{listingAssetTypePlural}{#if totalVaultCount > matchingVaultCount}
 						<span>&nbsp;out of {totalVaultCount}</span>{/if}</svelte:fragment
 				>
 				<svelte:fragment slot="popup"
@@ -990,7 +994,7 @@ The AMM checkbox hides AMM pools and AMM-like vaults on listings with Filters.
 						not meet the minimum TVL threshold:
 						{hiddenVaultNames.join(', ')}{#if hiddenByTvl > 2}, and {hiddenByTvl - 2} more{/if}.
 					{:else}
-						The number of vaults listed on this page.
+						The number of {listingAssetTypePlural} listed on this page.
 					{/if}</svelte:fragment
 				>
 			</Tooltip>

--- a/src/lib/top-vaults/VaultPriceChart.svelte
+++ b/src/lib/top-vaults/VaultPriceChart.svelte
@@ -25,6 +25,7 @@ so relative performance is comparable on a single axis.
 	import { removeOnError } from '$lib/actions/image';
 	import { getLogoUrl } from '$lib/helpers/assets';
 	import { isPerpetualFuturesVault } from './isPerpetualFuturesVault';
+	import { getVaultAssetType } from './helpers';
 	import type { PriceScaleCalculator, SimpleDataItem } from '$lib/charts/types';
 	import {
 		formatDollar,
@@ -60,7 +61,7 @@ so relative performance is comparable on a single axis.
 	let { vault, chartLogoUrl, onTimeSpanChange }: Props = $props();
 
 	let showCryptoBenchmarks = $derived(isPerpetualFuturesVault(vault));
-	let assetType = $derived(vault.flags.includes('tokenised_fund') ? 'tokenised fund' : 'vault');
+	let assetType = $derived(getVaultAssetType(vault));
 	let isSharePriceEquivalent = $derived(vault.features.includes('share_price_equivalence'));
 	let chartTitle = $derived(isSharePriceEquivalent ? 'Equity curve' : 'Share token price');
 

--- a/src/lib/top-vaults/helpers.test.ts
+++ b/src/lib/top-vaults/helpers.test.ts
@@ -3,6 +3,7 @@ import {
 	CORE3_METHODOLOGY_URL,
 	isBlacklisted,
 	isPermissionedVault,
+	isPoolProtocol,
 	isEligibleFrontpageVault,
 	hasSupportedProtocol,
 	getProtocolDisplayName,
@@ -362,6 +363,16 @@ describe('isUnsupportedProtocolSlug', () => {
 
 	test('ignores supported protocol slugs', () => {
 		expect(isUnsupportedProtocolSlug('yearn')).toBe(false);
+	});
+});
+
+describe('isPoolProtocol', () => {
+	test('identifies GMX as a pool protocol', () => {
+		expect(isPoolProtocol('gmx')).toBe(true);
+	});
+
+	test('does not classify other protocols as pool protocols', () => {
+		expect(isPoolProtocol('yearn')).toBe(false);
 	});
 });
 

--- a/src/lib/top-vaults/helpers.ts
+++ b/src/lib/top-vaults/helpers.ts
@@ -316,6 +316,18 @@ export function getVaultProtocolDisplayName(vault: Pick<VaultInfo, 'protocol' | 
 	return displayName;
 }
 
+/** Return whether an asset is an AMM pool or AMM-like vault. */
+export function isAmmPoolLikeVault(vault: Pick<VaultInfo, 'features'>): boolean {
+	return vault.features.includes('amm_pool_like');
+}
+
+/** Return the user-facing type of a vault-like asset. */
+export function getVaultAssetType(vault: Pick<VaultInfo, 'flags' | 'features'>): 'vault' | 'pool' | 'tokenised fund' {
+	if (vault.flags.includes('tokenised_fund')) return 'tokenised fund';
+	if (isAmmPoolLikeVault(vault)) return 'pool';
+	return 'vault';
+}
+
 /**
  * Get combined Morpho warning flags from vault other_data
  */

--- a/src/lib/top-vaults/helpers.ts
+++ b/src/lib/top-vaults/helpers.ts
@@ -262,6 +262,11 @@ export function isUnsupportedProtocolSlug(protocolSlug: string | null | undefine
 	return protocolSlug != null && unsupportedProtocolSlugs.has(protocolSlug);
 }
 
+/** Return whether a protocol's vault listings should use pool terminology. */
+export function isPoolProtocol(protocolSlug: string | null | undefined): boolean {
+	return protocolSlug === 'gmx';
+}
+
 export function hasSupportedProtocol(vault: Pick<VaultInfo, 'protocol'> & Partial<Pick<VaultInfo, 'protocol_slug'>>) {
 	return !isUnsupportedProtocolName(vault.protocol) && !isUnsupportedProtocolSlug(vault.protocol_slug);
 }

--- a/src/lib/top-vaults/listing/definitions.ts
+++ b/src/lib/top-vaults/listing/definitions.ts
@@ -87,7 +87,12 @@ export const vaultListingDefinitions: Record<VaultListingKey, VaultListingDefini
 		requiresScope: false
 	},
 	chain: { key: 'chain', defaults: { tvl: '10k' }, options: commonOptions, requiresScope: true },
-	protocol: { key: 'protocol', defaults: { tvl: '10k', unknown: false }, options: commonOptions, requiresScope: true },
+	protocol: {
+		key: 'protocol',
+		defaults: { tvl: '10k', unknown: false, amm: false },
+		options: commonOptions,
+		requiresScope: true
+	},
 	stablecoin: {
 		key: 'stablecoin',
 		defaults: { tvl: '10k', unknown: false },

--- a/src/lib/top-vaults/listing/query.test.ts
+++ b/src/lib/top-vaults/listing/query.test.ts
@@ -167,7 +167,7 @@ describe('vault listing query', () => {
 
 		expect(
 			queryVaultListing([vault, pool], query, { ...options, showFilters: false }).vaults.map((item) => item.name)
-		).toEqual(['Pool', 'Vault']);
+		).toEqual(expect.arrayContaining(['Vault', 'Pool']));
 	});
 
 	it('keeps a blacklisted definition scoped to blacklisted vaults', () => {

--- a/src/lib/top-vaults/listing/query.test.ts
+++ b/src/lib/top-vaults/listing/query.test.ts
@@ -160,16 +160,6 @@ describe('vault listing query', () => {
 		expect(queryVaultListing([vault, pool], query, options).vaults.map((item) => item.name)).toEqual(['Vault']);
 	});
 
-	it('does not apply the AMM filter when a listing has no filter controls', () => {
-		const vault = createTestVault('Vault', { current_nav: 100_000 });
-		const pool = createTestVault('Pool', { current_nav: 100_000, features: ['amm_pool_like'] });
-		const query = parseVaultListingQuery(new URLSearchParams('amm=1'), { tvl: '10k' });
-
-		expect(
-			queryVaultListing([vault, pool], query, { ...options, showFilters: false }).vaults.map((item) => item.name)
-		).toEqual(expect.arrayContaining(['Vault', 'Pool']));
-	});
-
 	it('keeps a blacklisted definition scoped to blacklisted vaults', () => {
 		const safe = createTestVault('Safe', { current_nav: 100_000 });
 		const blacklisted = createTestVault('Blacklisted', { current_nav: 100_000, risk: 'Blacklisted' });

--- a/src/lib/top-vaults/listing/query.test.ts
+++ b/src/lib/top-vaults/listing/query.test.ts
@@ -152,6 +152,24 @@ describe('vault listing query', () => {
 		).toEqual(['Public']);
 	});
 
+	it('hides AMM-like vaults when requested', () => {
+		const vault = createTestVault('Vault', { current_nav: 100_000 });
+		const pool = createTestVault('Pool', { current_nav: 100_000, features: ['amm_pool_like'] });
+		const query = parseVaultListingQuery(new URLSearchParams('amm=1'), { tvl: '10k' });
+
+		expect(queryVaultListing([vault, pool], query, options).vaults.map((item) => item.name)).toEqual(['Vault']);
+	});
+
+	it('does not apply the AMM filter when a listing has no filter controls', () => {
+		const vault = createTestVault('Vault', { current_nav: 100_000 });
+		const pool = createTestVault('Pool', { current_nav: 100_000, features: ['amm_pool_like'] });
+		const query = parseVaultListingQuery(new URLSearchParams('amm=1'), { tvl: '10k' });
+
+		expect(
+			queryVaultListing([vault, pool], query, { ...options, showFilters: false }).vaults.map((item) => item.name)
+		).toEqual(['Pool', 'Vault']);
+	});
+
 	it('keeps a blacklisted definition scoped to blacklisted vaults', () => {
 		const safe = createTestVault('Safe', { current_nav: 100_000 });
 		const blacklisted = createTestVault('Blacklisted', { current_nav: 100_000, risk: 'Blacklisted' });
@@ -181,6 +199,11 @@ describe('vault listing query', () => {
 		expect(getVaultListingDefaults('protocol', 'unknown').unknown).toBe(false);
 		expect(getVaultListingDefaults('stablecoin', 'usdc').unknown).toBe(false);
 		expect(getVaultListingDefaults('curator', 'mev-capital').unknown).toBe(false);
+	});
+
+	it('shows AMM-like pools by default on protocol listings', () => {
+		expect(parseVaultListingQuery(new URLSearchParams(), getVaultListingDefaults('top')).amm).toBe(true);
+		expect(parseVaultListingQuery(new URLSearchParams(), getVaultListingDefaults('protocol', 'gmx')).amm).toBe(false);
 	});
 
 	it('does not expose the complete dataset through an international scope predicate', () => {

--- a/src/lib/top-vaults/listing/query.ts
+++ b/src/lib/top-vaults/listing/query.ts
@@ -169,7 +169,7 @@ export function queryVaultListing(
 		}
 		if (query.closed && vault.deposit_closed_reason != null) return false;
 		if (query.unknown && !hasSupportedProtocol(vault)) return false;
-		if (options.showFilters && query.amm && isAmmPoolLikeVault(vault)) return false;
+		if (query.amm && isAmmPoolLikeVault(vault)) return false;
 		if (query.private && isPermissionedVault(vault)) return false;
 		const search = [
 			vault.chain_id,

--- a/src/lib/top-vaults/listing/query.ts
+++ b/src/lib/top-vaults/listing/query.ts
@@ -17,6 +17,7 @@ import {
 	getVaultPeakTvlUsd,
 	getVaultProtocolDisplayName,
 	hasSupportedProtocol,
+	isAmmPoolLikeVault,
 	isBlacklisted,
 	isPermissionedVault,
 	matchesVolatilityFilter,
@@ -41,6 +42,7 @@ export interface VaultListingQuery {
 	q: string;
 	closed: boolean;
 	unknown: boolean;
+	amm: boolean;
 	private: boolean;
 	sort: string;
 	direction: VaultSortDirection;
@@ -167,6 +169,7 @@ export function queryVaultListing(
 		}
 		if (query.closed && vault.deposit_closed_reason != null) return false;
 		if (query.unknown && !hasSupportedProtocol(vault)) return false;
+		if (options.showFilters && query.amm && isAmmPoolLikeVault(vault)) return false;
 		if (query.private && isPermissionedVault(vault)) return false;
 		const search = [
 			vault.chain_id,

--- a/src/lib/top-vaults/listing/state.ts
+++ b/src/lib/top-vaults/listing/state.ts
@@ -38,6 +38,7 @@ export interface VaultListingQueryDefaults {
 	sort?: string;
 	direction?: VaultSortDirection;
 	unknown?: boolean;
+	amm?: boolean;
 	mr?: string;
 }
 
@@ -69,6 +70,7 @@ export function parseVaultListingQuery(
 		q: (params.get('q') ?? '').slice(0, 100),
 		closed: params.get('closed') === '1',
 		unknown: params.get('unknown') == null ? (defaults.unknown ?? true) : params.get('unknown') === '1',
+		amm: params.get('amm') == null ? (defaults.amm ?? true) : params.get('amm') === '1',
 		private: params.get('private') === '1',
 		sort: sortKeys.has(sort) ? sort : (defaults.sort ?? DEFAULT_RETURN_COLUMN_IDS[0]),
 		direction: direction === 'asc' || direction === 'desc' ? direction : (defaults.direction ?? 'desc')

--- a/src/routes/vaults/[vault=slug]/+page.svelte
+++ b/src/routes/vaults/[vault=slug]/+page.svelte
@@ -28,6 +28,7 @@ Vault detail page with performance, protocol, private-deposit, and third-party r
 	import IconDiscord from '~icons/local/discord';
 	import {
 		getMorphoFlags,
+		getVaultAssetType,
 		getVaultProtocolDisplayName,
 		hasSupportedProtocol,
 		isBlacklisted,
@@ -49,6 +50,7 @@ Vault detail page with performance, protocol, private-deposit, and third-party r
 	let showBlacklistedAlert = $derived(blacklisted && !notesDuplicateMorphoFlags);
 	let showNotes = $derived(vault.notes != null && !notesDuplicateMorphoFlags);
 	let isTokenisedFund = $derived(vault.flags.includes('tokenised_fund'));
+	let assetType = $derived(getVaultAssetType(vault));
 	let isPrivate = $derived(isPermissionedVault(vault));
 	let isCapped = $derived(isVaultDepositCapped(vault));
 	let showTvlWarning = $derived(shouldShowVaultTvlDownMoreThan95PercentWarning(vault));
@@ -59,14 +61,14 @@ Vault detail page with performance, protocol, private-deposit, and third-party r
 	let operationWarning = $derived(
 		isCapped
 			? redemptionMayBeDisabled
-				? 'Deposits are capped and withdrawals may be disabled for this vault'
-				: 'Deposits are capped for this vault'
+				? `Deposits are capped and withdrawals may be disabled for this ${assetType}`
+				: `Deposits are capped for this ${assetType}`
 			: depositMayBeDisabled && redemptionMayBeDisabled
-				? 'Deposits and withdrawals may be disabled for this vault'
+				? `Deposits and withdrawals may be disabled for this ${assetType}`
 				: depositMayBeDisabled
-					? 'Deposits may be disabled for this vault'
+					? `Deposits may be disabled for this ${assetType}`
 					: redemptionMayBeDisabled
-						? 'Withdrawals may be disabled for this vault'
+						? `Withdrawals may be disabled for this ${assetType}`
 						: undefined
 	);
 	let hasNotifications = $derived(
@@ -112,25 +114,26 @@ Vault detail page with performance, protocol, private-deposit, and third-party r
 
 				{#if isPrivate && !isTokenisedFund}
 					<Alert size="md" status="warning"
-						>This is a permissioned vault and is not accepting deposits from outsiders</Alert
+						>This is a permissioned {assetType} and is not accepting deposits from outsiders</Alert
 					>
 				{/if}
 
 				{#if showTvlWarning}
 					<Alert size="md" status="warning">
-						The value in this vault is down more than 95% of its peak. The vault is likely abandoned or facing issues.
+						The value in this {assetType} is down more than 95% of its peak. The {assetType} is likely abandoned or facing
+						issues.
 					</Alert>
 				{/if}
 
 				{#if showLongDurationWarning}
 					<Alert size="md" status="error">
-						This vault may have especially long duration redemption periods. Make sure you check the redemptions before
+						This {assetType} may have especially long duration redemption periods. Make sure you check the redemptions before
 						depositing.
 					</Alert>
 				{/if}
 
 				{#if morphoFlags.length > 0}
-					<Alert size="md" status={morphoAlertStatus} title="Morpho has flagged this vault">
+					<Alert size="md" status={morphoAlertStatus} title={`Morpho has flagged this ${assetType}`}>
 						{morphoFlags.join(', ')}
 					</Alert>
 				{/if}
@@ -167,7 +170,7 @@ Vault detail page with performance, protocol, private-deposit, and third-party r
 
 		<div class="vault-information" class:single-card={vaultInformationCardCount === 1}>
 			{#if vault.description}
-				<MetricsBox class="description" title="About the vault">
+				<MetricsBox class="description" title={`About the ${assetType}`}>
 					<Markdown content={vault.description} />
 				</MetricsBox>
 			{/if}

--- a/src/routes/vaults/[vault=slug]/SocialMetaTags.svelte
+++ b/src/routes/vaults/[vault=slug]/SocialMetaTags.svelte
@@ -10,7 +10,7 @@
 	} from '$lib/social-card/helpers';
 	import { getStablecoinLogoUrl } from '$lib/stablecoin-metadata/helpers';
 	import type { StablecoinMetadata } from '$lib/stablecoin-metadata/schemas';
-	import { getVaultProtocolDisplayName } from '$lib/top-vaults/helpers';
+	import { getVaultAssetType, getVaultProtocolDisplayName } from '$lib/top-vaults/helpers';
 	import { getChainDisplayName } from '$lib/helpers/chain';
 	import type { CuratorInfo, VaultInfo } from '$lib/top-vaults/schemas';
 	import { getVaultProtocolLogoUrl } from '$lib/vault-protocol/helpers.js';
@@ -27,6 +27,8 @@
 	}
 
 	let { vault, chain, protocolMetadata, curatorMetadata, stablecoinMetadata }: Props = $props();
+	let assetType = $derived(getVaultAssetType(vault));
+	let socialTitle = $derived(`${vault.name} | DeFi ${assetType} | Trading Strategy`);
 
 	let generatedDescription = $derived.by(() => {
 		const parts = [`${vault.name} on ${getVaultProtocolDisplayName(vault)} on ${getChainDisplayName(vault.chain_id)}`];
@@ -141,7 +143,7 @@
 </script>
 
 <MetaTags
-	title={`${vault.name} | DeFi Vault | Trading Strategy`}
+	title={socialTitle}
 	{description}
 	canonical={pageUrl}
 	image={imageUrl}
@@ -149,14 +151,14 @@
 	openGraph={{
 		siteName: 'Trading Strategy',
 		url: pageUrl,
-		title: vault.name,
+		title: socialTitle,
 		description,
 		type: 'website'
 	}}
 	twitter={{
 		site: '@TradingProtocol',
 		cardType: 'summary_large_image',
-		title: vault.name,
+		title: socialTitle,
 		description
 	}}
 />

--- a/src/routes/vaults/[vault=slug]/VaultCuratorInfo.svelte
+++ b/src/routes/vaults/[vault=slug]/VaultCuratorInfo.svelte
@@ -28,6 +28,7 @@ curator.
 	let curatorPageUrl = $derived(resolve(`/vaults/curators/${curator.slug}`));
 	let curatorLogoUrl = $derived(curator.logos.generic ?? curator.logos.light ?? curator.logos.dark);
 	let assetType = $derived(getVaultAssetType(vault));
+	let assetTypePlural = $derived(`${assetType}s`);
 </script>
 
 <MetricsBox fill>
@@ -47,7 +48,8 @@ curator.
 			{/if}
 		</div>
 		<Button size="sm" class="view-all-btn" href={curatorPageUrl}>
-			View all {curator.name} vaults
+			View all {curator.name}
+			{assetTypePlural}
 		</Button>
 	</div>
 </MetricsBox>

--- a/src/routes/vaults/[vault=slug]/VaultCuratorInfo.svelte
+++ b/src/routes/vaults/[vault=slug]/VaultCuratorInfo.svelte
@@ -16,6 +16,7 @@ curator.
 	import Button from '$lib/components/Button.svelte';
 	import MetricsBox from '$lib/components/MetricsBox.svelte';
 	import type { CuratorInfo, VaultInfo } from '$lib/top-vaults/schemas';
+	import { getVaultAssetType } from '$lib/top-vaults/helpers';
 
 	interface Props {
 		curator: CuratorInfo;
@@ -26,7 +27,7 @@ curator.
 
 	let curatorPageUrl = $derived(resolve(`/vaults/curators/${curator.slug}`));
 	let curatorLogoUrl = $derived(curator.logos.generic ?? curator.logos.light ?? curator.logos.dark);
-	let assetType = $derived(vault.flags.includes('tokenised_fund') ? 'tokenised fund' : 'vault');
+	let assetType = $derived(getVaultAssetType(vault));
 </script>
 
 <MetricsBox fill>

--- a/src/routes/vaults/[vault=slug]/VaultProtocolInfo.svelte
+++ b/src/routes/vaults/[vault=slug]/VaultProtocolInfo.svelte
@@ -20,6 +20,7 @@
 
 	let protocolPageUrl = $derived(resolve(`/vaults/protocols/${vault.protocol_slug}`));
 	let assetType = $derived(getVaultAssetType(vault));
+	let assetTypePlural = $derived(`${assetType}s`);
 </script>
 
 <MetricsBox fill>
@@ -40,7 +41,8 @@
 			<p class="description">{protocolMetadata.short_description}</p>
 		</div>
 		<Button size="sm" class="view-all-btn" href={protocolPageUrl}>
-			View all {protocolMetadata.name} vaults
+			View all {protocolMetadata.name}
+			{assetTypePlural}
 		</Button>
 	</div>
 </MetricsBox>

--- a/src/routes/vaults/[vault=slug]/VaultProtocolInfo.svelte
+++ b/src/routes/vaults/[vault=slug]/VaultProtocolInfo.svelte
@@ -8,6 +8,7 @@
 	import Button from '$lib/components/Button.svelte';
 	import MetricsBox from '$lib/components/MetricsBox.svelte';
 	import { getVaultProtocolLogoUrl } from '$lib/vault-protocol/helpers.js';
+	import { getVaultAssetType } from '$lib/top-vaults/helpers';
 	import { resolve } from '$app/paths';
 
 	interface Props {
@@ -18,7 +19,7 @@
 	let { vault, protocolMetadata }: Props = $props();
 
 	let protocolPageUrl = $derived(resolve(`/vaults/protocols/${vault.protocol_slug}`));
-	let assetType = $derived(vault.flags.includes('tokenised_fund') ? 'tokenised fund' : 'vault');
+	let assetType = $derived(getVaultAssetType(vault));
 </script>
 
 <MetricsBox fill>

--- a/src/routes/vaults/[vault=slug]/VaultTechnicalDetailsTable.svelte
+++ b/src/routes/vaults/[vault=slug]/VaultTechnicalDetailsTable.svelte
@@ -19,6 +19,7 @@ Includes the source whitelist status and any source-provided whitelist notes.
 		getVaultDenominationUsdRate,
 		getVaultDenominationCurrency,
 		getVaultProtocolDisplayName,
+		isAmmPoolLikeVault,
 		getVaultTvlNative
 	} from '$lib/top-vaults/helpers';
 	import {
@@ -39,6 +40,7 @@ Includes the source whitelist status and any source-provided whitelist notes.
 	}
 
 	let { vault, chain, stablecoinMetadata = null, generated_at = null }: Props = $props();
+	let technicalAssetType = $derived(isAmmPoolLikeVault(vault) ? 'Pool' : 'Vault');
 
 	let copyWidget = $state<CopyWidget>();
 	let denominationSlug = $derived(
@@ -80,8 +82,12 @@ Includes the source whitelist status and any source-provided whitelist notes.
 	});
 
 	const rows = $derived([
-		{ label: 'Vault name', value: vault.name },
-		{ label: 'Vault address', value: vault.address, type: 'address' as const },
+		{ label: `${technicalAssetType} name`, value: vault.name },
+		{
+			label: `${technicalAssetType} address`,
+			value: vault.address,
+			type: 'address' as const
+		},
 		{ label: 'Chain', value: chain, type: 'chain' as const },
 		{
 			label: 'Denomination',

--- a/src/routes/vaults/[vault=slug]/VaultTechnicalDetailsTable.svelte
+++ b/src/routes/vaults/[vault=slug]/VaultTechnicalDetailsTable.svelte
@@ -19,7 +19,7 @@ Includes the source whitelist status and any source-provided whitelist notes.
 		getVaultDenominationUsdRate,
 		getVaultDenominationCurrency,
 		getVaultProtocolDisplayName,
-		isAmmPoolLikeVault,
+		getVaultAssetType,
 		getVaultTvlNative
 	} from '$lib/top-vaults/helpers';
 	import {
@@ -40,7 +40,7 @@ Includes the source whitelist status and any source-provided whitelist notes.
 	}
 
 	let { vault, chain, stablecoinMetadata = null, generated_at = null }: Props = $props();
-	let technicalAssetType = $derived(isAmmPoolLikeVault(vault) ? 'Pool' : 'Vault');
+	let technicalAssetType = $derived(getVaultAssetType(vault).replace(/^./, (character) => character.toUpperCase()));
 
 	let copyWidget = $state<CopyWidget>();
 	let denominationSlug = $derived(

--- a/src/routes/vaults/protocols/[protocol=slug]/+page.svelte
+++ b/src/routes/vaults/protocols/[protocol=slug]/+page.svelte
@@ -17,6 +17,8 @@
 	let isHyperliquidProtocolGroup = $derived(protocolSlug === 'hyperliquid');
 	let isApexProtocolGroup = $derived(protocolSlug === 'apex');
 	let isPoolProtocolGroup = $derived(isPoolProtocol(protocolSlug));
+	let listingAssetType = $derived(isPoolProtocolGroup ? 'pool' : 'vault');
+	let listingAssetTypePlural = $derived(`${listingAssetType}s`);
 
 	// Apex does not have a track record yet, so its vaults sit below the usual TVL
 	// threshold. Default the Min TVL filter to "Any" so they are not hidden.
@@ -45,7 +47,9 @@
 	let description = $derived(
 		isUnknownVaultProtocolGroup
 			? unknownVaultDescription
-			: (protocolMetadata?.short_description ?? `Top stablecoin vaults on ${protocolName}`)
+			: isPoolProtocolGroup
+				? `Explore ${protocolName} pools and yields, including TVL and performance metrics.`
+				: (protocolMetadata?.short_description ?? `Top stablecoin vaults on ${protocolName}`)
 	);
 	let pageUrl = $derived(new URL(page.url.pathname, page.url.origin).href);
 	let logoUrl = $derived.by(() => {
@@ -73,7 +77,9 @@
 	{#if averageMonthlyReturn != null}
 		<p>
 			The current listing contains <strong>{formatDollar(data.listingSummary.totalTvl, 1)}</strong> TVL in
-			<strong>{data.listingSummary.matchingCount} {data.listingSummary.matchingCount === 1 ? 'vault' : 'vaults'}</strong
+			<strong
+				>{data.listingSummary.matchingCount}
+				{data.listingSummary.matchingCount === 1 ? listingAssetType : listingAssetTypePlural}</strong
 			>
 			with the TVL-weighted average monthly returns of <strong>{formatPercent(averageMonthlyReturn, 1)}</strong>.
 		</p>
@@ -143,7 +149,7 @@
 >
 	{#snippet detailAside()}
 		<VaultGroupMiniChart
-			title="All {protocolName} vaults: TVL and TVL-weighted 3-month annualised return"
+			title="All {protocolName} {listingAssetTypePlural}: TVL and TVL-weighted 3-month annualised return"
 			dataUrl="/vaults/protocols/{protocolSlug}/chart-data"
 			compareLabel="Compare all protocols"
 			compareHref="/vaults/historical-tvl-protocol"

--- a/src/routes/vaults/protocols/[protocol=slug]/+page.svelte
+++ b/src/routes/vaults/protocols/[protocol=slug]/+page.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { UNKNOWN_VAULT_PROTOCOL_SLUG } from '$lib/top-vaults/helpers';
+	import { isPoolProtocol, UNKNOWN_VAULT_PROTOCOL_SLUG } from '$lib/top-vaults/helpers';
 	import { getVaultProtocolLogoUrl } from '$lib/vault-protocol/helpers.js';
 	import { formatDollar, formatPercent } from '$lib/helpers/formatters';
 	import { resolve } from '$app/paths';
@@ -16,6 +16,7 @@
 	let isUnknownVaultProtocolGroup = $derived(protocolSlug === UNKNOWN_VAULT_PROTOCOL_SLUG);
 	let isHyperliquidProtocolGroup = $derived(protocolSlug === 'hyperliquid');
 	let isApexProtocolGroup = $derived(protocolSlug === 'apex');
+	let isPoolProtocolGroup = $derived(isPoolProtocol(protocolSlug));
 
 	// Apex does not have a track record yet, so its vaults sit below the usual TVL
 	// threshold. Default the Min TVL filter to "Any" so they are not hidden.
@@ -27,9 +28,19 @@
 
 	const unknownVaultDescription = 'These vaults are not yet mapped out. Contact us to have your vaults listed.';
 
-	let title = $derived(isUnknownVaultProtocolGroup ? 'Unknown vaults' : `${protocolName} vaults and yields`);
+	let title = $derived(
+		isUnknownVaultProtocolGroup
+			? 'Unknown vaults'
+			: isPoolProtocolGroup
+				? `${protocolName} pools and yields`
+				: `${protocolName} vaults and yields`
+	);
 	let heroTitle = $derived(
-		isUnknownVaultProtocolGroup ? 'Unknown vaults' : `${protocolName} powered stablecoin vaults`
+		isUnknownVaultProtocolGroup
+			? 'Unknown vaults'
+			: isPoolProtocolGroup
+				? `${protocolName} powered pools`
+				: `${protocolName} powered stablecoin vaults`
 	);
 	let description = $derived(
 		isUnknownVaultProtocolGroup

--- a/tests/integration/vaults/index.test.ts
+++ b/tests/integration/vaults/index.test.ts
@@ -79,7 +79,7 @@ async function expectFilterControls(page: import('@playwright/test').Page) {
 
 	await expect(displayGroup.getByText('Columns', { exact: true })).toBeVisible();
 	await expect(returnColumnsTrigger(page)).toBeVisible();
-	for (const label of ['Currently closed', 'Unknown protocols', 'Private']) {
+	for (const label of ['Currently closed', 'Unknown protocols', 'AMM', 'Private']) {
 		await expect(hideGroup.getByLabel(label, { exact: true })).toBeVisible();
 	}
 	for (const label of ['Technical risk', 'Min TVL', 'Age', 'Max drawdown', 'Monthly returns', 'Volatility']) {
@@ -115,14 +115,16 @@ async function expectHorizontalFilterLayout(page: import('@playwright/test').Pag
 	expect(Number.parseFloat(hidePadding.left)).toBeGreaterThan(0);
 	expect(await performanceGroup.evaluate((element) => element.scrollWidth <= element.clientWidth + 1)).toBe(true);
 
-	const [closedBox, unknownBox, privateBox] = await Promise.all([
+	const [closedBox, unknownBox, ammBox, privateBox] = await Promise.all([
 		hideGroup.getByLabel('Currently closed', { exact: true }).boundingBox(),
 		hideGroup.getByLabel('Unknown protocols', { exact: true }).boundingBox(),
+		hideGroup.getByLabel('AMM', { exact: true }).boundingBox(),
 		hideGroup.getByLabel('Private', { exact: true }).boundingBox()
 	]);
-	if (!closedBox || !unknownBox || !privateBox) throw new Error('Expected visible Hide checkboxes');
+	if (!closedBox || !unknownBox || !ammBox || !privateBox) throw new Error('Expected visible Hide checkboxes');
 	expect(closedBox.y).toBeLessThan(unknownBox.y);
-	expect(unknownBox.y).toBeLessThan(privateBox.y);
+	expect(unknownBox.y).toBeLessThan(ammBox.y);
+	expect(ammBox.y).toBeLessThan(privateBox.y);
 	expect(closedBox.y).toBeLessThan(hideBox.y + hideBox.height / 2);
 }
 
@@ -626,6 +628,26 @@ test.describe('vault index page', () => {
 
 		await expect(page).toHaveURL(/private=1/);
 		await expect(page.locator('tbody tr.targetable')).toHaveCount(0);
+	});
+
+	test('hides AMM-like vaults by default and explains the AMM filter', async ({ page }) => {
+		await page.goto('/vaults/all?q=GMX');
+		await expect(page.locator('tbody tr.targetable')).toHaveCount(0);
+
+		await page.goto('/vaults');
+		await openFilters(page);
+
+		const ammFilter = filterGroup(page, 'hide').getByLabel('AMM', { exact: true });
+		await expect(ammFilter).toBeChecked();
+		await ammFilter.hover();
+		await expect(
+			page.getByText('Hide AMM pools and AMM-like vaults with direct exposure to underlying assets', { exact: true })
+		).toBeVisible();
+		await ammFilter.uncheck();
+		await expect(page).toHaveURL(/amm=0/);
+
+		await page.goto('/vaults/all?q=GMX&amm=0');
+		await expect(page.locator('tbody tr.targetable')).toContainText('GMX USDC pool');
 	});
 
 	test('does not offer the private filter on the whitelisted-vault listing', async ({ page }) => {

--- a/tests/integration/vaults/index.test.ts
+++ b/tests/integration/vaults/index.test.ts
@@ -641,8 +641,9 @@ test.describe('vault index page', () => {
 		await expect(ammFilter).toBeChecked();
 		await ammFilter.hover();
 		await expect(
-			page.getByText('Hide AMM pools and AMM-like vaults with direct exposure to underlying assets', { exact: true })
+			page.getByText('Hide AMM pools and AMM-like vaults with direct exposure to underlying assets.', { exact: true })
 		).toBeVisible();
+		await expect(page.getByRole('link', { name: 'What is AMM?' })).toHaveAttribute('href', '/glossary/amm');
 		await ammFilter.uncheck();
 		await expect(page).toHaveURL(/amm=0/);
 

--- a/tests/integration/vaults/protocol-detail.test.ts
+++ b/tests/integration/vaults/protocol-detail.test.ts
@@ -2,9 +2,11 @@ import { expect, test } from '@playwright/test';
 
 async function openFilters(page: import('@playwright/test').Page) {
 	const filters = page.getByTestId('vault-filters');
-	if (!(await filters.isVisible())) {
-		await page.getByRole('button', { name: 'Filters' }).click();
+	if (!(await filters.evaluate((details: HTMLDetailsElement) => details.open))) {
+		await page.getByTestId('filters-summary').click();
 	}
+	await expect(filters).toHaveJSProperty('open', true);
+	await expect(page.locator('.filters-content')).toBeVisible();
 }
 
 test.describe('vault protocol detail pages', () => {
@@ -20,9 +22,11 @@ test.describe('vault protocol detail pages', () => {
 
 		await page.goto('/vaults/gmx-usdc-pool');
 
+		await expect(page).toHaveTitle('GMX USDC pool | DeFi pool | Trading Strategy');
 		await expect(page.getByText('About the pool', { exact: true })).toBeVisible();
 		await expect(page.getByText('This pool is running on GMX:', { exact: true })).toBeVisible();
 		await expect(page.getByText('Pool name', { exact: true })).toBeVisible();
+		await expect(page.getByRole('link', { name: 'View all GMX pools' })).toBeVisible();
 	});
 
 	test('sorts ApeX vaults by TVL by default', async ({ page }) => {

--- a/tests/integration/vaults/protocol-detail.test.ts
+++ b/tests/integration/vaults/protocol-detail.test.ts
@@ -11,6 +11,8 @@ test.describe('vault protocol detail pages', () => {
 	test('shows GMX AMM pools by default and identifies an AMM vault as a pool', async ({ page }) => {
 		await page.goto('/vaults/protocols/gmx');
 
+		await expect(page).toHaveTitle('GMX pools and yields');
+		await expect(page.getByRole('heading', { name: 'GMX powered pools', level: 1 })).toBeVisible();
 		const gmxPoolRows = page.locator('tbody tr.targetable').filter({ hasText: 'GMX USDC pool' });
 		await expect(gmxPoolRows).toHaveCount(1);
 		await openFilters(page);

--- a/tests/integration/vaults/protocol-detail.test.ts
+++ b/tests/integration/vaults/protocol-detail.test.ts
@@ -1,6 +1,28 @@
 import { expect, test } from '@playwright/test';
 
+async function openFilters(page: import('@playwright/test').Page) {
+	const filters = page.getByTestId('vault-filters');
+	if (!(await filters.isVisible())) {
+		await page.getByRole('button', { name: 'Filters' }).click();
+	}
+}
+
 test.describe('vault protocol detail pages', () => {
+	test('shows GMX AMM pools by default and identifies an AMM vault as a pool', async ({ page }) => {
+		await page.goto('/vaults/protocols/gmx');
+
+		const gmxPoolRows = page.locator('tbody tr.targetable').filter({ hasText: 'GMX USDC pool' });
+		await expect(gmxPoolRows).toHaveCount(1);
+		await openFilters(page);
+		await expect(page.getByLabel('AMM', { exact: true })).not.toBeChecked();
+
+		await page.goto('/vaults/gmx-usdc-pool');
+
+		await expect(page.getByText('About the pool', { exact: true })).toBeVisible();
+		await expect(page.getByText('This pool is running on GMX:', { exact: true })).toBeVisible();
+		await expect(page.getByText('Pool name', { exact: true })).toBeVisible();
+	});
+
 	test('sorts ApeX vaults by TVL by default', async ({ page }) => {
 		await page.goto('/vaults/protocols/apex');
 

--- a/tests/mocks/top-vaults/list.mock.ts
+++ b/tests/mocks/top-vaults/list.mock.ts
@@ -293,6 +293,18 @@ const apexVaults = [
 	})
 ];
 
+const gmxPool = createTestVault('GMX USDC pool', {
+	address: '0x2000000000000000000000000000000000000001',
+	chain: 'arbitrum',
+	protocol: 'GMX',
+	current_nav: 750_000,
+	peak_nav: 900_000,
+	one_month_cagr: 0.08,
+	three_months_cagr: 0.12,
+	features: ['amm_pool_like', 'gmx_gm'],
+	description: 'A GMX liquidity pool with direct exposure to its underlying assets.'
+});
+
 // Named vault for YAML strategy integration tests
 const yamlStrategyVault = createTestVault('Trading Strategy ICHIv3 LS 2', {
 	address: '0x1234567890abcdef1234567890abcdef12345678',
@@ -621,6 +633,7 @@ export default defineMock({
 			privateVault,
 			privateTokenisedFund,
 			limitedCoverageVault,
+			gmxPool,
 			...apexVaults,
 			...parquetMatchedVaults,
 			...returnLeaders,

--- a/tests/mocks/vault-protocols/gmx-metadata.mock.ts
+++ b/tests/mocks/vault-protocols/gmx-metadata.mock.ts
@@ -1,0 +1,20 @@
+import { defineMock } from 'vite-plugin-mock-dev-server';
+
+export default defineMock({
+	url: '/api/vault-protocols/gmx/metadata.json',
+	body: {
+		name: 'GMX',
+		slug: 'gmx',
+		short_description: 'A decentralised exchange with liquidity pools for perpetual markets.',
+		long_description: 'GMX liquidity pools provide the counterparty liquidity for perpetual markets.',
+		links: {
+			homepage: 'https://gmx.io',
+			twitter: 'https://x.com/GMX_IO',
+			documentation: 'https://docs.gmx.io',
+			github: 'https://github.com/gmx-io',
+			defillama: 'https://defillama.com/protocol/gmx',
+			audits: null
+		},
+		logos: { light: null, dark: null }
+	}
+});


### PR DESCRIPTION
## Why
AMM pools and AMM-like vaults with direct underlying exposure should be hidden from general vault listings while remaining visible on their protocol pages.

## Lessons learnt
The production GMX export consistently uses the `amm_pool_like` feature, so listing filters can use that exported classification. GMX-specific labels are kept in a small protocol helper until another protocol needs the same treatment.

## Summary
- Add a default-on AMM Hide filter, with protocol listings defaulting to show pools.
- Use pool terminology and accurate metadata for GMX pages, with GMX integration coverage.
- Document the URL default behaviour and add the changelog entry.