### PR TITLE
fix: unify unknown vault protocol handling

### DIFF
--- a/docs/vault-data-source.md
+++ b/docs/vault-data-source.md
@@ -72,6 +72,12 @@ The public `/top-vaults/chart-data` endpoint remains for the landing-page chart,
 
 The frontend presents every raw `USD` accounting denomination as `USD (offchain)` with the `usd-offchain` slug. This includes Kinexys vaults, whose source data can instead expose a USDC settlement-token address. The normalisation happens in `src/lib/top-vaults/client.ts` before any server page, listing, or chart builder consumes the dataset. Despite the historical filename, this module is server-only because its dependency chain reads private runtime configuration. It groups all off-chain USD accounting balances together and prevents them from being presented as an on-chain stablecoin token.
 
+#### Unknown protocol identity
+
+The source export has used several values when it cannot identify a vault's underlying protocol: empty fields, angle-bracket placeholders, the literal `Unknown`, and generic or legacy slugs such as `erc-4626`. The frontend does not interpret these as evidence that a known protocol is unsupported. It classifies them as unidentified source records.
+
+`isUnknownVaultProtocol()` is the single classification path for both full vault records and slug-only consumers such as protocol-logo lookup. An explicit unknown value in either source field takes precedence, while a blank slug does not erase a recognised protocol name. During `fetchTopVaults()`, `normaliseVaultProtocol()` rewrites every recognised variant to the display name `Unknown vault protocol` and the canonical slug `unknown`. All page loaders, filters, charts, search results, metadata requests, and detail-page links therefore consume the same identity. Previously published routes using a recognised legacy placeholder slug permanently redirect to `/vaults/protocols/unknown`.
+
 #### Whitelist status
 
 Each vault may include a `whitelist` object that records whether deposits are publicly available:

--- a/docs/vault-listings.md
+++ b/docs/vault-listings.md
@@ -42,6 +42,12 @@ unchecking the control adds `amm=0` to show AMM pools. `amm=1` makes the
 default hiding explicit. The filter uses the exported feature classification,
 not a protocol-name allowlist.
 
+### Unknown protocol filter
+
+The **Unknown protocols** checkbox in the **Hide vaults** group excludes vault records whose underlying protocol was not identified by the source dataset. It does not mean that a known protocol is unsupported. Broad vault listings enable the filter by default; unchecking it adds `unknown=0` to the URL. Protocol, stablecoin, curator, fund, permissioned-vault, and provider-rating listings explicitly include unidentified records where required by their scope; the protocol detail page omits the control because hiding its own unknown-protocol group would contradict the page's purpose.
+
+Unknown-protocol classification is applied before sorting and pagination through the shared listing query. Consequently, changing the sort column—including **3M Sharpe**—cannot reintroduce unidentified records. The browser compatibility filter uses the same `isUnknownVaultProtocol()` predicate as the server query.
+
 ### Volatility filter
 
 The **Volatility** control filters the annualised three-month volatility value.

--- a/src/lib/server/top-vaults/chart-data.ts
+++ b/src/lib/server/top-vaults/chart-data.ts
@@ -4,8 +4,8 @@ import { getChain, getChainDisplayName } from '$lib/helpers/chain';
 import {
 	getProtocolDisplayName,
 	getVaultProtocolDisplayName,
-	hasSupportedProtocol,
 	isBlacklisted,
+	isUnknownVaultProtocol,
 	resolveVaultDetails
 } from '$lib/top-vaults/helpers';
 import type { VaultInfo } from '$lib/top-vaults/schemas';
@@ -152,7 +152,7 @@ export function buildYieldChartData(
 			excludedCount: base.length - included.length
 		};
 	}
-	const included = base.filter(hasSupportedProtocol);
+	const included = base.filter((vault) => !isUnknownVaultProtocol(vault));
 	return {
 		traces: groupedTraces(
 			included,
@@ -194,7 +194,7 @@ export function buildTvlChartData(
 			`3M return (ann.): ${returnLabel(vault.three_months_cagr)}`
 		].join('<br>')
 	});
-	const chartVaults = colourBy === 'chain' ? included : included.filter(hasSupportedProtocol);
+	const chartVaults = colourBy === 'chain' ? included : included.filter((vault) => !isUnknownVaultProtocol(vault));
 	const nameFor =
 		colourBy === 'chain'
 			? (vault: VaultInfo) => getChain(vault.chain_id)!.name

--- a/src/lib/top-vaults/RiskRatingsPage.svelte
+++ b/src/lib/top-vaults/RiskRatingsPage.svelte
@@ -165,6 +165,8 @@ the score in a column beside each vault name.
 	ratingProvider={provider}
 	defaultSort="provider_risk_rating"
 	defaultDirection={providerDetails.defaultDirection}
+	defaultHideUnknown={0}
+	showUnknownFilter={false}
 	{initialHasMore}
 	listingKey={provider === 'core3' ? 'core3-ratings' : 'xerberus-ratings'}
 	{listingSummary}

--- a/src/lib/top-vaults/TopVaultsTable.svelte
+++ b/src/lib/top-vaults/TopVaultsTable.svelte
@@ -70,9 +70,9 @@ The AMM checkbox hides AMM pools and AMM-like vaults on listings with Filters.
 		getVaultDenominationCurrency,
 		getVaultPeakTvlUsd,
 		getVaultTvlNative,
-		hasSupportedProtocol,
 		isAmmPoolLikeVault,
 		isBlacklisted,
+		isUnknownVaultProtocol,
 		isPoolProtocol,
 		isPermissionedVault,
 		isVaultDepositCapped,
@@ -668,7 +668,7 @@ The AMM checkbox hides AMM pools and AMM-like vaults on listings with Filters.
 			if (hideClosed && v.deposit_closed_reason != null) return false;
 
 			// Hide unknown protocol filter (checkbox-driven)
-			if (hideUnknown && !hasSupportedProtocol(v)) return false;
+			if (hideUnknown && isUnknownVaultProtocol(v)) return false;
 
 			// Hide AMM pool filter (checkbox-driven)
 			if (hideAmm && isAmmPoolLikeVault(v)) return false;

