### PR TITLE
feat: add Vault Pro datasets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Weblog of stuff
 
+- Add Vault Pro crypto price, metadata, and exchange-rate datasets (2026-08-28)
 - Add an AMM filter to vault listings and pool terminology on detail pages (2026-08-27)
 - Reorganise vault filters into responsive groups and add volatility filtering (2026-08-27)
 - Add a permissioned-vault filter to vault listings (2026-08-25)

--- a/src/lib/top-vaults/server-config.ts
+++ b/src/lib/top-vaults/server-config.ts
@@ -100,3 +100,18 @@ export async function headVaultPrices(fetch: Fetch) {
 	// No fallback — parquet file is only available via private R2
 	return { size: null, lastModified: null };
 }
+
+/**
+ * Get metadata (size, last-modified) for a Vault Pro dataset stored in R2.
+ *
+ * @param key R2 object key for the dataset
+ */
+export async function headVaultDataset(key: string) {
+	if (!isR2Configured()) return { size: null, lastModified: null };
+
+	const meta = await headR2Object(key);
+	return {
+		size: meta?.contentLength ?? null,
+		lastModified: meta?.lastModified ?? null
+	};
+}

--- a/src/routes/vaults/datasets/+page.server.ts
+++ b/src/routes/vaults/datasets/+page.server.ts
@@ -1,9 +1,16 @@
 import { error } from '@sveltejs/kit';
-import { headTopVaults, headVaultPrices } from '$lib/top-vaults/server-config';
+import { dev } from '$app/environment';
+import { headTopVaults, headVaultDataset, headVaultPrices } from '$lib/top-vaults/server-config';
 import { isR2Configured } from '$lib/r2/client';
 import { sampleDataUrl } from '$lib/config';
 
 const documentationUrl = 'https://tradingstrategy.ai/docs/overview/defi-vault-data.html';
+
+const CRYPTO_CLEANED_PRICES_PARQUET = 'crypto-cleaned-vault-prices-1d.parquet';
+const CRYPTO_VAULT_METADATA_JSON = 'crypto-vault-metadata.json';
+const EXCHANGE_RATES_PARQUET = 'exchange-rates.parquet';
+const CRYPTO_DATASET_DESCRIPTION =
+	'Vaults with BTC and ETH denominations. Performance metrics of these vaults have been calculated against the underlying token and they are not directly comparable to stablecoin vaults.';
 
 /** Origin of the public CDN that hosts the free sample files (host kept server-side). */
 const sampleBaseUrl = new URL(sampleDataUrl).origin;
@@ -96,6 +103,40 @@ export async function load({ fetch, setHeaders, url }) {
 			downloadUrl: '/vaults/datasets/download/vault-prices'
 		},
 		{
+			id: 'crypto-cleaned-prices',
+			name: 'Crypto cleaned prices',
+			description: CRYPTO_DATASET_DESCRIPTION,
+			instructions:
+				'Download the daily Parquet file to analyse cleaned crypto vault prices in notebooks, data warehouses, or your own research pipelines.',
+			filename: CRYPTO_CLEANED_PRICES_PARQUET,
+			format: 'Parquet',
+			documentation: documentationUrl,
+			downloadUrl: '/vaults/datasets/download/crypto-cleaned-prices'
+		},
+		{
+			id: 'crypto-metadata',
+			name: 'Crypto metadata',
+			description: CRYPTO_DATASET_DESCRIPTION,
+			instructions:
+				'Download the summary JSON when you need the latest crypto vault catalogue and metadata for offline research or your own pipelines.',
+			filename: CRYPTO_VAULT_METADATA_JSON,
+			format: 'JSON',
+			documentation: documentationUrl,
+			downloadUrl: '/vaults/datasets/download/crypto-metadata'
+		},
+		{
+			id: 'exchange-rates',
+			name: 'Exchange rates',
+			description:
+				'Historical exchange rates in Parquet format for converting and comparing dataset values across currencies.',
+			instructions:
+				'Download the Parquet file to join exchange rates with vault data in your own analysis and reporting workflows.',
+			filename: EXCHANGE_RATES_PARQUET,
+			format: 'Parquet',
+			documentation: documentationUrl,
+			downloadUrl: '/vaults/datasets/download/exchange-rates'
+		},
+		{
 			id: 'vault-metadata-sample',
 			name: 'Vault metadata (sample)',
 			description: SAMPLE_DESCRIPTION,
@@ -121,9 +162,20 @@ export async function load({ fetch, setHeaders, url }) {
 		}
 	];
 
