### PR TITLE
feat: add multi-vault equity comparison

### DIFF
--- a/.claude/plans/multi-vault-equity-comparison.md
+++ b/.claude/plans/multi-vault-equity-comparison.md
@@ -1,0 +1,408 @@
+# Multi-vault equity curve comparison
+
+## Goal
+
+Add a vault chart page where a user can search for several vaults, add or
+remove them from a comparison, and display their indexed equity curves on one
+TradingView lightweight-charts time series. The page also offers independently
+selectable US Treasury, ETH, and BTC benchmarks with fixed colours.
+
+The comparison must remain meaningful when vaults started at different times:
+the oldest selected vault begins at an index value of 100, and each younger
+vault begins at the highest already-active equity curve value at its own first
+observation. The page must not invent history before a vault's first real price
+sample.
+
+> Implementation note (2026-09-01): Later product decisions superseded parts
+> of the original proposal below. The page heading is "Compare vaults", defaults
+> to Savings USDS with T-Bill, ETH, and BTC enabled, offers 1M/3M/6M/1Y/Max
+> ranges, and reuses `Search.svelte` directly through formatting props and an
+> optional add-button snippet. An explicit `comparison=empty` query parameter
+> distinguishes a user-cleared selection from the default state. Accepted
+> search actions clear the input and close the suggestion panel.
+
+## Product decisions and scope
+
+- Add the page initially at `/vaults/compare` with the heading "Compare vaults"
+  and include it in both vault chart navigation surfaces.
+- Treat normal vaults, tokenised funds, and blacklisted vaults as valid URL
+  selections, but exclude vaults below $1,000 current TVL from search results.
+  Preserve the existing warning styling for eligible blacklisted search
+  results. A selected record which has no parquet rows follows the same
+  explicit "Equity history unavailable" path as any other vault.
+- Keep selected vault IDs and enabled benchmarks in the query string so a
+  comparison can be shared, refreshed, and restored through browser history.
+  Preserve vault insertion order because it participates in alignment and
+  legend order.
+- Propose a visible limit of eight selected vaults. Keep this in one exported
+  constant shared by the page, query parser, and data endpoint; the limit keeps
+  the chart, crosshair tooltip, URL, DuckDB query, and distinct-colour palette
+  bounded. If product wants another limit, change the constant and palette
+  together rather than silently truncating selections.
+- Start with Savings USDS and all three benchmarks selected unless the URL
+  contains explicit comparison state. Show an explanatory empty state after a
+  user removes all vaults; benchmarks need a selected vault's time range, so
+  the chart cannot render them alone.
+- Offer `1M`, `3M`, `6M`, `1Y`, and `Max` range controls and crosshair
+  behaviour. This page is an indexed equity comparison only: do not add the
+  detail page's TVL histogram, featured metrics, perpetual-vault classification,
+  or drawdown pane.
+
+## Current implementation to reuse
+
+- `src/lib/top-vaults/VaultPriceChart.svelte` is the visual reference. It uses
+  `ChartContainer`, lightweight-charts `Series`, a crosshair tooltip, range
+  controls, and a footer legend, but it assumes exactly one vault and couples
+  the price pane to TVL, drawdown, and automatic benchmark selection.
+- `src/routes/vaults/[vault=vaultId]/metrics/+server.ts` reads hourly
+  `share_price` data from `cleaned-vault-prices-1h.parquet`. Calling this route
+  once per selection would open several DuckDB connections and scan the same
+  parquet repeatedly, so the comparison needs a bounded batch endpoint.
+- `CoinbaseBenchmarkSeries.svelte`, `coinbase.ts`,
+  `TreasuryBenchmarkSeries.svelte`, and `treasury-benchmark.ts` already provide
+  the BTC, ETH, and US 3-month T-bill data paths, caching, resampling, and
+  benchmark metadata. Extract shared transformation pieces rather than adding
+  new upstream integrations.
+- `src/lib/search/components/Search.svelte` already implements debounced search,
+  cancellation, keyboard selection, responsive presentation, and result
+  rendering. It currently hard-codes navigation, the full mixed-entity index,
+  a site-search form, and a single DOM listbox ID, so it cannot safely be placed
+  on the comparison page unchanged.
+- `searchVaultEntities()` already builds public vault records containing the
+  internal `vaultId`, canonical detail link, logo, protocol, chain, APY, and
+  TVL. Extend its options rather than loading the complete top-vaults export in
+  the browser.
+
+## Proposed architecture
+
+### 1. Add canonical comparison state
+
+Create a small browser-safe module such as
+`src/lib/top-vaults/equity-comparison/state.ts` containing:
+
+- `MAX_SELECTED_VAULTS` and the benchmark keys `treasury`, `eth`, and `btc`;
+- a typed `EquityComparisonState` with ordered, unique vault IDs and a set/list
+  of enabled benchmark keys;
+- parsing and serialising helpers using repeated parameters
+  (`vault=<encoded ID>&vault=<encoded ID>` and
+  `benchmark=treasury&benchmark=btc`), avoiding assumptions about characters
+  allowed inside a vault ID;
+- canonicalisation that trims values, removes duplicates while retaining the
+  first occurrence, rejects unknown benchmark keys, and enforces the visible
+  selection limit.
+
+Use this module from the page loader, client interactions, and chart-data
+endpoint. Make canonicalisation idempotent: serialising already-canonical state
+must produce byte-identical ordered parameters. The server loader should
+compare only the raw repeated `vault` values to the resolved canonical vault
+list and perform at most one 307 redirect, preserving unrelated parameters,
+when duplicates, unknown IDs, or over-limit values are present. Canonicalise
+the fixed benchmark list client-side with one guarded `replaceState` only when
+the serialised value differs, preventing redirect/effect loops.
+
+Query changes should use SvelteKit `goto` with `replaceState: true`,
+`noScroll: true`, and `keepFocus: true`; do not make every checkbox click a new
+browser-history entry. The server load should resolve selected-vault metadata
+from `vault` parameters. It may inspect whether a `benchmark` parameter exists
+only while deciding whether an otherwise empty URL represents an explicit
+state; when vaults are selected, short-circuit before that access so
+benchmark-only changes reuse the existing page data. Add an integration
+assertion that a benchmark-only URL update does not request fresh selected-vault
+metadata.
+
+Add `src/routes/vaults/compare/+page.server.ts` to resolve selected IDs against
+`getCachedTopVaults(fetch)`. Return a compact projection for the selected cards
+and only the selected full vault rows plus their referenced curators for the
+shared comparison table. Unknown or stale IDs should be removed through the
+single canonical redirect, not cause a 500. Do not embed the complete vault
+export or any price history in the HTML.
+
+### 2. Refactor search into a reusable typeahead
+
+Refactor the search code without changing the existing header or `/search`
+page behaviour:
+
+- Extend `SearchOptions` in `src/lib/search/vault-search.server.ts` with an
+  allowed entity-type filter. Apply it before ranking/limiting so group results
+  cannot displace vault matches.
+- Add a small validated `scope=all|vaults` parameter to
+  `/search/suggestions`; keep `all` as the default and map `vaults` to
+  `vault`, `tokenised-fund`, and `blacklisted-vault`. Avoid accepting arbitrary
+  unbounded type strings that fragment the public cache.
+- Keep the common combobox behaviour and result row in `Search.svelte`, which
+  owns query debouncing, aborting stale requests, loading/error/empty states,
+  arrow-key navigation, Enter/Escape handling, and WAI-ARIA wiring.
+- Generate per-instance input, listbox, and option IDs with `$props.id()` so the
+  header search and page picker can coexist without duplicate IDs.
+- Add page-formatting props and an optional `addButton` snippet to
+  `Search.svelte`. The comparison page requests `scope=vaults`, supplies its Add
+  action, marks selected results as disabled, and explains when the selection
+  limit is reached. Clicking or pressing Enter on a result invokes that action
+  rather than navigating, then clears the query and closes the result panel.
+
+Keep result metrics, logos, protocol/chain context, address matching, and
+blacklisted styling shared. Do not duplicate the server-side search index or
+fetch the full vault catalogue for a client-side picker.
+
+### 3. Add a batched price-series endpoint
+
+Add `src/routes/vaults/compare/chart-data/+server.ts` and move the common
+DuckDB/parquet query code out of the single-vault metrics route into a
+server-only helper such as `src/lib/server/top-vaults/vault-price-series.ts`.
+
+The comparison endpoint should:
+
+- parse the canonical ordered vault IDs and reject an empty, malformed, or
+  over-limit request with a typed 400;
+- resolve IDs against the current cached top-vault dataset before querying, so
+  stale IDs can be returned explicitly and arbitrary values do not expand the
+  SQL shape;
+- open one DuckDB connection and use parameterised placeholders in one ordered
+  `WHERE id IN (...)` query for `timestamp` and `share_price`;
+- order by vault ID and timestamp, discard non-finite/non-positive samples, and
+  return a typed array of `{ id, points }` plus any requested IDs with no price
+  history;
+- regroup the SQL rows and explicitly project the response back into the
+  caller's requested-ID order; SQL ordering exists for efficient grouping and
+  is not the public series-order contract;
+- always close the connection in `finally`, retain the existing parquet refresh
+  behaviour, and use a bounded response/cache policy consistent with how often
+  the hourly parquet can update.
+
+Refactor `/vaults/[vault=vaultId]/metrics` to call the same helper while keeping
+its existing `{ price, tvl, utilisation }` response contract. The helper may
+accept a column selection so the comparison route does not read or serialise
+TVL/utilisation. This prevents the new page and detail page queries from
+drifting without breaking existing consumers.
+
+On the client, issue one comparison request for the current ordered selection.
+Abort or ignore stale responses after selections change. Keep previously
+rendered curves visible during a refresh, show a non-destructive loading state,
+and provide retry when the batch fails. A vault with no history remains in the
+selected list with an "Equity history unavailable" status and is omitted from
+the plotted series.
+
+### 4. Define and test the equity alignment algorithm
+
+Create pure functions in
+`src/lib/top-vaults/equity-comparison/equity-curves.ts`; keep alignment out of
+the Svelte component so its financial behaviour can be tested directly.
+
+Prepare the series as follows:
+
+1. Sort and de-duplicate each vault's valid samples by timestamp.
+2. Sort vault series by their first timestamp, using selected-list order only as
+   the deterministic tie-breaker.
+3. Group vaults with the same first timestamp so their alignment cannot depend
+   on processing order inside that cohort.
+4. Set every member of the oldest cohort to an equity index of 100 at its first
+   sample: `indexed = rawPrice / firstRawPrice * 100`.
+5. For each younger cohort, inspect every already-aligned older series whose
+   observed range covers the younger cohort's first timestamp. Use that older
+   series' most recent real/resampled value at or before the timestamp and take
+   the maximum as the cohort anchor.
+6. Scale each younger series from its own first valid price:
+   `indexed = rawPrice / firstRawPrice * anchor`. Never emit points before its
+   first observation.
+7. If no older curve overlaps the younger start, fall back to 100 and attach a
+   discontinuity flag for the tooltip/legend; do not indefinitely forward-fill
+   a finished vault merely to manufacture an anchor.
+
+Run this alignment over the complete selected histories before applying the
+visible window. Changing the range must only clip/resample the result, not
+change a vault's anchor or recolour the series. Recompute all anchors when a
+vault is added or removed because that can legitimately change which older
+curve supplies a younger vault's highest starting point.
+
+Each plotted point should contain only its timestamp and indexed value;
+alignment status belongs to the series. Label the Y-axis and tooltips as an
+equity index rather than a token price; share prices from different
+denominations must never be compared directly.
+
+### 5. Build the multi-series chart and benchmarks
+
+Add a focused component such as
+`src/lib/top-vaults/equity-comparison/VaultEquityComparisonChart.svelte` using
+the same `ChartContainer`, `Series`, time-span, formatting, and tooltip
+primitives as the current vault detail chart.
+
+- Render every aligned vault as a two-pixel line on the primary pane. Do not use
+  the detail chart's direction-driven bullish/bearish colour, which would make
+  multiple vaults indistinguishable.
+- Define an accessible vault colour palette that deliberately avoids the three
+  fixed benchmark colours. Assign the first unused palette entry when a vault
+  is added, retain existing assignments when another vault is removed, and
+  rebuild deterministically from URL order on a fresh load.
+- Put the colour constants in one module and reuse them for chart lines,
+  selected-vault rows, checkboxes, legend swatches, and tooltip markers.
+- Keep the established benchmark colours unless design review changes them:
+  US Treasury `#4a90d9a0`, BTC `#f7931a80`, and ETH `#627eea80`. Benchmark
+  colours never depend on price direction or selection order.
+- Start enabled benchmarks at index 100 on the oldest selected vault's first
+  observation. Fetch all enabled benchmarks over the complete comparison date
+  range, transform BTC/ETH closes into indexed cumulative returns, and use
+  `ratesToCumulativeReturn()` for Treasury compounding. Then clip them with the
+  same visible range as vault curves.
+- Treat the comparison start/end as part of each benchmark request/cache key.
+  Adding or removing the oldest/most-recent vault can expand or contract that
+  range, so abort the obsolete request, refetch or reuse the correctly keyed
+  data, and re-index the benchmark from the new global start before applying
+  it. Never retain a benchmark anchored to the previous selection range.
+- Extract/reuse a pure price-index transformation from
+  `CoinbaseBenchmarkSeries.svelte`; adapt the existing benchmark components or
+  add a generic indexed benchmark series rather than duplicating fetch/cache
+  logic. The vault detail chart must retain its current visible-range rebasing
+  behaviour.
+- Load each enabled benchmark independently. A FRED or Coinbase failure should
+  mark only that checkbox/legend entry unavailable and leave all vaults and
+  other benchmarks usable. Disabling a benchmark removes its series and
+  ignores any late request result.
+- Use a compact, single-column crosshair tooltip with date plus one marked row
+  per available vault/benchmark. Keep names truncated with accessible full
+  labels so the tooltip stays readable and not overly wide, including on small
+  viewports.
+
+### 6. Compose the page and navigation
+
+Create `src/routes/vaults/compare/+page.svelte` with the repository's page
+comment and existing chart-page shell:
+
+- metadata/JSON-LD, `VaultListingsSelector`, a concise `HeroBanner`, chart
+  section, and `ScatterPlotSelector`;
+- the inline vault picker;
+- a selected-vault list with colour swatch, name, protocol/chain context,
+  canonical detail link, data status, and an explicitly labelled Remove button;
+- a `fieldset` of three independent fixed-colour benchmark checkboxes; and
+- chart loading, empty, partial-data, error, and retry states that do not shift
+  or erase the selection controls.
+
+Use responsive wrapping/stacking and the existing semantic theme tokens. Avoid
+hard-coded surface/text colours outside the deliberately fixed series palette.
+Ensure all controls are keyboard reachable, checkbox state is announced, focus
+returns sensibly after removing a row, and the search input remains focused
+until an Add action is accepted. Adding a vault clears the query and closes the
+suggestion panel.
+
+Add the page link to both:
+
+- `src/lib/top-vaults/VaultListingsSelector.svelte` (`chartLinks`); and
+- `src/lib/scatter-plot/ScatterPlotSelector.svelte` (`charts`).
+
+Update chart navigation integration assertions and `docs/chart-pages.md` so the
+new route, lightweight-charts choice, and data flow are discoverable.
+
+## Verification
+
+### Unit and component tests
+
+- State parser/serialiser round trips, duplicate removal, order preservation,
+  invalid benchmark removal, unknown vault handling, and selection-limit
+  enforcement.
+- Equity alignment with one vault; differently dated vaults; same-start
+  cohorts; a younger vault anchored to the highest overlapping curve; sparse
+  timestamps; non-positive/invalid points; non-overlapping histories; and
+  removal-triggered realignment.
+- Range changes clip already-aligned data without changing anchors.
+- Benchmark indexing starts at 100 on the global comparison start, and the
+  three fixed colours never collide with the vault palette. Adding an older
+  vault widens the benchmark request range and re-indexes the enabled benchmark
+  from the new start.
+- Batch helper returns each requested series in request order, parameterises
+  IDs, reports missing histories, filters bad prices, and closes DuckDB on both
+  success and failure.
+- Search type filtering occurs before result limiting, while the default
+  site-wide results and diversified ranking remain unchanged.
+- Reusable search component preserves debounce/cancellation, unique ARIA IDs,
+  keyboard selection, site navigation mode, add mode, selected-result disabling,
+  query clearing, and limit messaging.
+
+### Integration tests
+
+Add a focused Playwright fixture/spec for `/vaults/compare` that verifies:
+
+- the empty state and all three benchmark checkboxes;
+- searching returns vault entities only and selecting one adds it without
+  navigating away;
+- multiple vaults produce distinct line/legend colours and one batched chart
+  request;
+- a younger fixture starts at the highest older curve value at that timestamp
+  and has no points before its own history begins;
+- removing a vault updates the URL, list, legend, and aligned chart while
+  preserving the remaining controls;
+- Treasury, ETH, and BTC can be toggled independently and use their fixed
+  colours;
+- refresh and back/forward navigation restore canonical selected state;
+- missing vault history and one failed benchmark show partial failure states
+  without clearing successful curves; and
+- mobile/tablet layouts keep the picker, remove controls, legend, and tooltip
+  readable.
+
+Update existing search integration tests to prove the header search still
+navigates across every entity type and update chart menu/selector link counts.
+Keep the two data layers deterministic without depending on live/private R2
+data:
+
+- helper/endpoint Vitest coverage creates a temporary parquet with DuckDB and
+  passes its explicit local path through the shared helper's injectable
+  `parquetFile`/resolver option; and
+- Playwright fulfils the client-side batch chart-data request with known
+  multi-vault JSON containing deliberately staggered starts, while separate
+  route tests cover validation and response shaping.
+
+Do not write the test parquet to the application's normal `data/` cache or rely
+on `TS_PRIVATE_VAULT_PRICES_PARQUET_URL`, as either can leak state between
+integration workers.
+
+Run focused tests first, then:
+
+```shell
+pnpm run format
+pnpm run check
+pnpm run test:unit --run
+pnpm run test:integration
+```
+
+For manual verification, follow `.claude/docs/worktree.md`, start the Vite
+development server with `pnpm run dev`, and use Playwright against
+`http://127.0.0.1:5173/vaults/compare`. Do not use Vite preview for manual
+route validation.
+
+## Implementation sequence
+
+1. Add canonical comparison state and pure equity-index/alignment functions
+   with unit tests.
+2. Extract the shared server-side parquet query and add the bounded batch
+   chart-data endpoint without changing the detail metrics response.
+3. Add search scope filtering, extract the reusable typeahead/result row, and
+   preserve the header search through component and integration tests.
+4. Build the inline vault picker and selected-vault/benchmark controls with URL
+   state.
+5. Build the multi-series chart, colour registry, benchmark transformations,
+   tooltip, and partial-failure handling.
+6. Compose the route, metadata, responsive states, and both navigation links.
+7. Add multi-vault integration fixtures/tests, update documentation and the
+   dated `CHANGELOG.md` entry required for a feature PR, format, and run the
+   full verification commands. Confirm `/vaults/compare` wins over the
+   dynamic vault-detail matcher in both Vite development and the adapter-node
+   production build.
+
+## Acceptance criteria
+
+- A user can search for, add, and remove vaults without leaving the comparison
+  page; already-selected results cannot be added twice.
+- Selected vaults are shown together as indexed equity curves with distinct,
+  stable colours, and the selection is recoverable from the URL.
+- The oldest vault starts at 100. Every younger overlapping vault starts at the
+  highest older equity value available at its first observation, with no
+  invented pre-start data; non-overlap fallback is explicit.
+- US Treasury, ETH, and BTC are independent checkboxes and always use their
+  fixed colours in the control, chart, legend, and tooltip.
+- Price history is loaded through one bounded, parameterised DuckDB query per
+  selection change rather than one parquet scan per vault.
+- The shared search endpoint filters to vault entities before limiting results,
+  while existing site-wide search behaviour and accessibility remain intact.
+- Stale requests, missing price history, or a failed benchmark cannot overwrite
+  newer state or remove successful curves.
+- The page is present in both chart navigation surfaces, works at desktop and
+  mobile sizes, and has focused unit and Playwright coverage using deterministic
+  local fixtures.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Weblog of stuff
 
+- Add multi-vault equity curve comparison with T-bill, ETH, and BTC benchmarks (2026-09-01)
 - Add Spotify and podcast-focused community links, and refine community and blog landing-page copy (2026-08-31)
 - Add Vault Pro crypto price, metadata, and exchange-rate datasets (2026-08-28)
 - Add an AMM filter to vault listings and pool terminology on detail pages (2026-08-27)

--- a/docs/chart-pages.md
+++ b/docs/chart-pages.md
@@ -40,6 +40,10 @@ benchmarks in repeated URL parameters, and preserves an intentionally empty
 selection with `comparison=empty`. Selected vaults also appear in the shared
 top-vaults table below the chart.
 
+The URL is the authoritative comparison state. Vault and benchmark choices are
+canonicalised on the server and survive reloads, so copying the current URL
+recreates the same selection for another user.
+
 The T-bill line uses FRED's DGS3MO 3-month constant-maturity Treasury market
 yield, quoted on an investment basis, as a cumulative-return approximation.
 

--- a/docs/chart-pages.md
+++ b/docs/chart-pages.md
@@ -35,14 +35,15 @@ below $1,000 current TVL. An accepted Add action clears the query and closes
 the suggestion panel.
 
 The page defaults to Savings USDS with the T-bill, ETH, and BTC benchmarks
-enabled. It supports up to eight vaults, stores the ordered selection and
-benchmarks in repeated URL parameters, and preserves an intentionally empty
-selection with `comparison=empty`. Selected vaults also appear in the shared
-top-vaults table below the chart.
+enabled. It supports up to eight vaults and stores the ordered selection,
+benchmarks, and selected chart period in URL parameters. The `period` parameter
+is always explicit, including the default `period=3M`, and an intentionally
+empty vault selection is preserved with `comparison=empty`. Selected vaults
+also appear in the shared top-vaults table below the chart.
 
-The URL is the authoritative comparison state. Vault and benchmark choices are
-canonicalised on the server and survive reloads, so copying the current URL
-recreates the same selection for another user.
+The URL is the authoritative comparison state. Vault, benchmark, and period
+choices are canonicalised on the server and survive reloads, so copying the
+current URL recreates the same chart for another user.
 
 The T-bill line uses FRED's DGS3MO 3-month constant-maturity Treasury market
 yield, quoted on an investment basis, as a cumulative-return approximation.

--- a/docs/chart-pages.md
+++ b/docs/chart-pages.md
@@ -6,6 +6,7 @@ This document describes chart pages and chart navigation in the Trading Strategy
 
 The vault chart pages linked from the top `Charts` menu are:
 
+- `/vaults/compare` - user-selected vault equity curves with optional US Treasury, ETH, and BTC benchmarks.
 - `/vaults/cumulative-tvl-apy` - cumulative vault TVL by annualised return, with benchmark lines.
 - `/vaults/yield-risk` - vault annualised return by TVL, grouped by risk level.
 - `/vaults/yield-protocol` - vault annualised return by TVL, grouped by protocol.
@@ -25,6 +26,31 @@ Related vault list pages also include charts:
 
 The home page vault ecosystem chart reuses the cumulative TVL / APY ECharts renderer through `src/routes/_components/VaultEcosystemChartECharts.svelte`.
 
+### Vault comparison
+
+`/vaults/compare` uses the shared `Search.svelte` result presentation as an
+in-page vault selector. Suggestions include the same logos, protocol and chain
+context, APY, TVL, and sparkline shown by site-wide search, but exclude vaults
+below $1,000 current TVL. An accepted Add action clears the query and closes
+the suggestion panel.
+
+The page defaults to Savings USDS with the T-bill, ETH, and BTC benchmarks
+enabled. It supports up to eight vaults, stores the ordered selection and
+benchmarks in repeated URL parameters, and preserves an intentionally empty
+selection with `comparison=empty`. Selected vaults also appear in the shared
+top-vaults table below the chart.
+
+The T-bill line uses FRED's DGS3MO 3-month constant-maturity Treasury market
+yield, quoted on an investment basis, as a cumulative-return approximation.
+
+The chart is labelled **Vault returns index**. The oldest selected vault starts
+at 100; each younger vault starts at the highest older curve that overlaps its
+first observation. A non-overlapping history starts at 100 and is marked in the
+legend. The 1M, 3M, 6M, 1Y, and Max controls drive both the visible range and
+the CAGR/Since values shown on selected-vault cards. T-bill, ETH, and BTC use
+fixed colours, while vaults receive stable, distinct colours for the current
+selection.
+
 ## Data flow
 
 Most vault chart pages read from the top-vaults dataset, not from page-specific backend APIs.
@@ -37,6 +63,9 @@ The common data sources are:
 - Client-side `fetch()` from `+page.svelte` for pages that opt out of SSR or need lazy chart data loading.
 - `+page.server.ts` for pages that can prepare their data during server rendering.
 - Vault detail metrics endpoints such as `/vaults/[vault]/metrics` for time-series data.
+- `/vaults/compare/chart-data` for a bounded, cached payload containing only the selected vaults. The endpoint performs
+  equity alignment, four-hour/daily resampling, benchmark fetching, and benchmark indexing on the server; the browser
+  receives chart-ready points rather than raw vault share-price histories.
 
 Before this dataset reaches chart payload builders, raw USD and Kinexys accounting denominations are normalised to the single `USD (offchain)` / `usd-offchain` group. Charts must use this normalised metadata and must not add provider-specific off-chain USD series.
 

--- a/docs/search.md
+++ b/docs/search.md
@@ -4,7 +4,7 @@
 
 The site-wide vault search is implemented in SvelteKit and searches the vault JSON data already used by the frontend.
 
-Search is available from the desktop navigation, the compact mobile navigation and the server-rendered [`/search`](/search) page. The full results page is a normal GET form, so links such as `/search?q=USDC` work without client-side JavaScript.
+Search is available from the desktop navigation, the compact mobile navigation, the vault-comparison selector, and the server-rendered [`/search`](/search) page. The full results page is a normal GET form, so links such as `/search?q=USDC` work without client-side JavaScript.
 
 ## Searchable entities and results
 
@@ -32,6 +32,13 @@ On desktop, interacting outside the search closes the quick-results panel.
 
 Desktop vault suggestions and full results show the 90-day price mini-map when chart data is available. Aggregate entities do not show a mini-map.
 
+The component also supports an in-page selector format. Callers can restrict
+results to vault entity types, apply a minimum current-TVL threshold, customise
+labels and placeholders, hide the full-results link, and supply an optional
+`addButton` snippet. When an action is supplied, clicking a result row or
+pressing Enter activates that action instead of navigating. The action callback
+clears the query and closes the suggestions after an accepted selection.
+
 ## Data and caching
 
 The index combines `getCachedTopVaults()` with stablecoin metadata. It is held in server memory for two minutes and is rebuilt early when the vault dataset's `generated_at` value changes. The suggestions response is publicly cacheable for 60 seconds.
@@ -46,7 +53,7 @@ The home page retains WebSite `SearchAction` structured data pointing to `/searc
 
 ## Tests
 
-`tests/integration/search.test.ts` covers desktop and mobile typeahead, the mobile navigation drawer, the result page, address lookup, blacklisted vault treatment, sortable entity types, desktop-only mini-maps, and all supported entity types. Vault-listing integration tests confirm the old in-listing search control remains absent.
+`tests/integration/search.test.ts` covers desktop and mobile typeahead, the mobile navigation drawer, the result page, address lookup, blacklisted vault treatment, sortable entity types, desktop-only mini-maps, and all supported entity types. `tests/integration/vaults/equity-compare.test.ts` covers the selector format and Add action at desktop, tablet, and mobile widths. Vault-listing integration tests confirm the old in-listing search control remains absent.
 
 Use:
 

--- a/docs/vault-data-source.md
+++ b/docs/vault-data-source.md
@@ -4,11 +4,11 @@ The frontend reads two server-side vault datasets and one external reference rat
 
 ## Datasets
 
-| Dataset              | Source                                | Local cache path                        | Used by                                                  |
-| -------------------- | ------------------------------------- | --------------------------------------- | -------------------------------------------------------- |
-| Top vaults JSON      | R2: `top_vaults_by_chain.json`        | In-memory (1-hour TTL)                  | Vault pages, strategy metadata, search, and summaries    |
-| Vault prices parquet | R2: `cleaned-vault-prices-1h.parquet` | `data/cleaned-vault-prices-1h.parquet`  | Share price chart, TVL charts, historical TVL aggregates |
-| Treasury benchmark   | FRED CSV: `DTB3` series               | `~/.cache/ts-frontend/fred-DTB3-*.json` | US 3M T-bill benchmark line on non-perp vault charts     |
+| Dataset              | Source                                | Local cache path                          | Used by                                                  |
+| -------------------- | ------------------------------------- | ----------------------------------------- | -------------------------------------------------------- |
+| Top vaults JSON      | R2: `top_vaults_by_chain.json`        | In-memory (1-hour TTL)                    | Vault pages, strategy metadata, search, and summaries    |
+| Vault prices parquet | R2: `cleaned-vault-prices-1h.parquet` | `data/cleaned-vault-prices-1h.parquet`    | Share price chart, TVL charts, historical TVL aggregates |
+| Treasury benchmark   | FRED CSV: `DGS3MO` series             | `~/.cache/ts-frontend/fred-DGS3MO-*.json` | US 3M Treasury benchmark line on non-perp vault charts   |
 
 ## Configuration
 
@@ -124,16 +124,16 @@ Protocol pages and the protocol listing also resolve Xerberus scores from these 
 
 R2 downloads stream the object body via the AWS SDK (`getR2Object`) and pipe it to disk using Node.js `stream.pipeline`. URL downloads use `fetch` with a 5-minute timeout.
 
-### Treasury benchmark (FRED DTB3)
+### Treasury benchmark (FRED DGS3MO)
 
 **Code:** `src/routes/vaults/treasury-benchmark/+server.ts` (server proxy) and `src/lib/top-vaults/treasury-benchmark.ts` (client fetcher)
 
-The US 3-month Treasury bill rate is used as a risk-free benchmark on non-perpetual-futures vault charts. FRED blocks browser CORS and rate-limits aggressively, so the data is proxied through a server endpoint.
+The US 3-month constant-maturity Treasury market yield is used as a reference benchmark on non-perpetual-futures vault charts. DGS3MO is quoted on an investment basis, which is compatible with the benchmark's cumulative-return approximation. FRED blocks browser CORS and rate-limits aggressively, so the data is proxied through a server endpoint.
 
 **Server endpoint** (`/vaults/treasury-benchmark?cosd=YYYY-MM-DD&coed=YYYY-MM-DD`):
 
-1. Validates and clamps date range (rejects future `cosd`, clamps to DTB3 series bounds)
-2. Checks file cache at `~/.cache/ts-frontend/fred-DTB3-{cosd}-{coed}.json` (24h TTL)
+1. Validates and clamps date range (rejects future `cosd`, clamps to DGS3MO series bounds)
+2. Checks file cache at `~/.cache/ts-frontend/fred-DGS3MO-{cosd}-{coed}.json` (24h TTL)
 3. If stale or missing → fetches from `https://fred.stlouisfed.org/graph/fredgraph.csv`
 4. On fetch failure → returns stale cache if available, otherwise 502
 5. Uses User-Agent rotation (FRED blocks bare Node.js requests)
@@ -182,7 +182,7 @@ R2 bucket (vaults-pro-data)
         └─→ historical-tvl-server.ts (DuckDB aggregate)
 
 FRED (fred.stlouisfed.org)
