### PR TITLE
fix: label YieldBasis listings as pools

### DIFF
--- a/src/lib/top-vaults/helpers.test.ts
+++ b/src/lib/top-vaults/helpers.test.ts
@@ -329,8 +329,8 @@ describe('normaliseVaultProtocol', () => {
 });
 
 describe('isPoolProtocol', () => {
-	test('identifies GMX as a pool protocol', () => {
-		expect(isPoolProtocol('gmx')).toBe(true);
+	test.each(['gmx', 'yieldbasis'])('identifies %s as a pool protocol', (protocolSlug) => {
+		expect(isPoolProtocol(protocolSlug)).toBe(true);
 	});
 
 	test('does not classify other protocols as pool protocols', () => {

--- a/src/lib/top-vaults/helpers.ts
+++ b/src/lib/top-vaults/helpers.ts
@@ -258,7 +258,7 @@ export function isPermissionedVault(vault: Pick<VaultInfo, 'whitelist'>) {
 
 /** Return whether a protocol's vault listings should use pool terminology. */
 export function isPoolProtocol(protocolSlug: string | null | undefined): boolean {
-	return protocolSlug === 'gmx';
+	return protocolSlug === 'gmx' || protocolSlug === 'yieldbasis';
 }
 
 type VaultProtocolIdentity =


### PR DESCRIPTION
## Why
YieldBasis vault listings represent pools and should use pool terminology, consistent with GMX.

## Lessons learnt
Protocol listing terminology is centralised in `isPoolProtocol`, which also keeps page metadata and table labels consistent.

## Summary
- Mark YieldBasis as a pool protocol.
- Add helper coverage for YieldBasis.