### PR TITLE
fix: restore risk rating card disclosure spacing

### DIFF
--- a/src/lib/top-vaults/Core3Ratings.svelte
+++ b/src/lib/top-vaults/Core3Ratings.svelte
@@ -226,6 +226,9 @@ page); omit it on the protocol page itself to render the name as plain text.
 	.content {
 		display: grid;
 		gap: 1.25rem;
+		/* The provider mark makes the disclosure header taller than text alone.
+		   Keep its opened copy at the same comfortable distance as Xerberus. */
+		margin-top: 1.25rem;
 	}
 
 	.box-header {


### PR DESCRIPTION
## Why

The deployed CORE3 disclosure places its explanatory copy directly below the taller provider-logo header. This restores the visual separation consistently on vault and protocol pages.

## Lessons learnt

Keep the implementation branch that is deployed aligned with a reviewed pull request. Shared risk-card disclosure spacing belongs on the disclosure content container, not on a single paragraph.

## Summary

- Bring the deployed unified CORE3 and Xerberus risk-card implementation into the reviewed branch.
- Add 1.25rem spacing between the CORE3 header and expanded content, matching the Xerberus card.
- Retain the shared component used by vault and protocol information pages.