### PR TITLE
fix: benchmark GMX pool price charts

### DIFF
--- a/docs/vault-data-source.md
+++ b/docs/vault-data-source.md
@@ -122,11 +122,13 @@ The US 3-month Treasury bill rate is used as a risk-free benchmark on non-perpet
 - `isValidDateString()` — strict YYYY-MM-DD validation with round-trip check
 - `readJsonFileCache()` / `writeJsonFileCache()` / `isCacheFresh()` — generic file cache with injectable `cacheDir` for testing
 
-**Vault classification** (`src/lib/top-vaults/isPerpetualFuturesVault.ts`):
+**Vault price-chart benchmark classification** (`src/lib/top-vaults/vault-price-benchmarks.ts`):
 
 - Perpetual futures vaults show BTC/ETH benchmarks (via Coinbase API)
-- All other vaults show the US 3M T-bill benchmark
-- Detection: `perp_dex_trading_vault` flag first, then chain_id fallback (9999 HyperCore, 325 GRVT, 9998 Lighter, 9997 Hibachi)
+- Crypto-exposed GMX pools show BTC/ETH benchmarks, except GM BTC and ETH pools, which show their respective market benchmark only
+- Stable-stable GMX GM swap pools show the US 3M T-bill benchmark
+- All remaining vaults show the US 3M T-bill benchmark
+- Perpetual futures detection: `perp_dex_trading_vault` flag first, then chain_id fallback (9999 HyperCore, 325 GRVT, 9998 Lighter, 9997 Hibachi)
 - HyperEVM (chain_id 999) is intentionally excluded — it hosts DeFi/lending vaults
 
 ### Datasets download endpoint
@@ -167,8 +169,8 @@ FRED (fred.stlouisfed.org)
 | Landing page (server load)         | Top vaults JSON      | `+page.server.ts` → `getCachedTopVaults()`                      |
 | Vault price chart (client fetch)   | Parquet              | `/vaults/[vault]/metrics` → `ensureVaultPricesParquet()`        |
 | Historical TVL charts (server)     | Parquet              | `historical-tvl-server.ts` → `ensureVaultPricesParquet()`       |
-| T-bill benchmark (non-perp vaults) | FRED DTB3            | `TreasuryBenchmarkSeries.svelte` → `/vaults/treasury-benchmark` |
-| BTC/ETH benchmark (perp vaults)    | Coinbase API         | `CoinbaseBenchmarkSeries.svelte` → `coinbase.ts`                |
+| T-bill benchmark (other vaults)    | FRED DTB3            | `TreasuryBenchmarkSeries.svelte` → `/vaults/treasury-benchmark` |
+| BTC/ETH benchmarks (perps and GMX) | Coinbase API         | `CoinbaseBenchmarkSeries.svelte` → `coinbase.ts`                |
 | Datasets listing page              | Both (metadata only) | `headTopVaults()` + `headVaultPrices()` via R2                  |
 | Datasets download                  | Both (proxied)       | `/datasets/download/[datasetId]` via Vault API                  |
 