-	const [topVaultsMeta, vaultPricesMeta, metadataSampleMeta, pricesSampleMeta] = await Promise.all([
+	const [
+		topVaultsMeta,
+		vaultPricesMeta,
+		cryptoCleanedPricesMeta,
+		cryptoMetadataMeta,
+		exchangeRatesMeta,
+		metadataSampleMeta,
+		pricesSampleMeta
+	] = await Promise.all([
 		headTopVaults(fetch).catch(() => ({ size: null, lastModified: null })),
 		headVaultPrices(fetch).catch(() => ({ size: null, lastModified: null })),
+		headVaultDataset(CRYPTO_CLEANED_PRICES_PARQUET).catch(() => ({ size: null, lastModified: null })),
+		headVaultDataset(CRYPTO_VAULT_METADATA_JSON).catch(() => ({ size: null, lastModified: null })),
+		headVaultDataset(EXCHANGE_RATES_PARQUET).catch(() => ({ size: null, lastModified: null })),
 		headSample(fetch, 'vault-metadata.sample.json'),
 		headSample(fetch, 'vault-historical.sample.parquet')
 	]);
@@ -131,6 +183,9 @@ export async function load({ fetch, setHeaders, url }) {
 	const metadataMap: Record<string, { size: number | null; lastModified: Date | null }> = {
 		'vault-metadata': topVaultsMeta,
 		'vault-prices': vaultPricesMeta,
+		'crypto-cleaned-prices': cryptoCleanedPricesMeta,
+		'crypto-metadata': cryptoMetadataMeta,
+		'exchange-rates': exchangeRatesMeta,
 		'vault-metadata-sample': metadataSampleMeta,
 		'vault-prices-sample': pricesSampleMeta
 	};
@@ -148,7 +203,7 @@ export async function load({ fetch, setHeaders, url }) {
 	enriched.sort((a, b) => Number(b.free ?? false) - Number(a.free ?? false));
 
 	setHeaders({
-		'cache-control': 'public, max-age=600'
+		'cache-control': dev ? 'no-cache' : 'public, max-age=600'
 	});
 
 	return { datasets: enriched, origin: url.origin };

--- a/src/routes/vaults/datasets/download/[datasetId]/+server.ts
+++ b/src/routes/vaults/datasets/download/[datasetId]/+server.ts
@@ -3,6 +3,9 @@ import { vaultApiUrl } from '$lib/config';
 import { VAULT_PRICES_PARQUET } from '$lib/top-vaults/constants';
 
 const TOP_VAULTS_JSON = 'top_vaults_by_chain.json';
+const CRYPTO_CLEANED_PRICES_PARQUET = 'crypto-cleaned-vault-prices-1d.parquet';
+const CRYPTO_VAULT_METADATA_JSON = 'crypto-vault-metadata.json';
+const EXCHANGE_RATES_PARQUET = 'exchange-rates.parquet';
 
 /** Map public dataset IDs to their Worker file key and download metadata. */
 function resolveDataset(datasetId: string): { fileKey: string; filename: string; contentType: string } | null {
@@ -14,6 +17,24 @@ function resolveDataset(datasetId: string): { fileKey: string; filename: string;
 				fileKey: VAULT_PRICES_PARQUET,
 				filename: 'vault-historical.parquet',
 				contentType: 'application/octet-stream'
+			};
+		case 'crypto-cleaned-prices':
+			return {
+				fileKey: CRYPTO_CLEANED_PRICES_PARQUET,
+				filename: CRYPTO_CLEANED_PRICES_PARQUET,
+				contentType: 'application/vnd.apache.parquet'
+			};
+		case 'crypto-metadata':
+			return {
+				fileKey: CRYPTO_VAULT_METADATA_JSON,
+				filename: CRYPTO_VAULT_METADATA_JSON,
+				contentType: 'application/json'
+			};
+		case 'exchange-rates':
+			return {
+				fileKey: EXCHANGE_RATES_PARQUET,
+				filename: EXCHANGE_RATES_PARQUET,
+				contentType: 'application/vnd.apache.parquet'
 			};
 		default:
 			return null;

--- a/tests/integration/vaults/datasets.test.ts
+++ b/tests/integration/vaults/datasets.test.ts
@@ -37,6 +37,12 @@ test.describe('vault datasets page', () => {
 		await expect(page.getByText('Vault prices', { exact: true })).toBeVisible();
 	});
 
+	test('lists Crypto and exchange-rate datasets', async ({ page }) => {
+		await expect(page.getByText('Crypto cleaned prices', { exact: true })).toBeVisible();
+		await expect(page.getByText('Crypto metadata', { exact: true })).toBeVisible();
+		await expect(page.getByText('Exchange rates', { exact: true })).toBeVisible();
+	});
+
 	test('lists free sample datasets', async ({ page }) => {
 		await expect(page.getByText('Vault metadata (sample)', { exact: true })).toBeVisible();
 		await expect(page.getByText('Vault prices (sample)', { exact: true })).toBeVisible();
@@ -50,6 +56,9 @@ test.describe('vault datasets page', () => {
 	test('shows expected filenames in dataset table', async ({ page }) => {
 		await expect(page.getByText('vault-metadata.json', { exact: true })).toBeVisible();
 		await expect(page.getByText('vault-historical.parquet', { exact: true })).toBeVisible();
+		await expect(page.getByText('crypto-cleaned-vault-prices-1d.parquet', { exact: true })).toBeVisible();
+		await expect(page.getByText('crypto-vault-metadata.json', { exact: true })).toBeVisible();
+		await expect(page.getByText('exchange-rates.parquet', { exact: true })).toBeVisible();
 	});
 
 	test('shows JSON and Parquet format labels', async ({ page }) => {
@@ -157,6 +166,28 @@ test.describe('vault dataset download endpoint', () => {
 		expect(res.headers()['content-disposition']).toContain('vault-historical.parquet');
 		expect(res.headers()['cache-control']).toBe('private, no-store');
 	});
+
+	for (const dataset of [
+		{
+			id: 'crypto-cleaned-prices',
+			contentType: 'application/vnd.apache.parquet',
+			filename: 'crypto-cleaned-vault-prices-1d.parquet'
+		},
+		{ id: 'crypto-metadata', contentType: 'application/json', filename: 'crypto-vault-metadata.json' },
+		{
+			id: 'exchange-rates',
+			contentType: 'application/vnd.apache.parquet',
+			filename: 'exchange-rates.parquet'
+		}
+	]) {
+		test(`returns ${dataset.id} with correct headers for valid key`, async ({ request }) => {
+			const res = await request.get(`/vaults/datasets/download/${dataset.id}?api-key=${VALID_API_KEY}`);
+			expect(res.status()).toBe(200);
+			expect(res.headers()['content-type']).toBe(dataset.contentType);
+			expect(res.headers()['content-disposition']).toContain(dataset.filename);
+			expect(res.headers()['cache-control']).toBe('private, no-store');
+		});
+	}
 
 	test('proxies content-length from upstream in download response', async ({ request }) => {
 		const res = await request.get(`/vaults/datasets/download/vault-metadata?api-key=${VALID_API_KEY}`);

--- a/tests/mocks/vault-api/files.mock.ts
+++ b/tests/mocks/vault-api/files.mock.ts
@@ -73,5 +73,68 @@ export default defineMock([
 				res.end(JSON.stringify({ error: 'Forbidden' }));
 			}
 		}
+	},
+
+	/**
+	 * Crypto cleaned prices download — proxied server-side by the download endpoint.
+	 */
+	{
+		url: '/api/files/crypto-cleaned-vault-prices-1d.parquet',
+		method: 'GET',
+		response(req, res) {
+			if (isAuthorised(req)) {
+				const body = Buffer.from('PAR1crypto-prices');
+				res.statusCode = 200;
+				res.setHeader('content-type', 'application/vnd.apache.parquet');
+				res.setHeader('content-length', String(body.byteLength));
+				res.end(body);
+			} else {
+				res.statusCode = 403;
+				res.setHeader('content-type', 'application/json');
+				res.end(JSON.stringify({ error: 'Forbidden' }));
+			}
+		}
+	},
+
+	/**
+	 * Crypto vault metadata download — proxied server-side by the download endpoint.
+	 */
+	{
+		url: '/api/files/crypto-vault-metadata.json',
+		method: 'GET',
+		response(req, res) {
+			if (isAuthorised(req)) {
+				const body = JSON.stringify({ vaults: [], generated_at: new Date().toISOString() });
+				res.statusCode = 200;
+				res.setHeader('content-type', 'application/json');
+				res.setHeader('content-length', String(Buffer.byteLength(body)));
+				res.end(body);
+			} else {
+				res.statusCode = 403;
+				res.setHeader('content-type', 'application/json');
+				res.end(JSON.stringify({ error: 'Forbidden' }));
+			}
+		}
+	},
+
+	/**
+	 * Exchange rates download — proxied server-side by the download endpoint.
+	 */
+	{
+		url: '/api/files/exchange-rates.parquet',
+		method: 'GET',
+		response(req, res) {
+			if (isAuthorised(req)) {
+				const body = Buffer.from('PAR1exchange-rates');
+				res.statusCode = 200;
+				res.setHeader('content-type', 'application/vnd.apache.parquet');
+				res.setHeader('content-length', String(body.byteLength));
+				res.end(body);
+			} else {
+				res.statusCode = 403;
+				res.setHeader('content-type', 'application/json');
+				res.end(JSON.stringify({ error: 'Forbidden' }));
+			}
+		}
 	}
 ]);


### PR DESCRIPTION
## Why

Make the new Vault Pro crypto-price, crypto-metadata, and exchange-rate files discoverable and downloadable from the Vault datasets catalogue.

## Lessons learnt

The catalogue obtains file size and freshness with server-side R2 HEAD requests. Development previews must not cache the SSR catalogue response, otherwise recent edits can remain visible for up to ten minutes.

## Summary

- Add the three Vault Pro datasets, their R2 metadata lookups, and download proxy mappings.
- Add the BTC/ETH-denominated vaults context to the crypto datasets.
- Add integration coverage and mock responses for the new downloads.
- Disable catalogue caching in development while preserving the production cache policy.
- Add a changelog entry.