--- a/src/lib/top-vaults/client.ts
+++ b/src/lib/top-vaults/client.ts
@@ -1,7 +1,7 @@
 import { error } from '@sveltejs/kit';
 import { fetchTopVaultsRaw } from './server-config';
 import { type TopVaults, topVaultsSchema } from './schemas';
-import { normaliseOffchainUsdVaultDenomination, normaliseVaultProtocolDisplayName } from './helpers';
+import { normaliseOffchainUsdVaultDenomination, normaliseVaultProtocol } from './helpers';
 
 function getSafeErrorSummary(errorValue: unknown): string {
 	if (errorValue instanceof Error) {
@@ -17,9 +17,7 @@ export async function fetchTopVaults(fetch: Fetch): Promise<TopVaults> {
 
 		return {
 			...data,
-			vaults: data.vaults.map((vault) =>
-				normaliseVaultProtocolDisplayName(normaliseOffchainUsdVaultDenomination(vault))
-			)
+			vaults: data.vaults.map((vault) => normaliseVaultProtocol(normaliseOffchainUsdVaultDenomination(vault)))
 		};
 	} catch (e) {
 		if (e && typeof e === 'object' && 'status' in e) throw e;

--- a/src/lib/top-vaults/helpers.test.ts
+++ b/src/lib/top-vaults/helpers.test.ts
@@ -5,11 +5,9 @@ import {
 	isPermissionedVault,
 	isPoolProtocol,
 	isEligibleFrontpageVault,
-	hasSupportedProtocol,
 	getProtocolDisplayName,
 	getVaultProtocolDisplayName,
 	isUnknownVaultProtocol,
-	isUnsupportedProtocolSlug,
 	meetsMinTvl,
 	getLockupDescription,
 	getFormattedLockup,
@@ -37,7 +35,7 @@ import {
 	getXerberusScoreColour,
 	isNonUsdDenominatedVault,
 	normaliseOffchainUsdVaultDenomination,
-	normaliseVaultProtocolDisplayName,
+	normaliseVaultProtocol,
 	withVaultCurrentTvlUsd,
 	withVaultDenominationTokenRate,
 	calculateTotalTvl,
@@ -246,39 +244,6 @@ describe('calculateTotalTvl', () => {
 	});
 });
 
-describe('hasSupportedProtocol', () => {
-	test('returns true for supported protocols', () => {
-		const vault = createTestVault('Test vault', { protocol: 'Yearn' });
-		expect(hasSupportedProtocol(vault)).toBe(true);
-	});
-
-	test('returns false for unsupported protocols starting with <', () => {
-		const vault = createTestVault('Test vault', { protocol: '<protocol not yet identified>' });
-		expect(hasSupportedProtocol(vault)).toBe(false);
-	});
-
-	test('returns false for empty protocols', () => {
-		const vault = createTestVault('Test vault', { protocol: ' ' });
-		expect(hasSupportedProtocol(vault)).toBe(false);
-	});
-
-	test('returns false for unsupported protocol slugs generated from placeholders', () => {
-		const vault = {
-			protocol: 'Yearn',
-			protocol_slug: 'unknown-erc-7450'
-		};
-		expect(hasSupportedProtocol(vault)).toBe(false);
-	});
-
-	test('returns false for manually mapped unknown protocol slugs', () => {
-		const vault = {
-			protocol: 'Unknown vault protocol',
-			protocol_slug: 'erc-4626'
-		};
-		expect(hasSupportedProtocol(vault)).toBe(false);
-	});
-});
-
 describe('isEligibleFrontpageVault', () => {
 	test('returns true for known protocol vaults with severe risk or safer', () => {
 		const vault = createTestVault('Test vault', { protocol: 'Yearn', risk: 'Severe' });
@@ -305,8 +270,8 @@ describe('isEligibleFrontpageVault', () => {
 });
 
 describe('getProtocolDisplayName', () => {
-	test('aliases unidentified protocol placeholder to Unknown', () => {
-		expect(getProtocolDisplayName('<protocol not yet identified>')).toBe('Unknown');
+	test('aliases unidentified protocol placeholders to the canonical display name', () => {
+		expect(getProtocolDisplayName('<protocol not yet identified>')).toBe('Unknown vault protocol');
 	});
 
 	test('aliases ERC-4626 slug to unknown vault protocol', () => {
@@ -337,32 +302,29 @@ describe('getVaultProtocolDisplayName', () => {
 	});
 });
 
-describe('normaliseVaultProtocolDisplayName', () => {
-	test('maps ERC-4626 vault protocol display name', () => {
+describe('normaliseVaultProtocol', () => {
+	test('canonicalises both fields for an unknown-protocol variant', () => {
 		const vault = createTestVault('ERC-4626 vault', {
 			protocol: 'ERC-4626',
 			protocol_slug: 'erc-4626'
 		});
 
-		expect(normaliseVaultProtocolDisplayName(vault).protocol).toBe('Unknown vault protocol');
-	});
-});
-
-describe('isUnsupportedProtocolSlug', () => {
-	test('matches the protocol not yet identified placeholder slug', () => {
-		expect(isUnsupportedProtocolSlug('protocol-not-yet-identified')).toBe(true);
+		expect(normaliseVaultProtocol(vault)).toMatchObject({
+			protocol: 'Unknown vault protocol',
+			protocol_slug: 'unknown'
+		});
 	});
 
-	test('matches the unknown ERC-7450 placeholder slug', () => {
-		expect(isUnsupportedProtocolSlug('unknown-erc-7450')).toBe(true);
+	test('preserves a recognised protocol object', () => {
+		const vault = createTestVault('Yearn vault', { protocol: 'Yearn' });
+
+		expect(normaliseVaultProtocol(vault)).toBe(vault);
 	});
 
-	test('matches manually mapped unknown protocol slugs', () => {
-		expect(isUnsupportedProtocolSlug('erc-4626')).toBe(true);
-	});
+	test('preserves a recognised protocol when its slug is blank', () => {
+		const vault = createTestVault('Yearn vault', { protocol: 'Yearn', protocol_slug: '' });
 
-	test('ignores supported protocol slugs', () => {
-		expect(isUnsupportedProtocolSlug('yearn')).toBe(false);
+		expect(normaliseVaultProtocol(vault)).toBe(vault);
 	});
 });
 
@@ -378,15 +340,36 @@ describe('isPoolProtocol', () => {
 
 describe('isUnknownVaultProtocol', () => {
 	test.each([
-		{ protocol: 'ERC-4626', protocol_slug: 'erc-4626' },
-		{ protocol: '<protocol not yet identified>', protocol_slug: 'protocol-not-yet-identified' },
-		{ protocol: 'Unknown', protocol_slug: 'unknown' }
-	])('groups $protocol as unknown', (vault) => {
-		expect(isUnknownVaultProtocol(vault)).toBe(true);
+		['the canonical name', { protocol: 'Unknown' }],
+		['the canonical display name', { protocol: 'Unknown vault protocol' }],
+		['an empty name', { protocol: ' ' }],
+		['a placeholder name', { protocol: '<protocol not yet identified>' }],
+		['the canonical slug', { protocol_slug: 'unknown' }],
+		['the generic ERC-4626 slug', { protocol_slug: 'erc-4626' }],
+		['the unidentified placeholder slug', { protocol_slug: 'protocol-not-yet-identified' }],
+		['the unknown ERC placeholder slug', { protocol_slug: 'unknown-erc-7450' }],
+		['a blank slug without a name', { protocol_slug: ' ' }]
+	])('classifies %s as unknown', (_, identity) => {
+		expect(isUnknownVaultProtocol(identity)).toBe(true);
 	});
 
-	test('does not group a recognised protocol as unknown', () => {
+	test.each([
+		['a recognised name with a placeholder slug', { protocol: 'Yearn', protocol_slug: 'unknown-erc-7450' }],
+		['an unknown name with a recognised slug', { protocol: 'Unknown', protocol_slug: 'yearn' }]
+	])('gives an explicit unknown value precedence for %s', (_, identity) => {
+		expect(isUnknownVaultProtocol(identity)).toBe(true);
+	});
+
+	test('does not classify a recognised protocol as unknown', () => {
 		expect(isUnknownVaultProtocol({ protocol: 'Yearn', protocol_slug: 'yearn' })).toBe(false);
+	});
+
+	test('does not let a blank slug override a recognised name', () => {
+		expect(isUnknownVaultProtocol({ protocol: 'Yearn', protocol_slug: '' })).toBe(false);
+	});
+
+	test('supports slug-only callers for recognised protocols', () => {
+		expect(isUnknownVaultProtocol({ protocol_slug: 'yearn' })).toBe(false);
 	});
 });
 

--- a/src/lib/top-vaults/helpers.ts
+++ b/src/lib/top-vaults/helpers.ts
@@ -5,7 +5,6 @@ import { resolve } from '$app/paths';
 import { vaultSparklinesUrl } from '$lib/config';
 import { capitalize, isNumber } from '$lib/helpers/formatters';
 import { getChain } from '$lib/helpers/chain';
-import { slugify } from '$lib/helpers/slugify';
 import { OFFCHAIN_USD_DENOMINATION, OFFCHAIN_USD_STABLECOIN_SLUG } from '$lib/stablecoin-metadata/helpers';
 
 /**
@@ -22,9 +21,15 @@ export function slimVault(vault: Record<string, unknown>): SlimVaultInfo {
 const HYPERCORE_CHAIN_ID = 9999;
 const KINEXYS_PROTOCOL_SLUG = 'kinexys';
 export const UNKNOWN_VAULT_PROTOCOL_DISPLAY_NAME = 'Unknown vault protocol';
-/** Canonical group used for vaults whose underlying protocol is unidentified or unsupported. */
+/** Canonical group for vault records whose underlying protocol is not identified. */
 export const UNKNOWN_VAULT_PROTOCOL_SLUG = 'unknown';
-const UNKNOWN_VAULT_PROTOCOL_SLUGS = new Set(['erc-4626']);
+const UNKNOWN_VAULT_PROTOCOL_NAMES = new Set(['unknown', UNKNOWN_VAULT_PROTOCOL_DISPLAY_NAME.toLowerCase()]);
+const UNKNOWN_VAULT_PROTOCOL_SLUGS = new Set([
+	UNKNOWN_VAULT_PROTOCOL_SLUG,
+	'erc-4626',
+	'protocol-not-yet-identified',
+	'unknown-erc-7450'
+]);
 
 /**
  * Raw USD and Kinexys vault balances are denominated in off-chain USD dollars,
@@ -49,13 +54,17 @@ export function normaliseOffchainUsdVaultDenomination(vault: VaultInfo): VaultIn
 	};
 }
 
-export function normaliseVaultProtocolDisplayName(vault: VaultInfo): VaultInfo {
-	const displayName = getProtocolDisplayName(vault.protocol, vault.protocol_slug);
-	if (displayName === vault.protocol) return vault;
+/** Canonicalise every recognised unknown-protocol source variant at ingestion. */
+export function normaliseVaultProtocol(vault: VaultInfo): VaultInfo {
+	if (!isUnknownVaultProtocol(vault)) return vault;
+	if (vault.protocol === UNKNOWN_VAULT_PROTOCOL_DISPLAY_NAME && vault.protocol_slug === UNKNOWN_VAULT_PROTOCOL_SLUG) {
+		return vault;
+	}
 
 	return {
 		...vault,
-		protocol: displayName
+		protocol: UNKNOWN_VAULT_PROTOCOL_DISPLAY_NAME,
+		protocol_slug: UNKNOWN_VAULT_PROTOCOL_SLUG
 	};
 }
 
@@ -247,44 +256,31 @@ export function isPermissionedVault(vault: Pick<VaultInfo, 'whitelist'>) {
 	return vault.whitelist?.status === 'whitelisted';
 }
 
-const unsupportedProtocolNames = ['<protocol not yet identified>', '<unknown erc-7450>'] as const;
-const unsupportedProtocolSlugs = new Set([
-	...unsupportedProtocolNames.map((protocol) => slugify(protocol)),
-	...UNKNOWN_VAULT_PROTOCOL_SLUGS
-]);
-
-export function isUnsupportedProtocolName(protocol: string | null | undefined) {
-	const normalisedProtocol = protocol?.trim();
-	return !normalisedProtocol || normalisedProtocol.startsWith('<');
-}
-
-export function isUnsupportedProtocolSlug(protocolSlug: string | null | undefined) {
-	return protocolSlug != null && unsupportedProtocolSlugs.has(protocolSlug);
-}
-
 /** Return whether a protocol's vault listings should use pool terminology. */
 export function isPoolProtocol(protocolSlug: string | null | undefined): boolean {
 	return protocolSlug === 'gmx';
 }
 
-export function hasSupportedProtocol(vault: Pick<VaultInfo, 'protocol'> & Partial<Pick<VaultInfo, 'protocol_slug'>>) {
-	return !isUnsupportedProtocolName(vault.protocol) && !isUnsupportedProtocolSlug(vault.protocol_slug);
-}
-
-export function isManuallyMappedUnknownProtocolSlug(protocolSlug: string | null | undefined) {
-	return protocolSlug != null && UNKNOWN_VAULT_PROTOCOL_SLUGS.has(protocolSlug);
-}
+type VaultProtocolIdentity =
+	| { protocol: string | null | undefined; protocol_slug?: string | null }
+	| { protocol?: string | null; protocol_slug: string | null | undefined };
 
 /**
  * Whether a vault belongs in the combined unknown-protocol group.
  *
- * This includes protocol placeholders from the data source, the generic ERC-4626
- * classification, and records explicitly labelled "Unknown".
+ * This is the canonical classification path for full vaults and callers that
+ * only have a protocol slug. Explicit unknown values in either field take
+ * precedence over recognised values in the other. A blank slug alone is
+ * unknown, but does not override a recognised protocol name.
  */
-export function isUnknownVaultProtocol(vault: Pick<VaultInfo, 'protocol'> & Partial<Pick<VaultInfo, 'protocol_slug'>>) {
-	if (isManuallyMappedUnknownProtocolSlug(vault.protocol_slug)) return true;
-	if (isUnsupportedProtocolName(vault.protocol) || isUnsupportedProtocolSlug(vault.protocol_slug)) return true;
-	return vault.protocol?.trim().toLowerCase() === 'unknown';
+export function isUnknownVaultProtocol(vault: VaultProtocolIdentity): boolean {
+	const protocol = vault.protocol?.trim().toLowerCase();
+	const protocolSlug = vault.protocol_slug?.trim().toLowerCase();
+
+	if (vault.protocol !== undefined && (!protocol || protocol.startsWith('<'))) return true;
+	if (protocol && UNKNOWN_VAULT_PROTOCOL_NAMES.has(protocol)) return true;
+	if (protocolSlug && UNKNOWN_VAULT_PROTOCOL_SLUGS.has(protocolSlug)) return true;
+	return vault.protocol === undefined && !protocolSlug;
 }
 
 const FRONTPAGE_RISK_FILTER = riskFilterOptions.find((option) => option.label === 'Severe');
@@ -296,7 +292,7 @@ export function isEligibleFrontpageVault(
 	vault: Pick<VaultInfo, 'protocol' | 'risk_numeric'> & Partial<Pick<VaultInfo, 'protocol_slug' | 'risk'>>
 ) {
 	if (!FRONTPAGE_RISK_FILTER) return false;
-	if (!hasSupportedProtocol(vault)) return false;
+	if (isUnknownVaultProtocol(vault)) return false;
 	if (isBlacklisted(vault)) return false;
 	if (vault.risk_numeric == null) return false;
 
@@ -304,9 +300,8 @@ export function isEligibleFrontpageVault(
 }
 
 export function getProtocolDisplayName(protocol: string | null | undefined, protocolSlug?: string | null): string {
-	if (isManuallyMappedUnknownProtocolSlug(protocolSlug)) return UNKNOWN_VAULT_PROTOCOL_DISPLAY_NAME;
-	if (protocol == null || isUnsupportedProtocolName(protocol)) return 'Unknown';
-	return protocol;
+	if (isUnknownVaultProtocol({ protocol, protocol_slug: protocolSlug })) return UNKNOWN_VAULT_PROTOCOL_DISPLAY_NAME;
+	return protocol ?? UNKNOWN_VAULT_PROTOCOL_DISPLAY_NAME;
 }
 
 /**
@@ -630,15 +625,15 @@ const DEFAULT_DETAIL_RISK_FILTER = riskFilterOptions[1];
 /**
  * Check if vault is included in vault group (protocol/chain/curator/stablecoin)
  * mini charts and headline stats: not blacklisted, meets the minimum TVL,
- * supported protocol and within the default risk filter (unknown risk passes).
+ * has an identified protocol and is within the default detail risk threshold
+ * (unknown risk passes).
  *
- * Matches the default vault listing table filters, so stats derived from this
- * set agree with the table's initial stats row.
+ * Individual routes apply their own scope and any additional listing filters.
  */
 export function isEligibleVaultGroupMiniChartVault(vault: VaultInfo) {
 	if (isBlacklisted(vault)) return false;
 	if (!meetsMinTvl(vault)) return false;
-	if (!hasSupportedProtocol(vault)) return false;
+	if (isUnknownVaultProtocol(vault)) return false;
 
 	if (vault.risk_numeric == null) return true;
 	return (

--- a/src/lib/top-vaults/listing/definitions.ts
+++ b/src/lib/top-vaults/listing/definitions.ts
@@ -8,6 +8,7 @@ import { getChainsBySlug } from '$lib/helpers/chain';
 import {
 	DEFAULT_TVL_KEY,
 	MAX_SUMMARY_TVL_USD,
+	UNKNOWN_VAULT_PROTOCOL_SLUG,
 	isBlacklisted,
 	isPermissionedVault,
 	isUnknownVaultProtocol
@@ -165,7 +166,7 @@ export function filterVaultListingScope(vaults: VaultInfo[], key: VaultListingKe
 		case 'protocol':
 			if (!scope) return [];
 			return vaults.filter((vault) =>
-				scope === 'unknown' ? isUnknownVaultProtocol(vault) : vault.protocol_slug === scope
+				scope === UNKNOWN_VAULT_PROTOCOL_SLUG ? isUnknownVaultProtocol(vault) : vault.protocol_slug === scope
 			);
 		case 'stablecoin':
 			return scope ? vaults.filter((vault) => vault.denomination_slug === scope) : [];

--- a/src/lib/top-vaults/listing/query.test.ts
+++ b/src/lib/top-vaults/listing/query.test.ts
@@ -193,6 +193,22 @@ describe('vault listing query', () => {
 		expect(queryVaultListing([vault, pool], query, options).vaults.map((item) => item.name)).toEqual(['Vault']);
 	});
 
+	it('hides explicitly unknown protocols when sorting by three-month Sharpe', () => {
+		const known = createTestVault('Known', {
+			current_nav: 100_000,
+			three_months_sharpe: 1
+		});
+		const unknown = createTestVault('Unknown', {
+			current_nav: 100_000,
+			protocol: 'Unknown',
+			protocol_slug: 'unrelated-slug',
+			three_months_sharpe: 10
+		});
+		const query = parseVaultListingQuery(new URLSearchParams('sort=three_months_sharpe'), { tvl: '10k' });
+
+		expect(queryVaultListing([known, unknown], query, options).vaults.map((item) => item.name)).toEqual(['Known']);
+	});
+
 	it('only accepts provider rating sorting on a provider listing', () => {
 		const params = new URLSearchParams('sort=provider_risk_rating');
 

--- a/src/lib/top-vaults/listing/query.ts
+++ b/src/lib/top-vaults/listing/query.ts
@@ -17,10 +17,10 @@ import {
 	getVaultPeakTvlUsd,
 	getCore3PolForVault,
 	getVaultProtocolDisplayName,
-	hasSupportedProtocol,
 	isAmmPoolLikeVault,
 	isBlacklisted,
 	isPermissionedVault,
+	isUnknownVaultProtocol,
 	matchesVolatilityFilter,
 	monthlyReturnFilterOptions,
 	rankVaultsBy,
@@ -198,7 +198,7 @@ export function queryVaultListing(
 				return false;
 		}
 		if (query.closed && vault.deposit_closed_reason != null) return false;
-		if (query.unknown && !hasSupportedProtocol(vault)) return false;
+		if (query.unknown && isUnknownVaultProtocol(vault)) return false;
 		if (query.amm && isAmmPoolLikeVault(vault)) return false;
 		if (query.private && isPermissionedVault(vault)) return false;
 		const search = [

--- a/src/lib/vault-protocol/client.ts
+++ b/src/lib/vault-protocol/client.ts
@@ -1,10 +1,6 @@
 // Client functions for fetching vault protocol metadata
 import { vaultProtocolMetadataUrl } from '$lib/config';
-import {
-	hasSupportedProtocol,
-	isManuallyMappedUnknownProtocolSlug,
-	isUnsupportedProtocolSlug
-} from '$lib/top-vaults/helpers';
+import { isUnknownVaultProtocol } from '$lib/top-vaults/helpers';
 import { type VaultProtocolMetadata, vaultProtocolMetadataSchema } from './schemas';
 
 const CLIENT_TIMEOUT = 5000;
@@ -14,6 +10,7 @@ const CLIENT_TIMEOUT = 5000;
  *
  * @param fetch SvelteKit's fetch function
  * @param protocolSlug the protocol slug (e.g., 'lagoon-finance')
+ * @param protocolName optional protocol display name used to recognise source placeholders
  * @returns parsed metadata or undefined on failure
  */
 export async function fetchVaultProtocolMetadata(
@@ -26,11 +23,7 @@ export async function fetchVaultProtocolMetadata(
 		return undefined;
 	}
 
-	if (
-		isManuallyMappedUnknownProtocolSlug(protocolSlug) ||
-		isUnsupportedProtocolSlug(protocolSlug) ||
-		(protocolName != null && !hasSupportedProtocol({ protocol: protocolName, protocol_slug: protocolSlug }))
-	) {
+	if (isUnknownVaultProtocol({ protocol: protocolName, protocol_slug: protocolSlug })) {
 		return undefined;
 	}
 

--- a/src/lib/vault-protocol/helpers.ts
+++ b/src/lib/vault-protocol/helpers.ts
@@ -1,10 +1,10 @@
 import { vaultProtocolMetadataUrl } from '$lib/config';
 import { buildMetadataLogoProxyPath, type MetadataLogoOptions } from '$lib/metadata-logo/proxy';
-import { isUnsupportedProtocolSlug, UNKNOWN_VAULT_PROTOCOL_SLUG } from '$lib/top-vaults/helpers';
+import { isUnknownVaultProtocol } from '$lib/top-vaults/helpers';
 
 /**
  * Return the "light" version of the vault protocol logo URL for a given
- * vault slug.
+ * protocol slug.
  *
  * NOTE: there is no guarantee that a logo actually exists at this URL,
  * so the context in which this is used (e.g., <img> tag) should have
@@ -14,7 +14,7 @@ import { isUnsupportedProtocolSlug, UNKNOWN_VAULT_PROTOCOL_SLUG } from '$lib/top
  */
 export function getVaultProtocolLogoUrl(slug: string, options: MetadataLogoOptions = {}): string | undefined {
 	if (!vaultProtocolMetadataUrl) return undefined;
-	if (slug === UNKNOWN_VAULT_PROTOCOL_SLUG || isUnsupportedProtocolSlug(slug)) return undefined;
+	if (isUnknownVaultProtocol({ protocol_slug: slug })) return undefined;
 	return buildMetadataLogoProxyPath('protocol', slug, {
 		format: 'webp',
 		...options

--- a/src/routes/vaults/VaultGroupDescription.svelte
+++ b/src/routes/vaults/VaultGroupDescription.svelte
@@ -20,9 +20,9 @@ excluded vault count from the loaded vault data.
 	import {
 		calculateTotalTvl,
 		calculateTvlWeightedApy,
-		hasSupportedProtocol,
 		isBlacklisted,
 		isEligibleVaultGroupMiniChartVault,
+		isUnknownVaultProtocol,
 		getProtocolDisplayName,
 		resolveVaultDetails
 	} from '$lib/top-vaults/helpers';
@@ -53,7 +53,7 @@ excluded vault count from the loaded vault data.
 
 	let totalTvl = $derived(listingSummary?.totalTvl ?? calculateTotalTvl(statsVaults));
 	let protocolCount = $derived(
-		new SvelteSet(statsVaults.filter(hasSupportedProtocol).map((v) => v.protocol_slug)).size
+		new SvelteSet(statsVaults.filter((vault) => !isUnknownVaultProtocol(vault)).map((v) => v.protocol_slug)).size
 	);
 	// dedupe by name so the same fund deployed on multiple chains isn't repeated
 	let largestVaults = $derived.by(() => {
@@ -70,7 +70,7 @@ excluded vault count from the loaded vault data.
 	let topProtocols = $derived.by(() => {
 		const tvlByProtocol = new SvelteMap<string, { slug: string; name: string; tvl: number }>();
 		for (const vault of statsVaults) {
-			if (!hasSupportedProtocol(vault)) continue;
+			if (isUnknownVaultProtocol(vault)) continue;
 			const entry = tvlByProtocol.get(vault.protocol_slug) ?? {
 				slug: vault.protocol_slug,
 				name: getProtocolDisplayName(vault.protocol, vault.protocol_slug),

--- a/src/routes/vaults/[vault=slug]/+page.svelte
+++ b/src/routes/vaults/[vault=slug]/+page.svelte
@@ -30,9 +30,9 @@ Vault detail page with performance, protocol, private-deposit, and third-party r
 		getMorphoFlags,
 		getVaultAssetType,
 		getVaultProtocolDisplayName,
-		hasSupportedProtocol,
 		isBlacklisted,
 		isPermissionedVault,
+		isUnknownVaultProtocol,
 		isVaultDepositCapped,
 		shouldShowVaultTvlDownMoreThan95PercentWarning
 	} from '$lib/top-vaults/helpers';
@@ -55,7 +55,7 @@ Vault detail page with performance, protocol, private-deposit, and third-party r
 	let isCapped = $derived(isVaultDepositCapped(vault));
 	let showTvlWarning = $derived(shouldShowVaultTvlDownMoreThan95PercentWarning(vault));
 	let showLongDurationWarning = $derived(vault.flags.includes('long_duration'));
-	let hasUnsupportedProtocol = $derived(!hasSupportedProtocol(vault));
+	let hasUnknownProtocol = $derived(isUnknownVaultProtocol(vault));
 	let depositMayBeDisabled = $derived(vault.deposit_closed_reason != null);
 	let redemptionMayBeDisabled = $derived(vault.redemption_closed_reason != null);
 	let operationWarning = $derived(
@@ -78,7 +78,7 @@ Vault detail page with performance, protocol, private-deposit, and third-party r
 			showTvlWarning ||
 			showLongDurationWarning ||
 			showBlacklistedAlert ||
-			hasUnsupportedProtocol
+			hasUnknownProtocol
 	);
 	let chartLogoUrl = $derived(
 		getCuratorSocialLogoUrl(curatorMetadata) ??
@@ -144,11 +144,11 @@ Vault detail page with performance, protocol, private-deposit, and third-party r
 					</Alert>
 				{/if}
 
-				{#if hasUnsupportedProtocol}
-					<Alert size="md" status="warning" title="Protocol not supported">
+				{#if hasUnknownProtocol}
+					<Alert size="md" status="warning" title="Protocol not identified">
 						<div>
-							This protocol is not supported yet. Contact us on Discord for information about how to include new
-							protocols.
+							The underlying protocol has not been identified in the vault dataset yet. Contact us on Discord if you can
+							help identify it.
 						</div>
 						<Button slot="cta" size="sm" label="Join Discord" href={discordUrl} target="_blank" rel="noreferrer">
 							<IconDiscord slot="icon" />

--- a/src/routes/vaults/[vault=slug]/VaultPageHeader.svelte
+++ b/src/routes/vaults/[vault=slug]/VaultPageHeader.svelte
@@ -7,7 +7,7 @@ Displays a vault's heading, external link, update action, and description.
 	import Button from '$lib/components/Button.svelte';
 	import PageHeader from '$lib/components/PageHeader.svelte';
 	import UpdateInfoButton from '$lib/top-vaults/UpdateInfoButton.svelte';
-	import { getVaultProtocolDisplayName, hasSupportedProtocol } from '$lib/top-vaults/helpers';
+	import { getVaultProtocolDisplayName, isUnknownVaultProtocol } from '$lib/top-vaults/helpers';
 
 	interface Props {
 		vault: VaultInfo;
@@ -31,7 +31,7 @@ Displays a vault's heading, external link, update action, and description.
 		if (externalVaultUrl && new URL(externalVaultUrl).hostname === FIRA_HOSTNAME) return 'Fira';
 
 		// Other supported vaults continue to use their protocol name in the call to action.
-		if (hasSupportedProtocol(vault)) return getVaultProtocolDisplayName(vault);
+		if (!isUnknownVaultProtocol(vault)) return getVaultProtocolDisplayName(vault);
 
 		// Unknown-protocol vaults fall back to the hostname of their external destination.
 		if (externalVaultUrl) return new URL(externalVaultUrl).host;

--- a/src/routes/vaults/[vault=slug]/VaultPeriodicMetrics.svelte
+++ b/src/routes/vaults/[vault=slug]/VaultPeriodicMetrics.svelte
@@ -14,6 +14,7 @@ Performance metrics table for a vault across multiple lookback periods.
 		formatNumber,
 		notFilledMarker
 	} from '$lib/helpers/formatters';
+	import { getVaultProtocolDisplayName, isUnknownVaultProtocol } from '$lib/top-vaults/helpers';
 	import { base } from '$app/paths';
 
 	interface Props {
@@ -69,6 +70,7 @@ Performance metrics table for a vault across multiple lookback periods.
 
 	type RowDefinition = {
 		label: string | (() => string);
+		href?: string;
 		field: keyof PeriodMetrics;
 		formatter: (value: unknown) => string;
 		hidden?: boolean; // hidden until expanded
@@ -85,30 +87,35 @@ Performance metrics table for a vault across multiple lookback periods.
 	// Row definitions in display order
 	let rows: RowDefinition[] = $derived([
 		{
-			label: `<a href="${base}/vaults">Ranking overall</a>`,
+			label: 'Ranking overall',
+			href: `${base}/vaults`,
 			field: 'ranking_overall',
 			formatter: (v) => (v != null ? `#${v}` : notFilledMarker),
 			excluded: !showRankings
 		},
 		{
-			label: `<a href="${base}/vaults/chains/${chain.slug}">Ranking on ${chain.name}</a>`,
+			label: `Ranking on ${chain.name}`,
+			href: `${base}/vaults/chains/${chain.slug}`,
 			field: 'ranking_chain',
 			formatter: (v) => (v != null ? `#${v}` : notFilledMarker),
 			excluded: !showRankings
 		},
 		{
-			label: `<a href="${base}/vaults/protocols/${vault.protocol_slug}">Ranking on ${vault.protocol}</a>`,
+			label: `Ranking on ${getVaultProtocolDisplayName(vault)}`,
+			href: `${base}/vaults/protocols/${vault.protocol_slug}`,
 			field: 'ranking_protocol',
 			formatter: (v) => (v != null ? `#${v}` : notFilledMarker),
-			excluded: !showRankings || vault.protocol?.includes('<')
+			excluded: !showRankings || isUnknownVaultProtocol(vault)
 		},
 		{
-			label: '<a href="/glossary/cagr">CAGR</a> (net)',
+			label: 'CAGR (net)',
+			href: `${base}/glossary/cagr`,
 			field: 'cagr_net',
 			formatter: (v) => (hasNetFees ? formatPercentProfit(v as number | null) : notFilledMarker)
 		},
 		{
-			label: '<a href="/glossary/cagr">CAGR</a> (gross)',
+			label: 'CAGR (gross)',
+			href: `${base}/glossary/cagr`,
 			field: 'cagr_gross',
 			formatter: (v) => formatPercentProfit(v as number | null)
 		},
@@ -119,29 +126,34 @@ Performance metrics table for a vault across multiple lookback periods.
 		},
 		{ label: 'Returns (gross)', field: 'returns_gross', formatter: (v) => formatPercentProfit(v as number | null) },
 		{
-			label: '<a href="/glossary/sharpe">Sharpe</a> ratio',
+			label: 'Sharpe ratio',
+			href: `${base}/glossary/sharpe`,
 			field: 'sharpe',
 			formatter: (v) => formatKeyMetricNumber(v as number | null)
 		},
 		{
-			label: '<a href="/glossary/maximum-drawdown">Max drawdown</a>',
+			label: 'Max drawdown',
+			href: `${base}/glossary/maximum-drawdown`,
 			field: 'max_drawdown',
 			formatter: (v) => formatPercent(v as number | null)
 		},
 		{
-			label: '<a href="/glossary/volatility">Volatility</a>',
+			label: 'Volatility',
+			href: `${base}/glossary/volatility`,
 			field: 'volatility',
 			formatter: (v) => formatPercent(v as number | null),
 			hidden: true
 		},
 		{
-			label: '<a href="/glossary/total-value-locked-tvl">TVL</a> low',
+			label: 'TVL low',
+			href: `${base}/glossary/total-value-locked-tvl`,
 			field: 'tvl_low',
 			formatter: (v) => formatDollar(v as number | null),
 			hidden: true
 		},
 		{
-			label: '<a href="/glossary/total-value-locked-tvl">TVL</a> high',
+			label: 'TVL high',
+			href: `${base}/glossary/total-value-locked-tvl`,
 			field: 'tvl_high',
 			formatter: (v) => formatDollar(v as number | null),
 			hidden: true
@@ -210,7 +222,7 @@ Performance metrics table for a vault across multiple lookback periods.
 					<thead>
 						<tr>
 							<th class="label-col">Metric</th>
-							{#each periodOrder as period}
+							{#each periodOrder as period (period)}
 								<th>{periodLabels[period]}</th>
 							{/each}
 						</tr>
@@ -219,15 +231,22 @@ Performance metrics table for a vault across multiple lookback periods.
 						{#if hasAnyError}
 							<tr class="error-row">
 								<td class="label">Error</td>
-								{#each periodOrder as period}
+								{#each periodOrder as period (period)}
 									<td class="error-value">{periodMap[period]?.error_reason ?? notFilledMarker}</td>
 								{/each}
 							</tr>
 						{/if}
-						{#each visibleRows as row}
+						{#each visibleRows as row (row.field)}
 							<tr>
-								<td class="label">{@html getLabel(row)}</td>
-								{#each periodOrder as period}
+								<td class="label">
+									{#if row.href}
+										<!-- eslint-disable-next-line svelte/no-navigation-without-resolve -- href includes the configured base path -->
+										<a href={row.href}>{getLabel(row)}</a>
+									{:else}
+										{getLabel(row)}
+									{/if}
+								</td>
+								{#each periodOrder as period (period)}
 									<td>
 										{#if hasNetTransactionFees && isNetReturn(row)}
 											<Tooltip>

--- a/src/routes/vaults/protocols/[protocol=slug]/+page.server.ts
+++ b/src/routes/vaults/protocols/[protocol=slug]/+page.server.ts
@@ -1,4 +1,4 @@
-import { error } from '@sveltejs/kit';
+import { error, redirect } from '@sveltejs/kit';
 import { getCachedTopVaults } from '$lib/top-vaults/cache';
 import { loadVaultListing } from '$lib/server/top-vaults/listing';
 import { fetchVaultProtocolMetadata } from '$lib/vault-protocol/client';
@@ -13,6 +13,9 @@ import { getXerberusProtocolAssessment } from '$lib/server/top-vaults/xerberus';
 
 export async function load({ params, fetch, url }) {
 	const { protocol } = params;
+	if (protocol !== UNKNOWN_VAULT_PROTOCOL_SLUG && isUnknownVaultProtocol({ protocol_slug: protocol })) {
+		redirect(301, `/vaults/protocols/${UNKNOWN_VAULT_PROTOCOL_SLUG}${url.search}`);
+	}
 	const topVaults = await getCachedTopVaults(fetch);
 	const { vaults, core3_protocols } = topVaults;
 

--- a/src/routes/vaults/protocols/[protocol=slug]/+page.svelte
+++ b/src/routes/vaults/protocols/[protocol=slug]/+page.svelte
@@ -24,18 +24,19 @@ Vault listing and overview for one protocol.
 	let listingAssetTypePlural = $derived(`${listingAssetType}s`);
 	let listingDefaults = $derived(getVaultListingDefaults(data.listingKey, data.listingScope));
 
-	const unknownVaultDescription = 'These vaults are not yet mapped out. Contact us to have your vaults listed.';
+	const unknownVaultDescription =
+		'These vaults are listed, but their underlying protocols have not been identified in the source dataset.';
 
 	let title = $derived(
 		isUnknownVaultProtocolGroup
-			? 'Unknown vaults'
+			? 'Vaults with unidentified protocols'
 			: isPoolProtocolGroup
 				? `${protocolName} pools and yields`
 				: `${protocolName} vaults and yields`
 	);
 	let heroTitle = $derived(
 		isUnknownVaultProtocolGroup
-			? 'Unknown vaults'
+			? 'Vaults with unidentified protocols'
 			: isPoolProtocolGroup
 				? `${protocolName} powered pools`
 				: `${protocolName} powered stablecoin vaults`
@@ -58,8 +59,7 @@ Vault listing and overview for one protocol.
 </script>
 
 {#snippet unknownVaultSubtitle()}
-	These vaults are not yet mapped out. <a class="body-link" href={resolve('/community')}>Contact us</a> to have your vaults
-	listed.
+	{unknownVaultDescription}
 {/snippet}
 
 {#snippet hyperliquidChainDescription()}
@@ -83,6 +83,18 @@ Vault listing and overview for one protocol.
 	{#if isHyperliquidProtocolGroup}
 		{@render hyperliquidChainDescription()}
 	{/if}
+{/snippet}
+
+{#snippet protocolMiniChart()}
+	<VaultGroupMiniChart
+		title={`All ${protocolName} ${listingAssetTypePlural}: TVL and TVL-weighted 3-month annualised return`}
+		dataUrl="/vaults/protocols/{protocolSlug}/chart-data"
+		compareLabel="Compare all protocols"
+		compareHref="/vaults/historical-tvl-protocol"
+		returnTooltipLabel="TVL-weighted 3-month ann. return"
+		returnWindowLabel="trailing 3-month"
+		returnHistoryMonthsRequired={3}
+	/>
 {/snippet}
 
 <MetaTags
@@ -133,6 +145,7 @@ Vault listing and overview for one protocol.
 	protocolDescriptionExtra={averageMonthlyReturn != null || isHyperliquidProtocolGroup
 		? protocolDescriptionExtra
 		: undefined}
+	detailAside={isUnknownVaultProtocolGroup ? undefined : protocolMiniChart}
 	title={heroTitle}
 	subtitle={isUnknownVaultProtocolGroup ? unknownVaultSubtitle : undefined}
 	showFilters
@@ -142,18 +155,6 @@ Vault listing and overview for one protocol.
 	defaultDirection={listingDefaults.direction}
 	defaultHideUnknown={(listingDefaults.unknown ?? true) ? 1 : 0}
 >
-	{#snippet detailAside()}
-		<VaultGroupMiniChart
-			title="All {protocolName} {listingAssetTypePlural}: TVL and TVL-weighted 3-month annualised return"
-			dataUrl="/vaults/protocols/{protocolSlug}/chart-data"
-			compareLabel="Compare all protocols"
-			compareHref="/vaults/historical-tvl-protocol"
-			returnTooltipLabel="TVL-weighted 3-month ann. return"
-			returnWindowLabel="trailing 3-month"
-			returnHistoryMonthsRequired={3}
-		/>
-	{/snippet}
-
 	{#snippet beforeTable()}
 		{#if core3}
 			<Core3Ratings {core3} {protocolName} />

--- a/tests/integration/vaults/protocol-detail.test.ts
+++ b/tests/integration/vaults/protocol-detail.test.ts
@@ -10,6 +10,15 @@ async function openFilters(page: import('@playwright/test').Page) {
 }
 
 test.describe('vault protocol detail pages', () => {
+	test('redirects legacy unknown-protocol slugs to the canonical group', async ({ page }) => {
+		await page.goto('/vaults/protocols/protocol-not-yet-identified?sort=tvl');
+
+		await expect(page).toHaveURL('/vaults/protocols/unknown?sort=tvl');
+		await expect(page).toHaveTitle('Vaults with unidentified protocols');
+		await expect(page.getByRole('heading', { level: 1 })).toHaveText('Vaults with unidentified protocols');
+		await expect(page.getByText('No chart data available.')).not.toBeVisible();
+	});
+
 	test('shows GMX AMM pools by default and identifies an AMM vault as a pool', async ({ page }) => {
 		await page.goto('/vaults/protocols/gmx');
 


### PR DESCRIPTION
## Why

The unknown-protocol filter used a narrower predicate than grouping, so records labelled `Unknown` could leak back into listings when sorted by 3M Sharpe. Multiple source representations and support-oriented wording also caused inconsistent UI behaviour and misleading explanations.

## Lessons learnt

- Unknown protocol identity must be classified before sorting and pagination through one shared predicate.
- Canonicalising source aliases at ingestion requires redirects for previously published legacy slugs.
- A missing slug must not erase a recognised protocol name, while an explicit unidentified value must take precedence.
- Unidentified protocol records should not expose protocol ranking links or empty protocol mini charts.

## Summary

- Centralise unknown protocol classification and canonicalise recognised names and slugs at ingestion.
- Use the shared classification for listings, charts, metadata, logos, grouping, rankings, and detail pages.
- Correct unidentified-protocol copy, preserve legacy URLs with permanent redirects, and remove unsafe HTML metric labels.
- Document the source variants and filter semantics, with unit and browser regression coverage.