--- a/src/lib/top-vaults/CoinbaseBenchmarkSeries.svelte
+++ b/src/lib/top-vaults/CoinbaseBenchmarkSeries.svelte
@@ -75,7 +75,7 @@ visible range so the lines can be compared on a single axis.
 				return {
 					time: item.time,
 					value: initialVaultValue * (1 + percentChange),
-					customValues: { percentChange, usdPrice: item.value }
+					customValues: { symbol: productId.slice(0, 3), percentChange, usdPrice: item.value }
 				};
 			});
 		} catch (error) {

--- a/src/lib/top-vaults/VaultPriceChart.svelte
+++ b/src/lib/top-vaults/VaultPriceChart.svelte
@@ -2,9 +2,10 @@
 @component
 Render the vault share-price chart with TVL bars and benchmark overlays.
 
-Perpetual futures vaults (Hyperliquid, GRVT, Lighter, Hibachi, ApeX) show BTC/ETH benchmarks
-and an underwater drawdown pane (equity curve tearsheet style).
-All other vaults show a US 3M T-bill (risk-free rate) benchmark instead.
+Perpetual futures and crypto-exposed GMX pools show BTC/ETH benchmarks. GMX GM BTC and ETH
+pools show their respective market asset only, while stable-stable GM swap pools use the U.S.
+Treasury benchmark. Perpetual futures vaults also include an underwater
+drawdown pane (equity curve tearsheet style); remaining vaults show a US 3M T-bill instead.
 
 Benchmark lines are rebased to the vault share price for the selected range
 so relative performance is comparable on a single axis.
@@ -26,6 +27,7 @@ so relative performance is comparable on a single axis.
 	import { getLogoUrl } from '$lib/helpers/assets';
 	import { isPerpetualFuturesVault } from './isPerpetualFuturesVault';
 	import { getVaultAssetType } from './helpers';
+	import { getVaultPriceBenchmarkTokens } from './vault-price-benchmarks';
 	import type { PriceScaleCalculator, SimpleDataItem } from '$lib/charts/types';
 	import {
 		formatDollar,
@@ -60,7 +62,9 @@ so relative performance is comparable on a single axis.
 
 	let { vault, chartLogoUrl, onTimeSpanChange }: Props = $props();
 
-	let showCryptoBenchmarks = $derived(isPerpetualFuturesVault(vault));
+	let benchmarkTokens = $derived(getVaultPriceBenchmarkTokens(vault));
+	let showCryptoBenchmarks = $derived(benchmarkTokens.length > 0);
+	let showDrawdown = $derived(isPerpetualFuturesVault(vault));
 	let assetType = $derived(getVaultAssetType(vault));
 	let isSharePriceEquivalent = $derived(vault.features.includes('share_price_equivalence'));
 	let chartTitle = $derived(isSharePriceEquivalent ? 'Equity curve' : 'Share token price');
@@ -100,7 +104,11 @@ so relative performance is comparable on a single axis.
 
 	function getBenchmarkCustomValues(point: unknown) {
 		if (!point || typeof point !== 'object' || !('customValues' in point)) return undefined;
-		return (point as { customValues?: { percentChange?: number; usdPrice?: number } }).customValues;
+		return (point as { customValues?: { symbol?: string; percentChange?: number; usdPrice?: number } }).customValues;
+	}
+
+	function getCryptoBenchmarkCustomValues(points: unknown[], symbol: string) {
+		return points.map(getBenchmarkCustomValues).find((values) => values?.symbol === symbol);
 	}
 
 	function getTreasuryCustomValues(point: unknown) {
@@ -159,8 +167,11 @@ so relative performance is comparable on a single axis.
 		showCryptoBenchmarks
 			? [
 					{ label: vault.name, color: getVaultColor(vaultDirection), logoUrl: chartLogoUrl },
-					{ label: 'BTC', color: '#f7931a80', logoUrl: getLogoUrl('token', 'btc') },
-					{ label: 'ETH', color: '#627eea80', logoUrl: getLogoUrl('token', 'eth') }
+					...benchmarkTokens.map((token) => ({
+						label: token,
+						color: token === 'BTC' ? '#f7931a80' : '#627eea80',
+						logoUrl: getLogoUrl('token', token.toLowerCase())
+					}))
 				]
 			: [
 					{ label: vault.name, color: getVaultColor(vaultDirection), logoUrl: chartLogoUrl },
@@ -175,7 +186,7 @@ so relative performance is comparable on a single axis.
 	);
 </script>
 
-<div class={['vault-price-chart', showCryptoBenchmarks && 'has-drawdown']}>
+<div class={['vault-price-chart', showDrawdown && 'has-drawdown']}>
 	<ChartContainer
 		timeSpanOptions={['1M', '3M', 'Max']}
 		{onTimeSpanChange}
@@ -185,7 +196,7 @@ so relative performance is comparable on a single axis.
 		options={{
 			handleScroll: false,
 			handleScale: false,
-			...(showCryptoBenchmarks && {
+			...(showDrawdown && {
 				localization: { priceFormatter: (v: number) => (v >= -1 && v < 0 ? formatPercent(v, 1) : formatValue(v)) }
 			})
 		}}
@@ -222,57 +233,54 @@ so relative performance is comparable on a single axis.
 
 			{#if data.length > 1 && range}
 				{#if showCryptoBenchmarks}
-					<CoinbaseBenchmarkSeries
-						productId="BTC-USD"
-						{data}
-						timeBucket={timeSpan.timeBucket}
-						{range}
-						color="#f7931a80"
-					/>
-					<CoinbaseBenchmarkSeries
-						productId="ETH-USD"
-						{data}
-						timeBucket={timeSpan.timeBucket}
-						{range}
-						color="#627eea80"
-					/>
+					{#each benchmarkTokens as token (token)}
+						<CoinbaseBenchmarkSeries
+							productId={`${token}-USD` as 'BTC-USD' | 'ETH-USD'}
+							{data}
+							timeBucket={timeSpan.timeBucket}
+							{range}
+							color={token === 'BTC' ? '#f7931a80' : '#627eea80'}
+						/>
+					{/each}
 
-					{@const ddPeriod = !timeSpan.spanDays ? 'All-time' : timeSpan.spanDays <= 30 ? '1M' : '3M'}
-					{@const rangeStart = range ? Math.floor(range[0].getTime() / 1000) : 0}
-					{@const windowData = range ? data.filter((d) => d.time >= rangeStart) : data}
-					{@const drawdownSeriesData = (() => {
-						let peak = -Infinity;
-						return windowData.map((item) => {
-							if (item.value > peak) peak = item.value;
-							const dd = peak > 0 ? (item.value - peak) / peak : 0;
-							return { time: item.time, value: dd, customValues: { series: 'drawdown' as const, period: ddPeriod } };
-						});
-					})()}
-					<Series
-						type={BaselineSeriesType}
-						data={drawdownSeriesData}
-						options={{
-							baseValue: { type: 'price', price: 0 },
-							priceLineVisible: false,
-							crosshairMarkerVisible: false,
-							lineWidth: 1
-						}}
-						paneIndex={1}
-						priceScaleOptions={{ scaleMargins: { top: 0.12, bottom: 0.16 } }}
-						callback={({ series, colors }) => {
-							series.getPane().setHeight(120);
-							series.applyOptions({
-								topLineColor: 'transparent',
-								topFillColor1: 'transparent',
-								topFillColor2: 'transparent',
-								bottomLineColor: '#c0392b',
-								bottomFillColor1: 'rgba(192, 57, 43, 0.25)',
-								bottomFillColor2: 'rgba(192, 57, 43, 0.25)'
+					{#if showDrawdown}
+						{@const ddPeriod = !timeSpan.spanDays ? 'All-time' : timeSpan.spanDays <= 30 ? '1M' : '3M'}
+						{@const rangeStart = range ? Math.floor(range[0].getTime() / 1000) : 0}
+						{@const windowData = range ? data.filter((d) => d.time >= rangeStart) : data}
+						{@const drawdownSeriesData = (() => {
+							let peak = -Infinity;
+							return windowData.map((item) => {
+								if (item.value > peak) peak = item.value;
+								const dd = peak > 0 ? (item.value - peak) / peak : 0;
+								return { time: item.time, value: dd, customValues: { series: 'drawdown' as const, period: ddPeriod } };
 							});
-						}}
-					>
-						<SeriesLabel heading>Drawdown</SeriesLabel>
-					</Series>
+						})()}
+						<Series
+							type={BaselineSeriesType}
+							data={drawdownSeriesData}
+							options={{
+								baseValue: { type: 'price', price: 0 },
+								priceLineVisible: false,
+								crosshairMarkerVisible: false,
+								lineWidth: 1
+							}}
+							paneIndex={1}
+							priceScaleOptions={{ scaleMargins: { top: 0.12, bottom: 0.16 } }}
+							callback={({ series }) => {
+								series.getPane().setHeight(120);
+								series.applyOptions({
+									topLineColor: 'transparent',
+									topFillColor1: 'transparent',
+									topFillColor2: 'transparent',
+									bottomLineColor: '#c0392b',
+									bottomFillColor1: 'rgba(192, 57, 43, 0.25)',
+									bottomFillColor2: 'rgba(192, 57, 43, 0.25)'
+								});
+							}}
+						>
+							<SeriesLabel heading>Drawdown</SeriesLabel>
+						</Series>
+					{/if}
 				{:else}
 					<TreasuryBenchmarkSeries {data} timeBucket={timeSpan.timeBucket} {range} color="#4a90d9a0" />
 				{/if}
@@ -281,7 +289,7 @@ so relative performance is comparable on a single axis.
 					type={HistogramSeries}
 					data={tvlSeriesData}
 					options={{ priceLineVisible: false, color: 'transparent' }}
-					paneIndex={showCryptoBenchmarks ? 2 : 1}
+					paneIndex={showDrawdown ? 2 : 1}
 					priceScaleOptions={{ scaleMargins: { top: 0.25, bottom: 0 } }}
 					callback={({ series, colors }) => {
 						series.getPane().setHeight(150);
@@ -296,8 +304,8 @@ so relative performance is comparable on a single axis.
 		{#snippet tooltip({ point, time }, seriesData, timeSpan)}
 			{#if showCryptoBenchmarks}
 				{@const price = getSeriesValuePoint(seriesData, 'vault-price')}
-				{@const btc = getBenchmarkCustomValues(seriesData[1])}
-				{@const eth = getBenchmarkCustomValues(seriesData[2])}
+				{@const btc = getCryptoBenchmarkCustomValues(seriesData, 'BTC')}
+				{@const eth = getCryptoBenchmarkCustomValues(seriesData, 'ETH')}
 				{@const drawdown = getSeriesValuePoint(seriesData, 'drawdown')}
 				{@const tvl = getSeriesValuePoint(seriesData, 'tvl')}
 				{#if price || btc || eth || tvl}
@@ -308,18 +316,24 @@ so relative performance is comparable on a single axis.
 							<dd>{formatPercent(price?.customValues?.annualizedReturn, 1, 1, { signDisplay: 'exceptZero' })}</dd>
 							<dt>Price:</dt>
 							<dd>{price ? formatValue(price.value) : notFilledMarker} {vault.denomination}</dd>
-							<dt>BTC:</dt>
-							<dd>
-								{formatPercent(btc?.percentChange, 1, 1, { signDisplay: 'exceptZero' })}
-								{#if btc?.usdPrice}<span class="benchmark-usd">{formatDollar(btc.usdPrice, 1)}</span>{/if}
-							</dd>
-							<dt>ETH:</dt>
-							<dd>
-								{formatPercent(eth?.percentChange, 1, 1, { signDisplay: 'exceptZero' })}
-								{#if eth?.usdPrice}<span class="benchmark-usd">{formatDollar(eth.usdPrice, 1)}</span>{/if}
-							</dd>
-							<dt>Drawdown {drawdown?.customValues?.period ?? ''}:</dt>
-							<dd>{formatPercent(drawdown?.value, 2, 2)}</dd>
+							{#if benchmarkTokens.includes('BTC')}
+								<dt>BTC:</dt>
+								<dd>
+									{formatPercent(btc?.percentChange, 1, 1, { signDisplay: 'exceptZero' })}
+									{#if btc?.usdPrice}<span class="benchmark-usd">{formatDollar(btc.usdPrice, 1)}</span>{/if}
+								</dd>
+							{/if}
+							{#if benchmarkTokens.includes('ETH')}
+								<dt>ETH:</dt>
+								<dd>
+									{formatPercent(eth?.percentChange, 1, 1, { signDisplay: 'exceptZero' })}
+									{#if eth?.usdPrice}<span class="benchmark-usd">{formatDollar(eth.usdPrice, 1)}</span>{/if}
+								</dd>
+							{/if}
+							{#if showDrawdown}
+								<dt>Drawdown {drawdown?.customValues?.period ?? ''}:</dt>
+								<dd>{formatPercent(drawdown?.value, 2, 2)}</dd>
+							{/if}
 							<dt>TVL:</dt>
 							<dd>{tvl ? formatValue(tvl.value) : notFilledMarker}</dd>
 						</dl>
@@ -463,8 +477,7 @@ so relative performance is comparable on a single axis.
 				border-top: 1px solid var(--c-box-3);
 
 				dt,
-				dd,
-				.benchmark-usd {
+				dd {
 					font-size: 80%;
 				}
 			}

--- a/src/lib/top-vaults/vault-price-benchmarks.test.ts
+++ b/src/lib/top-vaults/vault-price-benchmarks.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, test } from 'vitest';
+import { getVaultPriceBenchmarkTokens } from './vault-price-benchmarks';
+
+const gmxVault = (vault_slug: string, name = 'GM [WBTC-USDC]') => ({
+	flags: [],
+	chain_id: 42161,
+	name,
+	protocol_slug: 'gmx',
+	vault_slug
+});
+
+describe('getVaultPriceBenchmarkTokens', () => {
+	test('compares a GM BTC pool with BTC only', () => {
+		expect(getVaultPriceBenchmarkTokens(gmxVault('gm-btc-wbtc-usdc', 'GM BTC [WBTC-USDC]'))).toEqual(['BTC']);
+	});
+
+	test('compares a GM ETH pool with ETH only', () => {
+		expect(getVaultPriceBenchmarkTokens(gmxVault('gm-eth-weth-usdc', 'GM ETH [WETH-USDC]'))).toEqual(['ETH']);
+	});
+
+	test('compares other GM pools with BTC and ETH', () => {
+		expect(getVaultPriceBenchmarkTokens(gmxVault('gm-aster-wbtc-usdc'))).toEqual(['BTC', 'ETH']);
+	});
+
+	test('keeps the Treasury benchmark for stable-stable GM swap pools', () => {
+		expect(getVaultPriceBenchmarkTokens(gmxVault('gm-swap-usdc-usdt0', 'GM swap [USDC-USD₮0]'))).toEqual([]);
+	});
+
+	test('recognises additional GMX stablecoin assets', () => {
+		expect(getVaultPriceBenchmarkTokens(gmxVault('gm-swap-usdg-usds', 'GM swap [USDG-USDS]'))).toEqual([]);
+	});
+
+	test('compares a crypto GM swap pool with BTC and ETH', () => {
+		expect(getVaultPriceBenchmarkTokens(gmxVault('gm-swap-wsteth-weth', 'GM swap [wstETH-WETH]'))).toEqual([
+			'BTC',
+			'ETH'
+		]);
+	});
+
+	test('compares GLV pools with BTC and ETH', () => {
+		expect(getVaultPriceBenchmarkTokens(gmxVault('glv-wbtc-usdc'))).toEqual(['BTC', 'ETH']);
+	});
+
+	test('keeps both benchmarks for perpetual futures vaults', () => {
+		expect(
+			getVaultPriceBenchmarkTokens({
+				flags: ['perp_dex_trading_vault'],
+				chain_id: 1,
+				name: 'Perp vault',
+				protocol_slug: 'trading-strategy',
+				vault_slug: 'perp-vault'
+			})
+		).toEqual(['BTC', 'ETH']);
+	});
+
+	test('keeps the Treasury benchmark for non-GMX vaults', () => {
+		expect(
+			getVaultPriceBenchmarkTokens({
+				flags: [],
+				chain_id: 1,
+				name: 'USDC vault',
+				protocol_slug: 'aave',
+				vault_slug: 'gm-swap-usdc-usdt'
+			})
+		).toEqual([]);
+	});
+});

--- a/src/lib/top-vaults/vault-price-benchmarks.ts
+++ b/src/lib/top-vaults/vault-price-benchmarks.ts
@@ -1,0 +1,83 @@
+import type { VaultInfo } from './schemas';
+import { isPerpetualFuturesVault } from './isPerpetualFuturesVault';
+
+export type VaultPriceBenchmarkToken = 'BTC' | 'ETH';
+
+const BTC_AND_ETH = ['BTC', 'ETH'] as const;
+const GMX_STABLECOIN_SYMBOLS = new Set([
+	'usdc',
+	'usdc.e',
+	'usdt',
+	'usdt.e',
+	'usdt0',
+	'usde',
+	'susde',
+	'dai',
+	'usdg',
+	'usds',
+	'usdf',
+	'usd1',
+	'gho',
+	'frax',
+	'pyusd',
+	'fdusd',
+	'usdb',
+	'usdx',
+	'usda',
+	'crvusd',
+	'usdd',
+	'lusd',
+	'dola',
+	'usdp',
+	'usd0',
+	'usdn',
+	'usdr',
+	'usdy'
+]);
+
+type BenchmarkVault = Pick<VaultInfo, 'flags' | 'chain_id' | 'name' | 'protocol_slug' | 'vault_slug'>;
+
+/**
+ * Whether a GMX GM swap pool has two stablecoin assets.
+ *
+ * GMX uses its human-readable pool name because slugification makes token symbols
+ * such as `USDC.e` ambiguous. A token name may itself contain hyphens, so every
+ * possible separator is considered.
+ *
+ * @param vault - GMX vault metadata containing the market name
+ */
+function isGmxStableStablePool(vault: BenchmarkVault): boolean {
+	if (vault.protocol_slug !== 'gmx' || !vault.vault_slug.startsWith('gm-swap-')) return false;
+
+	const poolName = vault.name.match(/^GM swap \[(.+)]$/)?.[1];
+	if (!poolName) return false;
+
+	const isStablecoin = (token: string) => GMX_STABLECOIN_SYMBOLS.has(token.toLowerCase().replace('₮', 't'));
+
+	return [...poolName].some(
+		(token, index) => token === '-' && isStablecoin(poolName.slice(0, index)) && isStablecoin(poolName.slice(index + 1))
+	);
+}
+
+/**
+ * Return crypto price benchmarks that are relevant to a vault's underlying exposure.
+ *
+ * Perpetual futures, GMX GLV, and crypto-exposed GMX GM vaults are compared with BTC and ETH.
+ * GLV pools deliberately use both benchmarks to match perpetual futures vault comparisons.
+ * GM BTC and ETH pools use only their respective market asset, while stable-stable GM swap
+ * pools keep the U.S. Treasury benchmark.
+ *
+ * @param vault - Vault metadata used to determine its market exposure
+ */
+export function getVaultPriceBenchmarkTokens(vault: BenchmarkVault): VaultPriceBenchmarkToken[] {
+	if (isPerpetualFuturesVault(vault) || (vault.protocol_slug === 'gmx' && vault.vault_slug.startsWith('glv-'))) {
+		return [...BTC_AND_ETH];
+	}
+
+	if (vault.protocol_slug !== 'gmx') return [];
+	if (isGmxStableStablePool(vault)) return [];
+	if (vault.vault_slug.startsWith('gm-btc-')) return ['BTC'];
+	if (vault.vault_slug.startsWith('gm-eth-')) return ['ETH'];
+
+	return [...BTC_AND_ETH];
+}


### PR DESCRIPTION
## Why

GMX vault price charts need benchmarks that reflect their market exposure: BTC-only and ETH-only for their respective GM pools, both assets for GLVs and other crypto GM pools, and Treasury rates for stable-stable GM swap pools.

## Lessons learnt

GMX pool slugs alone cannot reliably identify stablecoin pairs because token slugification is ambiguous. The human-readable GM swap name provides the required asset distinction.

## Summary

- Add exposure-aware BTC and ETH price comparisons to GMX and GLV vault charts
- Keep the U.S. Treasury benchmark for stable-stable GM swap pools
- Add benchmark classification tests and document the data-source behaviour