### PR TITLE
feat: clarify vault gross and net returns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Weblog of stuff
 
 - Add a dedicated podcast episode page with YouTube and Spotify links (2026-09-02)
+- Clarify vault gross and net returns, add fee-aware return examples, and improve vault comparison metadata (2026-09-02)
 - Add multi-vault equity curve comparison with T-bill, ETH, and BTC benchmarks (2026-09-01)
 - Add Spotify and podcast-focused community links, and refine community and blog landing-page copy (2026-08-31)
 - Add Vault Pro crypto price, metadata, and exchange-rate datasets (2026-08-28)

--- a/docs/vault-data-source.md
+++ b/docs/vault-data-source.md
@@ -99,6 +99,31 @@ The frontend treats unrecognised source values as `unknown`, and preserves optio
 
 Other reasons, including high utilisation or permissioning, remain their source-provided status rather than being inferred as a cap.
 
+#### Return and fee calculations
+
+Vault period metrics provide gross and net absolute returns alongside their annualised equivalents. The frontend treats raw period returns as authoritative and only derives an absolute return from CAGR when the raw value is unavailable. Derived values use the backend's 365.25-day year convention.
+
+The fee fields have distinct presentation and calculation roles:
+
+| Field        | Meaning                                                                                                       |
+| ------------ | ------------------------------------------------------------------------------------------------------------- |
+| `gross_fees` | The disclosed fee schedule before protocol revenue share, including fees already embedded in the share price. |
+| `net_fees`   | The investor fee schedule after protocol revenue share, used by the backend when calculating net returns.     |
+
+For `internalised_minting` and `internalised_skimming` vaults, management and performance fees are already reflected in share-price returns. The frontend displays their disclosed percentage as **Internalised in share price** and does not invent or deduct a second dollar amount. An exact internalised fee amount cannot be reconstructed from a post-fee share price because crystallisation timing, dilution, and high-water marks are not available in the frontend dataset.
+
+The vault return example presents the backend calculation order:
+
+1. Deduct the deposit fee from capital in.
+2. Apply the gross period return to capital invested.
+3. Deduct externalised management fees, prorated using 365.25 days per year.
+4. Deduct externalised performance fees from positive profit after management fees.
+5. Deduct the withdrawal fee from the pre-withdrawal balance.
+
+The gross return in the backend dataset means the share-price return before external fee adjustments. For an internalised vault, that share price already reflects internalised management and performance fees. The percentage remains labelled gross to match the backend field, and the tooltip states this explicitly.
+
+Capital out and displayed net returns use the backend's net period return as the source of truth. Fee amounts are itemised from the corresponding fee rates and calculation bases; internalised fees remain percentage-only disclosures. The calculation is covered by tests for deposit fees, externalised management and performance fees, internalised fees, and withdrawal fees.
+
 #### Detail-page risk summaries
 
 The vault detail page's **Other metrics** card shows one third-party provider result when it is available. A vault-level or protocol-level Xerberus assessment takes precedence and is shown as **Xerberus risk**. Its score is displayed as `score / 100`; higher scores indicate a stronger rating (lower estimated risk), so it is not a Probability of Loss percentage. The score tooltip states whether Xerberus assessed the vault directly or its underlying protocol.