-└── DTB3 (3-month T-bill rate)
+└── DGS3MO (3-month Treasury market yield, investment basis)
     └─→ /vaults/treasury-benchmark endpoint (server proxy)
         ─→ file cache (~/.cache/ts-frontend/, 24h TTL)
         └─→ TreasuryBenchmarkSeries.svelte (client component)
@@ -199,7 +199,7 @@ FRED (fred.stlouisfed.org)
 | Strategy vault metadata            | Top vaults JSON      | Server loads or `/strategies/position-vault-data` matches       |
 | Vault price chart (client fetch)   | Parquet              | `/vaults/[vault]/metrics` → `ensureVaultPricesParquet()`        |
 | Historical TVL charts (server)     | Parquet              | `historical-tvl-server.ts` → `ensureVaultPricesParquet()`       |
-| T-bill benchmark (other vaults)    | FRED DTB3            | `TreasuryBenchmarkSeries.svelte` → `/vaults/treasury-benchmark` |
+| T-bill benchmark (other vaults)    | FRED DGS3MO          | `TreasuryBenchmarkSeries.svelte` → `/vaults/treasury-benchmark` |
 | BTC/ETH benchmarks (perps and GMX) | Coinbase API         | `CoinbaseBenchmarkSeries.svelte` → `coinbase.ts`                |
 | Datasets listing page              | Both (metadata only) | `headTopVaults()` + `headVaultPrices()`                         |
 | Datasets download                  | Both (proxied)       | `/datasets/download/[datasetId]` via Vault API                  |

--- a/src/lib/charts/ChartContainer.svelte
+++ b/src/lib/charts/ChartContainer.svelte
@@ -1,6 +1,10 @@
+<!--
+@component
+Shared time-series chart shell with range controls, loading state, tooltip and optional frame.
+-->
 <script lang="ts">
 	import type { ComponentProps, Snippet } from 'svelte';
-	import type { SimpleDataItem, TimeSpan, TvChartOptions, TvDataItem } from './types';
+	import type { SimpleDataItem, TimeSpan, TvChartOptions } from './types';
 	import { OptionGroup } from '$lib/helpers/option-group.svelte';
 	import { TimeSpans, type TimeSpanKey } from '$lib/charts/time-span';
 	import SegmentedControl from '$lib/components/SegmentedControl.svelte';
@@ -21,7 +25,8 @@
 		data: [number, number][] | undefined;
 		formatValue: Formatter<number>;
 		boxed?: boolean;
-		timeSpanOptions?: TimeSpanKey[];
+		timeSpanOptions?: readonly TimeSpanKey[];
+		initialTimeSpan?: TimeSpanKey;
 		/** Called when the chart range selector changes. */
 		onTimeSpanChange?: (timeSpan: TimeSpanKey) => void;
 		title?: Snippet<[TimeSpan]> | string;
@@ -35,7 +40,8 @@
 		data,
 		formatValue,
 		boxed = false,
-		timeSpanOptions = TimeSpans.keys,
+		timeSpanOptions = TimeSpans.defaultKeys,
+		initialTimeSpan = '3M',
 		onTimeSpanChange,
 		options,
 		title,
@@ -46,7 +52,7 @@
 		...restProps
 	}: Props = $props();
 
-	let timeSpans = $derived(new OptionGroup(timeSpanOptions, '3M'));
+	let timeSpans = $derived(new OptionGroup(timeSpanOptions, '3M', initialTimeSpan));
 
 	let timeSpan = $derived(TimeSpans.get(timeSpans.selected));
 

--- a/src/lib/charts/time-span.test.ts
+++ b/src/lib/charts/time-span.test.ts
@@ -1,0 +1,10 @@
+import { describe, expect, test } from 'vitest';
+import { TimeSpans } from './time-span';
+
+describe('TimeSpans', () => {
+	test('provides long comparison ranges without changing chart defaults', () => {
+		expect(TimeSpans.get('6M')).toMatchObject({ spanDays: 180, timeBucket: '1d' });
+		expect(TimeSpans.get('1Y')).toMatchObject({ spanDays: 365, timeBucket: '1d' });
+		expect(TimeSpans.defaultKeys).toEqual(['1W', '1M', '3M', 'Max']);
+	});
+});

--- a/src/lib/charts/time-span.ts
+++ b/src/lib/charts/time-span.ts
@@ -17,6 +17,16 @@ const timeSpans = {
 		spanDays: 90,
 		timeBucket: '1d'
 	},
