### PR TITLE
fix: use USD in vault denomination column

### DIFF
--- a/src/lib/top-vaults/TopVaultsTable.svelte
+++ b/src/lib/top-vaults/TopVaultsTable.svelte
@@ -41,7 +41,7 @@ Whitelisted vaults are marked as Private, except tokenised funds, which are mark
 		formatValue,
 		notFilledMarker
 	} from '$lib/helpers/formatters';
-	import { isStablecoinDepegged } from '$lib/stablecoin-metadata/helpers';
+	import { isStablecoinDepegged, OFFCHAIN_USD_STABLECOIN_SLUG } from '$lib/stablecoin-metadata/helpers';
 	import { getVaultProtocolLogoUrl } from '$lib/vault-protocol/helpers';
 	import {
 		DEFAULT_TVL_KEY,
@@ -1256,7 +1256,7 @@ Whitelisted vaults are marked as Private, except tokenised funds, which are mark
 							{getLifetimeMaxDrawdown(vault) != null ? formatPercent(getLifetimeMaxDrawdown(vault)) : notFilledMarker}
 						</td>
 						<td class="denomination center">
-							{formatValue(vault.denomination)}
+							{vault.denomination_slug === OFFCHAIN_USD_STABLECOIN_SLUG ? 'USD' : formatValue(vault.denomination)}
 						</td>
 						<td class="tvl right">
 							{#if shouldShowTvlBreakdown(vault)}


### PR DESCRIPTION
## Why

Off-chain USD does not fit within the vault-listing denomination column.

## Lessons learnt

Keep accounting-denomination grouping separate from its compact table presentation.

## Summary

- Display off-chain USD as `USD` in the shared vault denomination column.
- Preserve the off-chain denomination slug for grouping and routing.