--- a/src/lib/components/Tooltip.svelte
+++ b/src/lib/components/Tooltip.svelte
@@ -23,12 +23,83 @@ For more information see:
 </Tooltip>
 ```
 -->
-<dfn class="tooltip ds-3">
+<script lang="ts">
+	import { onMount, tick } from 'svelte';
+
+	const VIEWPORT_MARGIN = 8;
+
+	let tooltip: HTMLElement;
+	let popup: HTMLButtonElement;
+	let isOpen = $state(false);
+	let isPositioned = $state(false);
+	let popupPosition = $state('');
+
+	async function showPopup(): Promise<void> {
+		isOpen = true;
+		isPositioned = false;
+		await tick();
+		positionPopup();
+	}
+
+	function hidePopup(): void {
+		isOpen = false;
+		isPositioned = false;
+	}
+
+	function repositionPopup(): void {
+		if (isOpen) positionPopup();
+	}
+
+	function positionPopup(): void {
+		if (tooltip == null || popup == null) return;
+
+		const triggerRect = tooltip.getBoundingClientRect();
+		const popupRect = popup.getBoundingClientRect();
+		const popupWidth = Math.min(popupRect.width, window.innerWidth - VIEWPORT_MARGIN * 2);
+		const popupHeight = Math.min(popupRect.height, window.innerHeight - VIEWPORT_MARGIN * 2);
+		const preferredLeft = triggerRect.left + (triggerRect.width - popupWidth) / 2;
+		const maxLeft = window.innerWidth - popupWidth - VIEWPORT_MARGIN;
+		const left = Math.max(VIEWPORT_MARGIN, Math.min(preferredLeft, maxLeft));
+		const belowTop = triggerRect.bottom;
+		const aboveTop = triggerRect.top - popupHeight;
+		const top =
+			belowTop + popupHeight <= window.innerHeight - VIEWPORT_MARGIN ? belowTop : Math.max(VIEWPORT_MARGIN, aboveTop);
+
+		popupPosition = `left: ${left}px; top: ${top}px; right: auto; bottom: auto; transform: none;`;
+		isPositioned = true;
+	}
+
+	onMount(() => {
+		window.addEventListener('resize', repositionPopup);
+		window.addEventListener('scroll', repositionPopup, true);
+
+		return () => {
+			window.removeEventListener('resize', repositionPopup);
+			window.removeEventListener('scroll', repositionPopup, true);
+		};
+	});
+</script>
+
+<dfn
+	bind:this={tooltip}
+	class="tooltip ds-3"
+	onmouseenter={showPopup}
+	onmouseleave={hidePopup}
+	onfocusin={showPopup}
+	onfocusout={hidePopup}
+>
 	<span class="trigger targetable-above">
 		<slot name="trigger" />
 	</span>
 	<!-- popup MUST be a button element (disabled); see Tooltip.test.ts -->
-	<button class="popup" disabled>
+	<button
+		bind:this={popup}
+		class="popup"
+		data-open={isOpen}
+		data-positioned={isPositioned}
+		style={popupPosition}
+		disabled
+	>
 		<div class="inner">
 			<slot name="popup" />
 		</div>
@@ -51,10 +122,12 @@ For more information see:
 
 		.popup {
 			display: none;
-			position: absolute;
+			position: fixed;
 			contain: content;
 			width: max-content;
-			max-width: min(90vw, 300px);
+			max-width: min(calc(100vw - 1rem), 300px);
+			max-height: calc(100vh - 1rem);
+			overflow: auto;
 			padding: 0.25rem 0 0 0;
 			border: none;
 			background: transparent;
@@ -63,10 +136,8 @@ For more information see:
 			z-index: 10000;
 
 			@media (--viewport-sm-down) {
-				bottom: 1rem;
-				position: fixed;
-				left: 0.5rem;
-				right: 0.5rem;
+				width: calc(100vw - 1rem) !important;
+				max-width: none !important;
 				padding: 0;
 			}
 
@@ -92,8 +163,13 @@ For more information see:
 			}
 		}
 
-		&:is(:hover, :focus) .popup {
+		.popup[data-open='true'] {
 			display: block;
+			visibility: hidden;
+		}
+
+		.popup[data-open='true'][data-positioned='true'] {
+			visibility: visible;
 		}
 	}
 </style>

--- a/src/lib/components/Tooltip.test.ts
+++ b/src/lib/components/Tooltip.test.ts
@@ -1,4 +1,4 @@
-import { mount } from 'svelte';
+import { mount, tick, unmount } from 'svelte';
 import Tooltip from './Tooltip.svelte';
 
 describe('Tooltip component', () => {
@@ -7,11 +7,44 @@ describe('Tooltip component', () => {
 	// you end up with illegal element nesting which leads to page jank
 	// (the popup content is not hidden on initial page render).
 	// see: https://stackoverflow.com/questions/40531029 updates 3 & 4
-	test('should use button tag for popup content', () => {
-		mount(Tooltip, { target: document.body });
+	test('should use button tag for popup content', async () => {
+		const component = mount(Tooltip, { target: document.body });
 		const popup = document.body.querySelector('.popup');
 		expect(popup?.tagName).toBe('BUTTON');
 		// button should be disabled to remove from tab index and prevent click events
 		expect(popup).toBeDisabled();
+		await unmount(component);
+	});
+
+	test('keeps an open popup inside the viewport and repositions it on scroll', async () => {
+		let triggerLeft = 350;
+		const originalInnerWidth = window.innerWidth;
+		Object.defineProperty(window, 'innerWidth', { configurable: true, value: 400 });
+		vi.spyOn(HTMLElement.prototype, 'getBoundingClientRect').mockImplementation(function (this: HTMLElement) {
+			if (this.classList.contains('popup')) {
+				return new DOMRect(0, 0, 300, 200);
+			}
+			return new DOMRect(triggerLeft, 100, 40, 20);
+		});
+
+		const component = mount(Tooltip, { target: document.body });
+		const tooltip = document.body.querySelector('.tooltip')!;
+		const popup = document.body.querySelector<HTMLElement>('.popup')!;
+		await tick();
+		tooltip.dispatchEvent(new MouseEvent('mouseenter'));
+		await tick();
+		await tick();
+
+		expect(popup.dataset.positioned).toBe('true');
+		expect(popup.style.left).toBe('92px');
+
+		triggerLeft = 10;
+		document.dispatchEvent(new Event('scroll'));
+		await tick();
+		expect(popup.style.left).toBe('8px');
+
+		vi.restoreAllMocks();
+		Object.defineProperty(window, 'innerWidth', { configurable: true, value: originalInnerWidth });
+		await unmount(component);
 	});
 });

--- a/src/lib/top-vaults/helpers.test.ts
+++ b/src/lib/top-vaults/helpers.test.ts
@@ -14,6 +14,8 @@ import {
 	getLockupTooltip,
 	isVaultDepositCapped,
 	getFormattedFeeMode,
+	hasInternalisedVaultFees,
+	hasNetVaultFeeInformation,
 	getFeeModeLabel,
 	getFeeModeDescription,
 	getCore3PolForVault,
@@ -682,6 +684,55 @@ describe('getFormattedFeeMode', () => {
 	test('handles feeless mode', () => {
 		const vault = createTestVault('Test vault', { fee_mode: 'feeless' });
 		expect(getFormattedFeeMode(vault)).toBe('Feeless');
+	});
+});
+
+describe('hasInternalisedVaultFees', () => {
+	test('recognises the explicit flag and either fee schedule', () => {
+		expect(hasInternalisedVaultFees(createTestVault('Flagged', { fee_internalised: true }))).toBe(true);
+		expect(
+			hasInternalisedVaultFees(
+				createTestVault('Gross mode', {
+					gross_fees: {
+						fee_mode: 'internalised_minting',
+						management: 0,
+						performance: 0,
+						deposit: 0,
+						withdraw: 0
+					}
+				})
+			)
+		).toBe(true);
+		expect(
+			hasInternalisedVaultFees(
+				createTestVault('External', {
+					fee_internalised: false,
+					gross_fees: {
+						fee_mode: 'externalised',
+						management: 0,
+						performance: 0,
+						deposit: 0,
+						withdraw: 0
+					}
+				})
+			)
+		).toBe(false);
+	});
+});
+
+describe('hasNetVaultFeeInformation', () => {
+	test('requires a net fee mode', () => {
+		expect(hasNetVaultFeeInformation({ net_fees: null })).toBe(false);
+		expect(
+			hasNetVaultFeeInformation({
+				net_fees: { fee_mode: null, management: 0, performance: 0, deposit: 0, withdraw: 0 }
+			})
+		).toBe(false);
+		expect(
+			hasNetVaultFeeInformation({
+				net_fees: { fee_mode: 'externalised', management: 0, performance: 0, deposit: 0, withdraw: 0 }
+			})
+		).toBe(true);
 	});
 });
 

--- a/src/lib/top-vaults/helpers.ts
+++ b/src/lib/top-vaults/helpers.ts
@@ -700,6 +700,22 @@ export function getFormattedFeeMode({ fee_mode }: VaultInfo): string {
 	return capitalize(fee_mode.replaceAll('_', ' '));
 }
 
+/** Return whether management or performance fees are embedded in the share price. */
+export function hasInternalisedVaultFees(
+	vault: Pick<VaultInfo, 'fee_internalised' | 'gross_fees' | 'net_fees'>
+): boolean {
+	return (
+		vault.fee_internalised === true ||
+		vault.gross_fees?.fee_mode?.startsWith('internalised') === true ||
+		vault.net_fees?.fee_mode?.startsWith('internalised') === true
+	);
+}
+
+/** Return whether the backend supplied the investor fee schedule used for net returns. */
+export function hasNetVaultFeeInformation(vault: Pick<VaultInfo, 'net_fees'>): boolean {
+	return vault.net_fees?.fee_mode != null;
+}
+
 /** Human-readable labels and descriptions for each fee mode */
 const feeModeDetails: Record<FeeMode, { label: string; description: string }> = {
 	internalised_skimming: {

--- a/src/lib/top-vaults/schemas.ts
+++ b/src/lib/top-vaults/schemas.ts
@@ -332,9 +332,9 @@ export const vaultInfoSchema = z.object({
 	fee_mode: z.string().nullable(),
 	/** Whether fees are internalised (taken from NAV rather than on transactions) */
 	fee_internalised: z.boolean().nullable(),
-	/** Fee schedule before protocol revenue share */
+	/** Fee schedule before protocol revenue share; also discloses fees embedded in share-price returns */
 	gross_fees: vaultFeesSchema.nullable(),
-	/** Fee schedule after protocol revenue share (what the user actually pays) */
+	/** Investor fee schedule after protocol revenue share, used by the backend to calculate net returns */
 	net_fees: vaultFeesSchema.nullable(),
 
 	// --- Operational metadata ---

--- a/src/routes/vaults/[vault=slug]/ChartWithFeaturedMetrics.svelte
+++ b/src/routes/vaults/[vault=slug]/ChartWithFeaturedMetrics.svelte
@@ -12,47 +12,48 @@ amounts in the denomination's native currency.
 	import Profitability from '$lib/components/Profitability.svelte';
 	import Tooltip from '$lib/components/Tooltip.svelte';
 	import Metric from './Metric.svelte';
+	import FeaturedPerformanceExample from './FeaturedPerformanceExample.svelte';
 	import { formatDollar, formatNumber, formatPercent, formatTokenAmount } from '$lib/helpers/formatters';
 	import type { TimeSpanKey } from '$lib/charts/time-span';
 	import {
 		getVaultCurrentTvlUsd,
 		getVaultDenominationCurrency,
 		getVaultPeakTvlUsd,
-		getVaultTvlNative
+		getVaultTvlNative,
+		hasNetVaultFeeInformation
 	} from '$lib/top-vaults/helpers';
+	import {
+		getFeaturedPerformanceExample,
+		getFeaturedPerformancePeriod,
+		getFeaturedPerformanceReturnLabel,
+		getFeaturedPerformanceReturnMode,
+		type FeaturedPerformancePeriodKey
+	} from './featured-performance';
 
 	interface Props {
 		vault: VaultInfo;
 		chartLogoUrl?: string;
 	}
 
-	let { vault, chartLogoUrl }: Props = $props();
-	let selectedReturnPeriod = $state<'1M' | '3M' | 'Max'>('3M');
-	let oneMonthMetrics = $derived(vault.period_results.find((period) => period.period.toLowerCase() === '1m'));
-	let lifetimeMetrics = $derived(vault.period_results.find((period) => period.period.toLowerCase() === 'lifetime'));
-	let featuredPerformance = $derived(
-		selectedReturnPeriod === '1M'
-			? {
-					label: '1M',
-					return: { gross: vault.one_month_cagr, net: vault.one_month_cagr_net },
-					sharpe: oneMonthMetrics?.sharpe,
-					volatility: oneMonthMetrics?.volatility
-				}
-			: selectedReturnPeriod === '3M'
-				? {
-						label: '3M',
-						return: { gross: vault.three_months_cagr, net: vault.three_months_cagr_net },
-						sharpe: vault.three_months_sharpe,
-						volatility: vault.three_months_volatility
-					}
-				: {
-						label: 'Lifetime',
-						return: { gross: vault.cagr, net: vault.cagr_net },
-						sharpe: lifetimeMetrics?.sharpe,
-						volatility: lifetimeMetrics?.volatility
-					}
-	);
+	const EXAMPLE_CAPITAL_IN = 10_000;
 
+	let { vault, chartLogoUrl }: Props = $props();
+	let selectedReturnPeriod = $state<FeaturedPerformancePeriodKey>('3M');
+	let featuredPerformance = $derived(getFeaturedPerformancePeriod(vault, selectedReturnPeriod));
+
+	let hasNetFeeInformation = $derived(hasNetVaultFeeInformation(vault));
+	let featuredPerformanceReturnMode = $derived(
+		getFeaturedPerformanceReturnMode(hasNetFeeInformation, featuredPerformance.return.net.annualised)
+	);
+	let featuredPerformanceReturn = $derived(
+		featuredPerformanceReturnMode === 'net'
+			? featuredPerformance.return.net.annualised
+			: featuredPerformance.return.gross.annualised
+	);
+	let featuredPerformanceReturnLabel = $derived(
+		getFeaturedPerformanceReturnLabel(featuredPerformance.label, featuredPerformanceReturnMode)
+	);
+	let performanceExample = $derived(getFeaturedPerformanceExample(vault, featuredPerformance, EXAMPLE_CAPITAL_IN));
 	let denominationCurrency = $derived(getVaultDenominationCurrency(vault));
 	let showNativeTvl = $derived(denominationCurrency != null && denominationCurrency !== 'usd');
 	let currentNativeTvl = $derived(getVaultTvlNative(vault, vault.current_nav));
@@ -88,17 +89,30 @@ amounts in the denomination's native currency.
 		<div class="divider"></div>
 
 		<div class="featured-metrics">
-			<Metric size="xl" label={`${featuredPerformance.label} return (ann)`}>
-				{#if featuredPerformance.return.net != null}
-					<Profitability of={featuredPerformance.return.net} />
+			<Metric size="xl" label={featuredPerformanceReturnLabel}>
+				{#if featuredPerformanceReturnMode === 'net'}
+					<span class="net-return-tooltip">
+						<Tooltip>
+							<span slot="trigger" class="net-return-tooltip-trigger">
+								<Profitability of={featuredPerformanceReturn} />
+							</span>
+							<svelte:fragment slot="popup">
+								<FeaturedPerformanceExample example={performanceExample} />
+							</svelte:fragment>
+						</Tooltip>
+					</span>
 				{:else}
 					<Tooltip>
 						<span slot="trigger" style:white-space="nowrap">
-							<Profitability of={featuredPerformance.return.gross} /><span class="gross-indicator">*</span>
+							<Profitability of={featuredPerformanceReturn} /><span class="gross-indicator">*</span>
 						</span>
 						<svelte:fragment slot="popup">
-							Fee information for this protocol is not yet available. The calculation is based on gross profit and fees
-							may apply.
+							{#if hasNetFeeInformation}
+								Net annualised return data is not available for this period. The calculation is based on gross returns.
+							{:else}
+								Fee information for this protocol is not yet available. The calculation is based on gross profit and
+								fees may apply.
+							{/if}
 						</svelte:fragment>
 					</Tooltip>
 				{/if}
@@ -172,6 +186,15 @@ amounts in the denomination's native currency.
 
 			.gross-indicator {
 				color: var(--c-text-light);
+			}
+
+			.net-return-tooltip-trigger {
+				border-bottom: 1px dashed var(--c-text-light);
+				white-space: nowrap;
+			}
+
+			.net-return-tooltip :global(.popup) {
+				max-width: min(90vw, 28rem);
 			}
 
 			.tvl-tooltip-trigger {

--- a/src/routes/vaults/[vault=slug]/ChartWithFeaturedMetrics.test.ts
+++ b/src/routes/vaults/[vault=slug]/ChartWithFeaturedMetrics.test.ts
@@ -1,0 +1,236 @@
+import { describe, expect, test } from 'vitest';
+import { createTestVault } from '$lib/top-vaults/test-utils';
+import {
+	getAbsolutePeriodReturn,
+	getDaysInvested,
+	getFeaturedPerformanceExample,
+	getFeaturedPerformancePeriod,
+	getFeaturedPerformanceReturnLabel,
+	getFeaturedPerformanceReturnMode
+} from './featured-performance';
+
+describe('featured vault performance', () => {
+	test.each(['1M', '3M', 'Lifetime'])('labels %s gross returns', (periodLabel) => {
+		expect(getFeaturedPerformanceReturnLabel(periodLabel, 'gross')).toBe(`${periodLabel} ann. gross returns`);
+	});
+
+	test.each(['1M', '3M', 'Lifetime'])('labels %s net returns', (periodLabel) => {
+		expect(getFeaturedPerformanceReturnLabel(periodLabel, 'net')).toBe(`${periodLabel} ann. net returns`);
+	});
+
+	test('uses net returns only when fee information and net CAGR are available', () => {
+		expect(getFeaturedPerformanceReturnMode(true, 0.12)).toBe('net');
+		expect(getFeaturedPerformanceReturnMode(true, null)).toBe('gross');
+		expect(getFeaturedPerformanceReturnMode(false, 0.12)).toBe('gross');
+	});
+
+	test('calculates elapsed days and uses the backend 365.25-day convention', () => {
+		expect(getDaysInvested('2026-01-01T00:00:00Z', '2026-04-01T00:00:00Z')).toBe(90);
+		expect(getDaysInvested(null, '2026-04-01T00:00:00Z')).toBeNull();
+		expect(getAbsolutePeriodReturn(null, 0.1, 365.25)).toBeCloseTo(0.1);
+	});
+
+	test('keeps metrics and dates from the same period result', () => {
+		const vault = createTestVault('Period result vault', {
+			one_month_cagr: 0.1,
+			one_month_returns: 0.01,
+			period_results: [
+				{
+					period: '1M',
+					error_reason: null,
+					period_start_at: '2026-08-01T00:00:00',
+					period_end_at: '2026-09-01T00:00:00',
+					share_price_start: 1,
+					share_price_end: 1.015,
+					raw_samples: 31,
+					samples_start_at: '2026-08-01T00:00:00',
+					samples_end_at: '2026-09-01T00:00:00',
+					daily_samples: 31,
+					cagr_gross: 0.2,
+					cagr_net: 0.18,
+					returns_gross: 0.015,
+					returns_net: 0.014,
+					sharpe: 1.2,
+					volatility: 0.3,
+					max_drawdown: -0.02,
+					tvl_start: 10_000,
+					tvl_end: 10_150,
+					tvl_low: 9_900,
+					tvl_high: 10_200,
+					ranking_overall: null,
+					ranking_chain: null,
+					ranking_protocol: null
+				}
+			]
+		});
+
+		expect(getFeaturedPerformancePeriod(vault, '1M')).toMatchObject({
+			return: {
+				gross: { annualised: 0.2, absolute: 0.015 },
+				net: { annualised: 0.18, absolute: 0.014 }
+			},
+			startDate: '2026-08-01T00:00:00',
+			endDate: '2026-09-01T00:00:00'
+		});
+	});
+
+	test('reconciles Kingfisher deposit fees and internalised performance fees', () => {
+		const vault = createTestVault('The Kingfisher Vault', {
+			fee_internalised: true,
+			gross_fees: {
+				fee_mode: 'internalised_minting',
+				management: 0,
+				performance: 0.3,
+				deposit: 0.01,
+				withdraw: 0
+			},
+			net_fees: {
+				fee_mode: 'internalised_minting',
+				management: 0,
+				performance: 0,
+				deposit: 0.01,
+				withdraw: 0
+			},
+			three_months_cagr: 0.07485289164219067,
+			three_months_cagr_net: -0.11398435934727147,
+			three_months_returns: 0.003762000000000043,
+			three_months_returns_net: -0.006275619999999926,
+			three_months_start: '2026-08-12T00:00:00',
+			three_months_end: '2026-08-31T00:00:00'
+		});
+		const example = getFeaturedPerformanceExample(vault, getFeaturedPerformancePeriod(vault, '3M'), 10_000);
+
+		expect(example.daysInvested).toBe(19);
+		expect(example.depositFee.amount).toBe(100);
+		expect(example.capitalInvested).toBe(9_900);
+		expect(example.grossCapitalAtEnd).toBeCloseTo(9_937.2438);
+		expect(example.capitalOut).toBeCloseTo(9_937.2438);
+		expect(example.performanceFee).toEqual({ rate: 0.3, amount: null, internalised: true });
+		expect(example.managementFee).toEqual({ rate: 0, amount: 0, internalised: false });
+	});
+
+	test('applies externalised management before performance fees', () => {
+		const vault = createTestVault('Block4Block', {
+			fee_internalised: false,
+			gross_fees: {
+				fee_mode: 'externalised',
+				management: 0.0075,
+				performance: 0.075,
+				deposit: 0,
+				withdraw: 0
+			},
+			net_fees: {
+				fee_mode: 'externalised',
+				management: 0.0075,
+				performance: 0.075,
+				deposit: 0,
+				withdraw: 0
+			},
+			three_months_returns: 0.02101479423192898,
+			three_months_returns_net: 0.01772923907931867,
+			three_months_start: '2026-06-03T00:00:00',
+			three_months_end: '2026-09-01T00:00:00'
+		});
+		const example = getFeaturedPerformanceExample(vault, getFeaturedPerformancePeriod(vault, '3M'), 10_000);
+
+		expect(example.managementFee.amount).toBeCloseTo(18.4805);
+		expect(example.performanceFee.amount).toBeCloseTo(14.3751);
+		expect(example.grossCapitalAtEnd! - example.managementFee.amount! - example.performanceFee.amount!).toBeCloseTo(
+			example.capitalOut!
+		);
+	});
+
+	test('reconciles combined externalised and withdrawal fees', () => {
+		const grossReturn = 0.02101479423192898;
+		const managementFee = 10_000 * 0.0075 * (90 / 365.25);
+		const performanceFee = (10_000 * grossReturn - managementFee) * 0.075;
+		const preWithdrawalCapital = 10_000 * (1 + grossReturn) - managementFee - performanceFee;
+		const capitalOut = preWithdrawalCapital * (1 - 0.005);
+		const vault = createTestVault('Combined fee vault', {
+			fee_internalised: false,
+			gross_fees: {
+				fee_mode: 'externalised',
+				management: 0.0075,
+				performance: 0.075,
+				deposit: 0,
+				withdraw: 0.005
+			},
+			net_fees: {
+				fee_mode: 'externalised',
+				management: 0.0075,
+				performance: 0.075,
+				deposit: 0,
+				withdraw: 0.005
+			},
+			three_months_returns: grossReturn,
+			three_months_returns_net: capitalOut / 10_000 - 1,
+			three_months_start: '2026-06-03T00:00:00',
+			three_months_end: '2026-09-01T00:00:00'
+		});
+		const example = getFeaturedPerformanceExample(vault, getFeaturedPerformancePeriod(vault, '3M'), 10_000);
+
+		expect(example.withdrawalFee.amount).toBeCloseTo(preWithdrawalCapital * 0.005);
+		expect(
+			example.grossCapitalAtEnd! -
+				example.managementFee.amount! -
+				example.performanceFee.amount! -
+				example.withdrawalFee.amount!
+		).toBeCloseTo(example.capitalOut!);
+	});
+
+	test('never invents a dollar deduction for internalised fees', () => {
+		const vault = createTestVault('Internalised fee vault', {
+			fee_internalised: true,
+			gross_fees: {
+				fee_mode: 'internalised_minting',
+				management: 0.02,
+				performance: 0.2,
+				deposit: 0,
+				withdraw: 0
+			},
+			net_fees: {
+				fee_mode: 'internalised_minting',
+				management: 0.01,
+				performance: 0.1,
+				deposit: 0,
+				withdraw: 0
+			},
+			three_months_returns: 0.02,
+			three_months_returns_net: 0.02,
+			three_months_start: '2026-06-03T00:00:00',
+			three_months_end: '2026-09-01T00:00:00'
+		});
+		const example = getFeaturedPerformanceExample(vault, getFeaturedPerformancePeriod(vault, '3M'), 10_000);
+
+		expect(example.managementFee).toEqual({ rate: 0.02, amount: null, internalised: true });
+		expect(example.performanceFee).toEqual({ rate: 0.2, amount: null, internalised: true });
+	});
+
+	test('calculates withdrawal fees from the pre-withdrawal balance', () => {
+		const vault = createTestVault('Midas MEV', {
+			fee_internalised: true,
+			gross_fees: {
+				fee_mode: 'internalised_skimming',
+				management: null,
+				performance: null,
+				deposit: 0,
+				withdraw: 0.005
+			},
+			net_fees: {
+				fee_mode: 'internalised_skimming',
+				management: 0,
+				performance: 0,
+				deposit: 0,
+				withdraw: 0.005
+			},
+			three_months_returns: 0.01725660478978197,
+			three_months_returns_net: 0.012170321765833103,
+			three_months_start: '2026-06-03T00:00:00',
+			three_months_end: '2026-09-01T00:00:00'
+		});
+		const example = getFeaturedPerformanceExample(vault, getFeaturedPerformancePeriod(vault, '3M'), 10_000);
+
+		expect(example.withdrawalFee.amount).toBeCloseTo(50.8628);
+		expect(example.grossCapitalAtEnd! - example.withdrawalFee.amount!).toBeCloseTo(example.capitalOut!);
+	});
+});

--- a/src/routes/vaults/[vault=slug]/FeaturedPerformanceExample.svelte
+++ b/src/routes/vaults/[vault=slug]/FeaturedPerformanceExample.svelte
@@ -1,0 +1,130 @@
+<!--
+@component
+Displays a reconciled investment example for a vault's selected return period.
+-->
+<script lang="ts">
+	import { formatDollar, formatNumber, formatPercent } from '$lib/helpers/formatters';
+	import type { ExampleFee, FeaturedPerformanceExample } from './featured-performance';
+
+	interface Props {
+		example: FeaturedPerformanceExample;
+	}
+
+	let { example }: Props = $props();
+	let formattedCapitalIn = $derived(formatDollar(example.capitalIn, 0, 0, { notation: 'standard' }));
+
+	let explanation = $derived(
+		example.hasInternalisedFees
+			? `This ${formattedCapitalIn} example applies known fees to the selected-period return; gross follows the backend definition and already includes internalised fees, while annualised net return extrapolates one-time entry and exit fees over a year.`
+			: `This ${formattedCapitalIn} example applies known fees to the selected-period return; annualised net return extrapolates one-time entry and exit fees over a year.`
+	);
+
+	function formatDate(value: string | null): string {
+		return value?.split('T')[0] ?? '---';
+	}
+
+	function formatFee(fee: ExampleFee): string {
+		if (fee.internalised) return `Internalised in share price (${formatPercent(fee.rate, 0, 2)})`;
+		if (fee.rate == null) return '---';
+
+		return `${formatDollar(fee.amount, 0, 2)} (${formatPercent(fee.rate, 0, 2)})`;
+	}
+</script>
+
+<p>{explanation}</p>
+<table class="return-example-table">
+	<tbody>
+		<tr>
+			<th scope="row"><strong>Capital in</strong></th>
+			<td><strong>{formatDollar(example.capitalIn)}</strong></td>
+		</tr>
+		<tr>
+			<th scope="row">Deposit fee</th>
+			<td>{formatFee(example.depositFee)}</td>
+		</tr>
+		{#if (example.depositFee.rate ?? 0) > 0}
+			<tr>
+				<th scope="row">Capital invested</th>
+				<td>{formatDollar(example.capitalInvested)}</td>
+			</tr>
+		{/if}
+		<tr>
+			<th scope="row">Annualised gross return</th>
+			<td>{formatPercent(example.grossReturn.annualised, 0, 2)}</td>
+		</tr>
+		<tr>
+			<th scope="row">Absolute gross return</th>
+			<td>{formatPercent(example.grossReturn.absolute, 0, 2)}</td>
+		</tr>
+		<tr>
+			<th scope="row">Gross capital at end</th>
+			<td>{formatDollar(example.grossCapitalAtEnd)}</td>
+		</tr>
+		<tr>
+			<th scope="row">Management fee</th>
+			<td>{formatFee(example.managementFee)}</td>
+		</tr>
+		<tr>
+			<th scope="row">Performance fee</th>
+			<td>{formatFee(example.performanceFee)}</td>
+		</tr>
+		<tr>
+			<th scope="row">Withdrawal fee</th>
+			<td>{formatFee(example.withdrawalFee)}</td>
+		</tr>
+		<tr>
+			<th scope="row"><strong>Capital out</strong></th>
+			<td><strong>{formatDollar(example.capitalOut)}</strong></td>
+		</tr>
+		<tr>
+			<th scope="row">Annualised net return</th>
+			<td>{formatPercent(example.netReturn.annualised, 0, 2)}</td>
+		</tr>
+		<tr>
+			<th scope="row">Absolute net return</th>
+			<td>{formatPercent(example.netReturn.absolute, 0, 2)}</td>
+		</tr>
+		<tr>
+			<th scope="row">Start date</th>
+			<td>{formatDate(example.startDate)}</td>
+		</tr>
+		<tr>
+			<th scope="row">End date</th>
+			<td>{formatDate(example.endDate)}</td>
+		</tr>
+		<tr>
+			<th scope="row">Days invested</th>
+			<td>{formatNumber(example.daysInvested, 0, 0)}</td>
+		</tr>
+	</tbody>
+</table>
+
+<style>
+	.return-example-table {
+		width: 100%;
+		margin-top: 0.75rem;
+		border-collapse: collapse;
+
+		th,
+		td {
+			padding: 0.25rem 0;
+			border-bottom: 1px solid var(--c-box-3);
+			vertical-align: top;
+		}
+
+		th {
+			padding-right: 1rem;
+			color: var(--c-text-light);
+			font-weight: 500;
+			text-align: left;
+		}
+
+		td {
+			text-align: right;
+		}
+
+		tr:last-child :is(th, td) {
+			border-bottom: 0;
+		}
+	}
+</style>

--- a/src/routes/vaults/[vault=slug]/VaultMetrics.svelte
+++ b/src/routes/vaults/[vault=slug]/VaultMetrics.svelte
@@ -11,7 +11,7 @@ Displays supplementary vault information, performance, fees, and risk metrics.
 	import Metric from './Metric.svelte';
 	import { resolve } from '$app/paths';
 	import IconWarningFilled from '~icons/local/warning-filled';
-	import { getFormattedLockup } from '$lib/top-vaults/helpers';
+	import { getFormattedLockup, hasInternalisedVaultFees, hasNetVaultFeeInformation } from '$lib/top-vaults/helpers';
 	import { formatNumber, formatPercent, formatPercentProfit } from '$lib/helpers/formatters';
 	import { getChainDisplayName } from '$lib/helpers/chain';
 	import {
@@ -39,12 +39,8 @@ Displays supplementary vault information, performance, fees, and risk metrics.
 	let { vault, stablecoinMetadata = null, core3 = null }: Props = $props();
 
 	let hasLimitedHistory = $derived(LIMITED_HISTORY_CHAINS.includes(vault.chain_id));
-	let hasNetFeeInformation = $derived(vault.net_fees?.fee_mode != null);
-	let hasInternalisedFees = $derived(
-		vault.fee_internalised === true ||
-			vault.gross_fees?.fee_mode?.startsWith('internalised') ||
-			vault.net_fees?.fee_mode?.startsWith('internalised')
-	);
+	let hasNetFeeInformation = $derived(hasNetVaultFeeInformation(vault));
+	let hasInternalisedFees = $derived(hasInternalisedVaultFees(vault));
 	let denominationSlug = $derived(
 		resolveStablecoinSlug({
 			slug: vault.denomination_slug,

--- a/src/routes/vaults/[vault=slug]/featured-performance.ts
+++ b/src/routes/vaults/[vault=slug]/featured-performance.ts
@@ -1,0 +1,230 @@
+import type { VaultInfo } from '$lib/top-vaults/schemas';
+import { hasInternalisedVaultFees } from '$lib/top-vaults/helpers';
+
+export type FeaturedPerformancePeriodKey = '1M' | '3M' | 'Max';
+export type FeaturedPerformanceReturnMode = 'gross' | 'net';
+
+interface ReturnValue {
+	annualised: number | null;
+	absolute: number | null;
+}
+
+export interface FeaturedPerformancePeriod {
+	label: '1M' | '3M' | 'Lifetime';
+	return: {
+		gross: ReturnValue;
+		net: ReturnValue;
+	};
+	startDate: string | null;
+	endDate: string | null;
+	sharpe: number | null;
+	volatility: number | null;
+}
+
+export interface ExampleFee {
+	rate: number | null;
+	amount: number | null;
+	internalised: boolean;
+}
+
+export interface FeaturedPerformanceExample {
+	capitalIn: number;
+	capitalInvested: number;
+	grossCapitalAtEnd: number | null;
+	capitalOut: number | null;
+	grossReturn: ReturnValue;
+	netReturn: ReturnValue;
+	depositFee: ExampleFee;
+	performanceFee: ExampleFee;
+	managementFee: ExampleFee;
+	withdrawalFee: ExampleFee;
+	startDate: string | null;
+	endDate: string | null;
+	daysInvested: number | null;
+	hasInternalisedFees: boolean;
+}
+
+const DAYS_PER_YEAR = 365.25;
+
+/** Return the selected chart period and its matching gross and net metrics. */
+export function getFeaturedPerformancePeriod(
+	vault: VaultInfo,
+	periodKey: FeaturedPerformancePeriodKey
+): FeaturedPerformancePeriod {
+	const periodResults = new Map(vault.period_results.map((period) => [period.period.toLowerCase(), period]));
+
+	if (periodKey === '1M') {
+		const period = periodResults.get('1m');
+		return {
+			label: '1M',
+			return: {
+				gross: {
+					annualised: period?.cagr_gross ?? vault.one_month_cagr,
+					absolute: period?.returns_gross ?? vault.one_month_returns
+				},
+				net: {
+					annualised: period?.cagr_net ?? vault.one_month_cagr_net,
+					absolute: period?.returns_net ?? vault.one_month_returns_net
+				}
+			},
+			startDate: period?.period_start_at ?? vault.one_month_start,
+			endDate: period?.period_end_at ?? vault.one_month_end,
+			sharpe: period?.sharpe ?? null,
+			volatility: period?.volatility ?? null
+		};
+	}
+
+	if (periodKey === '3M') {
+		const period = periodResults.get('3m');
+		return {
+			label: '3M',
+			return: {
+				gross: {
+					annualised: period?.cagr_gross ?? vault.three_months_cagr,
+					absolute: period?.returns_gross ?? vault.three_months_returns
+				},
+				net: {
+					annualised: period?.cagr_net ?? vault.three_months_cagr_net,
+					absolute: period?.returns_net ?? vault.three_months_returns_net
+				}
+			},
+			startDate: period?.period_start_at ?? vault.three_months_start,
+			endDate: period?.period_end_at ?? vault.three_months_end,
+			sharpe: vault.three_months_sharpe,
+			volatility: vault.three_months_volatility
+		};
+	}
+
+	const period = periodResults.get('lifetime');
+	return {
+		label: 'Lifetime',
+		return: {
+			gross: {
+				annualised: period?.cagr_gross ?? vault.cagr,
+				absolute: period?.returns_gross ?? vault.lifetime_return
+			},
+			net: {
+				annualised: period?.cagr_net ?? vault.cagr_net,
+				absolute: period?.returns_net ?? vault.lifetime_return_net
+			}
+		},
+		startDate: period?.period_start_at ?? vault.lifetime_start,
+		endDate: period?.period_end_at ?? vault.lifetime_end,
+		sharpe: period?.sharpe ?? null,
+		volatility: period?.volatility ?? null
+	};
+}
+
+export function getFeaturedPerformanceReturnMode(
+	hasNetFeeInformation: boolean,
+	netReturn: number | null | undefined
+): FeaturedPerformanceReturnMode {
+	return hasNetFeeInformation && netReturn != null ? 'net' : 'gross';
+}
+
+export function getFeaturedPerformanceReturnLabel(periodLabel: string, mode: FeaturedPerformanceReturnMode): string {
+	return `${periodLabel} ann. ${mode} returns`;
+}
+
+/** Return elapsed calendar days, or null when the period dates are unusable. */
+export function getDaysInvested(
+	startDate: string | null | undefined,
+	endDate: string | null | undefined
+): number | null {
+	if (startDate == null || endDate == null) return null;
+
+	const start = new Date(startDate);
+	const end = new Date(endDate);
+	if (!Number.isFinite(start.getTime()) || !Number.isFinite(end.getTime()) || end <= start) return null;
+
+	return Math.max(1, Math.round((end.getTime() - start.getTime()) / 86_400_000));
+}
+
+/** Convert an annualised return to its period return only when raw data is unavailable. */
+export function getAbsolutePeriodReturn(
+	absoluteReturn: number | null | undefined,
+	annualisedReturn: number | null | undefined,
+	daysInvested: number | null | undefined
+): number | null {
+	if (absoluteReturn != null) return absoluteReturn;
+	if (annualisedReturn == null || daysInvested == null) return null;
+
+	return (1 + annualisedReturn) ** (daysInvested / DAYS_PER_YEAR) - 1;
+}
+
+function isInternalisedFee(vault: VaultInfo, fee: 'management' | 'performance'): boolean {
+	return hasInternalisedVaultFees(vault) && (vault.gross_fees?.[fee] ?? 0) > 0;
+}
+
+function createFee(rate: number | null | undefined, amount: number | null, internalised = false): ExampleFee {
+	return { rate: rate ?? null, amount, internalised };
+}
+
+/**
+ * Build a reconciled $10,000-style return example from backend period metrics.
+ *
+ * Internalised management and performance fees are disclosures only because
+ * they are already reflected in the share-price return. Transaction fees and
+ * externalised fees are applied in backend order: deposit, management,
+ * performance, then withdrawal.
+ */
+export function getFeaturedPerformanceExample(
+	vault: VaultInfo,
+	period: FeaturedPerformancePeriod,
+	capitalIn: number
+): FeaturedPerformanceExample {
+	const daysInvested = getDaysInvested(period.startDate, period.endDate);
+	const grossAbsoluteReturn = getAbsolutePeriodReturn(
+		period.return.gross.absolute,
+		period.return.gross.annualised,
+		daysInvested
+	);
+	const netAbsoluteReturn = getAbsolutePeriodReturn(
+		period.return.net.absolute,
+		period.return.net.annualised,
+		daysInvested
+	);
+	const depositRate = vault.net_fees?.deposit ?? null;
+	const depositAmount = depositRate == null ? null : capitalIn * depositRate;
+	const capitalInvested = capitalIn - (depositAmount ?? 0);
+	const grossCapitalAtEnd = grossAbsoluteReturn == null ? null : capitalInvested * (1 + grossAbsoluteReturn);
+	const managementInternalised = isInternalisedFee(vault, 'management');
+	const performanceInternalised = isInternalisedFee(vault, 'performance');
+	const managementRate = managementInternalised
+		? (vault.gross_fees?.management ?? null)
+		: (vault.net_fees?.management ?? null);
+	const managementAmount =
+		managementInternalised || managementRate == null || daysInvested == null
+			? null
+			: capitalInvested * managementRate * (daysInvested / DAYS_PER_YEAR);
+	const performanceRate = performanceInternalised
+		? (vault.gross_fees?.performance ?? null)
+		: (vault.net_fees?.performance ?? null);
+	const performanceAmount =
+		performanceInternalised || performanceRate == null || grossAbsoluteReturn == null || managementAmount == null
+			? null
+			: Math.max(0, capitalInvested * grossAbsoluteReturn - managementAmount) * performanceRate;
+	const capitalOut = netAbsoluteReturn == null ? null : capitalIn * (1 + netAbsoluteReturn);
+	const withdrawalRate = vault.net_fees?.withdraw ?? null;
+	const withdrawalAmount =
+		capitalOut == null || withdrawalRate == null || withdrawalRate >= 1
+			? null
+			: (capitalOut * withdrawalRate) / (1 - withdrawalRate);
+
+	return {
+		capitalIn,
+		capitalInvested,
+		grossCapitalAtEnd,
+		capitalOut,
+		grossReturn: { ...period.return.gross, absolute: grossAbsoluteReturn },
+		netReturn: { ...period.return.net, absolute: netAbsoluteReturn },
+		depositFee: createFee(depositRate, depositAmount),
+		performanceFee: createFee(performanceRate, performanceAmount, performanceInternalised),
+		managementFee: createFee(managementRate, managementAmount, managementInternalised),
+		withdrawalFee: createFee(withdrawalRate, withdrawalAmount),
+		startDate: period.startDate,
+		endDate: period.endDate,
+		daysInvested,
+		hasInternalisedFees: hasInternalisedVaultFees(vault)
+	};
+}

--- a/src/routes/vaults/compare/+page.server.ts
+++ b/src/routes/vaults/compare/+page.server.ts
@@ -13,6 +13,7 @@ import {
 import { comparisonBenchmarkKeys, type ComparisonVault } from '$lib/top-vaults/equity-comparison/types';
 import { getVaultProtocolDisplayName, isBlacklisted, resolveVaultDetails } from '$lib/top-vaults/helpers';
 import { getVaultProtocolLogoUrl } from '$lib/vault-protocol/helpers';
+import { getVaultCompareMeta } from './compare-meta';
 
 export async function load({ fetch, url }) {
 	const requestedVaultIds = url.searchParams.getAll('vault');
@@ -95,6 +96,7 @@ export async function load({ fetch, url }) {
 	);
 
 	return {
+		compareMeta: getVaultCompareMeta(url.searchParams, topVaults.vaults),
 		selectedVaults,
 		selectedTopVaults: {
 			generated_at: topVaults.generated_at,

--- a/src/routes/vaults/compare/+page.svelte
+++ b/src/routes/vaults/compare/+page.svelte
@@ -61,9 +61,13 @@ Compare selected vault equity curves and fixed market benchmarks on one indexed 
 	let handledRetryVersion = 0;
 
 	const pageTitle = 'Compare vaults';
-	const metaTitle = 'Compare and find best DeFi vault yield';
-	const description = 'Analyse more than 5000 vaults';
-	let pageUrl = $derived(new URL(page.url.pathname, page.url.origin).href);
+	let metaTitle = $derived(data.compareMeta.title);
+	let description = $derived(data.compareMeta.description);
+	let pageUrl = $derived.by(() => {
+		const canonicalUrl = new URL(page.url.pathname, page.url.origin);
+		for (const vaultId of data.compareMeta.selectedVaultIds) canonicalUrl.searchParams.append('vault', vaultId);
+		return canonicalUrl.href;
+	});
 	const benchmarkOptions: { key: ComparisonBenchmark; label: string }[] = [
 		{ key: 'treasury', label: 'T-Bill' },
 		{ key: 'eth', label: 'ETH' },
@@ -213,15 +217,17 @@ Compare selected vault equity curves and fixed market benchmarks on one indexed 
 	title={metaTitle}
 	{description}
 	canonical={pageUrl}
+	image={data.compareMeta.image}
+	imageAlt={data.compareMeta.imageAlt}
 	openGraph={{ siteName: 'Trading Strategy', url: pageUrl, title: metaTitle, description, type: 'website' }}
-	twitter={{ site: '@TradingProtocol', cardType: 'summary', title: metaTitle, description }}
+	twitter={{ site: '@TradingProtocol', cardType: 'summary_large_image', title: metaTitle, description }}
 />
 
 <JsonLd
 	schema={{
 		'@context': 'http://schema.org',
 		'@type': 'CollectionPage',
-		name: pageTitle,
+		name: metaTitle,
 		description,
 		url: pageUrl,
 		provider: { '@type': 'Organization', name: 'Trading Strategy' },
@@ -233,7 +239,7 @@ Compare selected vault equity curves and fixed market benchmarks on one indexed 
 	<Section tag="header">
 		<VaultListingsSelector />
 		<HeroBanner
-			subtitle="Compare the historical performance of vaults with each other and US Treasury, ETH, and BTC benchmarks. The index may include or exclude fees depending on the vault type; check the vault pages for fee details."
+			subtitle="Compare the historical performance of vaults with each other and US Treasury, ETH, and BTC benchmarks. Comparison is gross performance; check the vault pages for fee details."
 		>
 			{#snippet title()}
 				<span class="page-title">

--- a/src/routes/vaults/compare/compare-meta.test.ts
+++ b/src/routes/vaults/compare/compare-meta.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, test } from 'vitest';
+import type { VaultInfo } from '$lib/top-vaults/schemas';
+import {
+	DEFAULT_COMPARE_TITLE,
+	getSelectedCompareVaults,
+	getVaultCompareMeta,
+	getVaultCompareTitle
+} from './compare-meta';
+
+function vault(id: string, name: string): VaultInfo {
+	return { id, name } as VaultInfo;
+}
+
+describe('vault compare metadata', () => {
+	const vaults = [
+		vault('first', 'First Vault'),
+		vault('second', 'Second Vault'),
+		vault('third', 'Third Vault'),
+		vault('fourth', 'Fourth Vault'),
+		vault('fifth', 'Fifth Vault')
+	];
+
+	test('uses the default title when no vaults are requested', () => {
+		expect(getVaultCompareTitle([], 0)).toBe(DEFAULT_COMPARE_TITLE);
+	});
+
+	test('builds title for one selected vault', () => {
+		expect(getVaultCompareTitle([vaults[0]], 1)).toBe('Compare First Vault and other vaults');
+	});
+
+	test('builds title for up to four selected vaults', () => {
+		expect(getVaultCompareTitle(vaults.slice(0, 2), 2)).toBe('Compare vault First Vault and Second Vault');
+		expect(getVaultCompareTitle(vaults.slice(0, 3), 3)).toBe('Compare vault First Vault, Second Vault and Third Vault');
+		expect(getVaultCompareTitle(vaults.slice(0, 4), 4)).toBe(
+			'Compare vault First Vault, Second Vault, Third Vault and Fourth Vault'
+		);
+	});
+
+	test('uses "and others" when more than four vault IDs are requested', () => {
+		expect(getVaultCompareTitle(vaults, 5)).toBe('Compare First Vault and others');
+	});
+
+	test('resolves selected vaults in URL order', () => {
+		const selected = getSelectedCompareVaults(new URLSearchParams('vault=third&vault=first&vault=missing'), vaults);
+
+		expect(selected.map(({ id }) => id)).toEqual(['third', 'first']);
+	});
+
+	test('uses the first selected vault sparkline for social metadata', () => {
+		const meta = getVaultCompareMeta(new URLSearchParams('vault=second&vault=first'), vaults);
+
+		expect(meta.title).toBe('Compare vault Second Vault and First Vault');
+		expect(meta.selectedVaultIds).toEqual(['second', 'first']);
+		expect(meta.image).toBeTruthy();
+		expect(meta.imageAlt).toBe('Second Vault preview image');
+	});
+});

--- a/src/routes/vaults/compare/compare-meta.ts
+++ b/src/routes/vaults/compare/compare-meta.ts
@@ -1,0 +1,69 @@
+import { TRADING_STRATEGY_SOCIAL_IMAGE_PATH, getVaultSocialCardImageUrl } from '$lib/social-card/helpers';
+import type { VaultInfo } from '$lib/top-vaults/schemas';
+
+export interface VaultCompareMeta {
+	title: string;
+	description: string;
+	image?: string;
+	imageAlt?: string;
+	selectedVaultIds: string[];
+}
+
+export const DEFAULT_COMPARE_TITLE = 'Compare and find best DeFi vault yield';
+export const DEFAULT_COMPARE_DESCRIPTION = 'Analyse more than 5000 vaults';
+
+/**
+ * Build a human-readable comparison title from URL-selected vault names.
+ *
+ * @param vaults Vaults selected by the URL, already ordered by query parameter order
+ * @param requestedVaultCount Number of vault IDs supplied in the URL
+ */
+export function getVaultCompareTitle(vaults: Pick<VaultInfo, 'name'>[], requestedVaultCount: number): string {
+	if (vaults.length === 0 || requestedVaultCount === 0) return DEFAULT_COMPARE_TITLE;
+
+	const [first, second, third, fourth] = vaults;
+
+	if (requestedVaultCount === 1 || vaults.length === 1) return `Compare ${first.name} and other vaults`;
+	if (requestedVaultCount > 4) return `Compare ${first.name} and others`;
+	if (vaults.length === 2) return `Compare vault ${first.name} and ${second.name}`;
+	if (vaults.length === 3) return `Compare vault ${first.name}, ${second.name} and ${third.name}`;
+
+	return `Compare vault ${first.name}, ${second.name}, ${third.name} and ${fourth.name}`;
+}
+
+/**
+ * Resolve selected vaults from repeated `vault` URL parameters.
+ *
+ * @param searchParams Page query parameters
+ * @param allVaults Available vault dataset
+ */
+export function getSelectedCompareVaults(searchParams: URLSearchParams, allVaults: VaultInfo[]): VaultInfo[] {
+	const vaultsById = new Map(allVaults.map((vault) => [vault.id, vault]));
+	return searchParams
+		.getAll('vault')
+		.filter(Boolean)
+		.flatMap((id) => vaultsById.get(id) ?? []);
+}
+
+/**
+ * Build metadata used by title, Open Graph, Twitter/X and structured data tags.
+ *
+ * @param searchParams Page query parameters
+ * @param allVaults Available vault dataset
+ */
+export function getVaultCompareMeta(searchParams: URLSearchParams, allVaults: VaultInfo[]): VaultCompareMeta {
+	const requestedVaultCount = searchParams.getAll('vault').filter(Boolean).length;
+	const selectedVaults = getSelectedCompareVaults(searchParams, allVaults);
+	const title = getVaultCompareTitle(selectedVaults, requestedVaultCount);
+	const firstVault = selectedVaults[0];
+
+	return {
+		title,
+		description: DEFAULT_COMPARE_DESCRIPTION,
+		selectedVaultIds: selectedVaults.map(({ id }) => id),
+		image: firstVault
+			? getVaultSocialCardImageUrl(firstVault, TRADING_STRATEGY_SOCIAL_IMAGE_PATH)
+			: TRADING_STRATEGY_SOCIAL_IMAGE_PATH,
+		imageAlt: firstVault ? `${firstVault.name} preview image` : 'Trading Strategy vault comparison preview image'
+	};
+}


### PR DESCRIPTION
## Why\n\nVault return labels did not distinguish gross from net performance, and fee-bearing net returns lacked a transparent calculation example. The comparison route also needed stable, vault-specific social metadata and content.\n\n## Lessons learnt\n\nInternalised management and performance fees are already represented in share-price returns, so their percentages can be disclosed but exact dollar amounts cannot be reconstructed safely. Period returns and dates must come from the same backend record, and transaction fees can make annualised short-period returns look materially different from the absolute result.\n\n## Summary\n\n- Label featured returns as annualised gross or net returns across all supported periods.\n- Add a reconciled USD 10,000 return tooltip with gross and net returns, fee amounts and rates, dates, and internalised-fee disclosures.\n- Keep tooltips within the viewport and reposition them on scrolling or resizing.\n- Make vault comparison content and social metadata follow URL-selected vaults, using the first vault sparkline for previews.\n- Clarify that comparison charts show gross performance and document the return and fee calculation model.