### PR TITLE
fix: search vaults by share token symbol

### DIFF
--- a/src/lib/search/vault-search.server.test.ts
+++ b/src/lib/search/vault-search.server.test.ts
@@ -1,0 +1,37 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+import { createTestVault } from '$lib/top-vaults/test-utils';
+import type { TopVaults } from '$lib/top-vaults/schemas';
+
+const mocks = vi.hoisted(() => ({
+	getCachedTopVaults: vi.fn(),
+	fetchStablecoinMetadataIndex: vi.fn()
+}));
+
+vi.mock('$lib/top-vaults/cache', () => ({ getCachedTopVaults: mocks.getCachedTopVaults }));
+vi.mock('$lib/stablecoin-metadata/client', () => ({
+	fetchStablecoinMetadataIndex: mocks.fetchStablecoinMetadataIndex
+}));
+
+import { searchVaultEntities } from './vault-search.server';
+
+describe('vault search', () => {
+	beforeEach(() => {
+		mocks.getCachedTopVaults.mockResolvedValue({
+			generated_at: '2026-09-02T00:00:00.000Z',
+			vaults: [{ ...createTestVault('Yearn Bold vault'), share_token: 'yBOLD' }],
+			core3_protocols: {},
+			curators: {}
+		} satisfies TopVaults);
+		mocks.fetchStablecoinMetadataIndex.mockResolvedValue([]);
+	});
+
+	test('finds a vault by its share token symbol without case sensitivity', async () => {
+		const response = await searchVaultEntities(vi.fn() as unknown as Fetch, 'ybold');
+
+		expect(response.results).toHaveLength(1);
+		expect(response.results[0]).toMatchObject({
+			entityType: 'vault',
+			name: 'Yearn Bold vault'
+		});
+	});
+});

--- a/src/lib/search/vault-search.server.ts
+++ b/src/lib/search/vault-search.server.ts
@@ -142,6 +142,7 @@ function buildIndex(topVaults: TopVaults, stablecoins: StablecoinMetadata[]): In
 			[
 				vault.vault_slug,
 				vault.address,
+				vault.share_token,
 				vault.protocol,
 				vault.protocol_slug,
 				vault.curator_name,


### PR DESCRIPTION
## Why

Vault share-token symbols such as `yBOLD` are useful identifiers, but search did not index them.

## Lessons learnt

Vault search aliases are centralised in the server-side index; adding a searchable vault property there makes it available to every search widget.

## Summary

- Index vault share-token symbols in search.
- Add coverage for a case-insensitive `ybold` lookup.