+	'6M': {
+		performanceLabel: 'past 6 months',
+		spanDays: 180,
+		timeBucket: '1d'
+	},
+	'1Y': {
+		performanceLabel: 'past year',
+		spanDays: 365,
+		timeBucket: '1d'
+	},
 	Max: {
 		performanceLabel: 'lifetime',
 		timeBucket: '1d'
@@ -25,9 +35,15 @@ const timeSpans = {
 
 export type TimeSpanKey = keyof typeof timeSpans;
 
+const defaultTimeSpanKeys = ['1W', '1M', '3M', 'Max'] as const satisfies readonly TimeSpanKey[];
+
 export const TimeSpans = {
 	get keys() {
 		return Object.keys(timeSpans) as TimeSpanKey[];
+	},
+
+	get defaultKeys(): readonly TimeSpanKey[] {
+		return defaultTimeSpanKeys;
 	},
 
 	get(key: TimeSpanKey): TimeSpan {

--- a/src/lib/components/Footer.svelte
+++ b/src/lib/components/Footer.svelte
@@ -20,6 +20,14 @@ Set `small` to use the compact spacing variant.
 </script>
 
 <footer>
+	{#if !small}
+		<nav class="footer-navigation" aria-label="Footer navigation">
+			<a href={resolve('/community')}>Community</a>
+			<a href={resolve('/blog')}>Blog</a>
+			<a href={resolve('/vaults/api')}>API</a>
+		</nav>
+	{/if}
+
 	<div class="social-links" class:small>
 		<div class="link-group">
 			<Tooltip>
@@ -103,6 +111,23 @@ Set `small` to use the compact spacing variant.
 		max-width: 100%;
 		margin-block: 3.5rem;
 		padding-inline: 1.5rem;
+	}
+
+	.footer-navigation {
+		display: flex;
+		flex-wrap: wrap;
+		justify-content: center;
+		gap: var(--space-xl);
+		font: var(--f-ui-md-medium);
+		letter-spacing: var(--ls-ui-md, var(--f-ui-md-spacing, normal));
+
+		a {
+			padding-block: var(--space-xs);
+
+			&:hover {
+				text-decoration: underline;
+			}
+		}
 	}
 
 	.social-links {
@@ -239,6 +264,10 @@ Set `small` to use the compact spacing variant.
 					0 1rem 2.2rem color-mix(in srgb, var(--c-text-inverted), transparent 84%);
 			}
 		}
+	}
+
+	.footer-navigation + .social-links {
+		padding-top: 2rem;
 	}
 
 	.disclaimer {

--- a/src/lib/components/Header.svelte
+++ b/src/lib/components/Header.svelte
@@ -5,13 +5,14 @@ Responsive site header with menu, search and compact-navigation controls.
 <script lang="ts">
 	import { onMount } from 'svelte';
 	import type { Snippet } from 'svelte';
+	import { resolve } from '$app/paths';
 	import Logo from '$lib/components/Logo.svelte';
 	import Menu from '$lib/components/Menu.svelte';
 	import NavPanel from '$lib/components/NavPanel.svelte';
 	import IconMenu from '~icons/local/menu';
 
 	interface Props {
-		menu?: Snippet;
+		menu?: Snippet<[mobile: boolean]>;
 		search?: Snippet<[menu: boolean, onNavigate: () => void]>;
 	}
 
@@ -35,14 +36,14 @@ Responsive site header with menu, search and compact-navigation controls.
 
 <div class="header-bar">
 	<div class="logo">
-		<a href="/" aria-label="Home">
+		<a href={resolve('/')} aria-label="Home">
 			<Logo />
 		</a>
 	</div>
 
-	<nav class="desktop-only">
+	<nav class="desktop-only" aria-label="Primary navigation">
 		<Menu horizontal align="center">
-			{@render menu?.()}
+			{@render menu?.(false)}
 		</Menu>
 	</nav>
 
@@ -75,7 +76,7 @@ Responsive site header with menu, search and compact-navigation controls.
 		{#snippet panelSearch()}
 			{@render search?.(true, closePanel)}
 		{/snippet}
-		{@render menu?.()}
+		{@render menu?.(true)}
 	</NavPanel>
 </div>
 

--- a/src/lib/echarts/cumulative-tvl-apy.ts
+++ b/src/lib/echarts/cumulative-tvl-apy.ts
@@ -267,7 +267,8 @@ export function buildBenchmarkPoints(
 
 	const totalTvl = betterTvl + worseTvl;
 	const label = kind === 'treasury' ? 'US Treasury note rate' : 'US bank savings rate';
-	const description = kind === 'treasury' ? 'The risk-free benchmark.' : 'Average yield on a US bank savings account.';
+	const description =
+		kind === 'treasury' ? 'A US Treasury yield benchmark.' : 'Average yield on a US bank savings account.';
 	const url = kind === 'treasury' ? benchmarkUrls.treasury : benchmarkUrls.savings;
 
 	return Array.from({ length: BENCHMARK_SAMPLE_COUNT }, (_, index) => {

--- a/src/lib/header/Navbar.svelte
+++ b/src/lib/header/Navbar.svelte
@@ -12,13 +12,16 @@ Primary site navigation and the site-wide vault search entry point.
 
 <Section tag="header">
 	<div class="nav-bar" style:overflow="visible">
-		{#snippet menu()}
+		{#snippet menu(mobile: boolean)}
 			<MenuItem label="Top vaults" targetUrl="/vaults" active={currentPage === '/vaults'} />
 			<MenuItem label="Our vaults" targetUrl="/strategies" active={currentPage === '/strategies'} />
-			<MenuItem label="API" targetUrl="/vaults/api" active={currentPage === '/vaults/api'} />
+			<MenuItem label="Compare" targetUrl="/vaults/compare" active={currentPage === '/vaults/compare'} />
 			<MenuItem label="Pricing" targetUrl="/pricing" active={currentPage === '/pricing'} />
-			<MenuItem label="Community" targetUrl="/community" active={currentPage === '/community'} />
-			<MenuItem label="Blog" targetUrl="/blog" active={currentPage === '/blog'} />
+			{#if mobile}
+				<MenuItem label="API" targetUrl="/vaults/api" active={currentPage === '/vaults/api'} />
+				<MenuItem label="Community" targetUrl="/community" active={currentPage === '/community'} />
+				<MenuItem label="Blog" targetUrl="/blog" active={currentPage === '/blog'} />
+			{/if}
 		{/snippet}
 
 		{#snippet search(menu: boolean, onNavigate: () => void)}

--- a/src/lib/helpers/url-search-state.test.ts
+++ b/src/lib/helpers/url-search-state.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, test } from 'vitest';
+import { deserialiseSearchParams, serialiseSearchParams, type ParamSchema } from './url-search-state';
+
+const schema = {
+	view: { type: 'string', defaultValue: 'all' },
+	selected: { type: 'string[]', defaultValue: [], options: ['a', 'b', 'c'] }
+} as const satisfies ParamSchema;
+
+describe('URL search state', () => {
+	test('reads repeated string values and excludes unsupported options', () => {
+		expect(deserialiseSearchParams(new URLSearchParams('selected=b&selected=unknown&selected=a'), schema)).toEqual({
+			view: 'all',
+			selected: ['b', 'a']
+		});
+	});
+
+	test('writes arrays as repeated parameters and omits array defaults', () => {
+		expect(serialiseSearchParams({ view: 'all', selected: ['a', 'c'] }, schema)).toBe('selected=a&selected=c');
+		expect(serialiseSearchParams({ view: 'all', selected: [] }, schema)).toBe('');
+	});
+});

--- a/src/lib/helpers/url-search-state.ts
+++ b/src/lib/helpers/url-search-state.ts
@@ -18,12 +18,19 @@ interface NumberParam {
 	defaultValue: number;
 }
 
-export type ParamDef = StringParam | NumberParam;
+interface StringArrayParam {
+	type: 'string[]';
+	defaultValue: readonly string[];
+	/** When provided, unsupported values are omitted. */
+	options?: readonly string[];
+}
+
+export type ParamDef = StringParam | NumberParam | StringArrayParam;
 export type ParamSchema = Record<string, ParamDef>;
 
 /** Infer the state object type from a schema definition */
 export type StateFromSchema<S extends ParamSchema> = {
-	[K in keyof S]: S[K] extends NumberParam ? number : string;
+	[K in keyof S]: S[K] extends NumberParam ? number : S[K] extends StringArrayParam ? string[] : string;
 };
 
 /**
@@ -34,15 +41,23 @@ export function deserialiseSearchParams<S extends ParamSchema>(
 	searchParams: URLSearchParams,
 	schema: S
 ): StateFromSchema<S> {
-	const state = {} as Record<string, string | number>;
+	const state = {} as Record<string, string | number | string[]>;
 
 	for (const [key, def] of Object.entries(schema)) {
-		const raw = searchParams.get(key);
-
-		if (def.type === 'number') {
+		if (def.type === 'string[]') {
+			const values = searchParams.getAll(key);
+			const options = def.options;
+			state[key] = values.length
+				? options
+					? values.filter((value) => options.includes(value))
+					: values
+				: [...def.defaultValue];
+		} else if (def.type === 'number') {
+			const raw = searchParams.get(key);
 			const parsed = Number(raw);
 			state[key] = Number.isFinite(parsed) && raw !== null ? parsed : def.defaultValue;
 		} else {
+			const raw = searchParams.get(key);
 			if (raw === null) {
 				state[key] = def.defaultValue;
 			} else if (def.options) {
@@ -66,7 +81,14 @@ export function serialiseSearchParams<S extends ParamSchema>(state: StateFromSch
 
 	for (const [key, def] of Object.entries(schema)) {
 		const value = state[key as keyof typeof state];
-		if (value !== undefined && value !== def.defaultValue) {
+		if (def.type === 'string[]') {
+			if (!Array.isArray(value)) continue;
+			const isDefault =
+				value.length === def.defaultValue.length && value.every((item, index) => item === def.defaultValue[index]);
+			if (!isDefault) {
+				for (const item of value) params.append(key, item);
+			}
+		} else if (value !== undefined && value !== def.defaultValue) {
 			params.set(key, String(value));
 		}
 	}

--- a/src/lib/scatter-plot/ScatterPlotSelector.svelte
+++ b/src/lib/scatter-plot/ScatterPlotSelector.svelte
@@ -12,6 +12,7 @@ Selector linking between vault scatter plot chart pages.
 	import { page } from '$app/state';
 
 	const charts = [
+		{ href: '/vaults/compare', label: 'Compare equity curves' },
 		{ href: '/vaults/cumulative-tvl-apy', label: 'Total vault earnings' },
 		{ href: '/vaults/yield-risk', label: 'Yield / Risk' },
 		{ href: '/vaults/yield-protocol', label: 'Yield / Protocol' },

--- a/src/lib/search/components/Search.svelte
+++ b/src/lib/search/components/Search.svelte
@@ -1,12 +1,14 @@
 <!--
 @component
-Site-wide vault search with a desktop/tablet typeahead and full-screen mobile dialog.
+Reusable vault and DeFi entity search with navigation and in-page selector layouts.
 
 The component fetches only public search suggestions; the server keeps the
 underlying vault JSON index private.
 -->
 <script lang="ts">
 	import { onMount, tick } from 'svelte';
+	import { SvelteURLSearchParams } from 'svelte/reactivity';
+	import type { Snippet } from 'svelte';
 	import { goto } from '$app/navigation';
 	import { resolve } from '$app/paths';
 	import { disableScroll } from '$lib/actions/scroll';
@@ -21,16 +23,45 @@ underlying vault JSON index private.
 	} from '$lib/search/entities';
 	import IconCancel from '~icons/local/cancel';
 	import IconSearch from '~icons/local/search';
+	import Spinner from '$lib/components/Spinner.svelte';
 	import VaultSparkline from '$lib/top-vaults/VaultSparkline.svelte';
 
 	interface Props {
 		menu?: boolean;
 		onNavigate?: () => void;
+		/** Limit the suggestions to vaults when search is used as a vault selector. */
+		scope?: 'all' | 'vaults';
+		/** Use page formatting to keep the full search input and anchored result panel at every viewport size. */
+		format?: 'navigation' | 'page';
+		label?: string;
+		inputLabel?: string;
+		placeholder?: string;
+		mobilePlaceholder?: string;
+		showAllResults?: boolean;
+		disabled?: boolean;
+		/** Exclude vault suggestions below this latest TVL in USD. */
+		minimumVaultTvlUsd?: number;
+		/** Optional action rendered beside each result. Call onAction after accepting the result. */
+		addButton?: Snippet<[result: SearchResult, onAction: () => void]>;
 	}
 
-	let { menu = false, onNavigate }: Props = $props();
+	let {
+		menu = false,
+		onNavigate,
+		scope = 'all',
+		format = 'navigation',
+		label,
+		inputLabel = 'Search vaults and DeFi entities',
+		placeholder = 'Search vaults',
+		mobilePlaceholder = 'Search vaults, curators, protocols and chains',
+		showAllResults = true,
+		disabled = false,
+		minimumVaultTvlUsd,
+		addButton
+	}: Props = $props();
 
-	const listboxId = 'site-search-suggestions';
+	const componentId = $props.id();
+	const listboxId = `${componentId}-site-search-suggestions`;
 	const TYPEAHEAD_DEBOUNCE_MS = 200;
 	const TYPEAHEAD_LIMIT = 10;
 	let query = $state('');
@@ -45,11 +76,20 @@ underlying vault JSON index private.
 	let mobileSearchInput = $state<HTMLInputElement>();
 	let searchTrigger = $state<HTMLButtonElement>();
 	let searchRoot: HTMLDivElement;
+	let ready = $state(false);
 
 	let hasQuery = $derived(query.trim().length > 0);
+	let dialogVisible = $derived(open && (format === 'navigation' || hasQuery));
 	let activeOptionId = $derived(selectedIndex >= 0 ? `${listboxId}-${selectedIndex}` : undefined);
 
 	onMount(() => {
+		if (format === 'page' && desktopSearchInput) {
+			// Browsers may restore the previous query across same-route GET submissions.
+			// Page-embedded selectors should always start from a fresh, reactive query.
+			desktopSearchInput.value = '';
+			query = '';
+		}
+		ready = true;
 		const inputWasFocusedBeforeHydration = desktopSearchInput?.dataset.prehydrationFocus === 'true';
 		delete desktopSearchInput?.dataset.prehydrationFocus;
 		if (!inputWasFocusedBeforeHydration) return;
@@ -69,17 +109,20 @@ underlying vault JSON index private.
 			return;
 		}
 		open = true;
+		loading = true;
 
 		const controller = new AbortController();
 		const timeout = setTimeout(async () => {
-			loading = true;
 			try {
-				const response = await fetch(
-					`/search/suggestions?q=${encodeURIComponent(searchQuery)}&limit=${TYPEAHEAD_LIMIT}`,
-					{
-						signal: controller.signal
-					}
-				);
+				const params = new SvelteURLSearchParams({
+					q: searchQuery,
+					limit: String(TYPEAHEAD_LIMIT),
+					scope
+				});
+				if (minimumVaultTvlUsd !== undefined) {
+					params.set('minimumVaultTvlUsd', String(minimumVaultTvlUsd));
+				}
+				const response = await fetch(`/search/suggestions?${params}`, { signal: controller.signal });
 				if (!response.ok) throw new Error('Search is temporarily unavailable.');
 				const data = (await response.json()) as Partial<SearchResponse>;
 				if (sequence === requestSequence) results = Array.isArray(data.results) ? data.results : [];
@@ -131,10 +174,34 @@ underlying vault JSON index private.
 		if (restoreFocus) tick().then(() => searchTrigger?.focus());
 	}
 
+	/** Reset selector-style search after its result action is activated. */
+	function clearActionSearch() {
+		query = '';
+		results = [];
+		closeSearch();
+	}
+
 	/** Close the quick-search UI before navigating to a search or entity page. */
 	function closeSearchForNavigation() {
 		closeSearch();
 		onNavigate?.();
+	}
+
+	/** Trigger the action supplied for a result row instead of navigating away. */
+	function activateResultAction(index: number): boolean {
+		if (!addButton) return false;
+		const actionButton = searchRoot.querySelectorAll<HTMLButtonElement>('.result-action button')[index];
+		actionButton?.click();
+		return true;
+	}
+
+	function handleResultClick(event: MouseEvent, index: number) {
+		if (!activateResultAction(index)) {
+			closeSearchForNavigation();
+			return;
+		}
+
+		event.preventDefault();
 	}
 
 	function handleKeydown(event: KeyboardEvent) {
@@ -155,15 +222,20 @@ underlying vault JSON index private.
 		}
 		if (event.key === 'Enter' && selectedIndex >= 0) {
 			event.preventDefault();
-			goto(resolve(results[selectedIndex].href as `/vaults/${string}`));
-			closeSearchForNavigation();
+			if (!activateResultAction(selectedIndex)) {
+				goto(resolve(results[selectedIndex].href as `/vaults/${string}`));
+				closeSearchForNavigation();
+			}
 		}
 	}
 
 	function handleSubmit(event: SubmitEvent) {
+		if (format === 'page') event.preventDefault();
 		if (selectedIndex >= 0) {
 			event.preventDefault();
-			goto(resolve(results[selectedIndex].href as `/vaults/${string}`));
+			if (!activateResultAction(selectedIndex)) {
+				goto(resolve(results[selectedIndex].href as `/vaults/${string}`));
+			}
 		}
 		closeSearchForNavigation();
 	}
@@ -175,30 +247,36 @@ underlying vault JSON index private.
 	bind:this={searchRoot}
 	class="search"
 	class:menu-search={menu}
-	data-testid={menu ? 'mobile-menu-search' : 'nav-search'}
+	class:page-search={format === 'page'}
+	data-ready={ready}
+	data-testid={format === 'page' ? 'page-search' : menu ? 'mobile-menu-search' : 'nav-search'}
 >
+	{#if label}<label class="search-label" for={`${componentId}-desktop-input`}>{label}</label>{/if}
 	<form class="desktop-search" action="/search" role="search" onsubmit={handleSubmit}>
 		<input
 			bind:this={desktopSearchInput}
-			bind:value={query}
+			value={query}
+			id={`${componentId}-desktop-input`}
 			data-preserve-hydration-focus
 			aria-activedescendant={activeOptionId}
 			aria-autocomplete="list"
 			aria-controls={listboxId}
-			aria-expanded={open}
-			aria-label="Search vaults and DeFi entities"
+			aria-expanded={dialogVisible}
+			aria-label={inputLabel}
 			role="combobox"
 			name="q"
 			type="search"
-			placeholder="Search vaults"
+			{placeholder}
 			autocomplete="off"
 			autocapitalize="none"
 			spellcheck="false"
+			{disabled}
 			onfocus={() => {
 				mobileDialogOpen = false;
 				open = true;
 			}}
-			oninput={() => {
+			oninput={(event) => {
+				query = event.currentTarget.value;
 				mobileDialogOpen = false;
 				open = true;
 			}}
@@ -218,49 +296,55 @@ underlying vault JSON index private.
 		{#if menu}<span>Search vaults</span>{/if}
 	</button>
 
-	{#if open}
+	{#if dialogVisible}
 		<div class="dialog" role="dialog" aria-modal={mobileDialogOpen} aria-label="Search">
-			<div class="mobile-search-row">
-				<form action="/search" role="search" onsubmit={handleSubmit}>
-					<input
-						bind:this={mobileSearchInput}
-						bind:value={query}
-						aria-activedescendant={activeOptionId}
-						aria-autocomplete="list"
-						aria-controls={listboxId}
-						aria-expanded={open}
-						aria-label="Search vaults and DeFi entities"
-						role="combobox"
-						name="q"
-						type="search"
-						placeholder="Search vaults, curators, protocols and chains"
-						autocomplete="off"
-						autocapitalize="none"
-						spellcheck="false"
-						onkeydown={handleKeydown}
-					/>
-				</form>
-				<button
-					class="close-button"
-					type="button"
-					aria-label="Close search"
-					onclick={() => closeSearch({ restoreFocus: true })}
-				>
-					<IconCancel />
-				</button>
-			</div>
+			{#if format === 'navigation'}
+				<div class="mobile-search-row">
+					<form action="/search" role="search" onsubmit={handleSubmit}>
+						<input
+							bind:this={mobileSearchInput}
+							value={query}
+							aria-activedescendant={activeOptionId}
+							aria-autocomplete="list"
+							aria-controls={listboxId}
+							aria-expanded={dialogVisible}
+							aria-label={inputLabel}
+							role="combobox"
+							name="q"
+							type="search"
+							placeholder={mobilePlaceholder}
+							autocomplete="off"
+							autocapitalize="none"
+							spellcheck="false"
+							{disabled}
+							oninput={(event) => (query = event.currentTarget.value)}
+							onkeydown={handleKeydown}
+						/>
+					</form>
+					<button
+						class="close-button"
+						type="button"
+						aria-label="Close search"
+						onclick={() => closeSearch({ restoreFocus: true })}
+					>
+						<IconCancel />
+					</button>
+				</div>
+			{/if}
 
 			<div class="results" aria-live="polite" data-testid="entity-search-results">
 				{#if loading}
-					<p>Searching…</p>
+					<div class="search-loading" role="status"><Spinner size="20" /><span>Searching…</span></div>
 				{:else if errorMessage}
 					<p>{errorMessage}</p>
 				{:else if hasQuery && results.length}
-					<p class="result-count">{results.length} suggestion{results.length === 1 ? '' : 's'}</p>
+					<p class="result-count">
+						{results.length} suggestion{results.length === 1 ? '' : 's'}
+					</p>
 					<ul id={listboxId} role="listbox" aria-label="Search suggestions">
 						{#each results as result, index (result.id)}
 							{@const address = formatVaultAddressPrefix(result.address)}
-							<li>
+							<li class:has-action={Boolean(addButton)}>
 								<a
 									id={`${listboxId}-${index}`}
 									class:active={selectedIndex === index}
@@ -269,8 +353,9 @@ underlying vault JSON index private.
 									href={resolve(result.href as `/vaults/${string}`)}
 									role="option"
 									aria-selected={selectedIndex === index}
+									class="result-link"
 									onpointerdown={(event) => event.preventDefault()}
-									onclick={closeSearchForNavigation}
+									onclick={(event) => handleResultClick(event, index)}
 								>
 									<span class="logo-slot"
 										>{#if result.logoUrl}<img src={result.logoUrl} alt="" use:removeOnError />{/if}</span
@@ -303,6 +388,9 @@ underlying vault JSON index private.
 										></span
 									>
 								</a>
+								{#if addButton}
+									<span class="result-action">{@render addButton(result, clearActionSearch)}</span>
+								{/if}
 							</li>
 						{/each}
 					</ul>
@@ -313,7 +401,7 @@ underlying vault JSON index private.
 				{/if}
 			</div>
 
-			{#if hasQuery}
+			{#if hasQuery && showAllResults}
 				<a
 					class="show-all"
 					href={resolve(`/search?q=${encodeURIComponent(query.trim())}` as '/search')}
@@ -328,6 +416,18 @@ underlying vault JSON index private.
 	.search {
 		position: relative;
 		width: 100%;
+	}
+	.search-label {
+		display: block;
+		margin-bottom: var(--space-xs);
+		color: var(--c-text-light);
+		font: var(--f-ui-sm-medium);
+	}
+	.page-search .search-label {
+		font: var(--f-heading-xs-medium);
+		font-size: 1rem;
+		letter-spacing: 0.06em;
+		text-transform: uppercase;
 	}
 	.desktop-search input,
 	.mobile-search-row input {
@@ -377,6 +477,11 @@ underlying vault JSON index private.
 		box-shadow: var(--shadow-3);
 		padding: var(--space-md);
 	}
+	.page-search .dialog {
+		left: 0;
+		box-sizing: border-box;
+		width: 100%;
+	}
 	.mobile-search-row {
 		display: none;
 	}
@@ -399,7 +504,13 @@ underlying vault JSON index private.
 		padding: 0;
 		list-style: none;
 	}
-	li a {
+	li.has-action {
+		display: grid;
+		grid-template-columns: minmax(0, 1fr) auto;
+		align-items: center;
+		gap: var(--space-xs);
+	}
+	.result-link {
 		display: grid;
 		grid-template-columns: 2rem minmax(0, 1fr) auto;
 		gap: var(--space-sm);
@@ -409,15 +520,55 @@ underlying vault JSON index private.
 		color: inherit;
 		text-decoration: none;
 	}
-	li a:is(.no-logo, :has(.logo-slot:not(:has(img)))) {
+	.result-link:is(.no-logo, :has(.logo-slot:not(:has(img)))) {
 		grid-template-columns: minmax(0, 1fr) auto;
 	}
-	li a:is(.no-logo, :has(.logo-slot:not(:has(img)))) .logo-slot {
+	.result-link:is(.no-logo, :has(.logo-slot:not(:has(img)))) .logo-slot {
 		display: none;
 	}
-	li a:is(:hover, :focus-visible, .active) {
+	.result-link:is(:hover, :focus-visible, .active) {
 		outline: none;
 		background: var(--background-hover);
+	}
+	.result-action {
+		padding-right: var(--space-sm);
+
+		:global(button) {
+			display: inline-flex;
+			align-items: center;
+			justify-content: center;
+			gap: var(--space-xs);
+			min-width: 4rem;
+			min-height: 2.25rem;
+			padding: 0 var(--space-sm);
+			border: 1px solid var(--c-input-border);
+			border-radius: var(--radius-sm);
+			background: var(--c-input-background);
+			color: var(--c-link);
+			font: var(--f-ui-sm-medium);
+			cursor: pointer;
+		}
+
+		:global(button:is(:hover, :focus-visible)) {
+			border-color: var(--c-input-border-focus);
+			outline: none;
+			background: var(--background-hover);
+		}
+
+		:global(button:disabled) {
+			color: var(--c-text-extra-light);
+			cursor: default;
+			opacity: 0.6;
+		}
+	}
+	.search-loading {
+		display: flex;
+		align-items: center;
+		gap: var(--space-sm);
+		min-height: 4rem;
+		padding-inline: var(--space-sm);
+		color: var(--c-text-extra-light);
+		font: var(--f-ui-sm-medium);
 	}
 	.logo-slot {
 		display: grid;
@@ -509,6 +660,12 @@ underlying vault JSON index private.
 		text-align: center;
 	}
 
+	@media (--viewport-sm-down) {
+		.page-search .search-label {
+			font-size: 0.875rem;
+		}
+	}
+
 	@media (--nav-collapsed) {
 		.desktop-search {
 			display: none;
@@ -575,6 +732,33 @@ underlying vault JSON index private.
 			max-width: 31.25rem;
 			margin-inline: auto;
 		}
+		.page-search .desktop-search {
+			display: block;
+		}
+		.page-search .search-trigger,
+		.page-search .mobile-search-row {
+			display: none;
+		}
+		.page-search .dialog {
+			position: absolute;
+			inset: auto 0 auto 0;
+			top: calc(100% + var(--space-xs));
+			display: block;
+			box-sizing: border-box;
+			width: 100%;
+			height: auto;
+			padding: var(--space-md);
+			border: 1px solid var(--c-box-3);
+			border-radius: var(--radius-md);
+			box-shadow: var(--shadow-3);
+		}
+		.page-search .results {
+			max-height: min(26rem, calc(100dvh - var(--header-height) - var(--space-xl)));
+			margin-top: 0;
+		}
+		.page-search .results ul {
+			max-width: none;
+		}
 	}
 
 	@media (--nav-collapsed) and (--viewport-sm-up) {
@@ -597,7 +781,7 @@ underlying vault JSON index private.
 		.mobile-search-row {
 			display: none;
 		}
-		.dialog li a {
+		.dialog .result-link {
 			grid-template-columns: 2rem minmax(0, 1fr) 6rem auto;
 		}
 		.dialog .result-sparkline {
@@ -607,7 +791,7 @@ underlying vault JSON index private.
 	}
 
 	@media (--viewport-xs) {
-		.dialog li a {
+		.dialog .result-link {
 			grid-template-columns: 2rem minmax(0, 1fr) max-content;
 			grid-template-areas:
 				'logo main metrics'
@@ -615,7 +799,7 @@ underlying vault JSON index private.
 			align-items: start;
 			row-gap: var(--space-xs);
 		}
-		.dialog li a:is(.no-logo, :has(.logo-slot:not(:has(img)))) {
+		.dialog .result-link:is(.no-logo, :has(.logo-slot:not(:has(img)))) {
 			grid-template-columns: minmax(0, 1fr) max-content;
 			grid-template-areas:
 				'main metrics'
@@ -653,7 +837,7 @@ underlying vault JSON index private.
 				--sparkline-width: 7rem;
 			}
 		}
-		li a {
+		.result-link {
 			grid-template-columns: 2rem minmax(0, 1fr) 7rem auto;
 		}
 	}

--- a/src/lib/search/components/Search.test.ts
+++ b/src/lib/search/components/Search.test.ts
@@ -7,6 +7,24 @@ describe('Search component', () => {
 
 		const searchBox = screen.getByRole('combobox', { name: 'Search vaults and DeFi entities' });
 		expect(searchBox).toHaveAttribute('placeholder', 'Search vaults');
-		expect(searchBox.form).toHaveAttribute('action', '/search');
+		expect(searchBox.closest('form')).toHaveAttribute('action', '/search');
+	});
+
+	test('supports page formatting and vault-selector copy', () => {
+		render(Search, {
+			format: 'page',
+			scope: 'vaults',
+			label: 'Add vaults',
+			inputLabel: 'Search vaults to compare',
+			placeholder: 'Search by vault name or address',
+			showAllResults: false,
+			disabled: true
+		});
+
+		const searchBox = screen.getByRole('combobox', { name: 'Search vaults to compare' });
+		expect(searchBox).toHaveAttribute('placeholder', 'Search by vault name or address');
+		expect(searchBox).toBeDisabled();
+		expect(screen.getByText('Add vaults')).toBeVisible();
+		expect(screen.getByTestId('page-search')).toContainElement(searchBox);
 	});
 });

--- a/src/lib/search/vault-search.server.ts
+++ b/src/lib/search/vault-search.server.ts
@@ -44,6 +44,10 @@ type SearchIndex = {
 type SearchOptions = {
 	/** Return the highest-ranked match for each entity type before filling remaining slots. */
 	diversifyTypes?: boolean;
+	/** Limit results to these public entity types before ranking and limiting. */
+	entityTypes?: readonly SearchEntityType[];
+	/** Exclude vault results whose latest TVL is below this USD value. */
+	minimumVaultTvlUsd?: number;
 };
 
 let cachedIndex: SearchIndex | undefined;
@@ -312,7 +316,14 @@ export async function searchVaultEntities(
 	if (!normalisedQuery) return { query: trimmedQuery, results: [], total: 0 };
 	const tokens = normalisedQuery.split(' ').filter(Boolean);
 	const shortQuery = normalisedQuery.length === 1;
+	const allowedEntityTypes = options.entityTypes ? new Set(options.entityTypes) : null;
 	const matches = index.records
+		.filter((record) => !allowedEntityTypes || allowedEntityTypes.has(record.entityType))
+		.filter(
+			(record) =>
+				options.minimumVaultTvlUsd === undefined ||
+				(record.latestTvl !== null && record.latestTvl >= options.minimumVaultTvlUsd)
+		)
 		.map((record) => ({ record, score: getMatchScore(record, normalisedQuery, tokens) }))
 		.filter((match): match is { record: IndexedSearchRecord; score: number } => match.score !== null)
 		.filter((match) => !shortQuery || match.score >= 2)

--- a/src/lib/server/top-vaults/vault-price-series.test.ts
+++ b/src/lib/server/top-vaults/vault-price-series.test.ts
@@ -1,0 +1,66 @@
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { DuckDBConnection } from '@duckdb/node-api';
+import { queryVaultPriceRows } from './vault-price-series';
+
+describe('queryVaultPriceRows', () => {
+	test('queries several vault histories with optional metrics from one parquet file', async () => {
+		const directory = await mkdtemp(join(tmpdir(), 'vault-price-series-'));
+		const parquetFile = join(directory, 'prices.parquet');
+		const connection = await DuckDBConnection.create();
+
+		try {
+			await connection.run(`
+				CREATE TABLE prices (
+					id VARCHAR,
+					timestamp TIMESTAMP,
+					share_price DOUBLE,
+					total_assets DOUBLE,
+					utilisation DOUBLE
+				);
+				INSERT INTO prices VALUES
+					('vault-b', '2026-01-02 00:00:00', 2.1, 210, 2.5),
+					('vault-a', '2026-01-02 00:00:00', 1.1, 110, 0.8),
+					('vault-a', '2026-01-01 00:00:00', 1.0, 100, 0.7),
+					('not-selected', '2026-01-01 00:00:00', 9, 900, 0.9);
+				COPY prices TO '${parquetFile.replaceAll("'", "''")}' (FORMAT PARQUET);
+			`);
+		} finally {
+			connection.closeSync();
+		}
+
+		try {
+			const rows = await queryVaultPriceRows(['vault-b', 'vault-a'], {
+				includeVaultMetrics: true,
+				parquetFile
+			});
+
+			expect(rows).toEqual([
+				{
+					id: 'vault-a',
+					timestamp: Date.UTC(2026, 0, 1) / 1000,
+					sharePrice: 1,
+					totalAssets: 100,
+					utilisation: 0.7
+				},
+				{
+					id: 'vault-a',
+					timestamp: Date.UTC(2026, 0, 2) / 1000,
+					sharePrice: 1.1,
+					totalAssets: 110,
+					utilisation: 0.8
+				},
+				{
+					id: 'vault-b',
+					timestamp: Date.UTC(2026, 0, 2) / 1000,
+					sharePrice: 2.1,
+					totalAssets: 210,
+					utilisation: null
+				}
+			]);
+		} finally {
+			await rm(directory, { recursive: true, force: true });
+		}
+	});
+});

--- a/src/lib/server/top-vaults/vault-price-series.ts
+++ b/src/lib/server/top-vaults/vault-price-series.ts
@@ -1,0 +1,67 @@
+import { DuckDBConnection } from '@duckdb/node-api';
+import { ensureVaultPricesParquet } from '$lib/top-vaults/vault-prices-parquet';
+
+export interface VaultPriceQueryRow {
+	id: string;
+	timestamp: number;
+	sharePrice: number;
+	totalAssets?: number;
+	utilisation?: number | null;
+}
+
+interface VaultPriceQueryOptions {
+	includeVaultMetrics?: boolean;
+	parquetFile?: string;
+	resolveParquetFile?: () => Promise<string>;
+}
+
+/**
+ * Read one or more vault price histories with a single DuckDB connection and
+ * parquet scan.
+ *
+ * @param vaultIds Validated vault identifiers to query
+ * @param options Optional metric columns and injectable parquet source for tests
+ */
+export async function queryVaultPriceRows(
+	vaultIds: readonly string[],
+	options: VaultPriceQueryOptions = {}
+): Promise<VaultPriceQueryRow[]> {
+	if (!vaultIds.length) return [];
+
+	const parquetFile = options.parquetFile ?? (await (options.resolveParquetFile ?? ensureVaultPricesParquet)());
+	const connection = await DuckDBConnection.create();
+
+	try {
+		const idParameters = Object.fromEntries(vaultIds.map((vaultId, index) => [`vaultId${index}`, vaultId]));
+		const placeholders = vaultIds.map((_, index) => `$vaultId${index}`).join(', ');
+		const optionalColumns = options.includeVaultMetrics
+			? `, total_assets,
+              CASE WHEN utilisation >= 0 AND utilisation <= 2 THEN utilisation ELSE NULL END as utilisation`
+			: '';
+		const reader = await connection.runAndReadAll(
+			`SELECT id, EXTRACT(EPOCH FROM timestamp) as ts, share_price${optionalColumns}
+       FROM parquet_scan($parquetFile)
+       WHERE id IN (${placeholders})
+       ORDER BY id, timestamp`,
+			{ parquetFile, ...idParameters }
+		);
+
+		return reader.getRows().map((row) => {
+			const [id, timestamp, sharePrice, totalAssets, utilisation] = row as [
+				string,
+				number,
+				number,
+				number | undefined,
+				number | null | undefined
+			];
+			return {
+				id,
+				timestamp,
+				sharePrice,
+				...(options.includeVaultMetrics ? { totalAssets, utilisation } : {})
+			};
+		});
+	} finally {
+		connection.closeSync();
+	}
+}

--- a/src/lib/top-vaults/TopVaultsTable.svelte
+++ b/src/lib/top-vaults/TopVaultsTable.svelte
@@ -176,6 +176,10 @@ The AMM checkbox hides AMM pools and AMM-like vaults on listings with Filters.
 		listingKey?: VaultListingKey;
 		listingScope?: string;
 		listingSummary?: VaultListingSummary;
+		/** Query parameters retained when this table updates its own sorting and filtering state. */
+		preserveSearchParams?: string[];
+		/** Show the standard stablecoin-only badge in the listing metadata. */
+		showStablecoinOnlyMeta?: boolean;
 	}
 
 	interface ListingDataResponse {
@@ -221,7 +225,9 @@ The AMM checkbox hides AMM pools and AMM-like vaults on listings with Filters.
 		initialHasMore = false,
 		listingKey = 'top',
 		listingScope,
-		listingSummary
+		listingSummary,
+		preserveSearchParams = [],
+		showStablecoinOnlyMeta = true
 	}: Props = $props();
 	const defaultHideAmm = untrack(() => ((getVaultListingDefaults(listingKey, listingScope).amm ?? true) ? 1 : 0));
 	let listingAssetType = $derived(listingKey === 'protocol' && isPoolProtocol(listingScope) ? 'pool' : 'vault');
@@ -331,7 +337,11 @@ The AMM checkbox hides AMM pools and AMM-like vaults on listings with Filters.
 			...overrides
 		};
 		const url = new SvelteURL(page.url);
-		url.search = serialiseSearchParams(updated, searchParamsSchema);
+		const searchParams = new SvelteURLSearchParams(serialiseSearchParams(updated, searchParamsSchema));
+		for (const key of preserveSearchParams) {
+			for (const value of page.url.searchParams.getAll(key)) searchParams.append(key, value);
+		}
+		url.search = searchParams.toString();
 		return url;
 	}
 
@@ -1009,13 +1019,15 @@ The AMM checkbox hides AMM pools and AMM-like vaults on listings with Filters.
 					>
 				</Tooltip>
 			{/if}
-			<Tooltip>
-				<svelte:fragment slot="trigger">Stablecoin-only</svelte:fragment>
-				<svelte:fragment slot="popup"
-					>We list stablecoin-denominated vaults only. This excludes vaults with cryptocurrency denominator like ETH or
-					BTC.</svelte:fragment
-				>
-			</Tooltip>
+			{#if showStablecoinOnlyMeta}
+				<Tooltip>
+					<svelte:fragment slot="trigger">Stablecoin-only</svelte:fragment>
+					<svelte:fragment slot="popup"
+						>We list stablecoin-denominated vaults only. This excludes vaults with cryptocurrency denomination like ETH
+						or BTC.</svelte:fragment
+					>
+				</Tooltip>
+			{/if}
 			<span
 				><Tooltip>
 					<svelte:fragment slot="trigger">Updated <Timestamp date={topVaults.generated_at} relative /></svelte:fragment>

--- a/src/lib/top-vaults/TreasuryBenchmarkSeries.svelte
+++ b/src/lib/top-vaults/TreasuryBenchmarkSeries.svelte
@@ -2,7 +2,7 @@
 @component
 Overlay a US 3-month Treasury bill benchmark line on the vault share-price chart.
 
-The benchmark compounds daily FRED DTB3 rates into a cumulative return line
+The benchmark compounds daily investment-basis FRED DGS3MO yields into a cumulative return line
 rebased to the vault's starting share price, so relative performance is
 comparable on a single axis. Does not affect Y-axis scaling.
 -->

--- a/src/lib/top-vaults/VaultListingsSelector.svelte
+++ b/src/lib/top-vaults/VaultListingsSelector.svelte
@@ -29,6 +29,7 @@ Renders navigation links for vault listing and chart pages.
 	] as const;
 
 	const chartLinks = [
+		{ href: '/vaults/compare', label: 'Compare equity curves' },
 		{ href: '/vaults/cumulative-tvl-apy', label: 'Total vault earnings' },
 		{ href: '/vaults/yield-risk', label: 'Yield / Risk' },
 		{ href: '/vaults/yield-protocol', label: 'Yield / Protocol' },

--- a/src/lib/top-vaults/VaultPriceChart.svelte
+++ b/src/lib/top-vaults/VaultPriceChart.svelte
@@ -180,7 +180,7 @@ so relative performance is comparable on a single axis.
 						color: '#4a90d9a0',
 						logoUrl: usTreasuryLogo,
 						href: '/glossary/risk-free-rate',
-						tooltip: 'Risk-free rate: Equivalent investment to U.S. Treasury notes.'
+						tooltip: '3-month US Treasury market-yield benchmark.'
 					}
 				]
 	);

--- a/src/lib/top-vaults/coinbase.test.ts
+++ b/src/lib/top-vaults/coinbase.test.ts
@@ -3,8 +3,9 @@ import { fetchCoinbaseBenchmarkCloses, getCoinbaseGranularitySeconds } from './c
 
 function makeProxyFetch(responseData: [number, number][]) {
 	return vi.fn(async (input: RequestInfo | URL) => {
+		void input;
 		return new Response(JSON.stringify(responseData), { status: 200 });
-	}) as unknown as Fetch;
+	});
 }
 
 describe('getCoinbaseGranularitySeconds', () => {
@@ -34,7 +35,7 @@ describe('fetchCoinbaseBenchmarkCloses', () => {
 		];
 		const fetch = makeProxyFetch(expectedData);
 
-		const closes = await fetchCoinbaseBenchmarkCloses(fetch, 'BTC-USD', start, end);
+		const closes = await fetchCoinbaseBenchmarkCloses(fetch as unknown as Fetch, 'BTC-USD', start, end);
 
 		expect(fetch).toHaveBeenCalledOnce();
 		const calledUrl = new URL(String(fetch.mock.calls[0][0]), 'http://localhost');
@@ -44,6 +45,17 @@ describe('fetchCoinbaseBenchmarkCloses', () => {
 		expect(calledUrl.searchParams.get('start')).toBe(start.toISOString());
 		expect(calledUrl.searchParams.get('end')).toBe(end.toISOString());
 		expect(closes).toEqual(expectedData);
+	});
+
+	test('can bypass the module cache for callers with their own bounded cache', async () => {
+		const start = new Date('2025-02-01T00:00:00Z');
+		const end = new Date('2025-03-01T00:00:00Z');
+		const fetch = makeProxyFetch([[1_738_368_000, 42_000]]);
+
+		await fetchCoinbaseBenchmarkCloses(fetch as unknown as Fetch, 'BTC-USD', start, end, false);
+		await fetchCoinbaseBenchmarkCloses(fetch as unknown as Fetch, 'BTC-USD', start, end, false);
+
+		expect(fetch).toHaveBeenCalledTimes(2);
 	});
 
 	test('throws on proxy error response', async () => {

--- a/src/lib/top-vaults/coinbase.ts
+++ b/src/lib/top-vaults/coinbase.ts
@@ -22,17 +22,20 @@ export function getCoinbaseGranularitySeconds(start: Date, end: Date) {
  *
  * The proxy handles chunking, retries, and caching to avoid CORS issues
  * and Coinbase rate-limiting.
+ *
+ * @param useCache - Disable when the caller already has a bounded server-side cache.
  */
 export function fetchCoinbaseBenchmarkCloses(
 	fetch: Fetch,
 	productId: CoinbaseProductId,
 	start: Date,
-	end: Date
+	end: Date,
+	useCache = true
 ): Promise<[number, number][]> {
 	const granularitySeconds = getCoinbaseGranularitySeconds(start, end);
 	const cacheKey = `${productId}:${granularitySeconds}:${start.toISOString()}:${end.toISOString()}`;
 
-	const cachedResponse = benchmarkRequestCache.get(cacheKey);
+	const cachedResponse = useCache ? benchmarkRequestCache.get(cacheKey) : undefined;
 	if (cachedResponse) return cachedResponse;
 
 	const params = new URLSearchParams({
@@ -48,10 +51,10 @@ export function fetchCoinbaseBenchmarkCloses(
 			return resp.json() as Promise<[number, number][]>;
 		})
 		.catch((error) => {
-			benchmarkRequestCache.delete(cacheKey);
+			if (useCache) benchmarkRequestCache.delete(cacheKey);
 			throw error;
 		});
 
-	benchmarkRequestCache.set(cacheKey, responsePromise);
+	if (useCache) benchmarkRequestCache.set(cacheKey, responsePromise);
 	return responsePromise;
 }

--- a/src/lib/top-vaults/equity-comparison/BenchmarkLogo.svelte
+++ b/src/lib/top-vaults/equity-comparison/BenchmarkLogo.svelte
@@ -1,0 +1,29 @@
+<!--
+@component
+Render the bundled logo for a fixed vault-comparison benchmark.
+-->
+<script lang="ts">
+	import btcLogo from '$lib/assets/logos/tokens/btc.svg';
+	import ethLogo from '$lib/assets/logos/tokens/eth.svg';
+	import usTreasuryLogo from '$lib/assets/logos/tokens/us-treasury.svg';
+	import type { ComparisonBenchmark } from './types';
+
+	let { benchmark }: { benchmark: ComparisonBenchmark } = $props();
+
+	const logoUrls: Record<ComparisonBenchmark, string> = {
+		treasury: usTreasuryLogo,
+		eth: ethLogo,
+		btc: btcLogo
+	};
+</script>
+
+<img class="benchmark-logo" src={logoUrls[benchmark]} data-benchmark={benchmark} alt="" aria-hidden="true" />
+
+<style>
+	.benchmark-logo {
+		width: 1.25rem;
+		height: 1.25rem;
+		flex: 0 0 auto;
+		object-fit: contain;
+	}
+</style>

--- a/src/lib/top-vaults/equity-comparison/VaultEquityComparisonChart.svelte
+++ b/src/lib/top-vaults/equity-comparison/VaultEquityComparisonChart.svelte
@@ -214,6 +214,11 @@ on one TradingView lightweight-charts pane.
 	.comparison-chart {
 		min-width: 0;
 
+		:global(.chart-container > .tv-chart) {
+			width: calc(100% - var(--chart-container-padding) - var(--chart-container-padding));
+			margin-inline: var(--chart-container-padding);
+		}
+
 		:global(.chart-tooltip) {
 			background: var(--c-text-inverted);
 		}
@@ -291,11 +296,14 @@ on one TradingView lightweight-charts pane.
 	}
 
 	.legend {
+		box-sizing: border-box;
 		display: flex;
 		flex-wrap: wrap;
 		justify-content: center;
 		gap: var(--space-sm) var(--space-md);
+		width: 100%;
 		margin-top: var(--space-md);
+		padding-inline: var(--chart-container-padding);
 	}
 
 	.legend-item {

--- a/src/lib/top-vaults/equity-comparison/VaultEquityComparisonChart.svelte
+++ b/src/lib/top-vaults/equity-comparison/VaultEquityComparisonChart.svelte
@@ -1,0 +1,324 @@
+<!--
+@component
+Render server-prepared vault equity curves and fixed-colour market benchmarks
+on one TradingView lightweight-charts pane.
+
+@example
+
+```svelte
+  <VaultEquityComparisonChart {vaults} {data} {enabledBenchmarks} {colours} />
+```
+-->
+<script lang="ts">
+	import { LineSeries, type LineData, type UTCTimestamp } from 'lightweight-charts';
+	import ChartContainer from '$lib/charts/ChartContainer.svelte';
+	import ChartTooltip from '$lib/charts/ChartTooltip.svelte';
+	import Tooltip from '$lib/components/Tooltip.svelte';
+	import Series from '$lib/charts/Series.svelte';
+	import { formatDate } from '$lib/charts/helpers';
+	import { formatNumber } from '$lib/helpers/formatters';
+	import { benchmarkComparisonColours } from './colours';
+	import type {
+		ComparisonBenchmark,
+		ComparisonChartSeries,
+		ComparisonTimeBucket,
+		ComparisonTimeSpan,
+		ComparisonVault,
+		VaultComparisonChartResponse
+	} from './types';
+	import { comparisonTimeSpanKeys } from './types';
+
+	interface Props {
+		vaults: ComparisonVault[];
+		data?: VaultComparisonChartResponse;
+		enabledBenchmarks: ComparisonBenchmark[];
+		colours: ReadonlyMap<string, string>;
+		loading?: boolean;
+		selectedTimeSpan?: ComparisonTimeSpan;
+		onTimeSpanChange?: (timeSpan: ComparisonTimeSpan) => void;
+	}
+
+	type ChartPointMeta = {
+		kind: 'vault' | 'benchmark';
+		id: string;
+		label: string;
+		colour: string;
+		indexValue: number;
+		discontinuous?: boolean;
+	};
+
+	type ComparisonChartPoint = LineData<UTCTimestamp> & { customValues: ChartPointMeta };
+
+	let {
+		vaults,
+		data,
+		enabledBenchmarks,
+		colours,
+		loading = false,
+		selectedTimeSpan = '3M',
+		onTimeSpanChange
+	}: Props = $props();
+	let vaultById = $derived(new Map(vaults.map((vault) => [vault.id, vault])));
+	let vaultSeries = $derived(data?.vaultSeries ?? []);
+	let vaultSeriesById = $derived(new Map(vaultSeries.map((series) => [series.id, series])));
+	let benchmarkSeriesById = $derived(new Map((data?.benchmarkSeries ?? []).map((series) => [series.id, series])));
+	let rangeDriver = $derived(
+		data?.range
+			? ([
+					[data.range[0], 100],
+					[data.range[1], 100]
+				] as [number, number][])
+			: undefined
+	);
+
+	const benchmarkLabels: Record<ComparisonBenchmark, string> = {
+		treasury: 'US 3M T-bill',
+		eth: 'ETH',
+		btc: 'BTC'
+	};
+
+	function buildChartPoints(
+		series: ComparisonChartSeries | undefined,
+		timeBucket: ComparisonTimeBucket,
+		kind: ChartPointMeta['kind']
+	): ComparisonChartPoint[] {
+		if (!series) return [];
+		const benchmark = kind === 'benchmark' ? (series.id as ComparisonBenchmark) : undefined;
+		const label = benchmark ? benchmarkLabels[benchmark] : (vaultById.get(series.id)?.name ?? series.id);
+		const colour = benchmark
+			? benchmarkComparisonColours[benchmark]
+			: (colours.get(series.id) ?? 'var(--c-text-light)');
+
+		return series.points[timeBucket].map((point) => ({
+			time: point.time as UTCTimestamp,
+			value: point.value,
+			customValues: {
+				kind,
+				id: series.id,
+				label,
+				colour,
+				indexValue: point.value,
+				discontinuous: series.discontinuous
+			}
+		}));
+	}
+
+	function tooltipRows(points: unknown[]): ChartPointMeta[] {
+		return points.flatMap((point) => {
+			if (!point || typeof point !== 'object' || !('customValues' in point)) return [];
+			const customValues = (point as { customValues?: ChartPointMeta }).customValues;
+			return customValues ? [customValues] : [];
+		});
+	}
+</script>
+
+<div class="comparison-chart">
+	<ChartContainer
+		boxed
+		data={rangeDriver}
+		formatValue={(value) => formatNumber(value, 1)}
+		timeSpanOptions={comparisonTimeSpanKeys}
+		initialTimeSpan={selectedTimeSpan}
+		onTimeSpanChange={(timeSpan) => onTimeSpanChange?.(timeSpan as ComparisonTimeSpan)}
+		{loading}
+		crosshairs
+		options={{ handleScroll: false, handleScale: false }}
+	>
+		{#snippet title()}
+			<h2 aria-label="Vault returns index">
+				<Tooltip>
+					<span slot="trigger" class="chart-heading">Vault returns index</span>
+					<svelte:fragment slot="popup">
+						Oldest vault starts at 100; younger vaults join at the highest overlapping curve.
+					</svelte:fragment>
+				</Tooltip>
+			</h2>
+		{/snippet}
+
+		{#snippet series({ timeSpan })}
+			{@const timeBucket = timeSpan.timeBucket as ComparisonTimeBucket}
+			{#each vaults as vault (vault.id)}
+				<Series
+					type={LineSeries}
+					data={buildChartPoints(vaultSeriesById.get(vault.id), timeBucket, 'vault')}
+					options={{
+						color: colours.get(vault.id),
+						lineWidth: 2,
+						priceLineVisible: false,
+						lastValueVisible: false,
+						crosshairMarkerVisible: false
+					}}
+				/>
+			{/each}
+
+			{#each enabledBenchmarks as benchmark (benchmark)}
+				<Series
+					type={LineSeries}
+					data={buildChartPoints(benchmarkSeriesById.get(benchmark), timeBucket, 'benchmark')}
+					options={{
+						color: benchmarkComparisonColours[benchmark],
+						lineWidth: 2,
+						lineStyle: 2,
+						priceLineVisible: false,
+						lastValueVisible: false,
+						crosshairMarkerVisible: false
+					}}
+				/>
+			{/each}
+		{/snippet}
+
+		{#snippet tooltip({ point, time }, seriesData, timeSpan)}
+			{@const rows = tooltipRows(seriesData)}
+			{#if rows.length}
+				<ChartTooltip {point}>
+					<div class="tooltip-date">{formatDate(time as number, timeSpan.timeBucket)}</div>
+					<ul class="tooltip-rows">
+						{#each rows as row (`${row.kind}:${row.id}`)}
+							<li style:--series-colour={row.colour} title={row.label}>
+								<span class="swatch" aria-hidden="true"></span>
+								<span class="tooltip-label" class:vault-name={row.kind === 'vault'}>
+									{row.label}{#if row.discontinuous}<small> · no overlap</small>{/if}
+								</span>
+								<strong>{formatNumber(row.indexValue, 1)}</strong>
+							</li>
+						{/each}
+					</ul>
+				</ChartTooltip>
+			{/if}
+		{/snippet}
+
+		{#snippet footer()}
+			<footer class="legend" aria-label="Equity comparison chart legend">
+				{#each vaults as vault (vault.id)}
+					<div class="legend-item" style:--series-colour={colours.get(vault.id)} title={vault.name}>
+						<span class="swatch" aria-hidden="true"></span><span class="vault-name">{vault.name}</span>
+						{#if vaultSeriesById.get(vault.id)?.discontinuous}<small>No overlap</small>{/if}
+					</div>
+				{/each}
+				{#each enabledBenchmarks as benchmark (benchmark)}
+					<div
+						class="legend-item"
+						class:unavailable={data?.benchmarkErrors[benchmark]}
+						style:--series-colour={benchmarkComparisonColours[benchmark]}
+					>
+						<span class="swatch" aria-hidden="true"></span><span>{benchmarkLabels[benchmark]}</span>
+						{#if data?.benchmarkErrors[benchmark]}<small>Unavailable</small>{/if}
+					</div>
+				{/each}
+			</footer>
+		{/snippet}
+	</ChartContainer>
+</div>
+
+<style>
+	.comparison-chart {
+		min-width: 0;
+
+		:global(.chart-tooltip) {
+			background: var(--c-text-inverted);
+		}
+
+		@media (--viewport-xs) {
+			:global(.chart-container > header) {
+				grid-template-columns: 1fr;
+				gap: var(--space-sm);
+			}
+
+			:global(.chart-container > header .segmented-control) {
+				width: 100%;
+			}
+		}
+
+		:global([data-css-props]) {
+			--chart-aspect-ratio: auto;
+			--chart-height: 31rem;
+		}
+
+		h2 {
+			font: var(--f-heading-md-medium);
+		}
+
+		.chart-heading {
+			border-bottom: 1px dashed var(--c-text-light);
+		}
+	}
+
+	.tooltip-date {
+		margin-bottom: var(--space-sm);
+		color: var(--c-text-extra-light);
+		font: var(--f-ui-sm-bold);
+	}
+
+	.tooltip-rows {
+		display: grid;
+		gap: var(--space-xs);
+		min-width: 13rem;
+		max-width: min(23rem, 70vw);
+		margin: 0;
+		padding: 0;
+		list-style: none;
+
+		li {
+			display: grid;
+			grid-template-columns: auto minmax(0, 1fr) auto;
+			gap: var(--space-xs);
+			align-items: center;
+		}
+	}
+
+	.tooltip-label,
+	.legend-item span:last-of-type {
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+	}
+
+	.tooltip-label small {
+		color: var(--c-text-extra-light);
+		font: inherit;
+	}
+
+	.vault-name {
+		color: var(--c-text);
+	}
+
+	.swatch {
+		display: block;
+		width: 1.25rem;
+		height: 0;
+		border-top: 2px solid var(--series-colour);
+		border-radius: 999px;
+	}
+
+	.legend {
+		display: flex;
+		flex-wrap: wrap;
+		justify-content: center;
+		gap: var(--space-sm) var(--space-md);
+		margin-top: var(--space-md);
+	}
+
+	.legend-item {
+		display: inline-grid;
+		grid-template-columns: auto minmax(0, auto) auto;
+		gap: var(--space-xs);
+		align-items: center;
+		max-width: 18rem;
+		color: var(--c-text-extra-light);
+		font: var(--f-ui-sm-medium);
+
+		&.unavailable {
+			opacity: 0.6;
+		}
+
+		small {
+			color: var(--c-error);
+		}
+	}
+
+	@media (--viewport-xs) {
+		.comparison-chart :global([data-css-props]) {
+			--chart-height: 26rem;
+		}
+	}
+</style>

--- a/src/lib/top-vaults/equity-comparison/VaultEquityComparisonChart.svelte
+++ b/src/lib/top-vaults/equity-comparison/VaultEquityComparisonChart.svelte
@@ -17,6 +17,7 @@ on one TradingView lightweight-charts pane.
 	import Series from '$lib/charts/Series.svelte';
 	import { formatDate } from '$lib/charts/helpers';
 	import { formatNumber } from '$lib/helpers/formatters';
+	import BenchmarkLogo from './BenchmarkLogo.svelte';
 	import { benchmarkComparisonColours } from './colours';
 	import type {
 		ComparisonBenchmark,
@@ -44,6 +45,7 @@ on one TradingView lightweight-charts pane.
 		label: string;
 		colour: string;
 		indexValue: number;
+		benchmark?: ComparisonBenchmark;
 		discontinuous?: boolean;
 	};
 
@@ -76,7 +78,6 @@ on one TradingView lightweight-charts pane.
 		eth: 'ETH',
 		btc: 'BTC'
 	};
-
 	function buildChartPoints(
 		series: ComparisonChartSeries | undefined,
 		timeBucket: ComparisonTimeBucket,
@@ -98,6 +99,7 @@ on one TradingView lightweight-charts pane.
 				label,
 				colour,
 				indexValue: point.value,
+				benchmark,
 				discontinuous: series.discontinuous
 			}
 		}));
@@ -175,7 +177,11 @@ on one TradingView lightweight-charts pane.
 					<ul class="tooltip-rows">
 						{#each rows as row (`${row.kind}:${row.id}`)}
 							<li style:--series-colour={row.colour} title={row.label}>
-								<span class="swatch" aria-hidden="true"></span>
+								{#if row.kind === 'benchmark' && row.benchmark}
+									<BenchmarkLogo benchmark={row.benchmark} />
+								{:else}
+									<span class="swatch" aria-hidden="true"></span>
+								{/if}
 								<span class="tooltip-label" class:vault-name={row.kind === 'vault'}>
 									{row.label}{#if row.discontinuous}<small> · no overlap</small>{/if}
 								</span>
@@ -201,7 +207,7 @@ on one TradingView lightweight-charts pane.
 						class:unavailable={data?.benchmarkErrors[benchmark]}
 						style:--series-colour={benchmarkComparisonColours[benchmark]}
 					>
-						<span class="swatch" aria-hidden="true"></span><span>{benchmarkLabels[benchmark]}</span>
+						<BenchmarkLogo {benchmark} /><span>{benchmarkLabels[benchmark]}</span>
 						{#if data?.benchmarkErrors[benchmark]}<small>Unavailable</small>{/if}
 					</div>
 				{/each}

--- a/src/lib/top-vaults/equity-comparison/colours.test.ts
+++ b/src/lib/top-vaults/equity-comparison/colours.test.ts
@@ -1,0 +1,18 @@
+import { assignVaultComparisonColours, benchmarkComparisonColours, vaultComparisonColours } from './colours';
+
+describe('comparison colours', () => {
+	test('assigns unique vault colours and preserves surviving assignments', () => {
+		const initial = assignVaultComparisonColours(['a', 'b', 'c']);
+		const next = assignVaultComparisonColours(['a', 'c', 'd'], initial);
+		expect(new Set(next.values()).size).toBe(3);
+		expect(next.get('a')).toBe(initial.get('a'));
+		expect(next.get('c')).toBe(initial.get('c'));
+	});
+
+	test('does not reuse fixed benchmark colours', () => {
+		const benchmarkRgbColours = new Set(Object.values(benchmarkComparisonColours).map((colour) => colour.slice(0, 7)));
+		for (const colour of vaultComparisonColours) {
+			expect(benchmarkRgbColours).not.toContain(colour);
+		}
+	});
+});

--- a/src/lib/top-vaults/equity-comparison/colours.ts
+++ b/src/lib/top-vaults/equity-comparison/colours.ts
@@ -1,0 +1,53 @@
+import type { ComparisonBenchmark } from './types';
+
+/** Vault colours avoid the established blue, orange, and purple benchmark hues. */
+export const vaultComparisonColours = [
+	'#2fbf71',
+	'#ef476f',
+	'#ffd166',
+	'#06d6a0',
+	'#e76f51',
+	'#8ac926',
+	'#ff70a6',
+	'#a7c957'
+] as const;
+
+export const benchmarkComparisonColours: Record<ComparisonBenchmark, string> = {
+	treasury: '#4a90d9a0',
+	eth: '#627eea80',
+	btc: '#f7931a80'
+};
+
+/**
+ * Preserve existing colour assignments and allocate the first unused colour to
+ * newly selected vaults.
+ */
+export function assignVaultComparisonColours(
+	vaultIds: readonly string[],
+	previous: ReadonlyMap<string, string> = new Map()
+): Map<string, string> {
+	const assignments = new Map<string, string>();
+	const used = new Set<string>();
+
+	for (const vaultId of vaultIds) {
+		const colour = previous.get(vaultId);
+		if (
+			colour &&
+			vaultComparisonColours.includes(colour as (typeof vaultComparisonColours)[number]) &&
+			!used.has(colour)
+		) {
+			assignments.set(vaultId, colour);
+			used.add(colour);
+		}
+	}
+
+	for (const vaultId of vaultIds) {
+		if (assignments.has(vaultId)) continue;
+		const colour = vaultComparisonColours.find((candidate) => !used.has(candidate));
+		if (!colour) break;
+		assignments.set(vaultId, colour);
+		used.add(colour);
+	}
+
+	return assignments;
+}

--- a/src/lib/top-vaults/equity-comparison/equity-curves.test.ts
+++ b/src/lib/top-vaults/equity-comparison/equity-curves.test.ts
@@ -1,0 +1,192 @@
+import { utcHour } from 'd3-time';
+import {
+	alignVaultEquityCurves,
+	calculateComparisonPeriodMetrics,
+	indexBenchmarkPrices,
+	resampleComparisonPoints
+} from './equity-curves';
+
+describe('alignVaultEquityCurves', () => {
+	test('indexes the oldest vault to 100', () => {
+		const [vault] = alignVaultEquityCurves([
+			{
+				id: 'old',
+				points: [
+					[1, 2],
+					[2, 3]
+				]
+			}
+		]);
+		expect(vault.anchor).toBe(100);
+		expect(vault.points.map(({ value }) => value)).toEqual([100, 150]);
+	});
+
+	test('anchors a younger vault to the highest overlapping curve', () => {
+		const result = alignVaultEquityCurves([
+			{
+				id: 'lower',
+				points: [
+					[1, 1],
+					[3, 0.9],
+					[5, 1]
+				]
+			},
+			{
+				id: 'higher',
+				points: [
+					[1, 2],
+					[3, 3],
+					[5, 4]
+				]
+			},
+			{
+				id: 'young',
+				points: [
+					[4, 10],
+					[5, 12]
+				]
+			}
+		]);
+		const young = result.find(({ id }) => id === 'young')!;
+		expect(young.anchor).toBe(150);
+		expect(young.points[0].value).toBe(150);
+		expect(young.points[1].value).toBe(180);
+		expect(young.points[0].time).toBe(4);
+	});
+
+	test('aligns same-start cohorts without processing-order bias', () => {
+		const result = alignVaultEquityCurves([
+			{
+				id: 'first',
+				points: [
+					[1, 1],
+					[2, 2]
+				]
+			},
+			{
+				id: 'second',
+				points: [
+					[1, 5],
+					[2, 4]
+				]
+			}
+		]);
+		expect(result.map(({ anchor }) => anchor)).toEqual([100, 100]);
+	});
+
+	test('falls back to 100 for non-overlapping histories', () => {
+		const result = alignVaultEquityCurves([
+			{
+				id: 'finished',
+				points: [
+					[1, 1],
+					[2, 2]
+				]
+			},
+			{
+				id: 'later',
+				points: [
+					[4, 5],
+					[5, 6]
+				]
+			}
+		]);
+		expect(result[1]).toMatchObject({ anchor: 100, discontinuous: true });
+	});
+
+	test('sorts, de-duplicates, and removes invalid samples', () => {
+		const [vault] = alignVaultEquityCurves([
+			{
+				id: 'vault',
+				points: [
+					[2, 4],
+					[1, 2],
+					[2, 6],
+					[3, 0],
+					[4, Number.NaN]
+				]
+			}
+		]);
+		expect(vault.points.map(({ time, value }) => [time, value])).toEqual([
+			[1, 100],
+			[2, 300]
+		]);
+	});
+});
+
+describe('indexBenchmarkPrices', () => {
+	test('indexes valid market prices to the requested starting value', () => {
+		expect(
+			indexBenchmarkPrices(
+				[
+					[1, 20],
+					[2, 25]
+				],
+				100
+			)
+		).toEqual([
+			[1, 100],
+			[2, 125]
+		]);
+	});
+});
+
+describe('resampleComparisonPoints', () => {
+	test('prepares forward-filled chart points at the requested server-side interval', () => {
+		const [series] = alignVaultEquityCurves([
+			{
+				id: 'vault',
+				points: [
+					[0, 1],
+					[3 * 3_600, 1.1],
+					[8 * 3_600, 1.2]
+				]
+			}
+		]);
+
+		const points = resampleComparisonPoints(series.points, utcHour.every(4)!);
+		expect(points.map(({ time, value }) => [time, value])).toEqual([
+			[0, 100],
+			[4 * 3_600, 110.00000000000001],
+			[8 * 3_600, 120]
+		]);
+	});
+});
+
+describe('calculateComparisonPeriodMetrics', () => {
+	const day = 86_400;
+	const start = Date.UTC(2024, 0, 1) / 1_000;
+	const end = start + 400 * day;
+	const point = (time: number, value: number) => ({ time, value });
+
+	test('calculates CAGR and since date for each visible chart period', () => {
+		const dailyPoints = Array.from({ length: 401 }, (_, index) => point(start + index * day, 100 + index / 4));
+		const metrics = calculateComparisonPeriodMetrics(
+			{
+				'4h': dailyPoints,
+				'1d': dailyPoints
+			},
+			[start, end]
+		);
+
+		expect(metrics.Max.since).toBe('2024-01-01');
+		expect(metrics.Max.cagr).toBeCloseTo(0.882, 3);
+		expect(metrics['1M'].since).toBe('2025-01-06');
+		expect(metrics['1M'].cagr).toBeCloseTo(0.592, 3);
+	});
+
+	test('uses a younger vault first plotted point as its since date', () => {
+		const youngerStart = start + 350 * day;
+		const youngerPoints = [point(youngerStart, 150), point(end, 165)];
+		const metrics = calculateComparisonPeriodMetrics(
+			{
+				'4h': youngerPoints,
+				'1d': youngerPoints
+			},
+			[start, end]
+		);
+
+		expect(metrics['3M'].since).toBe('2024-12-16');
+		expect(metrics['3M'].cagr).toBeCloseTo(1.005, 3);
+	});
+});

--- a/src/lib/top-vaults/equity-comparison/equity-curves.ts
+++ b/src/lib/top-vaults/equity-comparison/equity-curves.ts
@@ -1,0 +1,204 @@
+import type { TimeInterval } from 'd3-time';
+import { getDataRange, resampleTimeSeries } from '$lib/charts/helpers';
+import { TimeSpans } from '$lib/charts/time-span';
+import { annualizedReturn } from '$lib/helpers/financial';
+import {
+	comparisonTimeSpanKeys,
+	type AlignedEquityPoint,
+	type AlignedVaultSeries,
+	type ComparisonChartPoint,
+	type ComparisonPeriodMetrics,
+	type ComparisonTimeBucket,
+	type ComparisonTimeSpan,
+	type VaultPriceSeries
+} from './types';
+
+interface PreparedSeries {
+	id: string;
+	selectionIndex: number;
+	points: [number, number][];
+}
+
+function prepareSeries(series: VaultPriceSeries, selectionIndex: number): PreparedSeries | null {
+	const pointsByTimestamp = new Map<number, number>();
+
+	for (const [timestamp, price] of series.points) {
+		if (!Number.isFinite(timestamp) || !Number.isFinite(price) || price <= 0) continue;
+		pointsByTimestamp.set(timestamp, price);
+	}
+
+	const points = [...pointsByTimestamp.entries()].sort(([left], [right]) => left - right);
+	return points.length ? { id: series.id, selectionIndex, points } : null;
+}
+
+function valueAtOrBefore(points: AlignedEquityPoint[], timestamp: number): number | null {
+	let low = 0;
+	let high = points.length - 1;
+	let match = -1;
+
+	while (low <= high) {
+		const middle = Math.floor((low + high) / 2);
+		if (points[middle].time <= timestamp) {
+			match = middle;
+			low = middle + 1;
+		} else {
+			high = middle - 1;
+		}
+	}
+
+	return match === -1 ? null : points[match].value;
+}
+
+function alignSeries(series: PreparedSeries, anchor: number, discontinuous: boolean): AlignedVaultSeries {
+	const firstPrice = series.points[0][1];
+	return {
+		id: series.id,
+		anchor,
+		discontinuous,
+		points: series.points.map(([time, rawPrice]) => ({
+			time,
+			value: (rawPrice / firstPrice) * anchor
+		}))
+	};
+}
+
+/**
+ * Convert raw vault prices to comparable indexed equity curves.
+ *
+ * The oldest cohort starts at 100. Each younger cohort starts at the highest
+ * value among older curves which still cover its first timestamp.
+ */
+export function alignVaultEquityCurves(series: readonly VaultPriceSeries[]): AlignedVaultSeries[] {
+	const prepared = series
+		.map(prepareSeries)
+		.filter((value): value is PreparedSeries => value !== null)
+		.sort((left, right) => left.points[0][0] - right.points[0][0] || left.selectionIndex - right.selectionIndex);
+
+	const alignedById = new Map<string, AlignedVaultSeries>();
+	let index = 0;
+
+	while (index < prepared.length) {
+		const cohortStart = prepared[index].points[0][0];
+		const cohort: PreparedSeries[] = [];
+		while (index < prepared.length && prepared[index].points[0][0] === cohortStart) {
+			cohort.push(prepared[index++]);
+		}
+
+		let anchor = 100;
+		let discontinuous = alignedById.size > 0;
+		if (alignedById.size > 0) {
+			const overlappingValues: number[] = [];
+			for (const older of alignedById.values()) {
+				const lastPoint = older.points.at(-1);
+				if (!lastPoint || lastPoint.time < cohortStart) continue;
+				const value = valueAtOrBefore(older.points, cohortStart);
+				if (value !== null) overlappingValues.push(value);
+			}
+
+			if (overlappingValues.length) {
+				anchor = Math.max(...overlappingValues);
+				discontinuous = false;
+			}
+		}
+
+		for (const member of cohort) alignedById.set(member.id, alignSeries(member, anchor, discontinuous));
+	}
+
+	return series.flatMap(({ id }) => {
+		const aligned = alignedById.get(id);
+		return aligned ? [aligned] : [];
+	});
+}
+
+/** Convert a market-price series to an equity index beginning at `startingValue`. */
+export function indexBenchmarkPrices(points: readonly [number, number][], startingValue = 100): [number, number][] {
+	const valid = points.filter(
+		(point): point is [number, number] => Number.isFinite(point[0]) && Number.isFinite(point[1]) && point[1] > 0
+	);
+	if (!valid.length || startingValue <= 0) return [];
+	const firstPrice = valid[0][1];
+	return valid.map(([timestamp, price]) => [timestamp, (price / firstPrice) * startingValue]);
+}
+
+/**
+ * Resample an aligned series on the server, forward-filling the latest point.
+ *
+ * @param points Complete aligned history
+ * @param interval Output time interval
+ */
+export function resampleComparisonPoints(
+	points: readonly AlignedEquityPoint[],
+	interval: TimeInterval
+): ComparisonChartPoint[] {
+	if (points.length < 2) return points.map(toComparisonChartPoint);
+
+	const result: ComparisonChartPoint[] = [toComparisonChartPoint(points[0])];
+	const lastMs = points.at(-1)!.time * 1000;
+	let sourceIndex = 0;
+	let current = interval.ceil(new Date(points[0].time * 1000));
+
+	while (current.getTime() <= lastMs) {
+		const timestamp = current.getTime() / 1000;
+		while (sourceIndex < points.length - 1 && points[sourceIndex + 1].time <= timestamp) sourceIndex++;
+		const source = points[sourceIndex];
+		if (timestamp > result.at(-1)!.time) result.push({ ...toComparisonChartPoint(source), time: timestamp });
+		current = interval.offset(current);
+	}
+
+	const lastPoint = points.at(-1)!;
+	if (lastPoint.time > result.at(-1)!.time) result.push(toComparisonChartPoint(lastPoint));
+	return result;
+}
+
+/**
+ * Calculate chart-window CAGR and first plotted date for every comparison period.
+ *
+ * @param points Server-resampled chart points
+ * @param range Complete comparison chart range
+ */
+export function calculateComparisonPeriodMetrics(
+	points: Record<ComparisonTimeBucket, ComparisonChartPoint[]>,
+	range: [number, number]
+): Record<ComparisonTimeSpan, ComparisonPeriodMetrics> {
+	const metrics = {} as Record<ComparisonTimeSpan, ComparisonPeriodMetrics>;
+
+	for (const key of comparisonTimeSpanKeys) {
+		const timeSpan = TimeSpans.get(key);
+		const rangeDriver = resampleTimeSeries(
+			[
+				[range[0], 100],
+				[range[1], 100]
+			],
+			timeSpan.interval
+		);
+		const visibleRange = getDataRange(rangeDriver, timeSpan);
+		const periodPoints = visibleRange
+			? points[timeSpan.timeBucket as ComparisonTimeBucket].filter(
+					(point) => point.time >= visibleRange[0].getTime() / 1_000 && point.time <= visibleRange[1].getTime() / 1_000
+				)
+			: [];
+		const first = periodPoints[0];
+		const last = periodPoints.at(-1);
+		let cagr: number | null = null;
+
+		if (first && last && last.time > first.time && first.value > 0 && last.value > 0) {
+			const annualised = annualizedReturn(
+				new Date(first.time * 1_000),
+				new Date(last.time * 1_000),
+				last.value / first.value - 1
+			);
+			if (annualised !== undefined && Number.isFinite(annualised)) cagr = annualised;
+		}
+
+		metrics[key] = {
+			cagr,
+			since: first ? new Date(first.time * 1_000).toISOString().slice(0, 10) : null
+		};
+	}
+
+	return metrics;
+}
+
+function toComparisonChartPoint(point: AlignedEquityPoint): ComparisonChartPoint {
+	return { time: point.time, value: point.value };
+}

--- a/src/lib/top-vaults/equity-comparison/state.test.ts
+++ b/src/lib/top-vaults/equity-comparison/state.test.ts
@@ -1,0 +1,44 @@
+import {
+	MAX_SELECTED_VAULTS,
+	EMPTY_COMPARISON_PARAMETER,
+	EMPTY_COMPARISON_VALUE,
+	canonicaliseComparisonBenchmarks,
+	canonicaliseComparisonVaultIds,
+	parseEquityComparisonState,
+	writeEquityComparisonState
+} from './state';
+
+describe('equity comparison state', () => {
+	test('canonicalises vault IDs while preserving insertion order', () => {
+		expect(canonicaliseComparisonVaultIds([' second ', 'first', 'second', '', 'third'])).toEqual([
+			'second',
+			'first',
+			'third'
+		]);
+	});
+
+	test('enforces the selection limit', () => {
+		const values = Array.from({ length: MAX_SELECTED_VAULTS + 2 }, (_, index) => `vault-${index}`);
+		expect(canonicaliseComparisonVaultIds(values)).toHaveLength(MAX_SELECTED_VAULTS);
+	});
+
+	test('uses fixed benchmark order and ignores unknown values', () => {
+		expect(canonicaliseComparisonBenchmarks(['btc', 'unknown', 'treasury', 'btc'])).toEqual(['treasury', 'btc']);
+	});
+
+	test('round trips repeated parameters and preserves unrelated state', () => {
+		const initial = new URLSearchParams('foo=bar&vault=a%2Cb&vault=two&benchmark=btc');
+		const parsed = parseEquityComparisonState(initial);
+		expect(parsed).toEqual({ vaultIds: ['a,b', 'two'], benchmarks: ['btc'] });
+
+		const written = writeEquityComparisonState(initial, parsed);
+		expect(written.get('foo')).toBe('bar');
+		expect(written.getAll('vault')).toEqual(['a,b', 'two']);
+		expect(written.getAll('benchmark')).toEqual(['btc']);
+	});
+
+	test('marks an intentionally empty selection so defaults are not restored', () => {
+		const written = writeEquityComparisonState(new URLSearchParams(), { vaultIds: [], benchmarks: [] });
+		expect(written.get(EMPTY_COMPARISON_PARAMETER)).toBe(EMPTY_COMPARISON_VALUE);
+	});
+});

--- a/src/lib/top-vaults/equity-comparison/state.test.ts
+++ b/src/lib/top-vaults/equity-comparison/state.test.ts
@@ -29,16 +29,33 @@ describe('equity comparison state', () => {
 	test('round trips repeated parameters and preserves unrelated state', () => {
 		const initial = new URLSearchParams('foo=bar&vault=a%2Cb&vault=two&benchmark=btc');
 		const parsed = parseEquityComparisonState(initial);
-		expect(parsed).toEqual({ vaultIds: ['a,b', 'two'], benchmarks: ['btc'] });
+		expect(parsed).toEqual({ vaultIds: ['a,b', 'two'], benchmarks: ['btc'], timeSpan: '3M' });
 
 		const written = writeEquityComparisonState(initial, parsed);
 		expect(written.get('foo')).toBe('bar');
 		expect(written.getAll('vault')).toEqual(['a,b', 'two']);
 		expect(written.getAll('benchmark')).toEqual(['btc']);
+		expect(written.get('period')).toBe('3M');
+	});
+
+	test('validates and persists the selected time period', () => {
+		expect(parseEquityComparisonState(new URLSearchParams('period=1Y')).timeSpan).toBe('1Y');
+		expect(parseEquityComparisonState(new URLSearchParams('period=invalid')).timeSpan).toBe('3M');
+
+		const written = writeEquityComparisonState(new URLSearchParams(), {
+			vaultIds: ['vault-one'],
+			benchmarks: [],
+			timeSpan: 'Max'
+		});
+		expect(written.get('period')).toBe('Max');
 	});
 
 	test('marks an intentionally empty selection so defaults are not restored', () => {
-		const written = writeEquityComparisonState(new URLSearchParams(), { vaultIds: [], benchmarks: [] });
+		const written = writeEquityComparisonState(new URLSearchParams(), {
+			vaultIds: [],
+			benchmarks: [],
+			timeSpan: '3M'
+		});
 		expect(written.get(EMPTY_COMPARISON_PARAMETER)).toBe(EMPTY_COMPARISON_VALUE);
 	});
 });

--- a/src/lib/top-vaults/equity-comparison/state.ts
+++ b/src/lib/top-vaults/equity-comparison/state.ts
@@ -1,0 +1,62 @@
+import { comparisonBenchmarkKeys, type ComparisonBenchmark } from './types';
+
+export const MAX_SELECTED_VAULTS = 8;
+export const EMPTY_COMPARISON_PARAMETER = 'comparison';
+export const EMPTY_COMPARISON_VALUE = 'empty';
+
+export interface EquityComparisonState {
+	vaultIds: string[];
+	benchmarks: ComparisonBenchmark[];
+}
+
+function uniqueTrimmed(values: readonly string[], limit = Number.POSITIVE_INFINITY): string[] {
+	const seen = new Set<string>();
+	const result: string[] = [];
+
+	for (const value of values) {
+		const trimmed = value.trim();
+		if (!trimmed || seen.has(trimmed)) continue;
+		seen.add(trimmed);
+		result.push(trimmed);
+		if (result.length === limit) break;
+	}
+
+	return result;
+}
+
+/** Canonicalise ordered vault IDs while preserving the first occurrence. */
+export function canonicaliseComparisonVaultIds(values: readonly string[]): string[] {
+	return uniqueTrimmed(values, MAX_SELECTED_VAULTS);
+}
+
+/** Canonicalise benchmarks into the fixed control/legend order. */
+export function canonicaliseComparisonBenchmarks(values: readonly string[]): ComparisonBenchmark[] {
+	const selected = new Set(uniqueTrimmed(values));
+	return comparisonBenchmarkKeys.filter((benchmark) => selected.has(benchmark));
+}
+
+/** Parse comparison state from repeated `vault` and `benchmark` parameters. */
+export function parseEquityComparisonState(searchParams: URLSearchParams): EquityComparisonState {
+	return {
+		vaultIds: canonicaliseComparisonVaultIds(searchParams.getAll('vault')),
+		benchmarks: canonicaliseComparisonBenchmarks(searchParams.getAll('benchmark'))
+	};
+}
+
+/** Replace comparison parameters while preserving unrelated query parameters. */
+export function writeEquityComparisonState(
+	searchParams: URLSearchParams,
+	state: EquityComparisonState
+): URLSearchParams {
+	const next = new URLSearchParams(searchParams);
+	next.delete('vault');
+	next.delete('benchmark');
+	next.delete(EMPTY_COMPARISON_PARAMETER);
+
+	const vaultIds = canonicaliseComparisonVaultIds(state.vaultIds);
+	for (const vaultId of vaultIds) next.append('vault', vaultId);
+	for (const benchmark of canonicaliseComparisonBenchmarks(state.benchmarks)) next.append('benchmark', benchmark);
+	if (!vaultIds.length) next.set(EMPTY_COMPARISON_PARAMETER, EMPTY_COMPARISON_VALUE);
+
+	return next;
+}

--- a/src/lib/top-vaults/equity-comparison/state.ts
+++ b/src/lib/top-vaults/equity-comparison/state.ts
@@ -1,4 +1,5 @@
 import { comparisonBenchmarkKeys, type ComparisonBenchmark } from './types';
+import { deserialiseSearchParams, serialiseSearchParams, type ParamSchema } from '$lib/helpers/url-search-state';
 
 export const MAX_SELECTED_VAULTS = 8;
 export const EMPTY_COMPARISON_PARAMETER = 'comparison';
@@ -8,6 +9,11 @@ export interface EquityComparisonState {
 	vaultIds: string[];
 	benchmarks: ComparisonBenchmark[];
 }
+
+const comparisonSearchParamsSchema = {
+	vault: { type: 'string[]', defaultValue: [] },
+	benchmark: { type: 'string[]', defaultValue: [], options: comparisonBenchmarkKeys }
+} as const satisfies ParamSchema;
 
 function uniqueTrimmed(values: readonly string[], limit = Number.POSITIVE_INFINITY): string[] {
 	const seen = new Set<string>();
@@ -37,9 +43,10 @@ export function canonicaliseComparisonBenchmarks(values: readonly string[]): Com
 
 /** Parse comparison state from repeated `vault` and `benchmark` parameters. */
 export function parseEquityComparisonState(searchParams: URLSearchParams): EquityComparisonState {
+	const state = deserialiseSearchParams(searchParams, comparisonSearchParamsSchema);
 	return {
-		vaultIds: canonicaliseComparisonVaultIds(searchParams.getAll('vault')),
-		benchmarks: canonicaliseComparisonBenchmarks(searchParams.getAll('benchmark'))
+		vaultIds: canonicaliseComparisonVaultIds(state.vault),
+		benchmarks: canonicaliseComparisonBenchmarks(state.benchmark)
 	};
 }
 
@@ -54,8 +61,13 @@ export function writeEquityComparisonState(
 	next.delete(EMPTY_COMPARISON_PARAMETER);
 
 	const vaultIds = canonicaliseComparisonVaultIds(state.vaultIds);
-	for (const vaultId of vaultIds) next.append('vault', vaultId);
-	for (const benchmark of canonicaliseComparisonBenchmarks(state.benchmarks)) next.append('benchmark', benchmark);
+	const comparisonParams = new URLSearchParams(
+		serialiseSearchParams(
+			{ vault: vaultIds, benchmark: canonicaliseComparisonBenchmarks(state.benchmarks) },
+			comparisonSearchParamsSchema
+		)
+	);
+	for (const [key, value] of comparisonParams) next.append(key, value);
 	if (!vaultIds.length) next.set(EMPTY_COMPARISON_PARAMETER, EMPTY_COMPARISON_VALUE);
 
 	return next;

--- a/src/lib/top-vaults/equity-comparison/state.ts
+++ b/src/lib/top-vaults/equity-comparison/state.ts
@@ -1,4 +1,9 @@
-import { comparisonBenchmarkKeys, type ComparisonBenchmark } from './types';
+import {
+	comparisonBenchmarkKeys,
+	comparisonTimeSpanKeys,
+	type ComparisonBenchmark,
+	type ComparisonTimeSpan
+} from './types';
 import { deserialiseSearchParams, serialiseSearchParams, type ParamSchema } from '$lib/helpers/url-search-state';
 
 export const MAX_SELECTED_VAULTS = 8;
@@ -8,11 +13,13 @@ export const EMPTY_COMPARISON_VALUE = 'empty';
 export interface EquityComparisonState {
 	vaultIds: string[];
 	benchmarks: ComparisonBenchmark[];
+	timeSpan: ComparisonTimeSpan;
 }
 
 const comparisonSearchParamsSchema = {
 	vault: { type: 'string[]', defaultValue: [] },
-	benchmark: { type: 'string[]', defaultValue: [], options: comparisonBenchmarkKeys }
+	benchmark: { type: 'string[]', defaultValue: [], options: comparisonBenchmarkKeys },
+	period: { type: 'string', defaultValue: '3M', options: comparisonTimeSpanKeys }
 } as const satisfies ParamSchema;
 
 function uniqueTrimmed(values: readonly string[], limit = Number.POSITIVE_INFINITY): string[] {
@@ -41,12 +48,13 @@ export function canonicaliseComparisonBenchmarks(values: readonly string[]): Com
 	return comparisonBenchmarkKeys.filter((benchmark) => selected.has(benchmark));
 }
 
-/** Parse comparison state from repeated `vault` and `benchmark` parameters. */
+/** Parse comparison state from the `vault`, `benchmark`, and `period` parameters. */
 export function parseEquityComparisonState(searchParams: URLSearchParams): EquityComparisonState {
 	const state = deserialiseSearchParams(searchParams, comparisonSearchParamsSchema);
 	return {
 		vaultIds: canonicaliseComparisonVaultIds(state.vault),
-		benchmarks: canonicaliseComparisonBenchmarks(state.benchmark)
+		benchmarks: canonicaliseComparisonBenchmarks(state.benchmark),
+		timeSpan: state.period as ComparisonTimeSpan
 	};
 }
 
@@ -58,16 +66,23 @@ export function writeEquityComparisonState(
 	const next = new URLSearchParams(searchParams);
 	next.delete('vault');
 	next.delete('benchmark');
+	next.delete('period');
 	next.delete(EMPTY_COMPARISON_PARAMETER);
 
 	const vaultIds = canonicaliseComparisonVaultIds(state.vaultIds);
 	const comparisonParams = new URLSearchParams(
 		serialiseSearchParams(
-			{ vault: vaultIds, benchmark: canonicaliseComparisonBenchmarks(state.benchmarks) },
+			{
+				vault: vaultIds,
+				benchmark: canonicaliseComparisonBenchmarks(state.benchmarks),
+				period: state.timeSpan
+			},
 			comparisonSearchParamsSchema
 		)
 	);
 	for (const [key, value] of comparisonParams) next.append(key, value);
+	// Keep the default explicit too, so every copied comparison URL fully describes the chart.
+	next.set('period', state.timeSpan);
 	if (!vaultIds.length) next.set(EMPTY_COMPARISON_PARAMETER, EMPTY_COMPARISON_VALUE);
 
 	return next;

--- a/src/lib/top-vaults/equity-comparison/types.ts
+++ b/src/lib/top-vaults/equity-comparison/types.ts
@@ -1,0 +1,66 @@
+/** Fixed comparison benchmarks available on the multi-vault equity chart. */
+export const comparisonBenchmarkKeys = ['treasury', 'eth', 'btc'] as const;
+
+export type ComparisonBenchmark = (typeof comparisonBenchmarkKeys)[number];
+
+/** Compact public vault metadata used by the comparison page. */
+export interface ComparisonVault {
+	id: string;
+	name: string;
+	href: string;
+	logoUrl: string | null;
+	protocolName: string;
+	chainName: string;
+	entityType: 'vault' | 'tokenised-fund' | 'blacklisted-vault';
+}
+
+/** Raw share-price history returned by the comparison chart-data endpoint. */
+export interface VaultPriceSeries {
+	id: string;
+	points: [timestamp: number, sharePrice: number][];
+}
+
+export interface AlignedEquityPoint {
+	time: number;
+	value: number;
+}
+
+export interface AlignedVaultSeries {
+	id: string;
+	anchor: number;
+	discontinuous: boolean;
+	points: AlignedEquityPoint[];
+}
+
+/** Server-prepared sampling resolutions used by the comparison chart controls. */
+export type ComparisonTimeBucket = '4h' | '1d';
+
+export const comparisonTimeSpanKeys = ['1M', '3M', '6M', '1Y', 'Max'] as const;
+
+export type ComparisonTimeSpan = (typeof comparisonTimeSpanKeys)[number];
+
+export interface ComparisonPeriodMetrics {
+	cagr: number | null;
+	since: string | null;
+}
+
+export interface ComparisonChartPoint {
+	time: number;
+	value: number;
+}
+
+export interface ComparisonChartSeries {
+	id: string;
+	discontinuous: boolean;
+	points: Record<ComparisonTimeBucket, ComparisonChartPoint[]>;
+	periodMetrics: Record<ComparisonTimeSpan, ComparisonPeriodMetrics>;
+}
+
+/** Compact, chart-ready response containing only the requested vaults and benchmarks. */
+export interface VaultComparisonChartResponse {
+	range: [start: number, end: number] | null;
+	vaultSeries: ComparisonChartSeries[];
+	benchmarkSeries: ComparisonChartSeries[];
+	missingVaultIds: string[];
+	benchmarkErrors: Partial<Record<ComparisonBenchmark, string>>;
+}

--- a/src/lib/top-vaults/test-utils.ts
+++ b/src/lib/top-vaults/test-utils.ts
@@ -56,7 +56,7 @@ const defaultVaultProps = {
 export function createTestVault(name: string, props: TestVaultProps = {}): VaultInfo {
 	const merged = { ...defaultVaultProps, ...props, name };
 	const address = merged.address ?? `0x${Math.random().toString(16).slice(2).padEnd(40, '0')}`;
-	const chain_id = getChain(merged.chain)?.id;
+	const chain_id = merged.chain_id ?? getChain(merged.chain)?.id;
 
 	return vaultInfoSchema.parse({
 		...getVaultNullableDefaults(),

--- a/src/lib/top-vaults/treasury-benchmark.test.ts
+++ b/src/lib/top-vaults/treasury-benchmark.test.ts
@@ -1,6 +1,6 @@
-import { describe, test, expect } from 'vitest';
+import { describe, test, expect, vi } from 'vitest';
 import { utcDay, utcHour } from 'd3-time';
-import { ratesToCumulativeReturn } from './treasury-benchmark';
+import { fetchTreasuryBenchmarkSeries, ratesToCumulativeReturn } from './treasury-benchmark';
 import { isPerpetualFuturesVault } from './isPerpetualFuturesVault';
 import { isValidDateString } from '$lib/fred-helpers';
 
@@ -156,6 +156,19 @@ describe('ratesToCumulativeReturn', () => {
 		const end = new Date('2025-01-31T00:00:00Z');
 		const rates = makeRates(start, 31, 4.0);
 		expect(ratesToCumulativeReturn(rates, 0, day, start, end)).toEqual([]);
+	});
+});
+
+describe('fetchTreasuryBenchmarkSeries', () => {
+	test('can bypass the module cache for callers with their own bounded cache', async () => {
+		const fetch = vi.fn(async () => new Response(JSON.stringify([[1_738_368_000, 4.2]])));
+		const start = new Date('2025-02-01T00:00:00Z');
+		const end = new Date('2025-03-01T00:00:00Z');
+
+		await fetchTreasuryBenchmarkSeries(fetch as unknown as Fetch, start, end, false);
+		await fetchTreasuryBenchmarkSeries(fetch as unknown as Fetch, start, end, false);
+
+		expect(fetch).toHaveBeenCalledTimes(2);
 	});
 });
 

--- a/src/lib/top-vaults/treasury-benchmark.ts
+++ b/src/lib/top-vaults/treasury-benchmark.ts
@@ -1,6 +1,6 @@
 /**
- * Client-side fetcher for FRED DTB3 (3-month Treasury bill) time series,
- * and cumulative return conversion for chart overlay.
+ * Fetch the FRED DGS3MO 3-month Treasury market-yield series and convert it
+ * to cumulative returns for chart overlays.
  */
 import type { TimeInterval } from 'd3-time';
 import type { UTCTimestamp } from 'lightweight-charts';
@@ -22,18 +22,25 @@ const YEAR_MS = 365.25 * 86_400 * 1000;
 const benchmarkRequestCache = new Map<string, Promise<RateEntry[]>>();
 
 /**
- * Fetch DTB3 time series from the server-side proxy endpoint.
+ * Fetch DGS3MO time series from the server-side proxy endpoint.
  *
  * Expands the start date backwards by 7 days to seed forward-fill,
  * so we have a rate observation even if the visible start falls on a weekend.
+ *
+ * @param useCache - Disable when the caller already has a bounded server-side cache.
  */
-export function fetchTreasuryBenchmarkSeries(fetch: Fetch, start: Date, end: Date): Promise<RateEntry[]> {
+export function fetchTreasuryBenchmarkSeries(
+	fetch: Fetch,
+	start: Date,
+	end: Date,
+	useCache = true
+): Promise<RateEntry[]> {
 	const seedStart = new Date(start.getTime() - SEED_DAYS * 86_400 * 1000);
 	const cosd = formatDateYMD(seedStart);
 	const coed = formatDateYMD(end);
 	const cacheKey = `${cosd}:${coed}`;
 
-	const cached = benchmarkRequestCache.get(cacheKey);
+	const cached = useCache ? benchmarkRequestCache.get(cacheKey) : undefined;
 	if (cached) return cached;
 
 	const params = new URLSearchParams({ cosd, coed });
@@ -43,16 +50,16 @@ export function fetchTreasuryBenchmarkSeries(fetch: Fetch, start: Date, end: Dat
 			return resp.json() as Promise<RateEntry[]>;
 		})
 		.catch((error) => {
-			benchmarkRequestCache.delete(cacheKey);
+			if (useCache) benchmarkRequestCache.delete(cacheKey);
 			throw error;
 		});
 
-	benchmarkRequestCache.set(cacheKey, promise);
+	if (useCache) benchmarkRequestCache.set(cacheKey, promise);
 	return promise;
 }
 
 /**
- * Convert FRED daily annual yield rates into a cumulative return price line.
+ * Convert FRED daily annual investment-basis yields into a cumulative return price line.
  *
  * Does NOT use resampleTimeSeries — that would discard customValues metadata.
  * Instead generates interval-aligned points directly, compounding based on

--- a/src/routes/_components/VaultEcosystemChart.svelte
+++ b/src/routes/_components/VaultEcosystemChart.svelte
@@ -223,7 +223,7 @@ loaded dynamically from CDN.
 						customdata: yPoints.map(() => '/glossary/risk-free-rate'),
 						hovertemplate: [
 							`<b>US Treasury note rate (${treasuryRate.toFixed(1)}%)</b>`,
-							`The risk-free benchmark.`,
+							`A US Treasury yield benchmark.`,
 							``,
 							`Earning better: ${formatUsd(tvlBetter)} (${pctBetter}%)`,
 							`Earning less: ${formatUsd(tvlWorse)} (${pctWorse}%)`,

--- a/src/routes/diagnostics/echarts-vault-ecosystem/+page.svelte
+++ b/src/routes/diagnostics/echarts-vault-ecosystem/+page.svelte
@@ -179,7 +179,7 @@ ECharts diagnostics page for experimenting with the vault ecosystem chart.
 		const totalTvl = betterTvl + worseTvl;
 		const benchmarkLabel = kind === 'treasury' ? 'US Treasury note rate' : 'US bank savings rate';
 		const benchmarkDescription =
-			kind === 'treasury' ? 'The risk-free benchmark.' : 'Average yield on a US bank savings account.';
+			kind === 'treasury' ? 'A US Treasury yield benchmark.' : 'Average yield on a US bank savings account.';
 		const benchmarkUrl = kind === 'treasury' ? TREASURY_URL : SAVINGS_URL;
 		const benchmarkData = Array.from({ length: BENCHMARK_SAMPLE_COUNT }, (_, index) => {
 			const ratio = index / Math.max(BENCHMARK_SAMPLE_COUNT - 1, 1);

--- a/src/routes/search/suggestions/+server.ts
+++ b/src/routes/search/suggestions/+server.ts
@@ -4,19 +4,36 @@ import { searchVaultEntities } from '$lib/search/vault-search.server';
 const MAX_QUERY_LENGTH = 100;
 const DEFAULT_LIMIT = 8;
 const MAX_LIMIT = 20;
+const VAULT_ENTITY_TYPES = ['vault', 'tokenised-fund', 'blacklisted-vault'] as const;
 
 export async function GET({ fetch, url }) {
 	const query = url.searchParams.get('q')?.trim() ?? '';
+	const scope = url.searchParams.get('scope') ?? 'all';
 	const limitParameter = url.searchParams.get('limit');
+	const minimumVaultTvlParameter = url.searchParams.get('minimumVaultTvlUsd');
 	const requestedLimit = limitParameter === null ? DEFAULT_LIMIT : Number(limitParameter);
 	const limit = Number.isInteger(requestedLimit) ? Math.min(Math.max(requestedLimit, 1), MAX_LIMIT) : DEFAULT_LIMIT;
+	const minimumVaultTvlUsd = minimumVaultTvlParameter === null ? undefined : Number(minimumVaultTvlParameter);
 
 	if (query.length > MAX_QUERY_LENGTH) {
 		return json({ message: `Search queries must be ${MAX_QUERY_LENGTH} characters or fewer.` }, { status: 400 });
 	}
+	if (scope !== 'all' && scope !== 'vaults') {
+		return json({ message: 'Search scope must be all or vaults.' }, { status: 400 });
+	}
+	if (
+		minimumVaultTvlUsd !== undefined &&
+		(scope !== 'vaults' || !Number.isFinite(minimumVaultTvlUsd) || minimumVaultTvlUsd < 0)
+	) {
+		return json({ message: 'Minimum vault TVL must be a non-negative number for vault searches.' }, { status: 400 });
+	}
 
 	try {
-		const response = await searchVaultEntities(fetch, query, limit, { diversifyTypes: true });
+		const response = await searchVaultEntities(fetch, query, limit, {
+			diversifyTypes: scope === 'all',
+			entityTypes: scope === 'vaults' ? VAULT_ENTITY_TYPES : undefined,
+			minimumVaultTvlUsd
+		});
 		return json(response, { headers: { 'cache-control': 'public, max-age=60' } });
 	} catch (error) {
 		console.error('Search suggestions could not be loaded:', error);

--- a/src/routes/search/suggestions/server.test.ts
+++ b/src/routes/search/suggestions/server.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, test, vi } from 'vitest';
+
+const { searchVaultEntities } = vi.hoisted(() => ({
+	searchVaultEntities: vi.fn().mockResolvedValue({ query: 'vault', results: [], total: 0 })
+}));
+
+vi.mock('$lib/search/vault-search.server', () => ({ searchVaultEntities }));
+
+import { GET } from './+server';
+
+describe('search suggestions endpoint', () => {
+	test('passes the minimum TVL to server-side vault search', async () => {
+		const fetch = vi.fn();
+		const response = await GET({
+			fetch,
+			url: new URL('http://localhost/search/suggestions?q=vault&scope=vaults&minimumVaultTvlUsd=1000')
+		} as never);
+
+		expect(response.status).toBe(200);
+		expect(searchVaultEntities).toHaveBeenCalledWith(fetch, 'vault', 8, {
+			diversifyTypes: false,
+			entityTypes: ['vault', 'tokenised-fund', 'blacklisted-vault'],
+			minimumVaultTvlUsd: 1000
+		});
+	});
+
+	test('rejects minimum TVL filtering for site-wide search', async () => {
+		const response = await GET({
+			fetch: vi.fn(),
+			url: new URL('http://localhost/search/suggestions?q=vault&scope=all&minimumVaultTvlUsd=1000')
+		} as never);
+
+		expect(response.status).toBe(400);
+	});
+});

--- a/src/routes/vaults/[vault=vaultId]/metrics/+server.ts
+++ b/src/routes/vaults/[vault=vaultId]/metrics/+server.ts
@@ -1,31 +1,26 @@
 import type { UTCTimestamp } from 'lightweight-charts';
 import { error, json } from '@sveltejs/kit';
-import { DuckDBConnection } from '@duckdb/node-api';
-import { ensureVaultPricesParquet } from '$lib/top-vaults/vault-prices-parquet';
+import { queryVaultPriceRows } from '$lib/server/top-vaults/vault-price-series';
 
 async function getPriceAndTvlData(vaultId: string) {
-	const connection = await DuckDBConnection.create();
-	const parquetFile = await ensureVaultPricesParquet();
-
 	try {
-		const reader = await connection.runAndReadAll(
-			`SELECT EXTRACT(EPOCH FROM timestamp) as ts, share_price, total_assets,
-              CASE WHEN utilisation >= 0 AND utilisation <= 2 THEN utilisation ELSE NULL END as utilisation
-       FROM parquet_scan($parquetFile)
-       WHERE id = $vaultId
-       ORDER BY timestamp`,
-			{ parquetFile, vaultId }
+		const rows = await queryVaultPriceRows([vaultId], { includeVaultMetrics: true });
+		return rows.map(
+			({ timestamp, sharePrice, totalAssets, utilisation }) =>
+				[timestamp as UTCTimestamp, sharePrice, totalAssets, utilisation ?? null] as [
+					UTCTimestamp,
+					number,
+					number,
+					number | null
+				]
 		);
-		return reader.getRows() as [UTCTimestamp, number, number, number | null][];
 	} catch (e) {
-		console.error(`Error loading data from ${parquetFile} for vault <${vaultId}>`);
+		console.error(`Error loading price data for vault <${vaultId}>`);
 		const { stack } = e as Error;
 		error(500, {
 			message: `Error loading vault data for vault id <${vaultId}>`,
 			stack: stack ? [stack] : undefined
 		});
-	} finally {
-		connection.closeSync();
 	}
 }
 

--- a/src/routes/vaults/compare/+page.server.ts
+++ b/src/routes/vaults/compare/+page.server.ts
@@ -3,6 +3,7 @@ import { getChainDisplayName } from '$lib/helpers/chain';
 import { getCachedTopVaults } from '$lib/top-vaults/cache';
 import {
 	canonicaliseComparisonVaultIds,
+	canonicaliseComparisonBenchmarks,
 	EMPTY_COMPARISON_PARAMETER,
 	EMPTY_COMPARISON_VALUE,
 	MAX_SELECTED_VAULTS,
@@ -14,6 +15,7 @@ import { getVaultProtocolLogoUrl } from '$lib/vault-protocol/helpers';
 
 export async function load({ fetch, url }) {
 	const requestedVaultIds = url.searchParams.getAll('vault');
+	const requestedBenchmarks = url.searchParams.getAll('benchmark');
 	const topVaults = await getCachedTopVaults(fetch);
 	const hasExplicitComparisonState =
 		requestedVaultIds.length > 0 ||
@@ -32,6 +34,7 @@ export async function load({ fetch, url }) {
 	}
 
 	const canonicalVaultIds = canonicaliseComparisonVaultIds(requestedVaultIds);
+	const canonicalBenchmarks = canonicaliseComparisonBenchmarks(requestedBenchmarks);
 	const vaultById = new Map(topVaults.vaults.map((vault) => [vault.id, vault]));
 	const resolvedVaultIds = canonicalVaultIds.filter((vaultId) => vaultById.has(vaultId));
 	const hasStaleEmptyMarker =
@@ -41,16 +44,15 @@ export async function load({ fetch, url }) {
 		requestedVaultIds.length > MAX_SELECTED_VAULTS ||
 		requestedVaultIds.length !== resolvedVaultIds.length ||
 		requestedVaultIds.some((value, index) => value !== resolvedVaultIds[index]) ||
+		requestedBenchmarks.length !== canonicalBenchmarks.length ||
+		requestedBenchmarks.some((value, index) => value !== canonicalBenchmarks[index]) ||
 		hasStaleEmptyMarker
 	) {
-		const canonicalUrl = new URL(url);
-		canonicalUrl.searchParams.delete('vault');
-		canonicalUrl.searchParams.delete(EMPTY_COMPARISON_PARAMETER);
-		for (const vaultId of resolvedVaultIds) canonicalUrl.searchParams.append('vault', vaultId);
-		if (!resolvedVaultIds.length) {
-			canonicalUrl.searchParams.set(EMPTY_COMPARISON_PARAMETER, EMPTY_COMPARISON_VALUE);
-		}
-		redirect(307, `${canonicalUrl.pathname}${canonicalUrl.search}`);
+		const canonicalSearchParams = writeEquityComparisonState(url.searchParams, {
+			vaultIds: resolvedVaultIds,
+			benchmarks: canonicalBenchmarks
+		});
+		redirect(307, `${url.pathname}?${canonicalSearchParams}`);
 	}
 
 	const selectedVaultRecords = resolvedVaultIds.map((vaultId) => vaultById.get(vaultId)!);

--- a/src/routes/vaults/compare/+page.server.ts
+++ b/src/routes/vaults/compare/+page.server.ts
@@ -1,0 +1,96 @@
+import { redirect } from '@sveltejs/kit';
+import { getChainDisplayName } from '$lib/helpers/chain';
+import { getCachedTopVaults } from '$lib/top-vaults/cache';
+import {
+	canonicaliseComparisonVaultIds,
+	EMPTY_COMPARISON_PARAMETER,
+	EMPTY_COMPARISON_VALUE,
+	MAX_SELECTED_VAULTS,
+	writeEquityComparisonState
+} from '$lib/top-vaults/equity-comparison/state';
+import { comparisonBenchmarkKeys, type ComparisonVault } from '$lib/top-vaults/equity-comparison/types';
+import { getVaultProtocolDisplayName, isBlacklisted, resolveVaultDetails } from '$lib/top-vaults/helpers';
+import { getVaultProtocolLogoUrl } from '$lib/vault-protocol/helpers';
+
+export async function load({ fetch, url }) {
+	const requestedVaultIds = url.searchParams.getAll('vault');
+	const topVaults = await getCachedTopVaults(fetch);
+	const hasExplicitComparisonState =
+		requestedVaultIds.length > 0 ||
+		url.searchParams.has('benchmark') ||
+		url.searchParams.get(EMPTY_COMPARISON_PARAMETER) === EMPTY_COMPARISON_VALUE;
+
+	if (!hasExplicitComparisonState) {
+		const defaultVault = topVaults.vaults.find((vault) => vault.name === 'Savings USDS');
+		if (defaultVault) {
+			const defaultSearchParams = writeEquityComparisonState(url.searchParams, {
+				vaultIds: [defaultVault.id],
+				benchmarks: [...comparisonBenchmarkKeys]
+			});
+			redirect(307, `${url.pathname}?${defaultSearchParams}`);
+		}
+	}
+
+	const canonicalVaultIds = canonicaliseComparisonVaultIds(requestedVaultIds);
+	const vaultById = new Map(topVaults.vaults.map((vault) => [vault.id, vault]));
+	const resolvedVaultIds = canonicalVaultIds.filter((vaultId) => vaultById.has(vaultId));
+	const hasStaleEmptyMarker =
+		resolvedVaultIds.length > 0 && url.searchParams.get(EMPTY_COMPARISON_PARAMETER) === EMPTY_COMPARISON_VALUE;
+
+	if (
+		requestedVaultIds.length > MAX_SELECTED_VAULTS ||
+		requestedVaultIds.length !== resolvedVaultIds.length ||
+		requestedVaultIds.some((value, index) => value !== resolvedVaultIds[index]) ||
+		hasStaleEmptyMarker
+	) {
+		const canonicalUrl = new URL(url);
+		canonicalUrl.searchParams.delete('vault');
+		canonicalUrl.searchParams.delete(EMPTY_COMPARISON_PARAMETER);
+		for (const vaultId of resolvedVaultIds) canonicalUrl.searchParams.append('vault', vaultId);
+		if (!resolvedVaultIds.length) {
+			canonicalUrl.searchParams.set(EMPTY_COMPARISON_PARAMETER, EMPTY_COMPARISON_VALUE);
+		}
+		redirect(307, `${canonicalUrl.pathname}${canonicalUrl.search}`);
+	}
+
+	const selectedVaultRecords = resolvedVaultIds.map((vaultId) => vaultById.get(vaultId)!);
+	const selectedVaults: ComparisonVault[] = selectedVaultRecords.map((vault) => {
+		const curatorLogos = vault.curator_slug ? topVaults.curators[vault.curator_slug]?.logos : undefined;
+		const logoUrl =
+			curatorLogos?.generic ??
+			curatorLogos?.light ??
+			curatorLogos?.dark ??
+			getVaultProtocolLogoUrl(vault.protocol_slug) ??
+			null;
+
+		return {
+			id: vault.id,
+			name: vault.name,
+			href: resolveVaultDetails(vault),
+			logoUrl,
+			protocolName: getVaultProtocolDisplayName(vault),
+			chainName: getChainDisplayName(vault.chain_id),
+			entityType: isBlacklisted(vault)
+				? 'blacklisted-vault'
+				: vault.flags.includes('tokenised_fund')
+					? 'tokenised-fund'
+					: 'vault'
+		};
+	});
+	const selectedCurators = Object.fromEntries(
+		selectedVaultRecords.flatMap((vault) => {
+			const curator = vault.curator_slug ? topVaults.curators[vault.curator_slug] : undefined;
+			return curator && vault.curator_slug ? [[vault.curator_slug, curator]] : [];
+		})
+	);
+
+	return {
+		selectedVaults,
+		selectedTopVaults: {
+			generated_at: topVaults.generated_at,
+			vaults: selectedVaultRecords,
+			core3_protocols: {},
+			curators: selectedCurators
+		}
+	};
+}

--- a/src/routes/vaults/compare/+page.server.ts
+++ b/src/routes/vaults/compare/+page.server.ts
@@ -7,6 +7,7 @@ import {
 	EMPTY_COMPARISON_PARAMETER,
 	EMPTY_COMPARISON_VALUE,
 	MAX_SELECTED_VAULTS,
+	parseEquityComparisonState,
 	writeEquityComparisonState
 } from '$lib/top-vaults/equity-comparison/state';
 import { comparisonBenchmarkKeys, type ComparisonVault } from '$lib/top-vaults/equity-comparison/types';
@@ -16,6 +17,8 @@ import { getVaultProtocolLogoUrl } from '$lib/vault-protocol/helpers';
 export async function load({ fetch, url }) {
 	const requestedVaultIds = url.searchParams.getAll('vault');
 	const requestedBenchmarks = url.searchParams.getAll('benchmark');
+	const requestedPeriods = url.searchParams.getAll('period');
+	const requestedState = parseEquityComparisonState(url.searchParams);
 	const topVaults = await getCachedTopVaults(fetch);
 	const hasExplicitComparisonState =
 		requestedVaultIds.length > 0 ||
@@ -27,7 +30,8 @@ export async function load({ fetch, url }) {
 		if (defaultVault) {
 			const defaultSearchParams = writeEquityComparisonState(url.searchParams, {
 				vaultIds: [defaultVault.id],
-				benchmarks: [...comparisonBenchmarkKeys]
+				benchmarks: [...comparisonBenchmarkKeys],
+				timeSpan: requestedState.timeSpan
 			});
 			redirect(307, `${url.pathname}?${defaultSearchParams}`);
 		}
@@ -35,6 +39,7 @@ export async function load({ fetch, url }) {
 
 	const canonicalVaultIds = canonicaliseComparisonVaultIds(requestedVaultIds);
 	const canonicalBenchmarks = canonicaliseComparisonBenchmarks(requestedBenchmarks);
+	const canonicalTimeSpan = requestedState.timeSpan;
 	const vaultById = new Map(topVaults.vaults.map((vault) => [vault.id, vault]));
 	const resolvedVaultIds = canonicalVaultIds.filter((vaultId) => vaultById.has(vaultId));
 	const hasStaleEmptyMarker =
@@ -46,11 +51,14 @@ export async function load({ fetch, url }) {
 		requestedVaultIds.some((value, index) => value !== resolvedVaultIds[index]) ||
 		requestedBenchmarks.length !== canonicalBenchmarks.length ||
 		requestedBenchmarks.some((value, index) => value !== canonicalBenchmarks[index]) ||
+		requestedPeriods.length !== 1 ||
+		requestedPeriods[0] !== canonicalTimeSpan ||
 		hasStaleEmptyMarker
 	) {
 		const canonicalSearchParams = writeEquityComparisonState(url.searchParams, {
 			vaultIds: resolvedVaultIds,
-			benchmarks: canonicalBenchmarks
+			benchmarks: canonicalBenchmarks,
+			timeSpan: canonicalTimeSpan
 		});
 		redirect(307, `${url.pathname}?${canonicalSearchParams}`);
 	}

--- a/src/routes/vaults/compare/+page.svelte
+++ b/src/routes/vaults/compare/+page.svelte
@@ -2,7 +2,7 @@
 Compare selected vault equity curves and fixed market benchmarks on one indexed chart.
 -->
 <script lang="ts">
-	import { goto, replaceState } from '$app/navigation';
+	import { goto } from '$app/navigation';
 	import { resolve } from '$app/paths';
 	import { page } from '$app/state';
 	import { tick, untrack } from 'svelte';
@@ -27,7 +27,6 @@ Compare selected vault equity curves and fixed market benchmarks on one indexed 
 	import { assignVaultComparisonColours } from '$lib/top-vaults/equity-comparison/colours';
 	import {
 		MAX_SELECTED_VAULTS,
-		canonicaliseComparisonBenchmarks,
 		parseEquityComparisonState,
 		writeEquityComparisonState
 	} from '$lib/top-vaults/equity-comparison/state';
@@ -76,22 +75,6 @@ Compare selected vault equity curves and fixed market benchmarks on one indexed 
 		untrack(() => {
 			colours = assignVaultComparisonColours(ids, colours);
 		});
-	});
-
-	$effect(() => {
-		const rawBenchmarks = page.url.searchParams.getAll('benchmark');
-		const canonicalBenchmarks = canonicaliseComparisonBenchmarks(rawBenchmarks);
-		if (
-			rawBenchmarks.length === canonicalBenchmarks.length &&
-			rawBenchmarks.every((value, index) => value === canonicalBenchmarks[index])
-		)
-			return;
-
-		const canonicalSearchParams = new SvelteURLSearchParams(page.url.searchParams);
-		canonicalSearchParams.delete('benchmark');
-		for (const benchmark of canonicalBenchmarks) canonicalSearchParams.append('benchmark', benchmark);
-		const canonicalSearch = canonicalSearchParams.size ? `?${canonicalSearchParams}` : '';
-		replaceState(resolve(`/vaults/compare${canonicalSearch}` as '/vaults/compare'), page.state);
 	});
 
 	$effect(() => {

--- a/src/routes/vaults/compare/+page.svelte
+++ b/src/routes/vaults/compare/+page.svelte
@@ -2,7 +2,7 @@
 Compare selected vault equity curves and fixed market benchmarks on one indexed chart.
 -->
 <script lang="ts">
-	import { goto } from '$app/navigation';
+	import { goto, replaceState } from '$app/navigation';
 	import { resolve } from '$app/paths';
 	import { page } from '$app/state';
 	import { tick, untrack } from 'svelte';
@@ -51,7 +51,7 @@ Compare selected vault equity curves and fixed market benchmarks on one indexed 
 	let comparisonPending = $state(false);
 	let pendingVaultId = $state<string | null>(null);
 	let colours = $state<ReadonlyMap<string, string>>(new Map());
-	let selectedTimeSpan = $state<ComparisonTimeSpan>('3M');
+	let selectedTimeSpan = $derived(comparisonState.timeSpan);
 	let selectedPeriodMetricsByVaultId = $derived(
 		new Map(
 			(chartData?.vaultSeries ?? []).map((series) => [series.id, series.periodMetrics?.[selectedTimeSpan]] as const)
@@ -130,8 +130,12 @@ Compare selected vault equity curves and fixed market benchmarks on one indexed 
 		return () => controller.abort();
 	}
 
-	async function updateComparison(vaultIds: string[], benchmarks: ComparisonBenchmark[]): Promise<void> {
-		const searchParams = writeEquityComparisonState(page.url.searchParams, { vaultIds, benchmarks });
+	async function updateComparison(
+		vaultIds: string[],
+		benchmarks: ComparisonBenchmark[],
+		timeSpan: ComparisonTimeSpan = selectedTimeSpan
+	): Promise<void> {
+		const searchParams = writeEquityComparisonState(page.url.searchParams, { vaultIds, benchmarks, timeSpan });
 		const search = searchParams.size ? `?${searchParams}` : '';
 		comparisonPending = true;
 		try {
@@ -143,6 +147,17 @@ Compare selected vault equity curves and fixed market benchmarks on one indexed 
 		} finally {
 			comparisonPending = false;
 		}
+	}
+
+	function selectTimeSpan(timeSpan: ComparisonTimeSpan): void {
+		selectedTimeSpan = timeSpan;
+		const searchParams = writeEquityComparisonState(page.url.searchParams, {
+			vaultIds: selectedVaultIds,
+			benchmarks: comparisonState.benchmarks,
+			timeSpan
+		});
+		const search = searchParams.size ? `?${searchParams}` : '';
+		replaceState(resolve(`/vaults/compare${search}` as '/vaults/compare'), page.state);
 	}
 
 	async function addVault(vaultId: string): Promise<void> {
@@ -323,7 +338,7 @@ Compare selected vault equity curves and fixed market benchmarks on one indexed 
 				{colours}
 				loading={chartLoading || comparisonPending}
 				{selectedTimeSpan}
-				onTimeSpanChange={(timeSpan) => (selectedTimeSpan = timeSpan)}
+				onTimeSpanChange={selectTimeSpan}
 			/>
 		{:else if !chartError}
 			<div class="empty-state">
@@ -342,7 +357,7 @@ Compare selected vault equity curves and fixed market benchmarks on one indexed 
 					tvlTriggerLabel="Selected vaults"
 					tvlTooltip="This table contains only the vaults selected for the equity comparison."
 					showStablecoinOnlyMeta={false}
-					preserveSearchParams={['vault', 'benchmark']}
+					preserveSearchParams={['vault', 'benchmark', 'period']}
 				/>
 			</section>
 		{/if}

--- a/src/routes/vaults/compare/+page.svelte
+++ b/src/routes/vaults/compare/+page.svelte
@@ -9,6 +9,7 @@ Compare selected vault equity curves and fixed market benchmarks on one indexed 
 	import { SvelteURLSearchParams } from 'svelte/reactivity';
 	import { JsonLd } from 'svelte-meta-tags';
 	import Alert from '$lib/components/Alert.svelte';
+	import DataBadge from '$lib/components/DataBadge.svelte';
 	import HeroBanner from '$lib/components/HeroBanner.svelte';
 	import Section from '$lib/components/Section.svelte';
 	import Spinner from '$lib/components/Spinner.svelte';
@@ -220,7 +221,12 @@ Compare selected vault equity curves and fixed market benchmarks on one indexed 
 		<HeroBanner
 			subtitle="Compare the historical performance of vaults with each other and US Treasury, ETH, and BTC benchmarks. The index may include or exclude fees depending on the vault type; check the vault pages for fee details."
 		>
-			{#snippet title()}<span>{pageTitle}</span>{/snippet}
+			{#snippet title()}
+				<span class="page-title">
+					{pageTitle}
+					<DataBadge class="beta-badge" status="beta">Beta</DataBadge>
+				</span>
+			{/snippet}
 		</HeroBanner>
 	</Section>
 
@@ -350,6 +356,14 @@ Compare selected vault equity curves and fixed market benchmarks on one indexed 
 <style>
 	.vault-compare-page {
 		--control-panel-padding: var(--space-lg);
+	}
+	.page-title {
+		display: inline-flex;
+		align-items: center;
+		gap: var(--space-sm);
+	}
+	:global(.page-title .beta-badge) {
+		font-size: 0.35em;
 	}
 	.comparison-controls {
 		display: grid;

--- a/src/routes/vaults/compare/+page.svelte
+++ b/src/routes/vaults/compare/+page.svelte
@@ -410,7 +410,7 @@ Compare selected vault equity curves and fixed market benchmarks on one indexed 
 		display: inline-flex;
 		align-items: center;
 		gap: var(--space-xs);
-		min-height: 3rem;
+		min-height: 2.625rem;
 		padding-inline: var(--space-sm);
 		border: 1px solid var(--c-input-border);
 		border-radius: var(--radius-sm);

--- a/src/routes/vaults/compare/+page.svelte
+++ b/src/routes/vaults/compare/+page.svelte
@@ -233,7 +233,7 @@ Compare selected vault equity curves and fixed market benchmarks on one indexed 
 	<Section tag="header">
 		<VaultListingsSelector />
 		<HeroBanner
-			subtitle="Compare the historical performance of vaults with each other and US Treasury, ETH, and BTC benchmarks."
+			subtitle="Compare the historical performance of vaults with each other and US Treasury, ETH, and BTC benchmarks. The index may include or exclude fees depending on the vault type; check the vault pages for fee details."
 		>
 			{#snippet title()}<span>{pageTitle}</span>{/snippet}
 		</HeroBanner>

--- a/src/routes/vaults/compare/+page.svelte
+++ b/src/routes/vaults/compare/+page.svelte
@@ -13,9 +13,7 @@ Compare selected vault equity curves and fixed market benchmarks on one indexed 
 	import HeroBanner from '$lib/components/HeroBanner.svelte';
 	import Section from '$lib/components/Section.svelte';
 	import Spinner from '$lib/components/Spinner.svelte';
-	import usTreasuryLogo from '$lib/assets/logos/tokens/us-treasury.svg';
 	import { removeOnError } from '$lib/actions/image';
-	import { getLogoUrl } from '$lib/helpers/assets';
 	import { formatPercentProfit, notFilledMarker } from '$lib/helpers/formatters';
 	import MetaTags from '$lib/social-card/SocialCardMetaTags.svelte';
 	import ScatterPlotSelector from '$lib/scatter-plot/ScatterPlotSelector.svelte';
@@ -24,6 +22,7 @@ Compare selected vault equity curves and fixed market benchmarks on one indexed 
 	import TopVaultsOptIn from '$lib/top-vaults/TopVaultsOptIn.svelte';
 	import TopVaultsTable from '$lib/top-vaults/TopVaultsTable.svelte';
 	import VaultListingsSelector from '$lib/top-vaults/VaultListingsSelector.svelte';
+	import BenchmarkLogo from '$lib/top-vaults/equity-comparison/BenchmarkLogo.svelte';
 	import VaultEquityComparisonChart from '$lib/top-vaults/equity-comparison/VaultEquityComparisonChart.svelte';
 	import { assignVaultComparisonColours } from '$lib/top-vaults/equity-comparison/colours';
 	import {
@@ -65,10 +64,10 @@ Compare selected vault equity curves and fixed market benchmarks on one indexed 
 	const metaTitle = 'Compare and find best DeFi vault yield';
 	const description = 'Analyse more than 5000 vaults';
 	let pageUrl = $derived(new URL(page.url.pathname, page.url.origin).href);
-	const benchmarkOptions: { key: ComparisonBenchmark; label: string; logoUrl: string }[] = [
-		{ key: 'treasury', label: 'T-Bill', logoUrl: usTreasuryLogo },
-		{ key: 'eth', label: 'ETH', logoUrl: getLogoUrl('token', 'eth') },
-		{ key: 'btc', label: 'BTC', logoUrl: getLogoUrl('token', 'btc') }
+	const benchmarkOptions: { key: ComparisonBenchmark; label: string }[] = [
+		{ key: 'treasury', label: 'T-Bill' },
+		{ key: 'eth', label: 'ETH' },
+		{ key: 'btc', label: 'BTC' }
 	];
 
 	$effect(() => {
@@ -275,7 +274,7 @@ Compare selected vault equity curves and fixed market benchmarks on one indexed 
 								disabled={!selectedVaults.length || comparisonPending}
 								onchange={(event) => toggleBenchmark(benchmark.key, event.currentTarget.checked)}
 							/>
-							<img class="benchmark-logo" src={benchmark.logoUrl} alt="" aria-hidden="true" use:removeOnError />
+							<BenchmarkLogo benchmark={benchmark.key} />
 							<span>{benchmark.label}</span>
 						</label>
 					{/each}
@@ -460,12 +459,6 @@ Compare selected vault equity curves and fixed market benchmarks on one indexed 
 		height: 0;
 		border-top: 3px solid var(--benchmark-colour);
 		border-radius: 999px;
-	}
-	.benchmark-logo {
-		width: 1.25rem;
-		height: 1.25rem;
-		flex: 0 0 auto;
-		object-fit: contain;
 	}
 	.selected-vaults {
 		display: grid;

--- a/src/routes/vaults/compare/+page.svelte
+++ b/src/routes/vaults/compare/+page.svelte
@@ -12,7 +12,9 @@ Compare selected vault equity curves and fixed market benchmarks on one indexed 
 	import HeroBanner from '$lib/components/HeroBanner.svelte';
 	import Section from '$lib/components/Section.svelte';
 	import Spinner from '$lib/components/Spinner.svelte';
+	import usTreasuryLogo from '$lib/assets/logos/tokens/us-treasury.svg';
 	import { removeOnError } from '$lib/actions/image';
+	import { getLogoUrl } from '$lib/helpers/assets';
 	import { formatPercentProfit, notFilledMarker } from '$lib/helpers/formatters';
 	import MetaTags from '$lib/social-card/SocialCardMetaTags.svelte';
 	import ScatterPlotSelector from '$lib/scatter-plot/ScatterPlotSelector.svelte';
@@ -22,7 +24,7 @@ Compare selected vault equity curves and fixed market benchmarks on one indexed 
 	import TopVaultsTable from '$lib/top-vaults/TopVaultsTable.svelte';
 	import VaultListingsSelector from '$lib/top-vaults/VaultListingsSelector.svelte';
 	import VaultEquityComparisonChart from '$lib/top-vaults/equity-comparison/VaultEquityComparisonChart.svelte';
-	import { assignVaultComparisonColours, benchmarkComparisonColours } from '$lib/top-vaults/equity-comparison/colours';
+	import { assignVaultComparisonColours } from '$lib/top-vaults/equity-comparison/colours';
 	import {
 		MAX_SELECTED_VAULTS,
 		canonicaliseComparisonBenchmarks,
@@ -63,10 +65,10 @@ Compare selected vault equity curves and fixed market benchmarks on one indexed 
 	const metaTitle = 'Compare and find best DeFi vault yield';
 	const description = 'Analyse more than 5000 vaults';
 	let pageUrl = $derived(new URL(page.url.pathname, page.url.origin).href);
-	const benchmarkOptions: { key: ComparisonBenchmark; label: string }[] = [
-		{ key: 'treasury', label: 'T-Bill' },
-		{ key: 'eth', label: 'ETH' },
-		{ key: 'btc', label: 'BTC' }
+	const benchmarkOptions: { key: ComparisonBenchmark; label: string; logoUrl: string }[] = [
+		{ key: 'treasury', label: 'T-Bill', logoUrl: usTreasuryLogo },
+		{ key: 'eth', label: 'ETH', logoUrl: getLogoUrl('token', 'eth') },
+		{ key: 'btc', label: 'BTC', logoUrl: getLogoUrl('token', 'btc') }
 	];
 
 	$effect(() => {
@@ -262,14 +264,14 @@ Compare selected vault equity curves and fixed market benchmarks on one indexed 
 				<legend>Benchmarks</legend>
 				<div class="benchmark-options">
 					{#each benchmarkOptions as benchmark (benchmark.key)}
-						<label style:--benchmark-colour={benchmarkComparisonColours[benchmark.key]}>
+						<label>
 							<input
 								type="checkbox"
 								checked={comparisonState.benchmarks.includes(benchmark.key)}
 								disabled={!selectedVaults.length || comparisonPending}
 								onchange={(event) => toggleBenchmark(benchmark.key, event.currentTarget.checked)}
 							/>
-							<span class="benchmark-swatch" aria-hidden="true"></span>
+							<img class="benchmark-logo" src={benchmark.logoUrl} alt="" aria-hidden="true" use:removeOnError />
 							<span>{benchmark.label}</span>
 						</label>
 					{/each}
@@ -436,13 +438,18 @@ Compare selected vault equity curves and fixed market benchmarks on one indexed 
 		opacity: 0.55;
 		cursor: default;
 	}
-	.benchmark-swatch,
 	.vault-colour {
 		display: block;
 		width: 1.25rem;
 		height: 0;
 		border-top: 3px solid var(--benchmark-colour);
 		border-radius: 999px;
+	}
+	.benchmark-logo {
+		width: 1.25rem;
+		height: 1.25rem;
+		flex: 0 0 auto;
+		object-fit: contain;
 	}
 	.selected-vaults {
 		display: grid;

--- a/src/routes/vaults/compare/+page.svelte
+++ b/src/routes/vaults/compare/+page.svelte
@@ -1,0 +1,596 @@
+<!--
+Compare selected vault equity curves and fixed market benchmarks on one indexed chart.
+-->
+<script lang="ts">
+	import { goto, replaceState } from '$app/navigation';
+	import { resolve } from '$app/paths';
+	import { page } from '$app/state';
+	import { tick, untrack } from 'svelte';
+	import { SvelteURLSearchParams } from 'svelte/reactivity';
+	import { JsonLd } from 'svelte-meta-tags';
+	import Alert from '$lib/components/Alert.svelte';
+	import HeroBanner from '$lib/components/HeroBanner.svelte';
+	import Section from '$lib/components/Section.svelte';
+	import Spinner from '$lib/components/Spinner.svelte';
+	import { removeOnError } from '$lib/actions/image';
+	import { formatPercentProfit, notFilledMarker } from '$lib/helpers/formatters';
+	import MetaTags from '$lib/social-card/SocialCardMetaTags.svelte';
+	import ScatterPlotSelector from '$lib/scatter-plot/ScatterPlotSelector.svelte';
+	import Search from '$lib/search/components/Search.svelte';
+	import type { SearchResult } from '$lib/search/entities';
+	import TopVaultsOptIn from '$lib/top-vaults/TopVaultsOptIn.svelte';
+	import TopVaultsTable from '$lib/top-vaults/TopVaultsTable.svelte';
+	import VaultListingsSelector from '$lib/top-vaults/VaultListingsSelector.svelte';
+	import VaultEquityComparisonChart from '$lib/top-vaults/equity-comparison/VaultEquityComparisonChart.svelte';
+	import { assignVaultComparisonColours, benchmarkComparisonColours } from '$lib/top-vaults/equity-comparison/colours';
+	import {
+		MAX_SELECTED_VAULTS,
+		canonicaliseComparisonBenchmarks,
+		parseEquityComparisonState,
+		writeEquityComparisonState
+	} from '$lib/top-vaults/equity-comparison/state';
+	import type {
+		ComparisonBenchmark,
+		ComparisonTimeSpan,
+		VaultComparisonChartResponse
+	} from '$lib/top-vaults/equity-comparison/types';
+	import IconCancel from '~icons/local/cancel';
+
+	let { data } = $props();
+	let selectedVaults = $derived(data.selectedVaults);
+	let selectedVaultIds = $derived(selectedVaults.map(({ id }) => id));
+	let selectionLimitReached = $derived(selectedVaultIds.length >= MAX_SELECTED_VAULTS);
+	let comparisonState = $derived(parseEquityComparisonState(page.url.searchParams));
+	let chartData = $state<VaultComparisonChartResponse>();
+	let chartLoading = $state(true);
+	let chartError = $state<string | null>(null);
+	let retryVersion = $state(0);
+	let chartRequestVersion = 0;
+	let comparisonPending = $state(false);
+	let pendingVaultId = $state<string | null>(null);
+	let colours = $state<ReadonlyMap<string, string>>(new Map());
+	let selectedTimeSpan = $state<ComparisonTimeSpan>('3M');
+	let selectedPeriodMetricsByVaultId = $derived(
+		new Map(
+			(chartData?.vaultSeries ?? []).map((series) => [series.id, series.periodMetrics?.[selectedTimeSpan]] as const)
+		)
+	);
+	let chartRequestKey = $derived(JSON.stringify([selectedVaultIds, comparisonState.benchmarks]));
+	let previousChartRequestKey: string | undefined;
+	let handledRetryVersion = 0;
+
+	const pageTitle = 'Compare vaults';
+	const metaTitle = 'Compare and find best DeFi vault yield';
+	const description = 'Analyse more than 5000 vaults';
+	let pageUrl = $derived(new URL(page.url.pathname, page.url.origin).href);
+	const benchmarkOptions: { key: ComparisonBenchmark; label: string }[] = [
+		{ key: 'treasury', label: 'T-Bill' },
+		{ key: 'eth', label: 'ETH' },
+		{ key: 'btc', label: 'BTC' }
+	];
+
+	$effect(() => {
+		const ids = selectedVaultIds;
+		untrack(() => {
+			colours = assignVaultComparisonColours(ids, colours);
+		});
+	});
+
+	$effect(() => {
+		const rawBenchmarks = page.url.searchParams.getAll('benchmark');
+		const canonicalBenchmarks = canonicaliseComparisonBenchmarks(rawBenchmarks);
+		if (
+			rawBenchmarks.length === canonicalBenchmarks.length &&
+			rawBenchmarks.every((value, index) => value === canonicalBenchmarks[index])
+		)
+			return;
+
+		const canonicalSearchParams = new SvelteURLSearchParams(page.url.searchParams);
+		canonicalSearchParams.delete('benchmark');
+		for (const benchmark of canonicalBenchmarks) canonicalSearchParams.append('benchmark', benchmark);
+		const canonicalSearch = canonicalSearchParams.size ? `?${canonicalSearchParams}` : '';
+		replaceState(resolve(`/vaults/compare${canonicalSearch}` as '/vaults/compare'), page.state);
+	});
+
+	$effect(() => {
+		const requestKey = chartRequestKey;
+		const currentRetryVersion = retryVersion;
+		const forceReload = currentRetryVersion !== handledRetryVersion;
+		if (requestKey === previousChartRequestKey && !forceReload) return;
+
+		previousChartRequestKey = requestKey;
+		handledRetryVersion = currentRetryVersion;
+		return untrack(() => loadChartData(selectedVaultIds, comparisonState.benchmarks, forceReload));
+	});
+
+	/** Load the compact server-prepared payload for the current comparison. */
+	function loadChartData(vaultIds: string[], benchmarks: ComparisonBenchmark[], forceReload: boolean): () => void {
+		const requestVersion = ++chartRequestVersion;
+		const controller = new AbortController();
+		chartError = null;
+
+		if (!vaultIds.length) {
+			chartData = undefined;
+			chartLoading = false;
+			return () => controller.abort();
+		}
+
+		chartLoading = true;
+		const params = new SvelteURLSearchParams();
+		for (const vaultId of vaultIds) params.append('vault', vaultId);
+		for (const benchmark of benchmarks) params.append('benchmark', benchmark);
+
+		void fetch(`/vaults/compare/chart-data?${params}`, {
+			signal: controller.signal,
+			cache: forceReload ? 'reload' : 'default'
+		})
+			.then(async (response) => {
+				if (!response.ok) throw new Error(`Chart data request failed with status ${response.status}`);
+				return (await response.json()) as VaultComparisonChartResponse;
+			})
+			.then((response) => {
+				if (requestVersion !== chartRequestVersion) return;
+				chartData = response;
+			})
+			.catch((error) => {
+				if ((error as Error).name === 'AbortError' || requestVersion !== chartRequestVersion) return;
+				console.error('Failed to load vault comparison chart data', error);
+				chartError = 'Equity history could not be loaded. Your vault selection has been preserved.';
+			})
+			.finally(() => {
+				if (requestVersion === chartRequestVersion) chartLoading = false;
+			});
+
+		return () => controller.abort();
+	}
+
+	async function updateComparison(vaultIds: string[], benchmarks: ComparisonBenchmark[]): Promise<void> {
+		const searchParams = writeEquityComparisonState(page.url.searchParams, { vaultIds, benchmarks });
+		const search = searchParams.size ? `?${searchParams}` : '';
+		comparisonPending = true;
+		try {
+			await goto(resolve(`/vaults/compare${search}` as '/vaults/compare'), {
+				replaceState: true,
+				noScroll: true,
+				keepFocus: true
+			});
+		} finally {
+			comparisonPending = false;
+		}
+	}
+
+	async function addVault(vaultId: string): Promise<void> {
+		pendingVaultId = vaultId;
+		try {
+			await updateComparison([...selectedVaultIds, vaultId], comparisonState.benchmarks);
+		} finally {
+			pendingVaultId = null;
+		}
+	}
+
+	async function removeVault(vaultId: string, index: number): Promise<void> {
+		await updateComparison(
+			selectedVaultIds.filter((id) => id !== vaultId),
+			comparisonState.benchmarks
+		);
+		await tick();
+		const buttons = document.querySelectorAll<HTMLButtonElement>('.selected-vaults button.remove');
+		buttons[Math.min(index, buttons.length - 1)]?.focus();
+	}
+
+	function toggleBenchmark(benchmark: ComparisonBenchmark, checked: boolean): void {
+		const benchmarks = checked
+			? [...comparisonState.benchmarks, benchmark]
+			: comparisonState.benchmarks.filter((value) => value !== benchmark);
+		void updateComparison(selectedVaultIds, benchmarks);
+	}
+</script>
+
+{#snippet addVaultButton(result: SearchResult, onAction: () => void)}
+	<button
+		type="button"
+		disabled={!result.vaultId ||
+			selectedVaultIds.includes(result.vaultId) ||
+			selectionLimitReached ||
+			comparisonPending}
+		aria-label={`Add ${result.name} to comparison`}
+		aria-busy={pendingVaultId === result.vaultId}
+		onclick={() => {
+			if (!result.vaultId) return;
+			onAction();
+			void addVault(result.vaultId);
+		}}
+	>
+		{#if pendingVaultId === result.vaultId}
+			<Spinner size="18" /><span>Adding…</span>
+		{:else}
+			{result.vaultId && selectedVaultIds.includes(result.vaultId) ? 'Added' : 'Add'}
+		{/if}
+	</button>
+{/snippet}
+
+<MetaTags
+	title={metaTitle}
+	{description}
+	canonical={pageUrl}
+	openGraph={{ siteName: 'Trading Strategy', url: pageUrl, title: metaTitle, description, type: 'website' }}
+	twitter={{ site: '@TradingProtocol', cardType: 'summary', title: metaTitle, description }}
+/>
+
+<JsonLd
+	schema={{
+		'@context': 'http://schema.org',
+		'@type': 'CollectionPage',
+		name: pageTitle,
+		description,
+		url: pageUrl,
+		provider: { '@type': 'Organization', name: 'Trading Strategy' },
+		mainEntity: { '@type': 'ItemList', numberOfItems: selectedVaults.length }
+	}}
+/>
+
+<main class="vault-compare-page ds-3">
+	<Section tag="header">
+		<VaultListingsSelector />
+		<HeroBanner
+			subtitle="Compare the historical performance of vaults with each other and US Treasury, ETH, and BTC benchmarks."
+		>
+			{#snippet title()}<span>{pageTitle}</span>{/snippet}
+		</HeroBanner>
+	</Section>
+
+	<Section padding="sm" class="comparison-section">
+		<div class="comparison-controls">
+			<div class="vault-search">
+				<Search
+					scope="vaults"
+					format="page"
+					label="Add vaults"
+					inputLabel="Search vaults to compare"
+					placeholder="Search by vault name, address, protocol or chain"
+					showAllResults={false}
+					minimumVaultTvlUsd={1_000}
+					disabled={selectionLimitReached || comparisonPending}
+					addButton={addVaultButton}
+				/>
+				{#if selectionLimitReached}
+					<p class="search-status">You can compare up to {MAX_SELECTED_VAULTS} vaults.</p>
+				{/if}
+			</div>
+
+			<fieldset class="benchmarks">
+				<legend>Benchmarks</legend>
+				<div class="benchmark-options">
+					{#each benchmarkOptions as benchmark (benchmark.key)}
+						<label style:--benchmark-colour={benchmarkComparisonColours[benchmark.key]}>
+							<input
+								type="checkbox"
+								checked={comparisonState.benchmarks.includes(benchmark.key)}
+								disabled={!selectedVaults.length || comparisonPending}
+								onchange={(event) => toggleBenchmark(benchmark.key, event.currentTarget.checked)}
+							/>
+							<span class="benchmark-swatch" aria-hidden="true"></span>
+							<span>{benchmark.label}</span>
+						</label>
+					{/each}
+				</div>
+			</fieldset>
+		</div>
+
+		{#if selectedVaults.length}
+			<section class="selected-vault-selection" aria-labelledby="selected-vaults-heading">
+				<h2 id="selected-vaults-heading" class="comparison-subheading">Selected vaults</h2>
+				<ul class="selected-vaults" aria-labelledby="selected-vaults-heading">
+					{#each selectedVaults as vault, index (vault.id)}
+						{@const periodMetrics = selectedPeriodMetricsByVaultId.get(vault.id)}
+						<li class:blacklisted={vault.entityType === 'blacklisted-vault'}>
+							<span class="vault-colour" style:--vault-colour={colours.get(vault.id)} aria-hidden="true"></span>
+							<span class="vault-logo">
+								{#if vault.logoUrl}<img src={vault.logoUrl} alt="" use:removeOnError />{/if}
+							</span>
+							<span class="vault-copy">
+								<a href={resolve(vault.href as `/vaults/${string}`)}>{vault.name}</a>
+								<small>{vault.protocolName} · {vault.chainName}</small>
+								{#if chartData?.missingVaultIds.includes(vault.id)}<em>Equity history unavailable</em>{/if}
+							</span>
+							<span class="vault-period-metrics" aria-live="polite">
+								<strong>{formatPercentProfit(periodMetrics?.cagr)} CAGR</strong>
+								<small>Since {periodMetrics?.since ?? notFilledMarker}</small>
+							</span>
+							<button
+								class="remove"
+								type="button"
+								disabled={comparisonPending}
+								aria-label={`Remove ${vault.name} from comparison`}
+								onclick={() => removeVault(vault.id, index)}
+							>
+								<IconCancel aria-hidden="true" />
+							</button>
+						</li>
+					{/each}
+				</ul>
+			</section>
+		{/if}
+
+		{#if chartError}
+			<Alert status="warning" size="sm">
+				{chartError}
+				<button class="retry" type="button" onclick={() => retryVersion++}>Retry</button>
+			</Alert>
+		{/if}
+
+		{#if !selectedVaults.length}
+			<div class="empty-state">
+				<h2>Add vaults to compare</h2>
+				<p>Search above to place up to eight vault equity curves on the same indexed chart.</p>
+			</div>
+		{:else if chartData?.vaultSeries.length || chartLoading}
+			<VaultEquityComparisonChart
+				vaults={selectedVaults}
+				data={chartData}
+				enabledBenchmarks={comparisonState.benchmarks}
+				{colours}
+				loading={chartLoading || comparisonPending}
+				{selectedTimeSpan}
+				onTimeSpanChange={(timeSpan) => (selectedTimeSpan = timeSpan)}
+			/>
+		{:else if !chartError}
+			<div class="empty-state">
+				<h2>No equity history available</h2>
+				<p>Try another vault or keep this selection and retry later.</p>
+			</div>
+		{/if}
+
+		{#if selectedVaults.length}
+			<section class="selected-comparison-table" aria-labelledby="selected-comparison-heading">
+				<h2 id="selected-comparison-heading">Selected vault comparison</h2>
+				<TopVaultsTable
+					topVaults={data.selectedTopVaults}
+					includeBlacklisted
+					defaultHideUnknown={0}
+					tvlTriggerLabel="Selected vaults"
+					tvlTooltip="This table contains only the vaults selected for the equity comparison."
+					showStablecoinOnlyMeta={false}
+					preserveSearchParams={['vault', 'benchmark']}
+				/>
+			</section>
+		{/if}
+
+		<ScatterPlotSelector />
+	</Section>
+
+	<Section><TopVaultsOptIn /></Section>
+</main>
+
+<style>
+	.vault-compare-page {
+		--control-panel-padding: var(--space-lg);
+	}
+	.comparison-controls {
+		display: grid;
+		grid-template-columns: minmax(20rem, 1fr) auto;
+		gap: var(--space-lg);
+		align-items: end;
+		padding: var(--control-panel-padding);
+		border: 1px solid var(--c-box-3);
+		border-radius: var(--radius-md);
+		background: var(--c-box-1);
+	}
+	.vault-search {
+		min-width: 0;
+	}
+	.comparison-subheading,
+	.benchmarks legend {
+		margin: 0;
+		color: var(--c-text-light);
+		font: var(--f-heading-xs-medium);
+		font-size: 1rem;
+		letter-spacing: 0.06em;
+		text-transform: uppercase;
+	}
+	.selected-vault-selection {
+		margin: var(--space-lg) 0;
+	}
+	.selected-vault-selection .comparison-subheading {
+		margin-bottom: var(--space-sm);
+	}
+	.search-status {
+		margin: var(--space-xs) 0 0;
+		color: var(--c-text-extra-light);
+		font: var(--f-ui-sm-medium);
+	}
+	.selected-comparison-table {
+		margin-top: var(--space-xl);
+
+		h2 {
+			margin-bottom: var(--space-sm);
+			font: var(--f-heading-md-medium);
+		}
+	}
+	.benchmarks {
+		min-width: 0;
+		margin: 0;
+		padding: 0;
+		border: 0;
+	}
+	.benchmarks legend {
+		margin-bottom: var(--space-xs);
+	}
+	.benchmark-options {
+		display: flex;
+		flex-wrap: wrap;
+		gap: var(--space-sm);
+	}
+	.benchmark-options label {
+		display: inline-flex;
+		align-items: center;
+		gap: var(--space-xs);
+		min-height: 3rem;
+		padding-inline: var(--space-sm);
+		border: 1px solid var(--c-input-border);
+		border-radius: var(--radius-sm);
+		font: var(--f-ui-sm-medium);
+		cursor: pointer;
+	}
+	.benchmark-options label:has(input:disabled) {
+		opacity: 0.55;
+		cursor: default;
+	}
+	.benchmark-swatch,
+	.vault-colour {
+		display: block;
+		width: 1.25rem;
+		height: 0;
+		border-top: 3px solid var(--benchmark-colour);
+		border-radius: 999px;
+	}
+	.selected-vaults {
+		display: grid;
+		grid-template-columns: repeat(auto-fit, minmax(min(18rem, 100%), 1fr));
+		gap: var(--space-sm);
+		margin: 0;
+		padding: 0;
+		list-style: none;
+	}
+	.selected-vaults li {
+		display: grid;
+		grid-template-columns: auto 2rem minmax(0, 1fr) auto auto;
+		gap: var(--space-sm);
+		align-items: center;
+		padding: var(--space-sm) var(--space-md);
+		padding-inline-start: 0;
+		border: 1px solid var(--c-box-3);
+		border-radius: var(--radius-sm);
+		background: var(--c-box-1);
+	}
+	.selected-vaults li.blacklisted .vault-copy a {
+		text-decoration: line-through;
+	}
+	.vault-colour {
+		border-color: var(--vault-colour);
+	}
+	.vault-logo {
+		display: grid;
+		width: 2rem;
+		height: 2rem;
+		place-items: center;
+		overflow: hidden;
+		border-radius: 50%;
+		background: var(--c-box-2);
+	}
+	.vault-logo img {
+		width: 100%;
+		height: 100%;
+		object-fit: contain;
+	}
+	.vault-copy {
+		display: grid;
+		min-width: 0;
+		gap: var(--space-xxs);
+	}
+	.vault-copy :is(a, small, em) {
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+	}
+	.vault-copy a {
+		color: var(--c-text);
+		font: var(--f-ui-md-medium);
+	}
+	.vault-copy small {
+		color: var(--c-text-extra-light);
+	}
+	.vault-copy em {
+		color: var(--c-warning);
+		font: var(--f-ui-xs-medium);
+		font-style: normal;
+	}
+	.vault-period-metrics {
+		display: grid;
+		gap: var(--space-xxs);
+		text-align: right;
+		white-space: nowrap;
+	}
+	.vault-period-metrics strong {
+		font: var(--f-ui-sm-medium);
+	}
+	.vault-period-metrics small {
+		color: var(--c-text-extra-light);
+	}
+	.remove {
+		display: grid;
+		width: 2rem;
+		height: 2rem;
+		place-items: center;
+		padding: 0;
+		border: 0;
+		border-radius: 50%;
+		background: transparent;
+		color: var(--c-text-extra-light);
+		cursor: pointer;
+	}
+	.remove:is(:hover, :focus-visible) {
+		background: var(--c-box-2);
+		color: var(--c-text);
+	}
+	.retry {
+		margin-left: var(--space-sm);
+		border: 0;
+		background: transparent;
+		color: var(--c-link);
+		font: inherit;
+		text-decoration: underline;
+		cursor: pointer;
+	}
+	.empty-state {
+		display: grid;
+		min-height: 25rem;
+		place-content: center;
+		gap: var(--space-sm);
+		margin-top: var(--space-lg);
+		border: 1px dashed var(--c-box-3);
+		border-radius: var(--radius-md);
+		color: var(--c-text-extra-light);
+		text-align: center;
+	}
+	.empty-state h2 {
+		color: var(--c-text);
+		font: var(--f-heading-md-medium);
+	}
+	@media (--viewport-md-down) {
+		.comparison-controls {
+			grid-template-columns: 1fr;
+		}
+	}
+	@media (--viewport-sm-down) {
+		.vault-compare-page {
+			--control-panel-padding: var(--space-md);
+		}
+		.comparison-subheading,
+		.benchmarks legend {
+			font-size: 0.875rem;
+		}
+		.benchmark-options label {
+			flex: 1 1 auto;
+			justify-content: center;
+		}
+		.empty-state {
+			min-height: 18rem;
+			padding-inline: var(--space-md);
+		}
+	}
+	@media (--viewport-xs) {
+		.selected-vaults li {
+			grid-template-columns: auto 2rem minmax(0, 1fr) auto;
+		}
+		.vault-period-metrics {
+			grid-column: 3;
+			grid-row: 2;
+			text-align: left;
+		}
+		.remove {
+			grid-column: 4;
+			grid-row: 1 / span 2;
+		}
+	}
+</style>

--- a/src/routes/vaults/compare/+page.svelte
+++ b/src/routes/vaults/compare/+page.svelte
@@ -387,6 +387,10 @@ Compare selected vault equity curves and fixed market benchmarks on one indexed 
 		letter-spacing: 0.06em;
 		text-transform: uppercase;
 	}
+	.comparison-controls :global(.search-label),
+	.benchmarks legend {
+		line-height: 1;
+	}
 	.selected-vault-selection {
 		margin: var(--space-lg) 0;
 	}

--- a/src/routes/vaults/compare/chart-data/+server.ts
+++ b/src/routes/vaults/compare/chart-data/+server.ts
@@ -1,0 +1,223 @@
+import { promisify } from 'node:util';
+import { brotliCompress, constants } from 'node:zlib';
+import { error } from '@sveltejs/kit';
+import { utcDay, utcHour } from 'd3-time';
+import { queryVaultPriceRows } from '$lib/server/top-vaults/vault-price-series';
+import { fetchCoinbaseBenchmarkCloses } from '$lib/top-vaults/coinbase';
+import {
+	alignVaultEquityCurves,
+	calculateComparisonPeriodMetrics,
+	indexBenchmarkPrices,
+	resampleComparisonPoints
+} from '$lib/top-vaults/equity-comparison/equity-curves';
+import {
+	MAX_SELECTED_VAULTS,
+	canonicaliseComparisonBenchmarks,
+	canonicaliseComparisonVaultIds
+} from '$lib/top-vaults/equity-comparison/state';
+import type {
+	AlignedEquityPoint,
+	AlignedVaultSeries,
+	ComparisonBenchmark,
+	ComparisonChartPoint,
+	ComparisonChartSeries,
+	VaultComparisonChartResponse,
+	VaultPriceSeries
+} from '$lib/top-vaults/equity-comparison/types';
+import { getCachedTopVaults } from '$lib/top-vaults/cache';
+import { fetchTreasuryBenchmarkSeries, ratesToCumulativeReturn } from '$lib/top-vaults/treasury-benchmark';
+
+const CACHE_TTL_MS = 5 * 60 * 1000;
+const RECENT_FOUR_HOUR_DAYS = 35;
+const fourHours = utcHour.every(4)!;
+const compress = promisify(brotliCompress);
+type CachedResponse = { json: string; br: Uint8Array };
+const responseCache = new Map<string, { expiresAt: number; response: Promise<CachedResponse> }>();
+
+const cacheHeaders = {
+	'cache-control': 'public, max-age=300',
+	'content-type': 'application/json',
+	vary: 'Accept-Encoding'
+};
+
+export async function GET({ fetch, request, url }) {
+	const requestedVaultIds = url.searchParams.getAll('vault');
+	const vaultIds = canonicaliseComparisonVaultIds(requestedVaultIds);
+	const requestedBenchmarks = url.searchParams.getAll('benchmark');
+	const benchmarks = canonicaliseComparisonBenchmarks(requestedBenchmarks);
+
+	if (!requestedVaultIds.length) error(400, 'At least one vault is required');
+	if (
+		requestedVaultIds.length > MAX_SELECTED_VAULTS ||
+		requestedVaultIds.length !== vaultIds.length ||
+		requestedVaultIds.some((value, index) => value !== vaultIds[index])
+	) {
+		error(400, `Provide up to ${MAX_SELECTED_VAULTS} unique, non-empty vault IDs`);
+	}
+	if (
+		requestedBenchmarks.length !== benchmarks.length ||
+		requestedBenchmarks.some((value, index) => value !== benchmarks[index])
+	) {
+		error(400, 'Provide unique supported benchmarks in canonical order');
+	}
+
+	const cacheKey = JSON.stringify([vaultIds, benchmarks]);
+	const now = Date.now();
+	const cached = responseCache.get(cacheKey);
+	if (cached && cached.expiresAt > now) {
+		return chartResponse(await cached.response, request);
+	}
+
+	const response = buildComparisonChartResponse(fetch, vaultIds, benchmarks)
+		.then(async (payload) => {
+			const json = JSON.stringify(payload);
+			const br = new Uint8Array(
+				await compress(new TextEncoder().encode(json), {
+					params: { [constants.BROTLI_PARAM_QUALITY]: 6 }
+				})
+			);
+			return { json, br };
+		})
+		.catch((cause) => {
+			responseCache.delete(cacheKey);
+			throw cause;
+		});
+	responseCache.set(cacheKey, { expiresAt: now + CACHE_TTL_MS, response });
+	trimResponseCache(now);
+
+	return chartResponse(await response, request);
+}
+
+function chartResponse(data: CachedResponse, request: Request): Response {
+	if (request.headers.get('accept-encoding')?.includes('br')) {
+		return new Response(data.br as BodyInit, { headers: { ...cacheHeaders, 'content-encoding': 'br' } });
+	}
+	return new Response(data.json, { headers: cacheHeaders });
+}
+
+/** Build the complete public chart payload from server-private vault history. */
+async function buildComparisonChartResponse(
+	fetch: Fetch,
+	vaultIds: string[],
+	benchmarks: ComparisonBenchmark[]
+): Promise<VaultComparisonChartResponse> {
+	const { vaults } = await getCachedTopVaults(fetch);
+	const knownVaultIds = new Set(vaults.map(({ id }) => id));
+	const queryIds = vaultIds.filter((vaultId) => knownVaultIds.has(vaultId));
+	const rows = await queryVaultPriceRows(queryIds);
+	const pointsById = new Map<string, [number, number][]>();
+
+	for (const { id, timestamp, sharePrice } of rows) {
+		if (!Number.isFinite(timestamp) || !Number.isFinite(sharePrice) || sharePrice <= 0) continue;
+		const points = pointsById.get(id) ?? [];
+		points.push([timestamp, sharePrice]);
+		pointsById.set(id, points);
+	}
+
+	const rawSeries: VaultPriceSeries[] = [];
+	const missingVaultIds: string[] = [];
+	for (const vaultId of vaultIds) {
+		const points = pointsById.get(vaultId);
+		if (points?.length) rawSeries.push({ id: vaultId, points });
+		else missingVaultIds.push(vaultId);
+	}
+
+	const alignedSeries = alignVaultEquityCurves(rawSeries);
+	const starts = alignedSeries.flatMap(({ points }) => (points[0] ? [points[0].time] : []));
+	const ends = alignedSeries.flatMap(({ points }) => (points.at(-1) ? [points.at(-1)!.time] : []));
+	const range: [number, number] | null = starts.length && ends.length ? [Math.min(...starts), Math.max(...ends)] : null;
+	const recentStart = range ? range[1] - RECENT_FOUR_HOUR_DAYS * 86_400 : 0;
+	const vaultSeries = range ? alignedSeries.map((series) => buildProcessedSeries(series, recentStart, range)) : [];
+	const benchmarkSeries: ComparisonChartSeries[] = [];
+	const benchmarkErrors: Partial<Record<ComparisonBenchmark, string>> = {};
+
+	if (range) {
+		await Promise.all(
+			benchmarks.map(async (benchmark) => {
+				try {
+					benchmarkSeries.push(await buildBenchmarkSeries(fetch, benchmark, range, recentStart));
+				} catch (cause) {
+					console.error(`Failed to prepare ${benchmark} comparison benchmark`, cause);
+					benchmarkErrors[benchmark] = 'Unavailable';
+				}
+			})
+		);
+		benchmarkSeries.sort(
+			(left, right) =>
+				benchmarks.indexOf(left.id as ComparisonBenchmark) - benchmarks.indexOf(right.id as ComparisonBenchmark)
+		);
+	}
+
+	return { range, vaultSeries, benchmarkSeries, missingVaultIds, benchmarkErrors };
+}
+
+function buildProcessedSeries(
+	series: AlignedVaultSeries,
+	recentStart: number,
+	range: [number, number]
+): ComparisonChartSeries {
+	const { id, points, discontinuous } = series;
+	const processedPoints = {
+		'4h': resampleComparisonPoints(points, fourHours).filter(({ time }) => time >= recentStart),
+		'1d': resampleComparisonPoints(points, utcDay)
+	};
+	return {
+		id,
+		discontinuous,
+		points: processedPoints,
+		periodMetrics: calculateComparisonPeriodMetrics(processedPoints, range)
+	};
+}
+
+async function buildBenchmarkSeries(
+	fetch: Fetch,
+	benchmark: ComparisonBenchmark,
+	range: [number, number],
+	recentStart: number
+): Promise<ComparisonChartSeries> {
+	const start = new Date(range[0] * 1000);
+	const end = new Date(range[1] * 1000);
+
+	if (benchmark === 'treasury') {
+		const rates = await fetchTreasuryBenchmarkSeries(fetch, start, end, false);
+		const points = {
+			'4h': ratesToCumulativeReturn(rates, 100, fourHours, start, end)
+				.map(({ time, value }) => toBenchmarkPoint(Number(time), value))
+				.filter(({ time }) => time >= recentStart),
+			'1d': ratesToCumulativeReturn(rates, 100, utcDay, start, end).map(({ time, value }) =>
+				toBenchmarkPoint(Number(time), value)
+			)
+		};
+		return {
+			id: benchmark,
+			discontinuous: false,
+			points,
+			periodMetrics: calculateComparisonPeriodMetrics(points, range)
+		};
+	}
+
+	const source = await fetchCoinbaseBenchmarkCloses(
+		fetch,
+		benchmark === 'btc' ? 'BTC-USD' : 'ETH-USD',
+		start,
+		end,
+		false
+	);
+	const indexedPoints: AlignedEquityPoint[] = indexBenchmarkPrices(source).map(([time, value]) => ({ time, value }));
+	return buildProcessedSeries(
+		{ id: benchmark, anchor: 100, discontinuous: false, points: indexedPoints },
+		recentStart,
+		range
+	);
+}
+
+function toBenchmarkPoint(time: number, value: number): ComparisonChartPoint {
+	return { time, value };
+}
+
+function trimResponseCache(now: number): void {
+	for (const [key, entry] of responseCache) {
+		if (entry.expiresAt <= now) responseCache.delete(key);
+	}
+	while (responseCache.size > 50) responseCache.delete(responseCache.keys().next().value!);
+}

--- a/src/routes/vaults/treasury-benchmark/+server.ts
+++ b/src/routes/vaults/treasury-benchmark/+server.ts
@@ -1,5 +1,5 @@
 /**
- * Server-side proxy for FRED DTB3 (3-month Treasury bill) time series.
+ * Server-side proxy for the FRED DGS3MO 3-month Treasury market-yield series.
  *
  * Proxies through the server to avoid CORS issues and FRED rate-limiting.
  * Uses file-based caching with stale-fallback on fetch failure.
@@ -17,9 +17,9 @@ import {
 	isCacheFresh
 } from '$lib/fred-helpers';
 
-const SERIES_ID = 'DTB3';
-/** Earliest DTB3 observation on FRED */
-const SERIES_START = '1954-01-04';
+const SERIES_ID = 'DGS3MO';
+/** Earliest DGS3MO observation on FRED. */
+const SERIES_START = '1981-09-01';
 
 type RateEntry = [timestamp: number, rate: number];
 
@@ -47,7 +47,7 @@ function validateAndClampDates(rawCosd: string | null, rawCoed: string | null): 
 		error(400, 'cosd must not be in the future');
 	}
 
-	// Clamp to DTB3 series bounds
+	// Clamp to DGS3MO series bounds
 	const cosd = rawCosd < SERIES_START ? SERIES_START : rawCosd;
 	const coed = rawCoed > today ? today : rawCoed;
 

--- a/tests/integration/navigation.test.ts
+++ b/tests/integration/navigation.test.ts
@@ -2,6 +2,46 @@ import { expect, test } from '@playwright/test';
 
 const searchName = 'Search vaults and DeFi entities';
 
+test('shows Compare and Pricing in desktop navigation and moves secondary links to the footer', async ({ page }) => {
+	await page.setViewportSize({ width: 1440, height: 1000 });
+	await page.goto('/vaults');
+
+	const primaryNavigation = page.getByRole('navigation', { name: 'Primary navigation' });
+	await expect(primaryNavigation.locator('menu > li > a')).toHaveText([
+		'Top vaults',
+		'Our vaults',
+		'Compare',
+		'Pricing'
+	]);
+	await expect(primaryNavigation.getByRole('link', { name: 'Compare' })).toHaveAttribute('href', '/vaults/compare');
+	await expect(primaryNavigation.getByRole('link', { name: 'Pricing' })).toHaveAttribute('href', '/pricing');
+	await expect(primaryNavigation.getByRole('link', { name: 'API' })).toHaveCount(0);
+	await expect(primaryNavigation.getByRole('link', { name: 'Community' })).toHaveCount(0);
+	await expect(primaryNavigation.getByRole('link', { name: 'Blog' })).toHaveCount(0);
+
+	const footerNavigation = page.getByRole('navigation', { name: 'Footer navigation' });
+	await expect(footerNavigation.getByRole('link')).toHaveText(['Community', 'Blog', 'API']);
+	await expect(footerNavigation.getByRole('link', { name: 'API' })).toHaveAttribute('href', '/vaults/api');
+});
+
+test('keeps every navigation link in the mobile menu', async ({ page }) => {
+	await page.setViewportSize({ width: 375, height: 667 });
+	await page.goto('/vaults');
+	await page.getByTestId('navigation-toggle').click();
+
+	const navigation = page.getByRole('navigation', { name: 'Mobile navigation' });
+	await expect(navigation.locator(':scope > menu > li > a')).toHaveText([
+		'Top vaults',
+		'Our vaults',
+		'Compare',
+		'Pricing',
+		'API',
+		'Community',
+		'Blog'
+	]);
+	await expect(navigation.getByRole('navigation', { name: 'Footer navigation' })).toHaveCount(0);
+});
+
 test('opens compact navigation on the first tap after page load', async ({ page }) => {
 	await page.setViewportSize({ width: 1024, height: 768 });
 	await page.goto('/pricing', { waitUntil: 'commit' });
@@ -93,6 +133,9 @@ async function searchFromNavigation(page: import('@playwright/test').Page, query
 			search = page.getByRole('dialog', { name: 'Search' }).getByRole('combobox', { name: searchName });
 		}
 	}
+	await expect(search.locator('xpath=ancestor::*[@data-ready][1]')).toHaveAttribute('data-ready', 'true', {
+		timeout: 30_000
+	});
 	await search.fill(query);
 	const results = page.getByTestId('entity-search-results');
 	await expect(results.getByRole('option').first()).toBeVisible();

--- a/tests/integration/vaults/charts-dropdown.test.ts
+++ b/tests/integration/vaults/charts-dropdown.test.ts
@@ -50,12 +50,13 @@ test.describe('charts dropdown in vault listings navigation', () => {
 			await expect(trigger).toBeVisible();
 		});
 
-		test('clicking Charts opens dropdown with 10 chart links', async ({ page }) => {
+		test('clicking Charts opens dropdown with 11 chart links', async ({ page }) => {
 			const { menu } = await openChartsMenu(page);
 
 			const items = menu.locator('[role="menuitem"]');
-			await expect(items).toHaveCount(10);
+			await expect(items).toHaveCount(11);
 
+			await expect(menu).toContainText('Compare equity curves');
 			await expect(menu).toContainText('Yield / Risk');
 			await expect(menu).toContainText('Yield / Protocol');
 			await expect(menu).toContainText('Yield / Chain');

--- a/tests/integration/vaults/cumulative-tvl-apy.test.ts
+++ b/tests/integration/vaults/cumulative-tvl-apy.test.ts
@@ -72,7 +72,7 @@ test.describe('cumulative TVL/APY chart page', () => {
 
 		const selector = page.locator('.scatter-plot-selector');
 		await expect(selector).toBeVisible();
-		await expect(selector.locator('a')).toHaveCount(10);
+		await expect(selector.locator('a')).toHaveCount(11);
 	});
 
 	test('page has no JavaScript errors', async ({ page }) => {

--- a/tests/integration/vaults/current-peak-tvl.test.ts
+++ b/tests/integration/vaults/current-peak-tvl.test.ts
@@ -18,7 +18,7 @@ test.describe('vault current/peak TVL scatter plot page', () => {
 		// Scatter plot selector links
 		const selector = page.locator('.scatter-plot-selector');
 		await expect(selector).toBeVisible();
-		await expect(selector.locator('a')).toHaveCount(10);
+		await expect(selector.locator('a')).toHaveCount(11);
 
 		// Chart renders with Plotly
 		const plotWrapper = page.getByTestId('vault-scatter-plot');

--- a/tests/integration/vaults/equity-compare-private-r2.test.ts
+++ b/tests/integration/vaults/equity-compare-private-r2.test.ts
@@ -1,0 +1,80 @@
+import { expect, test } from '@playwright/test';
+import { hasPrivateR2Secrets } from '../../helpers';
+
+const hasSecrets = hasPrivateR2Secrets('test', 'local');
+
+test.describe('live vault equity curve comparison', () => {
+	test.skip(!hasSecrets, 'Private R2 secrets are not configured for integration tests');
+
+	test('compares Hyperliquid HLP and Spark with BTC, ETH and US Treasury', async ({ page, request }) => {
+		test.setTimeout(120_000);
+
+		type LiveSearchResult = {
+			name: string;
+			vaultId?: string;
+			protocolName?: string;
+			chainName?: string;
+		};
+		const searchVaults = async (query: string): Promise<LiveSearchResult[]> => {
+			const response = await request.get('/search/suggestions', {
+				params: { q: query, scope: 'vaults', limit: 20 }
+			});
+			expect(response.status()).toBe(200);
+			return ((await response.json()) as { results: LiveSearchResult[] }).results;
+		};
+
+		const hlp = (await searchVaults('Hyperliquid HLP')).find(
+			(result) => result.name === 'Hyperliquidity Provider (HLP)'
+		);
+		const spark = (await searchVaults('Spark vault')).find(
+			(result) =>
+				result.name === 'Spark USDC Vault' && result.protocolName === 'Spark' && result.chainName === 'Ethereum'
+		);
+		expect(hlp?.vaultId).toBeTruthy();
+		expect(spark?.vaultId).toBeTruthy();
+
+		const chartResponsePromise = page.waitForResponse((response) => {
+			const url = new URL(response.url());
+			return url.pathname === '/vaults/compare/chart-data' && url.searchParams.getAll('vault').length === 2;
+		});
+
+		const selection = new URLSearchParams();
+		selection.append('vault', hlp!.vaultId!);
+		selection.append('vault', spark!.vaultId!);
+		selection.append('benchmark', 'treasury');
+		selection.append('benchmark', 'eth');
+		selection.append('benchmark', 'btc');
+		await page.goto(`/vaults/compare?${selection}`);
+
+		const chartResponse = await chartResponsePromise;
+		expect(chartResponse.status()).toBe(200);
+		const chartData = (await chartResponse.json()) as {
+			vaultSeries: { id: string; points: { '4h': unknown[]; '1d': unknown[] } }[];
+			benchmarkSeries: { id: string; points: { '4h': unknown[]; '1d': unknown[] } }[];
+			missingVaultIds: string[];
+		};
+		expect(chartData.vaultSeries).toHaveLength(2);
+		expect(chartData.vaultSeries.map(({ id }) => id)).toEqual([hlp!.vaultId, spark!.vaultId]);
+		expect(chartData.vaultSeries.every(({ points }) => points['1d'].length > 0)).toBe(true);
+		expect(chartData.benchmarkSeries.map(({ id }) => id)).toEqual(['treasury', 'eth', 'btc']);
+		expect(chartData.benchmarkSeries.every(({ points }) => points['1d'].length > 0)).toBe(true);
+		expect(chartData.missingVaultIds).toEqual([]);
+
+		const selectedVaults = page.getByRole('list', { name: 'Selected vaults' });
+		await expect(selectedVaults.locator('li')).toHaveCount(2);
+		await expect(selectedVaults).toContainText('Hyperliquidity Provider (HLP)');
+		await expect(selectedVaults).toContainText('Spark USDC Vault');
+
+		await expect(page.getByRole('checkbox', { name: 'T-Bill' })).toBeChecked();
+		await expect(page.getByRole('checkbox', { name: 'ETH' })).toBeChecked();
+		await expect(page.getByRole('checkbox', { name: 'BTC' })).toBeChecked();
+		expect(new URL(page.url()).searchParams.getAll('benchmark')).toEqual(['treasury', 'eth', 'btc']);
+
+		const legend = page.getByLabel('Equity comparison chart legend');
+		await expect(legend).toContainText('Hyperliquidity Provider (HLP)');
+		await expect(legend).toContainText('Spark USDC Vault');
+		await expect(legend).toContainText('US 3M T-bill');
+		await expect(legend).toContainText('ETH');
+		await expect(legend).toContainText('BTC');
+	});
+});

--- a/tests/integration/vaults/equity-compare.test.ts
+++ b/tests/integration/vaults/equity-compare.test.ts
@@ -108,6 +108,24 @@ test.describe('vault equity curve comparison page', () => {
 		await expect(page.getByRole('checkbox', { name: 'ETH' })).toBeChecked();
 		await expect(page.getByRole('checkbox', { name: 'BTC' })).toBeChecked();
 		await expect(page.locator('.benchmark-options .benchmark-logo')).toHaveCount(3);
+		const controlAlignment = await page.locator('.comparison-controls').evaluate((element) => {
+			const bounds = (selector: string) => element.querySelector(selector)!.getBoundingClientRect();
+			const searchHeading = bounds('.search-label');
+			const benchmarkHeading = bounds('.benchmarks legend');
+			const searchInput = bounds('.desktop-search input');
+			const benchmarkItem = bounds('.benchmark-options label');
+			return {
+				searchHeadingTop: searchHeading.top,
+				benchmarkHeadingTop: benchmarkHeading.top,
+				searchInputTop: searchInput.top,
+				benchmarkItemTop: benchmarkItem.top,
+				searchInputBottom: searchInput.bottom,
+				benchmarkItemBottom: benchmarkItem.bottom
+			};
+		});
+		expect(controlAlignment.searchHeadingTop).toBeCloseTo(controlAlignment.benchmarkHeadingTop, 0);
+		expect(controlAlignment.searchInputTop).toBeCloseTo(controlAlignment.benchmarkItemTop, 0);
+		expect(controlAlignment.searchInputBottom).toBeCloseTo(controlAlignment.benchmarkItemBottom, 0);
 		expect(new URL(page.url()).searchParams.getAll('vault')).toHaveLength(1);
 		expect(new URL(page.url()).searchParams.getAll('benchmark')).toEqual(['treasury', 'eth', 'btc']);
 		await expect.poll(() => chartRequests.at(-1)?.benchmarks).toEqual(['treasury', 'eth', 'btc']);

--- a/tests/integration/vaults/equity-compare.test.ts
+++ b/tests/integration/vaults/equity-compare.test.ts
@@ -334,6 +334,7 @@ test.describe('vault equity curve comparison page', () => {
 			const layout = await chart.evaluate((element) => {
 				const headingBounds = element.querySelector('h2')!.getBoundingClientRect();
 				const controlsBounds = element.querySelector('.segmented-control')!.getBoundingClientRect();
+				const plotBounds = element.querySelector('[data-testid="tv-chart"]')!.getBoundingClientRect();
 				const chartBounds = element.getBoundingClientRect();
 				const headingOverlapsControls = !(
 					headingBounds.right <= controlsBounds.left ||
@@ -343,6 +344,10 @@ test.describe('vault equity curve comparison page', () => {
 				);
 				return {
 					headingOverlapsControls,
+					contentLeft: headingBounds.left,
+					contentRight: controlsBounds.right,
+					plotLeft: plotBounds.left,
+					plotRight: plotBounds.right,
 					chartLeft: chartBounds.left,
 					chartRight: chartBounds.right,
 					viewportWidth: window.innerWidth,
@@ -350,6 +355,8 @@ test.describe('vault equity curve comparison page', () => {
 				};
 			});
 			expect(layout.headingOverlapsControls).toBe(false);
+			expect(layout.plotLeft).toBeCloseTo(layout.contentLeft, 0);
+			expect(layout.plotRight).toBeCloseTo(layout.contentRight, 0);
 			expect(layout.chartLeft).toBeGreaterThanOrEqual(0);
 			expect(layout.chartRight).toBeLessThanOrEqual(layout.viewportWidth);
 			expect(layout.documentWidth).toBeLessThanOrEqual(layout.viewportWidth);

--- a/tests/integration/vaults/equity-compare.test.ts
+++ b/tests/integration/vaults/equity-compare.test.ts
@@ -107,6 +107,7 @@ test.describe('vault equity curve comparison page', () => {
 		await expect(page.getByRole('checkbox', { name: 'T-Bill' })).toBeChecked();
 		await expect(page.getByRole('checkbox', { name: 'ETH' })).toBeChecked();
 		await expect(page.getByRole('checkbox', { name: 'BTC' })).toBeChecked();
+		await expect(page.locator('.benchmark-options .benchmark-logo')).toHaveCount(3);
 		expect(new URL(page.url()).searchParams.getAll('vault')).toHaveLength(1);
 		expect(new URL(page.url()).searchParams.getAll('benchmark')).toEqual(['treasury', 'eth', 'btc']);
 		await expect.poll(() => chartRequests.at(-1)?.benchmarks).toEqual(['treasury', 'eth', 'btc']);
@@ -250,12 +251,19 @@ test.describe('vault equity curve comparison page', () => {
 		expect(new Set(vaultColours).size).toBe(2);
 
 		await page.getByRole('checkbox', { name: 'ETH' }).check();
-		await expect(page.getByLabel('Equity comparison chart legend')).toContainText('ETH');
+		const chartLegend = page.getByLabel('Equity comparison chart legend');
+		await expect(chartLegend).toContainText('ETH');
 		expect(new URL(page.url()).searchParams.getAll('benchmark')).toEqual(['eth']);
-		expect(
-			await page
+		await expect(
+			page
 				.getByRole('checkbox', { name: 'ETH' })
-				.locator('xpath=following-sibling::*[contains(@class, "benchmark-swatch")]')
+				.locator('xpath=following-sibling::img[contains(@class, "benchmark-logo")]')
+		).toHaveAttribute('src', '/logos/tokens/eth');
+		expect(
+			await chartLegend
+				.locator('.legend-item')
+				.filter({ hasText: 'ETH' })
+				.locator('.swatch')
 				.evaluate((swatch) => getComputedStyle(swatch).borderTopColor)
 		).toBe('rgba(98, 126, 234, 0.5)');
 

--- a/tests/integration/vaults/equity-compare.test.ts
+++ b/tests/integration/vaults/equity-compare.test.ts
@@ -98,6 +98,9 @@ test.describe('vault equity curve comparison page', () => {
 
 		await page.goto('/vaults/compare');
 
+		const pageHeading = page.getByRole('heading', { level: 1, name: 'Compare vaults Beta' });
+		await expect(pageHeading).toBeVisible();
+		await expect(pageHeading.getByText('Beta', { exact: true })).toBeVisible();
 		const selectedVaults = page.getByRole('list', { name: 'Selected vaults' });
 		await expect(page.getByRole('heading', { name: 'Selected vaults' })).toBeVisible();
 		await expect(selectedVaults.locator('li')).toHaveCount(1);

--- a/tests/integration/vaults/equity-compare.test.ts
+++ b/tests/integration/vaults/equity-compare.test.ts
@@ -113,11 +113,15 @@ test.describe('vault equity curve comparison page', () => {
 		await expect(page.locator('.benchmark-options .benchmark-logo')).toHaveCount(3);
 		const controlAlignment = await page.locator('.comparison-controls').evaluate((element) => {
 			const bounds = (selector: string) => element.querySelector(selector)!.getBoundingClientRect();
+			const panel = element.getBoundingClientRect();
+			const searchBlock = bounds('.vault-search');
 			const searchHeading = bounds('.search-label');
 			const benchmarkHeading = bounds('.benchmarks legend');
 			const searchInput = bounds('.desktop-search input');
 			const benchmarkItem = bounds('.benchmark-options label');
 			return {
+				topInset: searchBlock.top - panel.top,
+				bottomInset: panel.bottom - searchBlock.bottom,
 				searchHeadingTop: searchHeading.top,
 				benchmarkHeadingTop: benchmarkHeading.top,
 				searchInputTop: searchInput.top,
@@ -126,6 +130,7 @@ test.describe('vault equity curve comparison page', () => {
 				benchmarkItemBottom: benchmarkItem.bottom
 			};
 		});
+		expect(controlAlignment.topInset).toBeCloseTo(controlAlignment.bottomInset, 0);
 		expect(controlAlignment.searchHeadingTop).toBeCloseTo(controlAlignment.benchmarkHeadingTop, 0);
 		expect(controlAlignment.searchInputTop).toBeCloseTo(controlAlignment.benchmarkItemTop, 0);
 		expect(controlAlignment.searchInputBottom).toBeCloseTo(controlAlignment.benchmarkItemBottom, 0);

--- a/tests/integration/vaults/equity-compare.test.ts
+++ b/tests/integration/vaults/equity-compare.test.ts
@@ -1,0 +1,359 @@
+import { expect, test, type APIRequestContext, type Page } from '@playwright/test';
+
+type SearchResult = {
+	name: string;
+	vaultId: string | null;
+};
+
+/**
+ * Resolve a vault ID through the same server-side search used by the selector.
+ */
+async function findVaultId(request: APIRequestContext, query: string, name: string): Promise<string> {
+	const response = await request.get('/search/suggestions', {
+		params: { q: query, scope: 'vaults', limit: 20, minimumVaultTvlUsd: 1_000 },
+		timeout: 30_000
+	});
+	expect(response.ok()).toBe(true);
+	const result = ((await response.json()) as { results: SearchResult[] }).results.find(
+		(candidate) => candidate.name === name
+	);
+	expect(result?.vaultId).toBeTruthy();
+	return result!.vaultId!;
+}
+
+/**
+ * Return chart-ready mock series spanning more than one year.
+ */
+function responsiveChartPoints(seriesIndex: number) {
+	const start = 1_704_067_200;
+	return Array.from({ length: 15 - seriesIndex * 2 }, (_, pointIndex) => {
+		const value = 100 + pointIndex * (2 + seriesIndex);
+		return {
+			time: start + (pointIndex + seriesIndex * 2) * 30 * 24 * 60 * 60,
+			value
+		};
+	});
+}
+
+/**
+ * Return deterministic server-calculated metrics for mocked chart periods.
+ */
+function mockPeriodMetrics(seriesIndex = 0) {
+	return {
+		'1M': { cagr: 0.11 + seriesIndex / 100, since: '2025-02-01' },
+		'3M': { cagr: 0.13 + seriesIndex / 100, since: '2024-12-01' },
+		'6M': { cagr: 0.16 + seriesIndex / 100, since: '2024-09-01' },
+		'1Y': { cagr: 0.21 + seriesIndex / 100, since: '2024-03-01' },
+		Max: { cagr: 0.25 + seriesIndex / 100, since: '2024-01-01' }
+	};
+}
+
+/**
+ * Mock only the server-prepared chart payload and retain request details for assertions.
+ */
+async function mockResponsiveChartData(page: Page) {
+	const requests: Array<{ vaults: string[]; benchmarks: string[] }> = [];
+	await page.route('**/vaults/compare/chart-data?*', async (route) => {
+		const params = new URL(route.request().url()).searchParams;
+		const vaults = params.getAll('vault');
+		const benchmarks = params.getAll('benchmark');
+		requests.push({ vaults, benchmarks });
+		const vaultSeries = vaults.map((id, index) => {
+			const points = responsiveChartPoints(index);
+			return {
+				id,
+				discontinuous: false,
+				points: { '4h': points, '1d': points },
+				periodMetrics: mockPeriodMetrics(index)
+			};
+		});
+		const benchmarkSeries = benchmarks.map((id) => {
+			const points = responsiveChartPoints(0);
+			return {
+				id,
+				discontinuous: false,
+				points: { '4h': points, '1d': points },
+				periodMetrics: mockPeriodMetrics()
+			};
+		});
+		const allPoints = [...vaultSeries, ...benchmarkSeries].flatMap((series) => series.points['1d']);
+
+		await route.fulfill({
+			contentType: 'application/json',
+			body: JSON.stringify({
+				range: [allPoints[0].time, allPoints.at(-1)!.time],
+				vaultSeries,
+				benchmarkSeries,
+				missingVaultIds: [],
+				benchmarkErrors: {}
+			})
+		});
+	});
+	return requests;
+}
+
+test.describe('vault equity curve comparison page', () => {
+	test('selects Savings USDS and all benchmarks by default', async ({ page }) => {
+		const chartRequests = await mockResponsiveChartData(page);
+
+		await page.goto('/vaults/compare');
+
+		const selectedVaults = page.getByRole('list', { name: 'Selected vaults' });
+		await expect(page.getByRole('heading', { name: 'Selected vaults' })).toBeVisible();
+		await expect(selectedVaults.locator('li')).toHaveCount(1);
+		await expect(selectedVaults).toContainText('Savings USDS');
+		await expect(selectedVaults).toContainText('13.0% CAGR');
+		await expect(selectedVaults).toContainText('Since 2024-12-01');
+		await expect(page.getByRole('checkbox', { name: 'T-Bill' })).toBeChecked();
+		await expect(page.getByRole('checkbox', { name: 'ETH' })).toBeChecked();
+		await expect(page.getByRole('checkbox', { name: 'BTC' })).toBeChecked();
+		expect(new URL(page.url()).searchParams.getAll('vault')).toHaveLength(1);
+		expect(new URL(page.url()).searchParams.getAll('benchmark')).toEqual(['treasury', 'eth', 'btc']);
+		await expect.poll(() => chartRequests.at(-1)?.benchmarks).toEqual(['treasury', 'eth', 'btc']);
+		await expect(page.getByTestId('page-search')).toHaveAttribute('data-ready', 'true', { timeout: 30_000 });
+
+		await page.getByRole('button', { name: 'Remove Savings USDS from comparison' }).click();
+		await expect(page.getByRole('list', { name: 'Selected vaults' })).toHaveCount(0);
+		expect(new URL(page.url()).searchParams.get('comparison')).toBe('empty');
+	});
+
+	test('adds, compares and removes vaults while keeping state in the URL', async ({ page }) => {
+		test.setTimeout(120_000);
+		const batchRequests: string[][] = [];
+		const suggestionMinimumTvls: string[] = [];
+		const pageErrors: string[] = [];
+		page.on('pageerror', (error) => pageErrors.push(error.message));
+		await page.route('**/vaults/compare/chart-data?*', async (route) => {
+			const searchParams = new URL(route.request().url()).searchParams;
+			const vaultIds = searchParams.getAll('vault');
+			const benchmarks = searchParams.getAll('benchmark');
+			batchRequests.push(vaultIds);
+			await new Promise((resolve) => setTimeout(resolve, 300));
+			const pointsFor = (index: number) =>
+				(index === 0
+					? [
+							[1_735_689_600, 100],
+							[1_735_776_000, 110],
+							[1_735_862_400, 120]
+						]
+					: [
+							[1_735_776_000, 110],
+							[1_735_862_400, 121]
+						]
+				).map(([time, value]) => ({
+					time,
+					value
+				}));
+			await route.fulfill({
+				contentType: 'application/json',
+				body: JSON.stringify({
+					range: [1_735_689_600, 1_735_862_400],
+					vaultSeries: vaultIds.map((id, index) => ({
+						id,
+						discontinuous: false,
+						points: { '4h': pointsFor(index), '1d': pointsFor(index) },
+						periodMetrics: mockPeriodMetrics(index)
+					})),
+					benchmarkSeries: benchmarks.map((id) => ({
+						id,
+						discontinuous: false,
+						points: { '4h': pointsFor(0), '1d': pointsFor(0) },
+						periodMetrics: mockPeriodMetrics()
+					})),
+					missingVaultIds: [],
+					benchmarkErrors: {}
+				})
+			});
+		});
+		await page.route('**/vaults/coinbase-candles?*', async (route) => {
+			await route.fulfill({
+				contentType: 'application/json',
+				body: JSON.stringify([
+					[1_735_689_600, 3_300],
+					[1_735_776_000, 3_400],
+					[1_735_862_400, 3_500]
+				])
+			});
+		});
+		await page.route('**/search/suggestions?*', async (route) => {
+			suggestionMinimumTvls.push(new URL(route.request().url()).searchParams.get('minimumVaultTvlUsd') ?? '');
+			await new Promise((resolve) => setTimeout(resolve, 300));
+			await route.continue();
+		});
+
+		await page.goto('/vaults/compare?comparison=empty');
+
+		await expect(page).toHaveTitle(/Compare and find best DeFi vault yield/);
+		await expect(page.locator('meta[name="description"]')).toHaveAttribute('content', 'Analyse more than 5000 vaults');
+		await expect(page.getByRole('heading', { name: 'Compare vaults' })).toBeVisible();
+		await expect(page.getByRole('heading', { name: 'Add vaults to compare' })).toBeVisible();
+		await expect(page.getByRole('checkbox')).toHaveCount(3);
+		await expect(page.getByTestId('page-search')).toHaveAttribute('data-ready', 'true', { timeout: 30_000 });
+
+		let search = page.getByRole('combobox', { name: 'Search vaults to compare' });
+		await search.fill('Savings USDS');
+		await expect(page.getByRole('status')).toContainText('Searching…');
+		const savingsUsdsResult = page.getByRole('option', { name: /Savings USDS/ }).first();
+		await expect(savingsUsdsResult.getByLabel('1 month APY')).toBeVisible();
+		await expect(savingsUsdsResult.getByLabel('Latest TVL')).toBeVisible();
+		await expect(savingsUsdsResult.getByRole('img', { name: /Savings USDS 90 day price/ })).toBeVisible();
+		expect(suggestionMinimumTvls.at(-1)).toBe('1000');
+		const [searchBounds, menuBounds] = await Promise.all([
+			search.boundingBox(),
+			page.getByRole('dialog', { name: 'Search' }).boundingBox()
+		]);
+		expect(Math.abs((searchBounds?.x ?? 0) - (menuBounds?.x ?? 0))).toBeLessThanOrEqual(1);
+		expect(Math.abs((searchBounds?.width ?? 0) - (menuBounds?.width ?? 0))).toBeLessThanOrEqual(1);
+		await savingsUsdsResult.click();
+		await expect(search).toHaveValue('');
+		await expect(page.getByRole('dialog', { name: 'Search' })).toBeHidden();
+
+		const selectedVaults = page.getByRole('list', { name: 'Selected vaults' });
+		await expect(selectedVaults).toContainText('Savings USDS');
+		await expect(selectedVaults.locator('li').first()).toHaveCSS('padding-left', '0px');
+		await expect(page.getByTestId('tv-chart').locator('.loading')).toBeVisible();
+		expect(new URL(page.url()).pathname).toBe('/vaults/compare');
+		await expect(page.getByRole('heading', { name: 'Vault returns index' })).toBeVisible();
+		await expect(page.locator('.comparison-chart .chart-container')).toHaveClass(/boxed/);
+		const timePeriodOptions = page.locator('.comparison-chart .segmented-control label');
+		await expect(timePeriodOptions).toHaveText(['1M', '3M', '6M', '1Y', 'Max']);
+		await timePeriodOptions.filter({ hasText: '1Y' }).click();
+		await expect(timePeriodOptions.filter({ hasText: '1Y' })).toHaveClass(/selected/);
+		await expect(selectedVaults).toContainText('21.0% CAGR');
+		await expect(selectedVaults).toContainText('Since 2024-03-01');
+		await expect(page.getByTestId('page-search')).toHaveAttribute('data-ready', 'true', { timeout: 30_000 });
+		expect(new URL(page.url()).searchParams.getAll('vault')).toHaveLength(1);
+		await expect.poll(() => batchRequests.at(-1)?.length).toBe(1);
+
+		search = page.getByTestId('page-search').getByRole('combobox', { name: 'Search vaults to compare' });
+		await search.fill('Savings infiniFi USD');
+		await page.getByRole('button', { name: 'Add Savings infiniFi USD to comparison' }).first().click();
+		await expect(search).toHaveValue('');
+		await expect(page.getByRole('dialog', { name: 'Search' })).toBeHidden();
+		await expect(selectedVaults.locator('li')).toHaveCount(2);
+		expect(new URL(page.url()).searchParams.getAll('vault')).toHaveLength(2);
+		await expect.poll(() => batchRequests.at(-1)?.length).toBe(2);
+		const comparisonTable = page.getByRole('region', { name: 'Selected vault comparison' });
+		await expect(comparisonTable.getByRole('table')).toBeVisible();
+		await expect(comparisonTable.getByRole('row').filter({ hasText: 'Savings USDS' })).toBeVisible();
+		await expect(comparisonTable.getByRole('row').filter({ hasText: 'Savings infiniFi USD' })).toBeVisible();
+		await expect(page.getByTestId('tv-chart').locator('.loading')).toBeHidden();
+		const chartRequestCountBeforeSort = batchRequests.length;
+		await comparisonTable.getByRole('button', { name: 'Vault' }).click();
+		await expect.poll(() => new URL(page.url()).searchParams.get('sort')).toBe('vault');
+		expect(new URL(page.url()).searchParams.getAll('vault')).toHaveLength(2);
+		await page.waitForTimeout(500);
+		expect(batchRequests).toHaveLength(chartRequestCountBeforeSort);
+		const vaultColours = await selectedVaults
+			.locator('.vault-colour')
+			.evaluateAll((swatches) => swatches.map((swatch) => getComputedStyle(swatch).borderTopColor));
+		expect(new Set(vaultColours).size).toBe(2);
+
+		await page.getByRole('checkbox', { name: 'ETH' }).check();
+		await expect(page.getByLabel('Equity comparison chart legend')).toContainText('ETH');
+		expect(new URL(page.url()).searchParams.getAll('benchmark')).toEqual(['eth']);
+		expect(
+			await page
+				.getByRole('checkbox', { name: 'ETH' })
+				.locator('xpath=following-sibling::*[contains(@class, "benchmark-swatch")]')
+				.evaluate((swatch) => getComputedStyle(swatch).borderTopColor)
+		).toBe('rgba(98, 126, 234, 0.5)');
+
+		await page.getByRole('button', { name: 'Remove Savings USDS from comparison' }).click();
+		await expect(selectedVaults.locator('li')).toHaveCount(1);
+		await expect(selectedVaults).not.toContainText('Savings USDS');
+		expect(new URL(page.url()).searchParams.getAll('vault')).toHaveLength(1);
+		await expect.poll(() => batchRequests.at(-1)?.length).toBe(1);
+
+		await page.getByRole('button', { name: 'Remove Savings infiniFi USD from comparison' }).click();
+		await expect(page.getByRole('heading', { name: 'Add vaults to compare' })).toBeVisible();
+		search = page.getByTestId('page-search').getByRole('combobox', { name: 'Search vaults to compare' });
+		await search.fill('Savings USDS');
+		await page
+			.getByRole('option', { name: /Savings USDS/ })
+			.first()
+			.click();
+		await expect(page.locator('.comparison-chart .segmented-control label').filter({ hasText: '1Y' })).toHaveClass(
+			/selected/
+		);
+		await expect(selectedVaults).toContainText('21.0% CAGR');
+		await expect(selectedVaults).toContainText('Since 2024-03-01');
+		expect(pageErrors).toEqual([]);
+	});
+
+	for (const viewport of [
+		{ name: 'tablet', width: 1024, height: 768 },
+		{ name: 'mobile', width: 375, height: 667 }
+	]) {
+		test(`compares two vaults and a benchmark in the ${viewport.name} viewport`, async ({ page, request }) => {
+			test.setTimeout(120_000);
+			await page.setViewportSize({ width: viewport.width, height: viewport.height });
+			const pageErrors: string[] = [];
+			page.on('pageerror', (error) => pageErrors.push(error.message));
+			const chartRequests = await mockResponsiveChartData(page);
+			const savingsUsdsId = await findVaultId(request, 'Savings USDS', 'Savings USDS');
+			const savingsInfiniFiId = await findVaultId(request, 'Savings infiniFi USD', 'Savings infiniFi USD');
+			const selection = new URLSearchParams();
+			selection.append('vault', savingsUsdsId);
+			selection.append('vault', savingsInfiniFiId);
+			selection.append('benchmark', 'btc');
+
+			await page.goto(`/vaults/compare?${selection}`);
+
+			const selectedVaults = page.getByRole('list', { name: 'Selected vaults' });
+			await expect(selectedVaults.locator('li')).toHaveCount(2);
+			await expect(selectedVaults).toContainText('Savings USDS');
+			await expect(selectedVaults).toContainText('Savings infiniFi USD');
+			await expect(page.getByRole('checkbox', { name: 'BTC' })).toBeChecked();
+			await expect
+				.poll(() => chartRequests.at(-1))
+				.toEqual({
+					vaults: [savingsUsdsId, savingsInfiniFiId],
+					benchmarks: ['btc']
+				});
+
+			const chart = page.locator('.comparison-chart .chart-container.boxed');
+			await expect(chart).toBeVisible();
+			await expect(chart.locator('canvas').first()).toBeVisible();
+			const legend = page.getByLabel('Equity comparison chart legend');
+			await expect(legend).toContainText('Savings USDS');
+			await expect(legend).toContainText('Savings infiniFi USD');
+			await expect(legend).toContainText('BTC');
+
+			const timePeriodOptions = chart.locator('.segmented-control label');
+			await expect(timePeriodOptions).toHaveText(['1M', '3M', '6M', '1Y', 'Max']);
+			await timePeriodOptions.filter({ hasText: '6M' }).click();
+			await expect(timePeriodOptions.filter({ hasText: '6M' })).toHaveClass(/selected/);
+			await expect(selectedVaults.locator('li').first()).toContainText('16.0% CAGR');
+			await expect(selectedVaults.locator('li').first()).toContainText('Since 2024-09-01');
+			await timePeriodOptions.filter({ hasText: '1Y' }).click();
+			await expect(timePeriodOptions.filter({ hasText: '1Y' })).toHaveClass(/selected/);
+			await expect(selectedVaults.locator('li').first()).toContainText('21.0% CAGR');
+			await expect(selectedVaults.locator('li').first()).toContainText('Since 2024-03-01');
+
+			const layout = await chart.evaluate((element) => {
+				const headingBounds = element.querySelector('h2')!.getBoundingClientRect();
+				const controlsBounds = element.querySelector('.segmented-control')!.getBoundingClientRect();
+				const chartBounds = element.getBoundingClientRect();
+				const headingOverlapsControls = !(
+					headingBounds.right <= controlsBounds.left ||
+					controlsBounds.right <= headingBounds.left ||
+					headingBounds.bottom <= controlsBounds.top ||
+					controlsBounds.bottom <= headingBounds.top
+				);
+				return {
+					headingOverlapsControls,
+					chartLeft: chartBounds.left,
+					chartRight: chartBounds.right,
+					viewportWidth: window.innerWidth,
+					documentWidth: document.documentElement.scrollWidth
+				};
+			});
+			expect(layout.headingOverlapsControls).toBe(false);
+			expect(layout.chartLeft).toBeGreaterThanOrEqual(0);
+			expect(layout.chartRight).toBeLessThanOrEqual(layout.viewportWidth);
+			expect(layout.documentWidth).toBeLessThanOrEqual(layout.viewportWidth);
+			expect(pageErrors).toEqual([]);
+		});
+	}
+});

--- a/tests/integration/vaults/equity-compare.test.ts
+++ b/tests/integration/vaults/equity-compare.test.ts
@@ -136,6 +136,7 @@ test.describe('vault equity curve comparison page', () => {
 		expect(controlAlignment.searchInputBottom).toBeCloseTo(controlAlignment.benchmarkItemBottom, 0);
 		expect(new URL(page.url()).searchParams.getAll('vault')).toHaveLength(1);
 		expect(new URL(page.url()).searchParams.getAll('benchmark')).toEqual(['treasury', 'eth', 'btc']);
+		expect(new URL(page.url()).searchParams.get('period')).toBe('3M');
 		await expect.poll(() => chartRequests.at(-1)?.benchmarks).toEqual(['treasury', 'eth', 'btc']);
 		await expect(page.getByTestId('page-search')).toHaveAttribute('data-ready', 'true', { timeout: 30_000 });
 
@@ -246,6 +247,7 @@ test.describe('vault equity curve comparison page', () => {
 		await expect(timePeriodOptions).toHaveText(['1M', '3M', '6M', '1Y', 'Max']);
 		await timePeriodOptions.filter({ hasText: '1Y' }).click();
 		await expect(timePeriodOptions.filter({ hasText: '1Y' })).toHaveClass(/selected/);
+		await expect.poll(() => new URL(page.url()).searchParams.get('period')).toBe('1Y');
 		await expect(selectedVaults).toContainText('21.0% CAGR');
 		await expect(selectedVaults).toContainText('Since 2024-03-01');
 		await expect(page.getByTestId('page-search')).toHaveAttribute('data-ready', 'true', { timeout: 30_000 });
@@ -269,6 +271,7 @@ test.describe('vault equity curve comparison page', () => {
 		await comparisonTable.getByRole('button', { name: 'Vault' }).click();
 		await expect.poll(() => new URL(page.url()).searchParams.get('sort')).toBe('vault');
 		expect(new URL(page.url()).searchParams.getAll('vault')).toHaveLength(2);
+		expect(new URL(page.url()).searchParams.get('period')).toBe('1Y');
 		await page.waitForTimeout(500);
 		expect(batchRequests).toHaveLength(chartRequestCountBeforeSort);
 		const vaultColours = await selectedVaults
@@ -303,8 +306,8 @@ test.describe('vault equity curve comparison page', () => {
 		await expect(page.getByRole('checkbox', { name: 'ETH' })).toBeChecked();
 		await expect(page.getByRole('checkbox', { name: 'BTC' })).not.toBeChecked();
 		expect(page.url()).toBe(sharedUrl);
-		await timePeriodOptions.filter({ hasText: '1Y' }).click();
 		await expect(timePeriodOptions.filter({ hasText: '1Y' })).toHaveClass(/selected/);
+		await expect(selectedVaults).toContainText('21.0% CAGR');
 
 		await page.getByRole('button', { name: 'Remove Savings USDS from comparison' }).click();
 		await expect(selectedVaults.locator('li')).toHaveCount(1);
@@ -344,6 +347,7 @@ test.describe('vault equity curve comparison page', () => {
 			selection.append('vault', savingsUsdsId);
 			selection.append('vault', savingsInfiniFiId);
 			selection.append('benchmark', 'btc');
+			selection.set('period', '6M');
 
 			await page.goto(`/vaults/compare?${selection}`);
 
@@ -369,12 +373,13 @@ test.describe('vault equity curve comparison page', () => {
 
 			const timePeriodOptions = chart.locator('.segmented-control label');
 			await expect(timePeriodOptions).toHaveText(['1M', '3M', '6M', '1Y', 'Max']);
-			await timePeriodOptions.filter({ hasText: '6M' }).click();
 			await expect(timePeriodOptions.filter({ hasText: '6M' })).toHaveClass(/selected/);
+			expect(new URL(page.url()).searchParams.get('period')).toBe('6M');
 			await expect(selectedVaults.locator('li').first()).toContainText('16.0% CAGR');
 			await expect(selectedVaults.locator('li').first()).toContainText('Since 2024-09-01');
 			await timePeriodOptions.filter({ hasText: '1Y' }).click();
 			await expect(timePeriodOptions.filter({ hasText: '1Y' })).toHaveClass(/selected/);
+			await expect.poll(() => new URL(page.url()).searchParams.get('period')).toBe('1Y');
 			await expect(selectedVaults.locator('li').first()).toContainText('21.0% CAGR');
 			await expect(selectedVaults.locator('li').first()).toContainText('Since 2024-03-01');
 

--- a/tests/integration/vaults/equity-compare.test.ts
+++ b/tests/integration/vaults/equity-compare.test.ts
@@ -267,6 +267,19 @@ test.describe('vault equity curve comparison page', () => {
 				.evaluate((swatch) => getComputedStyle(swatch).borderTopColor)
 		).toBe('rgba(98, 126, 234, 0.5)');
 
+		const sharedUrl = page.url();
+		await page.goto('/vaults/compare?comparison=empty');
+		await page.goto(sharedUrl);
+		await expect(selectedVaults.locator('li')).toHaveCount(2);
+		await expect(selectedVaults).toContainText('Savings USDS');
+		await expect(selectedVaults).toContainText('Savings infiniFi USD');
+		await expect(page.getByRole('checkbox', { name: 'T-Bill' })).not.toBeChecked();
+		await expect(page.getByRole('checkbox', { name: 'ETH' })).toBeChecked();
+		await expect(page.getByRole('checkbox', { name: 'BTC' })).not.toBeChecked();
+		expect(page.url()).toBe(sharedUrl);
+		await timePeriodOptions.filter({ hasText: '1Y' }).click();
+		await expect(timePeriodOptions.filter({ hasText: '1Y' })).toHaveClass(/selected/);
+
 		await page.getByRole('button', { name: 'Remove Savings USDS from comparison' }).click();
 		await expect(selectedVaults.locator('li')).toHaveCount(1);
 		await expect(selectedVaults).not.toContainText('Savings USDS');

--- a/tests/integration/vaults/equity-compare.test.ts
+++ b/tests/integration/vaults/equity-compare.test.ts
@@ -111,6 +111,10 @@ test.describe('vault equity curve comparison page', () => {
 		await expect(page.getByRole('checkbox', { name: 'ETH' })).toBeChecked();
 		await expect(page.getByRole('checkbox', { name: 'BTC' })).toBeChecked();
 		await expect(page.locator('.benchmark-options .benchmark-logo')).toHaveCount(3);
+		const chartLegend = page.getByLabel('Equity comparison chart legend');
+		const benchmarkLegendItems = chartLegend.locator('.legend-item').filter({ has: page.locator('.benchmark-logo') });
+		await expect(benchmarkLegendItems).toHaveCount(3);
+		await expect(benchmarkLegendItems.locator('.swatch')).toHaveCount(0);
 		const controlAlignment = await page.locator('.comparison-controls').evaluate((element) => {
 			const bounds = (selector: string) => element.querySelector(selector)!.getBoundingClientRect();
 			const panel = element.getBoundingClientRect();
@@ -287,14 +291,10 @@ test.describe('vault equity curve comparison page', () => {
 			page
 				.getByRole('checkbox', { name: 'ETH' })
 				.locator('xpath=following-sibling::img[contains(@class, "benchmark-logo")]')
-		).toHaveAttribute('src', '/logos/tokens/eth');
-		expect(
-			await chartLegend
-				.locator('.legend-item')
-				.filter({ hasText: 'ETH' })
-				.locator('.swatch')
-				.evaluate((swatch) => getComputedStyle(swatch).borderTopColor)
-		).toBe('rgba(98, 126, 234, 0.5)');
+		).toHaveAttribute('data-benchmark', 'eth');
+		const ethLegendItem = chartLegend.locator('.legend-item').filter({ hasText: 'ETH' });
+		await expect(ethLegendItem.locator('.benchmark-logo')).toHaveAttribute('data-benchmark', 'eth');
+		await expect(ethLegendItem.locator('.swatch')).toHaveCount(0);
 
 		const sharedUrl = page.url();
 		await page.goto('/vaults/compare?comparison=empty');

--- a/tests/integration/vaults/historical-tvl-chain.test.ts
+++ b/tests/integration/vaults/historical-tvl-chain.test.ts
@@ -83,7 +83,7 @@ test.describe('historical vault TVL by chain page', () => {
 	test('displays scatter plot selector with all chart links', async ({ page }) => {
 		const selector = page.locator('.scatter-plot-selector');
 		await expect(selector).toBeVisible();
-		await expect(selector.locator('a')).toHaveCount(10);
+		await expect(selector.locator('a')).toHaveCount(11);
 	});
 
 	test('page has no JavaScript errors', async ({ page }) => {

--- a/tests/integration/vaults/index.test.ts
+++ b/tests/integration/vaults/index.test.ts
@@ -459,8 +459,8 @@ test.describe('vault index page', () => {
 
 		const revealButton = page.getByTestId('show-blacklisted-vaults');
 		await expect(revealButton).toHaveText(/Show \d+ blacklisted vaults?/);
-		await expect(page.getByTestId('top-vaults-meta')).toContainText('254 vaults');
-		await expect(page.locator('tbody tr.targetable')).toHaveCount(254);
+		await expect(page.getByTestId('top-vaults-meta')).toContainText('256 vaults');
+		await expect(page.locator('tbody tr.targetable')).toHaveCount(256);
 		await revealButton.scrollIntoViewIfNeeded();
 
 		const scrollBefore = await page.evaluate(() => window.scrollY);
@@ -475,8 +475,8 @@ test.describe('vault index page', () => {
 
 		await expect.poll(() => new URL(page.url()).searchParams.get('risk')).toBe('0');
 		await expect(page.getByTestId('show-blacklisted-vaults')).toHaveCount(0);
-		await expect(page.getByTestId('top-vaults-meta')).toContainText('255 vaults');
-		await expect(page.locator('tbody tr.targetable')).toHaveCount(255);
+		await expect(page.getByTestId('top-vaults-meta')).toContainText('257 vaults');
+		await expect(page.locator('tbody tr.targetable')).toHaveCount(257);
 		await expect.poll(() => page.evaluate(() => window.scrollY)).toBeGreaterThanOrEqual(scrollBefore - 200);
 		expect(documentNavigationUrl).toBeUndefined();
 	});
@@ -486,14 +486,14 @@ test.describe('vault index page', () => {
 		await loadAllVaultRows(page);
 
 		await page.getByTestId('show-blacklisted-vaults').click();
-		await expect(page.locator('tbody tr.targetable')).toHaveCount(255);
+		await expect(page.locator('tbody tr.targetable')).toHaveCount(257);
 
 		await page.locator('th.vault button').click();
 		await expect(page).toHaveURL(/sort=vault/);
 		await loadAllVaultRows(page);
 
 		const rows = page.locator('tbody tr.targetable');
-		await expect(rows).toHaveCount(255);
+		await expect(rows).toHaveCount(257);
 		await expect(rows.filter({ hasText: 'atvPTmax' })).toHaveCount(1);
 	});
 
@@ -547,11 +547,11 @@ test.describe('vault index page', () => {
 		await expect(page.locator('tbody tr.targetable').filter({ hasText: 'Above TVL 009' })).toHaveCount(0);
 
 		await page.getByTestId('show-blacklisted-vaults').click();
-		await expect(page.getByTestId('top-vaults-meta')).toContainText('255 vaults');
+		await expect(page.getByTestId('top-vaults-meta')).toContainText('257 vaults');
 		await loadAllVaultRows(page);
 
 		await expect(page.locator('tbody tr.targetable').filter({ hasText: 'Above TVL 009' })).toHaveCount(1);
-		await expect(page.locator('tbody tr.targetable')).toHaveCount(255, { timeout: 15_000 });
+		await expect(page.locator('tbody tr.targetable')).toHaveCount(257, { timeout: 15_000 });
 	});
 
 	test('continues a blacklisted reveal when the original listing fits in one server page', async ({ page }) => {
@@ -601,7 +601,6 @@ test.describe('vault index page', () => {
 		await expect(paginationRows).toHaveCount(50);
 		const sentinel = page.getByTestId('load-more-sentinel');
 		await expect(sentinel).toBeVisible();
-		await sentinel.scrollIntoViewIfNeeded();
 		await expect(paginationRows).toHaveCount(51);
 		await expect(sentinel).toHaveCount(0);
 		expect(revealRequestCount).toBe(2);
@@ -624,8 +623,8 @@ test.describe('vault index page', () => {
 
 	test('displays vault count in table meta', async ({ page }) => {
 		const meta = page.getByTestId('top-vaults-meta');
-		// Should show 254 vaults (those above TVL threshold)
-		await expect(meta).toContainText('254 vaults');
+		// Should show 256 vaults (those above TVL threshold)
+		await expect(meta).toContainText('256 vaults');
 	});
 
 	test('renders an initial batch of more than 100 rows', async ({ page }) => {
@@ -692,9 +691,9 @@ test.describe('vault index page', () => {
 		await sentinel.scrollIntoViewIfNeeded();
 		await expect(rows).toHaveCount(225);
 
-		// The final continuation contains the remaining 29 rows.
+		// The final continuation contains the remaining 31 rows.
 		await sentinel.scrollIntoViewIfNeeded();
-		await expect(rows).toHaveCount(254);
+		await expect(rows).toHaveCount(256);
 
 		// All rows loaded - no more sentinel.
 		await expect(sentinel).not.toBeVisible();

--- a/tests/integration/vaults/yield-chain.test.ts
+++ b/tests/integration/vaults/yield-chain.test.ts
@@ -18,7 +18,7 @@ test.describe('vault yield / chain scatter plot page', () => {
 		// Scatter plot selector links
 		const selector = page.locator('.scatter-plot-selector');
 		await expect(selector).toBeVisible();
-		await expect(selector.locator('a')).toHaveCount(10);
+		await expect(selector.locator('a')).toHaveCount(11);
 
 		// Chart renders with Plotly
 		const plotWrapper = page.getByTestId('vault-scatter-plot');

--- a/tests/integration/vaults/yield-protocol.test.ts
+++ b/tests/integration/vaults/yield-protocol.test.ts
@@ -49,6 +49,6 @@ test.describe('vault yield / protocol scatter plot page', () => {
 	test('displays scatter plot selector with both chart links', async ({ page }) => {
 		const selector = page.locator('.scatter-plot-selector');
 		await expect(selector).toBeVisible();
-		await expect(selector.locator('a')).toHaveCount(10);
+		await expect(selector.locator('a')).toHaveCount(11);
 	});
 });

--- a/tests/mocks/top-vaults/list.mock.ts
+++ b/tests/mocks/top-vaults/list.mock.ts
@@ -584,6 +584,22 @@ const providerRatedAmmVault = createTestVault('Provider rated AMM vault', {
 // These IDs need to match the local Parquet dataset so blacklist filtering can be
 // exercised against real server-side aggregation.
 const parquetMatchedVaults = [
+	createTestVault('Hyperliquidity Provider (HLP)', {
+		address: '0xdfc24b077bc1425ad1dea75bcb6f8158e10df303',
+		chain: 'hyperliquid',
+		chain_id: 9999,
+		protocol: 'Hyperliquid',
+		current_nav: 350_000_000,
+		peak_nav: 400_000_000,
+		stablecoinish: false
+	}),
+	createTestVault('Spark USDC Vault', {
+		address: '0xbc65ad17c5c0a2a4d159fa5a503f4992c7b545fe',
+		chain: 'ethereum',
+		protocol: 'Spark',
+		current_nav: 100_000_000,
+		peak_nav: 120_000_000
+	}),
 	createTestVault('Savings infiniFi USD', {
 		address: '0x36585e7ae4b8a422135618a2c113b8b516067e7a',
 		chain: 'arbitrum',


### PR DESCRIPTION
## Why

Vault users need a direct way to compare historical returns across vaults with consistent market benchmarks, responsive controls, and shareable selection state. The existing search, chart, table, and benchmark code could support this without exposing private source datasets to the browser.

## Lessons learnt

- Curves with different launch dates need an explicit overlap rule; anchoring a younger vault to the highest older curve at its first observation keeps the comparison readable without inventing history.
- Search presentation is reusable when result actions and page formatting are optional component inputs, while ranking and TVL filtering stay server-side.
- FRED DTB3 is quoted on a discount basis and should not be compounded as an investment yield; DGS3MO provides the investment-basis 3-month Treasury market yield needed for this return approximation.
- Keeping chart transformations, resampling, and data selection on the server materially reduces browser payloads and prevents private vault exports from being serialised.

## Summary

- Add `/vaults/compare` with Savings USDS and T-Bill, ETH, and BTC enabled by default, shareable state, responsive controls, indexed curves, period CAGR/start dates, and the shared Top vaults table.
- Reuse the site search with optional Add actions, in-page formatting, immediate loading feedback, server-side vault scope, and a $1,000 TVL floor.
- Add server-side batched price queries, alignment, benchmark processing, compression, and bounded caching.
- Add Compare navigation and footer changes across desktop and mobile layouts.
- Add unit, integration, responsive, and live-data coverage, plus implementation and data-source documentation.