### PR TITLE
feat: add vault comparison selection controls

### DIFF
--- a/.claude/plans/vault-listing-comparison-selection.md
+++ b/.claude/plans/vault-listing-comparison-selection.md
@@ -11,8 +11,8 @@ viewports.
 Each rendered vault row gets a checkbox in the existing first/rank cell, below
 the rank number. Selecting at least one row highlights every selected row and
 shows a persistent **Compare vaults** action aligned with the table's left edge,
-immediately below the last selected row. While scrolling, it stays beneath the
-fixed table heading or at the viewport's safe bottom edge.
+in its own row immediately below the last selected row. That row stays beneath
+the fixed table heading while scrolling.
 
 ## Current implementation and constraints
 
@@ -151,12 +151,11 @@ Reuse `writeEquityComparisonState` from
   visible text exactly **Compare vaults**, add a compact visible selected-count
   badge, and expose an unambiguous accessible name such as “Compare 3 selected
   vaults”.
-- Position its wrapper at the table's left edge immediately after the last
-  selected row. Clamp its fixed position below the table heading and inside the
-  viewport's safe bottom edge with a deliberate stacking level, theme-derived
-  surface/border/shadow, standard spacing tokens, and
-  `env(safe-area-inset-bottom/left)` allowances. Ensure it does not create
-  page-level horizontal overflow on narrow screens.
+- Insert a dedicated full-width table row immediately after the last selected
+  row. Make its cell sticky below the table heading, with a deliberate stacking
+  level, opaque theme-derived surface/border/shadow, and standard spacing
+  tokens. Ensure it does not cover vault cells or create page-level horizontal
+  overflow on narrow screens.
 
 Set `allowVaultComparison={false}` on the `TopVaultsTable` instance in
 `src/routes/vaults/compare/+page.svelte`. Its existing selected-vault cards and

--- a/.claude/plans/vault-listing-comparison-selection.md
+++ b/.claude/plans/vault-listing-comparison-selection.md
@@ -10,9 +10,8 @@ viewports.
 
 Each rendered vault row gets a checkbox in the existing first/rank cell, below
 the rank number. Selecting at least one row highlights every selected row and
-shows a persistent **Compare vaults** action aligned with the table's left edge,
-in its own row immediately below the last selected row. That row stays beneath
-the fixed table heading while scrolling.
+shows a **Compare vaults** action aligned with the table's left edge,
+in its own row immediately below the most recently selected row.
 
 ## Current implementation and constraints
 
@@ -73,11 +72,11 @@ Update `src/lib/top-vaults/TopVaultsTable.svelte`:
   `listingKey` and `listingScope` are unchanged; a listing-identity change takes
   precedence regardless of how navigation encoded it.
 - Import and enforce `MAX_SELECTED_VAULTS`. Once the limit is reached, mark only
-  unchecked row controls `aria-disabled` and make their change handler a no-op;
+  unchecked row controls `aria-disabled` and make their activation a no-op;
   do not use native `disabled`, because the unavailable controls must remain in
   the keyboard tab order and announce why they cannot be selected. Keep checked
   controls operable so users can remove selections, and expose a visible/live
-  “8 vault maximum” status beside the action when the limit is reached.
+  “8 vault maximum” status in the action row when the limit is reached.
 - Add a small helper to identify and toggle a selected ID, keeping the table
   markup declarative and avoiding mutations of `Set` or array state in place.
 
@@ -98,7 +97,7 @@ the CSS counter as the source of the displayed rank:
   rank and checkbox must remain keyboard reachable and must not trigger the
   row-wide vault detail link.
 - Bind `checked` to the ordered selection and `aria-disabled` to the shared
-  maximum, with guarded pointer and keyboard handlers for unavailable controls.
+  maximum, with a guarded activation handler for unavailable controls.
   Expose stable test IDs or data attributes for the row, checkbox, and selected
   state where semantic role/name selectors are insufficient.
 - Apply a selected class/data attribute to the `<tr>`, without removing its
@@ -133,29 +132,34 @@ In `TopVaultsTable.svelte`:
 - Verify the result in both colour modes rather than relying only on the default
   dark theme.
 
-### 4. Build the prefilled comparison destination and persistent action
+### 4. Build the prefilled comparison destination and action row
 
 Reuse `writeEquityComparisonState` from
 `src/lib/top-vaults/equity-comparison/state.ts` to build the action URL:
 
-- Pass the selected IDs in click order, an empty benchmark list, and the
-  comparison page's default `3M` period. This produces repeated encoded `vault`
-  parameters and an explicit, shareable period. The presence of the `vault`
-  parameters—not the period—prevents the compare-page loader from injecting its
-  unrelated default Savings USDS selection.
+- Pass the selected IDs in click order, an empty benchmark list, the comparison
+  page's default `3M` period, and the return mode supported by the selected
+  vaults. Prefer `net` when fee data is available for every selected vault and
+  every selected record remains loaded; use `gross` otherwise. This produces
+  repeated encoded `vault` parameters and explicit, shareable chart settings.
+  The presence of the `vault` parameters—not the period—prevents the compare-page
+  loader from injecting its unrelated default Savings USDS selection.
 - Resolve the `/vaults/compare` path through `$app/paths` so configured base
   paths continue to work. Use an anchor-style action (the shared `Button`
   component is suitable) so the destination is inspectable, openable in a new
   tab, and usable without a bespoke click-navigation handler.
-- Render the persistent action only when at least one ID is selected. Keep the main
+- Render the action only when at least one ID is selected. Keep the main
   visible text exactly **Compare vaults**, add a compact visible selected-count
   badge, and expose an unambiguous accessible name such as “Compare 3 selected
   vaults”.
+- Keep the live selection-limit status outside the moving action-row snippet so
+  it is not remounted when the most recent selection changes. Show the same
+  message visually in the action row when the limit is reached.
 - Insert a dedicated full-width table row immediately after the last selected
-  row. Make its cell sticky below the table heading, with a deliberate stacking
-  level, opaque theme-derived surface/border/shadow, and standard spacing
-  tokens. Ensure it does not cover vault cells or create page-level horizontal
-  overflow on narrow screens.
+  row, with a theme-derived surface and standard spacing tokens. Keep it in the
+  table flow. When the most recently selected vault is not rendered, put the
+  action after the rendered vault rows. Ensure it does not create page-level
+  horizontal overflow on narrow screens.
 
 Set `allowVaultComparison={false}` on the `TopVaultsTable` instance in
 `src/routes/vaults/compare/+page.svelte`. Its existing selected-vault cards and
@@ -168,17 +172,17 @@ verify:
 
 - each non-loading row has one correctly named checkbox inside its rank cell;
 - checking a vault updates the native checked state, selected-row marker, and
-  makes the floating **Compare vaults** link appear;
+  makes the **Compare vaults** action row appear;
 - selecting several rows preserves click order in repeated `vault` parameters,
-  encodes IDs through the shared state writer, sets `period=3M`, and does not add
-  implicit benchmark parameters;
-- unchecking the last vault removes the floating action and row highlight;
+  encodes IDs through the shared state writer, sets `period=3M` and an explicit
+  compatible return mode, and does not add implicit benchmark parameters;
+- unchecking the last vault removes the action row and row highlight;
 - reaching `MAX_SELECTED_VAULTS` disables only unselected checkboxes; and
 - the limit uses focusable `aria-disabled` controls, announces its status, and
   guards both pointer and keyboard attempts to exceed the limit;
 - query-only sort/filter changes retain selections while a changed
   pathname/listing identity clears them; and
-- `allowVaultComparison={false}` omits both row checkboxes and the floating
+- `allowVaultComparison={false}` omits both row checkboxes and the comparison
   action.
 
 Where practical, also assert that the checkbox is marked `targetable-above` and
@@ -189,16 +193,15 @@ duplicating that helper's full test suite.
 ### 6. Cover listing-to-comparison behaviour responsively
 
 Extend `tests/integration/vaults/index.test.ts` with one complete desktop flow at
-1440px and focused layout/interaction passes at representative tablet (1024px)
+1600px and focused layout/interaction passes at representative tablet (1024px)
 and mobile (375px) widths:
 
 - open `/vaults`, select two visible vaults by accessible checkbox name, and
   assert the checkboxes—not the row detail links—receive the interaction;
 - assert both rows share the computed selected background while unselected rows
   retain their alternating backgrounds;
-- confirm the persistent action is below the last selected row when it is
-  visible, then remains beneath the fixed heading while scrolling, and causes
-  no document-level horizontal overflow at tablet or mobile widths;
+- confirm the action is below the last selected row and causes no document-level
+  horizontal overflow at tablet or mobile widths;
 - in the desktop flow, activate **Compare vaults** and verify `/vaults/compare`
   receives the same two IDs in selection order and renders those vaults in its
   Selected vaults list;
@@ -212,7 +215,7 @@ and mobile (375px) widths:
 
 Add an assertion to `tests/integration/vaults/equity-compare.test.ts` that the
 comparison page's embedded summary table does not render listing-selection
-checkboxes or another floating compare action.
+checkboxes or another comparison action.
 
 ## Documentation
 
@@ -234,12 +237,9 @@ vault payload change is expected.
 6. Follow `.claude/docs/worktree.md`, start the Vite development server with
    `pnpm run dev`, and use Playwright against the development server to inspect
    desktop, tablet, and mobile layouts in dark and light modes. Check checkbox
-   hit targets, rank alignment, row highlighting, floating-action safe-area
-   spacing, horizontal table scrolling, keyboard focus, tooltips, and the final
+   hit targets, rank alignment, row highlighting, action-row spacing,
+   horizontal table scrolling, keyboard focus, tooltips, and the final
    selected-vault order on `/vaults/compare`.
-   Also check the floating action alongside any mobile bottom navigation,
-   navigation drawer, search overlay, or consent UI that can coexist with the
-   listing, and confirm stacking does not make either control unusable.
 
 ## Acceptance criteria
 
@@ -249,8 +249,8 @@ vault payload change is expected.
   pointer and keyboard input.
 - Selected rows use a dedicated semantic background colour with readable light-
   and dark-theme contrast.
-- One or more selections reveal a table-left **Compare vaults** action that
-  stays within desktop, tablet, and mobile viewports while scrolling.
+- One or more selections reveal a table-left **Compare vaults** action in its
+  own row at desktop, tablet, and mobile widths.
 - Following the action opens `/vaults/compare` with exactly the selected vaults
   in selection order and no injected default vault.
 - Filtering, sorting, and progressive loading do not clear the current local

--- a/.claude/plans/vault-listing-comparison-selection.md
+++ b/.claude/plans/vault-listing-comparison-selection.md
@@ -10,8 +10,9 @@ viewports.
 
 Each rendered vault row gets a checkbox in the existing first/rank cell, below
 the rank number. Selecting at least one row highlights every selected row and
-shows a persistent **Compare vaults** action aligned with the table's left edge
-at the viewport's safe bottom edge.
+shows a persistent **Compare vaults** action aligned with the table's left edge,
+immediately below the last selected row. While scrolling, it stays beneath the
+fixed table heading or at the viewport's safe bottom edge.
 
 ## Current implementation and constraints
 
@@ -146,15 +147,16 @@ Reuse `writeEquityComparisonState` from
   paths continue to work. Use an anchor-style action (the shared `Button`
   component is suitable) so the destination is inspectable, openable in a new
   tab, and usable without a bespoke click-navigation handler.
-- Render the fixed action only when at least one ID is selected. Keep the main
+- Render the persistent action only when at least one ID is selected. Keep the main
   visible text exactly **Compare vaults**, add a compact visible selected-count
   badge, and expose an unambiguous accessible name such as “Compare 3 selected
   vaults”.
-- Position its wrapper at the table's left edge and the viewport's safe bottom
-  edge with a deliberate stacking level, theme-derived surface/border/shadow,
-  standard spacing tokens, and `env(safe-area-inset-bottom/left)` allowances.
-  Constrain it within the viewport on narrow screens and ensure it does not
-  create page-level horizontal overflow.
+- Position its wrapper at the table's left edge immediately after the last
+  selected row. Clamp its fixed position below the table heading and inside the
+  viewport's safe bottom edge with a deliberate stacking level, theme-derived
+  surface/border/shadow, standard spacing tokens, and
+  `env(safe-area-inset-bottom/left)` allowances. Ensure it does not create
+  page-level horizontal overflow on narrow screens.
 
 Set `allowVaultComparison={false}` on the `TopVaultsTable` instance in
 `src/routes/vaults/compare/+page.svelte`. Its existing selected-vault cards and
@@ -195,9 +197,9 @@ and mobile (375px) widths:
   assert the checkboxes—not the row detail links—receive the interaction;
 - assert both rows share the computed selected background while unselected rows
   retain their alternating backgrounds;
-- confirm the persistent action is fixed at the table's left edge, remains
-  visible after table scrolling, and causes no document-level horizontal
-  overflow at tablet or mobile widths;
+- confirm the persistent action is below the last selected row when it is
+  visible, then remains beneath the fixed heading while scrolling, and causes
+  no document-level horizontal overflow at tablet or mobile widths;
 - in the desktop flow, activate **Compare vaults** and verify `/vaults/compare`
   receives the same two IDs in selection order and renders those vaults in its
   Selected vaults list;

--- a/.claude/plans/vault-listing-comparison-selection.md
+++ b/.claude/plans/vault-listing-comparison-selection.md
@@ -1,0 +1,260 @@
+# Select vaults for comparison from listings
+
+## Goal
+
+Let users select vaults directly from the top-vaults table and open the existing
+`/vaults/compare` page with that ordered selection prefilled. The interaction
+must be available on `/vaults` and every related route that uses the shared
+vault listing table, and it must remain usable at desktop, tablet, and mobile
+viewports.
+
+Each rendered vault row gets a checkbox in the existing first/rank cell, below
+the rank number. Selecting at least one row highlights every selected row and
+shows a persistent **Compare vaults** action aligned with the table's left edge
+at the viewport's safe bottom edge.
+
+## Current implementation and constraints
+
+- `src/lib/top-vaults/TopVaultsTable.svelte` owns the shared table markup,
+  filtering, sorting, progressive loading, responsive horizontal scrolling,
+  row-wide detail links, and the CSS counter that renders each rank. Building
+  selection here makes it available to the top page and the chain, protocol,
+  curator, stablecoin, risk-rating, fund, and other listing variants without
+  duplicating route code.
+- Rows use a full-width `TargetableLink`. Any checkbox placed in a row must use
+  the existing `targetable-above` treatment so pointer and keyboard interaction
+  reaches the checkbox instead of the vault detail link.
+- `/vaults/compare` already accepts ordered repeated `vault=<id>` query
+  parameters. `src/lib/top-vaults/equity-comparison/state.ts` canonicalises the
+  IDs, preserves insertion order, and enforces `MAX_SELECTED_VAULTS` (currently
+  eight). The listing must reuse that contract rather than introduce another
+  parameter format or limit.
+- `TopVaultsTable` is also rendered inside the comparison page as the “Selected
+  vault comparison” table. Selection controls should be disabled for this one
+  consumer because the user is already on the destination page; all genuine
+  listing consumers should enable them by default.
+- The current direct consumers are `TopVaultsPage`, the funds page, and the
+  comparison page; `RiskRatingsPage` and the remaining listing routes reach the
+  table through `TopVaultsPage`. Re-run a repository-wide consumer search during
+  implementation before relying on a default-enabled prop, so a newly added
+  non-listing embed cannot acquire checkboxes accidentally.
+- Rows alternate `--c-col-a` and `--c-col-b` cell backgrounds, and swap that
+  alternation when the chain column is present. The selected-row rule must
+  override both paths across every cell while preserving blacklisted-row and
+  row-link behaviour.
+- The repository has no `theme.css`; the active theme colour source is
+  `src/lib/components/css/color.css`, imported through `index.css` and described
+  in `docs/theme.md`. Add the selection colour there as a semantic token rather
+  than hard-coding a colour inside the table.
+
+## Implementation plan
+
+### 1. Add local ordered selection to the shared table
+
+Update `src/lib/top-vaults/TopVaultsTable.svelte`:
+
+- Add a boolean prop such as `allowVaultComparison`, defaulting to `true`, so
+  all existing listing pages inherit the feature. The loading skeleton should
+  retain the rank-cell shape but should not render interactive checkboxes.
+- Store selected vault IDs as an ordered array in component-local Svelte 5
+  state. Toggle by immutable assignment so the checkbox state, row classes,
+  action visibility, and destination URL all update reactively. Removing and
+  reselecting a vault places it at the end, matching the comparison page's
+  insertion-order contract.
+- Keep selection independent of the current filtered/sorted/rendered rows.
+  Sorting, changing a filter, or fetching a continuation batch must not silently
+  clear a user's choices; a selected row regains its highlight whenever it is
+  visible again. Reset selection when the listing identity changes (pathname,
+  `listingKey`, or `listingScope`), even when SvelteKit reuses the same dynamic
+  route component; navigating from one chain/protocol/stablecoin listing to
+  another must not carry hidden selections across categories. Query-only
+  sorting/filtering on the same pathname keeps the selection only while
+  `listingKey` and `listingScope` are unchanged; a listing-identity change takes
+  precedence regardless of how navigation encoded it.
+- Import and enforce `MAX_SELECTED_VAULTS`. Once the limit is reached, mark only
+  unchecked row controls `aria-disabled` and make their change handler a no-op;
+  do not use native `disabled`, because the unavailable controls must remain in
+  the keyboard tab order and announce why they cannot be selected. Keep checked
+  controls operable so users can remove selections, and expose a visible/live
+  “8 vault maximum” status beside the action when the limit is reached.
+- Add a small helper to identify and toggle a selected ID, keeping the table
+  markup declarative and avoiding mutations of `Set` or array state in place.
+
+Do not place selection in the listing URL or server page data. It is transient
+UI state until the user chooses **Compare vaults**, so filter/sort URLs remain
+canonical and no continuation endpoint changes are required.
+
+### 2. Put each checkbox below its row rank
+
+Replace the empty body rank cell with a rank-and-selection layout while keeping
+the CSS counter as the source of the displayed rank:
+
+- Keep the existing `.index` cell as the first column. Render the counter value
+  above and a native checkbox below it; do not add another table column or shift
+  every existing column.
+- Wrap the checkbox in a `targetable-above` label/control and give it an
+  accessible name such as “Select {vault name} for comparison”. The visible
+  rank and checkbox must remain keyboard reachable and must not trigger the
+  row-wide vault detail link.
+- Bind `checked` to the ordered selection and `aria-disabled` to the shared
+  maximum, with guarded pointer and keyboard handlers for unavailable controls.
+  Expose stable test IDs or data attributes for the row, checkbox, and selected
+  state where semantic role/name selectors are insufficient.
+- Apply a selected class/data attribute to the `<tr>`, without removing its
+  `targetable` or conditional `blacklisted` classes.
+- Adjust the rank-column width, padding, vertical layout, and checkbox size at
+  `--viewport-sm-down` so the rank and a touch-usable control fit without
+  clipping. Preserve the table's current horizontal-scroll strategy and CSS
+  counter behaviour as more rows are progressively appended.
+
+### 3. Add a semantic selected-row colour
+
+Update `src/lib/components/css/color.css` with a purpose-specific token such as
+`--c-vault-row-selected`, defined for both dark and light themes from the
+existing warm-neutral semantic palette. Update `docs/theme.md` to list its
+purpose.
+
+In `TopVaultsTable.svelte`:
+
+- Add the selected-row cell rule after the alternating-column and chain-column
+  rules with sufficient specificity to paint every selected cell with the new
+  token.
+- Preserve visible cell borders, text contrast, focus indication, and the
+  blacklisted strikethrough treatment.
+- The current table has no frozen body columns. Its heading is sticky only on
+  full-width layouts because smaller viewports need horizontal scrolling. Still
+  include the first/rank cell explicitly in the selected override and verify it
+  after horizontal scrolling, so the highlight cannot appear broken at mobile
+  widths or if that cell later gains an opaque/sticky treatment.
+- Ensure the full-row hover link does not erase the selected state; use a
+  token-derived hover/focus mixture for selected rows if the current row-link
+  overlay otherwise masks the highlight.
+- Verify the result in both colour modes rather than relying only on the default
+  dark theme.
+
+### 4. Build the prefilled comparison destination and persistent action
+
+Reuse `writeEquityComparisonState` from
+`src/lib/top-vaults/equity-comparison/state.ts` to build the action URL:
+
+- Pass the selected IDs in click order, an empty benchmark list, and the
+  comparison page's default `3M` period. This produces repeated encoded `vault`
+  parameters and an explicit, shareable period. The presence of the `vault`
+  parameters—not the period—prevents the compare-page loader from injecting its
+  unrelated default Savings USDS selection.
+- Resolve the `/vaults/compare` path through `$app/paths` so configured base
+  paths continue to work. Use an anchor-style action (the shared `Button`
+  component is suitable) so the destination is inspectable, openable in a new
+  tab, and usable without a bespoke click-navigation handler.
+- Render the fixed action only when at least one ID is selected. Keep the main
+  visible text exactly **Compare vaults**, add a compact visible selected-count
+  badge, and expose an unambiguous accessible name such as “Compare 3 selected
+  vaults”.
+- Position its wrapper at the table's left edge and the viewport's safe bottom
+  edge with a deliberate stacking level, theme-derived surface/border/shadow,
+  standard spacing tokens, and `env(safe-area-inset-bottom/left)` allowances.
+  Constrain it within the viewport on narrow screens and ensure it does not
+  create page-level horizontal overflow.
+
+Set `allowVaultComparison={false}` on the `TopVaultsTable` instance in
+`src/routes/vaults/compare/+page.svelte`. Its existing selected-vault cards and
+remove controls remain the only selection editor on that page.
+
+### 5. Add focused component coverage
+
+Extend `src/lib/top-vaults/TopVaultsTable.test.ts` with deterministic vaults to
+verify:
+
+- each non-loading row has one correctly named checkbox inside its rank cell;
+- checking a vault updates the native checked state, selected-row marker, and
+  makes the floating **Compare vaults** link appear;
+- selecting several rows preserves click order in repeated `vault` parameters,
+  encodes IDs through the shared state writer, sets `period=3M`, and does not add
+  implicit benchmark parameters;
+- unchecking the last vault removes the floating action and row highlight;
+- reaching `MAX_SELECTED_VAULTS` disables only unselected checkboxes; and
+- the limit uses focusable `aria-disabled` controls, announces its status, and
+  guards both pointer and keyboard attempts to exceed the limit;
+- query-only sort/filter changes retain selections while a changed
+  pathname/listing identity clears them; and
+- `allowVaultComparison={false}` omits both row checkboxes and the floating
+  action.
+
+Where practical, also assert that the checkbox is marked `targetable-above` and
+that the rank cell remains the first body cell. Leave URL canonicalisation and
+limit edge cases in the existing equity-comparison state tests rather than
+duplicating that helper's full test suite.
+
+### 6. Cover listing-to-comparison behaviour responsively
+
+Extend `tests/integration/vaults/index.test.ts` with one complete desktop flow at
+1440px and focused layout/interaction passes at representative tablet (1024px)
+and mobile (375px) widths:
+
+- open `/vaults`, select two visible vaults by accessible checkbox name, and
+  assert the checkboxes—not the row detail links—receive the interaction;
+- assert both rows share the computed selected background while unselected rows
+  retain their alternating backgrounds;
+- confirm the persistent action is fixed at the table's left edge, remains
+  visible after table scrolling, and causes no document-level horizontal
+  overflow at tablet or mobile widths;
+- in the desktop flow, activate **Compare vaults** and verify `/vaults/compare`
+  receives the same two IDs in selection order and renders those vaults in its
+  Selected vaults list;
+- cover deselection and the eight-vault disabled state without relying on live
+  chart-history responses; and
+- verify query-only filtering/sorting retains the chosen IDs, while navigating
+  between two values of the same dynamic listing route clears them;
+- perform a small smoke assertion on one related listing route (for example a
+  protocol or stablecoin detail listing) to prove the shared table enables the
+  same control there.
+
+Add an assertion to `tests/integration/vaults/equity-compare.test.ts` that the
+comparison page's embedded summary table does not render listing-selection
+checkboxes or another floating compare action.
+
+## Documentation
+
+Update `docs/vault-listings.md` to describe that listing selection is local to
+the current page instance, survives in-page sorting/filtering/loading, is capped
+at the comparison page's shared limit, and is transferred as ordered repeated
+`vault` parameters only when the action is followed.
+
+No server loader, listing endpoint, compare chart-data endpoint, schema, or
+vault payload change is expected.
+
+## Verification
+
+1. Format the modified Svelte, TypeScript, CSS, and Markdown files.
+2. Run `pnpm run check src/lib/top-vaults/TopVaultsTable.svelte`.
+3. Run the focused `TopVaultsTable` unit tests.
+4. Run the focused vault listing and equity comparison Playwright specs.
+5. Run `pnpm run lint`, `pnpm run check`, and `pnpm run test:unit --run`.
+6. Follow `.claude/docs/worktree.md`, start the Vite development server with
+   `pnpm run dev`, and use Playwright against the development server to inspect
+   desktop, tablet, and mobile layouts in dark and light modes. Check checkbox
+   hit targets, rank alignment, row highlighting, floating-action safe-area
+   spacing, horizontal table scrolling, keyboard focus, tooltips, and the final
+   selected-vault order on `/vaults/compare`.
+   Also check the floating action alongside any mobile bottom navigation,
+   navigation drawer, search overlay, or consent UI that can coexist with the
+   listing, and confirm stacking does not make either control unusable.
+
+## Acceptance criteria
+
+- Every genuine `TopVaultsTable` listing lets a user select up to the existing
+  comparison limit, with the checkbox directly below the row rank.
+- Selecting rows never follows the row detail link, and all controls work with
+  pointer and keyboard input.
+- Selected rows use a dedicated semantic background colour with readable light-
+  and dark-theme contrast.
+- One or more selections reveal a table-left **Compare vaults** action that
+  stays within desktop, tablet, and mobile viewports while scrolling.
+- Following the action opens `/vaults/compare` with exactly the selected vaults
+  in selection order and no injected default vault.
+- Filtering, sorting, and progressive loading do not clear the current local
+  selection.
+- The comparison page's own summary table does not show a recursive selection
+  action.
+- Focused unit and Playwright coverage verifies the state, URL, related-listing,
+  accessibility, and responsive behaviour.

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ node_modules
 *.local
 vite.config.js.timestamp-*
 vite.config.ts.timestamp-*
+tests/mocks/**/*.timestamp-*.mjs
 .idea
 .vscode
 .zed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Weblog of stuff
 
+- Add vault comparison selection controls to public vault listings (2026-09-04)
 - Add Gross and Net fee-aware return modes to the multi-vault comparison chart (2026-09-04)
 - Show a "check your email for your API key" notice on the vault datasets page after a Creem checkout redirect (2026-09-03)
 - Add a dedicated podcast episode page with YouTube and Spotify links (2026-09-02)

--- a/docs/theme.md
+++ b/docs/theme.md
@@ -135,6 +135,7 @@ Use these defaults when generating new UI:
 - Default card border: `var(--c-box-3)`
 - Stronger border or control emphasis: `var(--c-box-4)`
 - Section accent wash: `var(--c-background-accent-1)`
+- Selected vault-listing row: `var(--c-vault-row-selected)`
 
 Avoid these mistakes:
 

--- a/docs/vault-data-optimisation-plan.md
+++ b/docs/vault-data-optimisation-plan.md
@@ -1,6 +1,6 @@
 # Vault data optimisation status
 
-The migration away from sending the complete top-vaults export to normal browser pages is implemented. The canonical architecture and configuration are documented in [Vault data sources](vault-data-source.md); listing pagination is documented in [Vault listing pagination](vault-listings.md).
+The migration away from sending the complete top-vaults export to normal browser pages is implemented. The canonical architecture and configuration are documented in [Vault data sources](vault-data-source.md); listing pagination is documented in [Vault listings](vault-listings.md#pagination).
 
 ## Current delivery model
 

--- a/docs/vault-listings.md
+++ b/docs/vault-listings.md
@@ -1,4 +1,4 @@
-# Vault listing pagination
+# Vault listings
 
 ## Comparing selected vaults
 
@@ -7,13 +7,18 @@ The selection is local to the current listing: it survives sorting, filtering,
 and progressive loading, but resets when the listing category changes. A filter
 can temporarily hide a selected vault; its selection remains in the count and
 comparison until the filter is relaxed or it is removed on the comparison page.
-Selecting one or more vaults reveals a persistent **Compare vaults** action at
-the listing section's left edge in its own table row, immediately after the
-last selected row. Its dedicated row sticks beneath the fixed table heading as
-the table scrolls, without covering vault cells. It opens the comparison page
-with the selected IDs in click order as repeated `vault` query parameters and
-`period=3M`. The comparison page's embedded selected-vault table does not
-render these controls.
+Selecting one or more vaults reveals a **Compare vaults** action in a dedicated
+table row immediately after the most recently selected vault. If that vault is
+not currently rendered—for example, because a filter hides it—the action follows
+the rendered vault rows instead. The action scrolls with the listing. It opens
+the comparison page with the selected IDs in click order as repeated `vault`
+query parameters and explicit chart settings. The initial period is three
+months. Net returns are selected when fee data is available for every chosen
+vault and its record remains loaded. Otherwise the comparison starts with gross
+returns. The comparison page's embedded selected-vault table does not render
+these controls.
+
+## Pagination
 
 Vault table pages render their first 125 matching rows in the SvelteKit server
 load. This makes the initial listing visible without downloading the complete

--- a/docs/vault-listings.md
+++ b/docs/vault-listings.md
@@ -8,12 +8,12 @@ and progressive loading, but resets when the listing category changes. A filter
 can temporarily hide a selected vault; its selection remains in the count and
 comparison until the filter is relaxed or it is removed on the comparison page.
 Selecting one or more vaults reveals a persistent **Compare vaults** action at
-the listing section's left edge, immediately below the last selected row. As
-that row reaches the fixed table heading or leaves the viewport, the action
-stays visible beneath the heading or at the viewport's safe bottom edge. It
-opens the comparison page with the selected IDs in click order as repeated
-`vault` query parameters and `period=3M`. The comparison page's embedded
-selected-vault table does not render these controls.
+the listing section's left edge in its own table row, immediately after the
+last selected row. Its dedicated row sticks beneath the fixed table heading as
+the table scrolls, without covering vault cells. It opens the comparison page
+with the selected IDs in click order as repeated `vault` query parameters and
+`period=3M`. The comparison page's embedded selected-vault table does not
+render these controls.
 
 Vault table pages render their first 125 matching rows in the SvelteKit server
 load. This makes the initial listing visible without downloading the complete

--- a/docs/vault-listings.md
+++ b/docs/vault-listings.md
@@ -8,11 +8,12 @@ and progressive loading, but resets when the listing category changes. A filter
 can temporarily hide a selected vault; its selection remains in the count and
 comparison until the filter is relaxed or it is removed on the comparison page.
 Selecting one or more vaults reveals a persistent **Compare vaults** action at
-the listing section's left edge and the viewport's safe bottom edge. It remains
-available while the user scrolls, including when selected rows are no longer in
-view, and opens the comparison page with the selected IDs in click order as
-repeated `vault` query parameters and `period=3M`. The comparison page's
-embedded selected-vault table does not render these controls.
+the listing section's left edge, immediately below the last selected row. As
+that row reaches the fixed table heading or leaves the viewport, the action
+stays visible beneath the heading or at the viewport's safe bottom edge. It
+opens the comparison page with the selected IDs in click order as repeated
+`vault` query parameters and `period=3M`. The comparison page's embedded
+selected-vault table does not render these controls.
 
 Vault table pages render their first 125 matching rows in the SvelteKit server
 load. This makes the initial listing visible without downloading the complete

--- a/docs/vault-listings.md
+++ b/docs/vault-listings.md
@@ -1,5 +1,19 @@
 # Vault listing pagination
 
+## Comparing selected vaults
+
+Public vault listing tables let visitors select up to eight vaults for comparison.
+The selection is local to the current listing: it survives sorting, filtering,
+and progressive loading, but resets when the listing category changes. A filter
+can temporarily hide a selected vault; its selection remains in the count and
+comparison until the filter is relaxed or it is removed on the comparison page.
+Selecting one or more vaults reveals a persistent **Compare vaults** action at
+the listing section's left edge and the viewport's safe bottom edge. It remains
+available while the user scrolls, including when selected rows are no longer in
+view, and opens the comparison page with the selected IDs in click order as
+repeated `vault` query parameters and `period=3M`. The comparison page's
+embedded selected-vault table does not render these controls.
+
 Vault table pages render their first 125 matching rows in the SvelteKit server
 load. This makes the initial listing visible without downloading the complete
 vault export in the browser.

--- a/src/lib/components/css/color.css
+++ b/src/lib/components/css/color.css
@@ -53,6 +53,7 @@
 	--box-4-alpha: 20%;
 
 	--c-background-accent-1: hsl(0 0% 0% / 20%);
+	--c-vault-row-selected: hsl(var(--hue-1) 22% 78% / 30%);
 
 	--c-input-background: var(--c-box-2);
 	--c-input-background-focus: var(--c-box-3);
@@ -108,6 +109,7 @@
 		--box-4-alpha: 48%;
 
 		--c-background-accent-1: var(--c-box-2);
+		--c-vault-row-selected: hsl(var(--hue-1) 46% 46% / 30%);
 
 		--c-input-background: color-mix(in srgb, white, transparent 5%);
 		--c-input-background-focus: white;

--- a/src/lib/top-vaults/TopVaultsTable.svelte
+++ b/src/lib/top-vaults/TopVaultsTable.svelte
@@ -18,7 +18,7 @@ The AMM checkbox hides AMM pools and AMM-like vaults on listings with Filters.
 	import type { TopVaults, VaultInfo } from './schemas';
 	import type { RiskRatingProvider } from './risk-rating-providers';
 	import type { ParamSchema } from '$lib/helpers/url-search-state';
-	import { onMount, untrack } from 'svelte';
+	import { onMount, tick, untrack } from 'svelte';
 	import { SvelteURL, SvelteURLSearchParams } from 'svelte/reactivity';
 	import { goto, replaceState } from '$app/navigation';
 	import { page } from '$app/state';
@@ -272,6 +272,9 @@ The AMM checkbox hides AMM pools and AMM-like vaults on listings with Filters.
 	});
 
 	let selectionLimitReached = $derived(selectedVaultIds.length >= MAX_SELECTED_VAULTS);
+	let comparisonTableElement = $state<HTMLTableElement>();
+	let comparisonActionElement = $state<HTMLDivElement>();
+	let comparisonActionTop = $state<number>();
 	let comparisonHref = $derived.by(() => {
 		const searchParams = writeEquityComparisonState(new URLSearchParams(), {
 			vaultIds: selectedVaultIds,
@@ -310,6 +313,50 @@ The AMM checkbox hides AMM pools and AMM-like vaults on listings with Filters.
 	function preventUnavailableVaultSelection(event: KeyboardEvent, vaultId: string): void {
 		if (isVaultSelectionUnavailable(vaultId) && event.key === ' ') event.preventDefault();
 	}
+
+	/**
+	 * Keep the action immediately below the last visible selected row, while
+	 * clamping it beneath the sticky table heading and inside the viewport.
+	 */
+	function positionComparisonAction(): void {
+		if (!comparisonTableElement || !comparisonActionElement) return;
+
+		const selectedRows = comparisonTableElement.querySelectorAll<HTMLTableRowElement>('tbody tr.selected');
+		const lastSelectedRow = selectedRows.item(selectedRows.length - 1);
+		const headerBottom = comparisonTableElement.querySelector('thead th')?.getBoundingClientRect().bottom ?? 0;
+		const actionHeight = comparisonActionElement.getBoundingClientRect().height;
+		const gap = 8;
+		const minimumTop = Math.max(0, headerBottom) + gap;
+		const maximumTop = Math.max(minimumTop, window.innerHeight - actionHeight - 16);
+		const naturalTop = lastSelectedRow ? lastSelectedRow.getBoundingClientRect().bottom + gap : maximumTop;
+
+		comparisonActionTop = Math.min(Math.max(naturalTop, minimumTop), maximumTop);
+	}
+
+	$effect(() => {
+		if (selectedVaultIds.length === 0) {
+			comparisonActionTop = undefined;
+			return;
+		}
+
+		let disposed = false;
+		const updatePosition = () => {
+			if (!disposed) positionComparisonAction();
+		};
+		void tick().then(updatePosition);
+		window.addEventListener('scroll', updatePosition, { passive: true });
+		window.addEventListener('resize', updatePosition);
+		const resizeObserver = new ResizeObserver(updatePosition);
+		if (comparisonTableElement) resizeObserver.observe(comparisonTableElement);
+		if (comparisonActionElement) resizeObserver.observe(comparisonActionElement);
+
+		return () => {
+			disposed = true;
+			window.removeEventListener('scroll', updatePosition);
+			window.removeEventListener('resize', updatePosition);
+			resizeObserver.disconnect();
+		};
+	});
 
 	// --- Sort column registry (key → default direction) ---
 
@@ -1037,7 +1084,12 @@ The AMM checkbox hides AMM pools and AMM-like vaults on listings with Filters.
 {/snippet}
 
 {#snippet comparisonAction()}
-	<div class="compare-vaults-action" data-testid="compare-vaults-action">
+	<div
+		bind:this={comparisonActionElement}
+		class="compare-vaults-action"
+		data-testid="compare-vaults-action"
+		style:top={comparisonActionTop == null ? undefined : `${comparisonActionTop}px`}
+	>
 		<p id="vault-comparison-selection-status" role="status" class:sr-only={!selectionLimitReached}>
 			{selectionLimitReached ? `You can compare up to ${MAX_SELECTED_VAULTS} vaults.` : ''}
 		</p>
@@ -1446,6 +1498,7 @@ The AMM checkbox hides AMM pools and AMM-like vaults on listings with Filters.
 	<div class="table-wrapper" class:comparison-selection-active={allowVaultComparison && selectedVaultIds.length > 0}>
 		<!-- --table-width needed for proper tr.targetable styling  -->
 		<table
+			bind:this={comparisonTableElement}
 			bind:offsetWidth
 			style:--table-width="{offsetWidth}px"
 			class:loading
@@ -1708,7 +1761,7 @@ The AMM checkbox hides AMM pools and AMM-like vaults on listings with Filters.
 			justify-items: start;
 			gap: var(--space-xs);
 			left: max(env(safe-area-inset-left), calc((100% - var(--SECTION-width, calc(100% - (2 * var(--space-lg))))) / 2));
-			bottom: max(var(--space-lg), env(safe-area-inset-bottom));
+			padding-bottom: env(safe-area-inset-bottom);
 
 			p {
 				margin: 0;

--- a/src/lib/top-vaults/TopVaultsTable.svelte
+++ b/src/lib/top-vaults/TopVaultsTable.svelte
@@ -25,6 +25,7 @@ The AMM checkbox hides AMM pools and AMM-like vaults on listings with Filters.
 	import { inview } from 'svelte-inview';
 	import { resolve } from '$app/paths';
 	import { deserialiseSearchParams, serialiseSearchParams } from '$lib/helpers/url-search-state';
+	import Button from '$lib/components/Button.svelte';
 	import Select from '$lib/components/Select.svelte';
 	import TargetableLink from '$lib/components/TargetableLink.svelte';
 	import Timestamp from '$lib/components/Timestamp.svelte';
@@ -104,6 +105,7 @@ The AMM checkbox hides AMM pools and AMM-like vaults on listings with Filters.
 	import { sortVaults } from './listing/query';
 	import { getVaultListingDefaults, type VaultListingKey } from './listing/definitions';
 	import { INITIAL_VAULT_LISTING_LIMIT, VAULT_LISTING_PAGE_SIZE, type VaultListingSummary } from './listing/types';
+	import { MAX_SELECTED_VAULTS, writeEquityComparisonState } from './equity-comparison/state';
 
 	const allVaultsPath = resolve('/vaults/all');
 	const filtersOpenStorageKey = 'top-vaults-filters-open';
@@ -181,6 +183,8 @@ The AMM checkbox hides AMM pools and AMM-like vaults on listings with Filters.
 		preserveSearchParams?: string[];
 		/** Show the standard stablecoin-only badge in the listing metadata. */
 		showStablecoinOnlyMeta?: boolean;
+		/** Allow selecting vault rows for the equity comparison page. */
+		allowVaultComparison?: boolean;
 	}
 
 	interface ListingDataResponse {
@@ -228,7 +232,8 @@ The AMM checkbox hides AMM pools and AMM-like vaults on listings with Filters.
 		listingScope,
 		listingSummary,
 		preserveSearchParams = [],
-		showStablecoinOnlyMeta = true
+		showStablecoinOnlyMeta = true,
+		allowVaultComparison = true
 	}: Props = $props();
 	const defaultHideAmm = untrack(() => ((getVaultListingDefaults(listingKey, listingScope).amm ?? true) ? 1 : 0));
 	let listingAssetType = $derived(listingKey === 'protocol' && isPoolProtocol(listingScope) ? 'pool' : 'vault');
@@ -253,6 +258,58 @@ The AMM checkbox hides AMM pools and AMM-like vaults on listings with Filters.
 		revealedListingSummary = undefined;
 		revealedFromRisk = null;
 	});
+
+	let selectedVaultIds = $state<string[]>([]);
+	let previousSelectionIdentity: string | undefined;
+
+	// Sorting and filters retain choices, while a new listing must start fresh.
+	$effect(() => {
+		const selectionIdentity = `${page.url.pathname}\u0000${listingKey}\u0000${listingScope ?? ''}`;
+		if (previousSelectionIdentity !== undefined && previousSelectionIdentity !== selectionIdentity) {
+			selectedVaultIds = [];
+		}
+		previousSelectionIdentity = selectionIdentity;
+	});
+
+	let selectionLimitReached = $derived(selectedVaultIds.length >= MAX_SELECTED_VAULTS);
+	let comparisonHref = $derived.by(() => {
+		const searchParams = writeEquityComparisonState(new URLSearchParams(), {
+			vaultIds: selectedVaultIds,
+			benchmarks: [],
+			timeSpan: '3M'
+		});
+		return resolve(`/vaults/compare?${searchParams}` as '/vaults/compare');
+	});
+
+	function isVaultSelected(vaultId: string): boolean {
+		return selectedVaultIds.includes(vaultId);
+	}
+
+	function isVaultSelectionUnavailable(vaultId: string): boolean {
+		return selectionLimitReached && !isVaultSelected(vaultId);
+	}
+
+	function toggleVaultComparisonSelection(vaultId: string): void {
+		if (isVaultSelected(vaultId)) {
+			selectedVaultIds = selectedVaultIds.filter((id) => id !== vaultId);
+			return;
+		}
+		if (selectionLimitReached) return;
+		selectedVaultIds = [...selectedVaultIds, vaultId];
+	}
+
+	function onVaultComparisonSelectionChange(event: Event, vaultId: string): void {
+		const input = event.currentTarget as HTMLInputElement;
+		if (isVaultSelectionUnavailable(vaultId)) {
+			input.checked = false;
+			return;
+		}
+		toggleVaultComparisonSelection(vaultId);
+	}
+
+	function preventUnavailableVaultSelection(event: KeyboardEvent, vaultId: string): void {
+		if (isVaultSelectionUnavailable(vaultId) && event.key === ' ') event.preventDefault();
+	}
 
 	// --- Sort column registry (key → default direction) ---
 
@@ -979,6 +1036,19 @@ The AMM checkbox hides AMM pools and AMM-like vaults on listings with Filters.
 	</section>
 {/snippet}
 
+{#snippet comparisonAction()}
+	<div class="compare-vaults-action" data-testid="compare-vaults-action">
+		<p id="vault-comparison-selection-status" role="status" class:sr-only={!selectionLimitReached}>
+			{selectionLimitReached ? `You can compare up to ${MAX_SELECTED_VAULTS} vaults.` : ''}
+		</p>
+		<Button href={comparisonHref} size="md" class="compare-vaults-button">
+			Compare vaults
+			<span class="comparison-selection-count" aria-hidden="true">{selectedVaultIds.length}</span>
+			<span class="sr-only">{selectedVaultIds.length} selected vault{selectedVaultIds.length === 1 ? '' : 's'}</span>
+		</Button>
+	</div>
+{/snippet}
+
 <div class="top-vaults-table">
 	<div class="table-extras">
 		<div class="table-stats" class:hidden={loading} data-testid="top-vaults-meta">
@@ -1373,7 +1443,7 @@ The AMM checkbox hides AMM pools and AMM-like vaults on listings with Filters.
 		{/if}
 	</div>
 
-	<div class="table-wrapper">
+	<div class="table-wrapper" class:comparison-selection-active={allowVaultComparison && selectedVaultIds.length > 0}>
 		<!-- --table-width needed for proper tr.targetable styling  -->
 		<table
 			bind:offsetWidth
@@ -1447,9 +1517,27 @@ The AMM checkbox hides AMM pools and AMM-like vaults on listings with Filters.
 					{@const statusReason = [vault.deposit_closed_reason, vault.redemption_closed_reason]
 						.filter(Boolean)
 						.join('; ')}
-					<tr class={['targetable', blacklisted && !disableBlacklistedStrikethrough && 'blacklisted']}>
+					<tr
+						class={['targetable', blacklisted && !disableBlacklistedStrikethrough && 'blacklisted']}
+						class:selected={isVaultSelected(vault.id)}
+					>
 						<!-- index cell is populated with row index via `rowNumber` CSS counter -->
-						<td class="index"></td>
+						<td class="index">
+							{#if allowVaultComparison}
+								<label class="vault-comparison-selection targetable-above">
+									<input
+										type="checkbox"
+										data-testid="vault-comparison-checkbox"
+										checked={isVaultSelected(vault.id)}
+										aria-disabled={isVaultSelectionUnavailable(vault.id)}
+										aria-describedby={selectionLimitReached ? 'vault-comparison-selection-status' : undefined}
+										onchange={(event) => onVaultComparisonSelectionChange(event, vault.id)}
+										onkeydown={(event) => preventUnavailableVaultSelection(event, vault.id)}
+									/>
+									<span class="sr-only">Select {vault.name} for comparison</span>
+								</label>
+							{/if}
+						</td>
 						{#if showChainCol}
 							<td class="chain">
 								<ChainCell {chain} label={getChainDisplayName(vault.chain_id)} />
@@ -1591,6 +1679,10 @@ The AMM checkbox hides AMM pools and AMM-like vaults on listings with Filters.
 		</table>
 	</div>
 
+	{#if allowVaultComparison && selectedVaultIds.length > 0}
+		{@render comparisonAction()}
+	{/if}
+
 	{#if hiddenBlacklistedCount > 0 && !remoteHasMore}
 		<button
 			class="show-blacklisted-vaults"
@@ -1608,6 +1700,42 @@ The AMM checkbox hides AMM pools and AMM-like vaults on listings with Filters.
 	.top-vaults-table {
 		display: grid;
 		gap: 1rem;
+
+		.compare-vaults-action {
+			position: fixed;
+			z-index: 20;
+			display: grid;
+			justify-items: start;
+			gap: var(--space-xs);
+			left: max(env(safe-area-inset-left), calc((100% - var(--SECTION-width, calc(100% - (2 * var(--space-lg))))) / 2));
+			bottom: max(var(--space-lg), env(safe-area-inset-bottom));
+
+			p {
+				margin: 0;
+				padding: var(--space-xs) var(--space-sm);
+				border: 1px solid var(--c-box-4);
+				border-radius: var(--radius-sm);
+				background: var(--c-body);
+				color: var(--c-text-light);
+				font: var(--f-ui-xs-medium);
+				box-shadow: 0 0.5rem 1rem color-mix(in srgb, var(--c-shadow), transparent 88%);
+			}
+
+			:global(.compare-vaults-button) {
+				box-shadow: 0 0.75rem 1.5rem color-mix(in srgb, var(--c-shadow), transparent 82%);
+			}
+
+			:global(.comparison-selection-count) {
+				display: inline-grid;
+				min-width: 1.25rem;
+				height: 1.25rem;
+				place-items: center;
+				padding: 0 var(--space-xxs);
+				border-radius: 999px;
+				background: var(--c-box-4);
+				font: var(--f-ui-xs-medium);
+			}
+		}
 
 		.table-extras {
 			display: flex;
@@ -1996,6 +2124,10 @@ The AMM checkbox hides AMM pools and AMM-like vaults on listings with Filters.
 		.table-wrapper {
 			width: 100%;
 
+			&.comparison-selection-active {
+				padding-bottom: calc(var(--space-lg) + 7rem);
+			}
+
 			/*
 				Setting overflow:auto breaks the sticky header, but is needed to allow horizontal scrolling
 				on smaller viewports. Best compromise is to only set overflow on smaller viewports.
@@ -2196,10 +2328,8 @@ The AMM checkbox hides AMM pools and AMM-like vaults on listings with Filters.
 				width: 2.25rem;
 
 				@media (--viewport-sm-down) {
-					width: 1.5rem;
-
 					&:is(td) {
-						padding-inline: 0;
+						padding-inline: 0.125rem;
 					}
 				}
 
@@ -2215,7 +2345,27 @@ The AMM checkbox hides AMM pools and AMM-like vaults on listings with Filters.
 					counter-increment: rowNumber;
 
 					&::before {
+						display: block;
 						content: counter(rowNumber);
+					}
+				}
+
+				.vault-comparison-selection {
+					display: grid;
+					place-items: center;
+					margin-top: 0.375rem;
+					cursor: pointer;
+
+					input {
+						width: 1.125rem;
+						height: 1.125rem;
+						margin: 0;
+						cursor: pointer;
+					}
+
+					input[aria-disabled='true'] {
+						opacity: 0.5;
+						cursor: not-allowed;
 					}
 				}
 			}
@@ -2467,6 +2617,14 @@ The AMM checkbox hides AMM pools and AMM-like vaults on listings with Filters.
 
 			:global(.row-link):hover {
 				background: var(--c-box-2);
+			}
+
+			tr.selected td {
+				background-color: var(--c-vault-row-selected);
+			}
+
+			tr.selected :global(.row-link):hover {
+				background: color-mix(in srgb, var(--c-vault-row-selected), var(--c-box-4) 35%);
 			}
 
 			.load-more-sentinel td {

--- a/src/lib/top-vaults/TopVaultsTable.svelte
+++ b/src/lib/top-vaults/TopVaultsTable.svelte
@@ -6,6 +6,7 @@ Use `ratingProvider` to add its risk-rating column beside the vault name.
 Permissioned vaults are marked as Private, except tokenised funds, which are marked as Fund.
 The Private checkbox in the Hide vaults group excludes all permissioned vaults.
 The AMM checkbox hides AMM pools and AMM-like vaults on listings with Filters.
+Set `allowVaultComparison={false}` for read-only or embedded tables.
 
 @example
 
@@ -105,6 +106,7 @@ The AMM checkbox hides AMM pools and AMM-like vaults on listings with Filters.
 	import { sortVaults } from './listing/query';
 	import { getVaultListingDefaults, type VaultListingKey } from './listing/definitions';
 	import { INITIAL_VAULT_LISTING_LIMIT, VAULT_LISTING_PAGE_SIZE, type VaultListingSummary } from './listing/types';
+	import { getCanonicalComparisonReturnMode } from './equity-comparison/net-returns';
 	import { MAX_SELECTED_VAULTS, writeEquityComparisonState } from './equity-comparison/state';
 
 	const allVaultsPath = resolve('/vaults/all');
@@ -272,12 +274,19 @@ The AMM checkbox hides AMM pools and AMM-like vaults on listings with Filters.
 	});
 
 	let selectionLimitReached = $derived(selectedVaultIds.length >= MAX_SELECTED_VAULTS);
+	let hasComparisonSelection = $derived(allowVaultComparison && selectedVaultIds.length > 0);
 	let lastSelectedVaultId = $derived(selectedVaultIds.at(-1));
 	let comparisonHref = $derived.by(() => {
+		const selectedVaults = accumulatedVaults.filter((vault) => selectedVaultIds.includes(vault.id));
+		const returnMode =
+			selectedVaults.length === selectedVaultIds.length
+				? getCanonicalComparisonReturnMode('net', selectedVaults)
+				: 'gross';
 		const searchParams = writeEquityComparisonState(new URLSearchParams(), {
 			vaultIds: selectedVaultIds,
 			benchmarks: [],
-			timeSpan: '3M'
+			timeSpan: '3M',
+			returnMode
 		});
 		return resolve(`/vaults/compare?${searchParams}` as '/vaults/compare');
 	});
@@ -290,26 +299,22 @@ The AMM checkbox hides AMM pools and AMM-like vaults on listings with Filters.
 		return selectionLimitReached && !isVaultSelected(vaultId);
 	}
 
-	function toggleVaultComparisonSelection(vaultId: string): void {
+	/**
+	 * Toggle an ordered comparison selection unless its checkbox is aria-disabled.
+	 *
+	 * @param event - Checkbox activation event.
+	 * @param vaultId - Vault identifier to add or remove.
+	 */
+	function toggleVaultComparisonSelection(event: MouseEvent, vaultId: string): void {
+		if (isVaultSelectionUnavailable(vaultId)) {
+			event.preventDefault();
+			return;
+		}
 		if (isVaultSelected(vaultId)) {
 			selectedVaultIds = selectedVaultIds.filter((id) => id !== vaultId);
 			return;
 		}
-		if (selectionLimitReached) return;
 		selectedVaultIds = [...selectedVaultIds, vaultId];
-	}
-
-	function onVaultComparisonSelectionChange(event: Event, vaultId: string): void {
-		const input = event.currentTarget as HTMLInputElement;
-		if (isVaultSelectionUnavailable(vaultId)) {
-			input.checked = false;
-			return;
-		}
-		toggleVaultComparisonSelection(vaultId);
-	}
-
-	function preventUnavailableVaultSelection(event: KeyboardEvent, vaultId: string): void {
-		if (isVaultSelectionUnavailable(vaultId) && event.key === ' ') event.preventDefault();
 	}
 
 	// --- Sort column registry (key → default direction) ---
@@ -581,6 +586,7 @@ The AMM checkbox hides AMM pools and AMM-like vaults on listings with Filters.
 	let showChainCol = $derived(!chain);
 	let showProviderRiskRating = $derived(ratingProvider != null);
 	let showTechnicalRisk = $derived(ratingProvider == null);
+	let tableColumnCount = $derived(12 + selectedReturnColumns.length + (showChainCol ? 1 : 0));
 
 	let offsetWidth = $state<number>();
 
@@ -805,6 +811,7 @@ The AMM checkbox hides AMM pools and AMM-like vaults on listings with Filters.
 	let maxVisibleRows = $state(INITIAL_VAULT_LISTING_LIMIT);
 	let visibleVaults = $derived(isServerBacked ? sortedVaults : sortedVaults.slice(0, maxVisibleRows));
 	let hasMoreRows = $derived(isServerBacked ? remoteHasMore : maxVisibleRows < sortedVaults.length);
+	let lastSelectedVaultIsVisible = $derived(visibleVaults.some((vault) => vault.id === lastSelectedVaultId));
 
 	/**
 	 * Fetch one server-side listing continuation.
@@ -1039,15 +1046,11 @@ The AMM checkbox hides AMM pools and AMM-like vaults on listings with Filters.
 
 {#snippet comparisonAction()}
 	<tr class="compare-vaults-action-row">
-		<td
-			class="compare-vaults-action"
-			data-testid="compare-vaults-action"
-			colspan={12 + selectedReturnColumns.length + (showChainCol ? 1 : 0) + (showProviderRiskRating ? 1 : 0)}
-		>
-			<p id="vault-comparison-selection-status" role="status" class:sr-only={!selectionLimitReached}>
-				{selectionLimitReached ? `You can compare up to ${MAX_SELECTED_VAULTS} vaults.` : ''}
-			</p>
-			<Button href={comparisonHref} size="md" class="compare-vaults-button">
+		<td class="compare-vaults-action" data-testid="compare-vaults-action" colspan={tableColumnCount}>
+			{#if selectionLimitReached}
+				<p aria-hidden="true">You can compare up to {MAX_SELECTED_VAULTS} vaults.</p>
+			{/if}
+			<Button href={comparisonHref} size="md">
 				Compare vaults
 				<span class="comparison-selection-count" aria-hidden="true">{selectedVaultIds.length}</span>
 				<span class="sr-only">{selectedVaultIds.length} selected vault{selectedVaultIds.length === 1 ? '' : 's'}</span>
@@ -1057,6 +1060,11 @@ The AMM checkbox hides AMM pools and AMM-like vaults on listings with Filters.
 {/snippet}
 
 <div class="top-vaults-table">
+	{#if allowVaultComparison}
+		<p id="vault-comparison-selection-status" role="status" class="sr-only">
+			{selectionLimitReached ? `You can compare up to ${MAX_SELECTED_VAULTS} vaults.` : ''}
+		</p>
+	{/if}
 	<div class="table-extras">
 		<div class="table-stats" class:hidden={loading} data-testid="top-vaults-meta">
 			<Tooltip>
@@ -1538,8 +1546,7 @@ The AMM checkbox hides AMM pools and AMM-like vaults on listings with Filters.
 										checked={isVaultSelected(vault.id)}
 										aria-disabled={isVaultSelectionUnavailable(vault.id)}
 										aria-describedby={selectionLimitReached ? 'vault-comparison-selection-status' : undefined}
-										onchange={(event) => onVaultComparisonSelectionChange(event, vault.id)}
-										onkeydown={(event) => preventUnavailableVaultSelection(event, vault.id)}
+										onclick={(event) => toggleVaultComparisonSelection(event, vault.id)}
 									/>
 									<span class="sr-only">Select {vault.name} for comparison</span>
 								</label>
@@ -1671,16 +1678,16 @@ The AMM checkbox hides AMM pools and AMM-like vaults on listings with Filters.
 							<TargetableLink label="View {vault.name} details" href={resolveVaultDetails(vault)} class="row-link" />
 						</td>
 					</tr>
-					{#if allowVaultComparison && selectedVaultIds.length > 0 && vault.id === lastSelectedVaultId}
+					{#if hasComparisonSelection && vault.id === lastSelectedVaultId}
 						{@render comparisonAction()}
 					{/if}
 				{/each}
-				{#if allowVaultComparison && selectedVaultIds.length > 0 && !visibleVaults.some((vault) => vault.id === lastSelectedVaultId)}
+				{#if hasComparisonSelection && !lastSelectedVaultIsVisible}
 					{@render comparisonAction()}
 				{/if}
 				{#if hasMoreRows}
 					<tr class="load-more-sentinel" data-testid="load-more-sentinel">
-						<td colspan={12 + selectedReturnColumns.length + (showChainCol ? 1 : 0) + (showProviderRiskRating ? 1 : 0)}>
+						<td colspan={tableColumnCount}>
 							<div use:inview={{ rootMargin: '300px' }} oninview_enter={loadMore}>
 								<Spinner size="18" /> Loading more vaults... ({visibleVaults.length}{#if !isServerBacked}
 									of {sortedVaults.length}{/if})
@@ -1711,31 +1718,14 @@ The AMM checkbox hides AMM pools and AMM-like vaults on listings with Filters.
 		gap: 1rem;
 
 		.compare-vaults-action-row .compare-vaults-action {
-			position: sticky;
-			top: 3.75rem;
-			z-index: 2;
 			padding: var(--space-sm) var(--space-md);
-			background: var(--c-body) !important;
-			box-shadow: 0 0.5rem 1rem color-mix(in srgb, var(--c-shadow), transparent 88%);
+			background: var(--c-body);
 			text-align: left;
 
-			@media (--viewport-sm-down) {
-				top: 3.25rem;
-			}
-
 			p {
-				margin: 0;
-				padding: var(--space-xs) var(--space-sm);
-				border: 1px solid var(--c-box-4);
-				border-radius: var(--radius-sm);
-				background: var(--c-body);
+				margin: 0 0 var(--space-xs);
 				color: var(--c-text-light);
 				font: var(--f-ui-xs-medium);
-				box-shadow: 0 0.5rem 1rem color-mix(in srgb, var(--c-shadow), transparent 88%);
-			}
-
-			:global(.compare-vaults-button) {
-				box-shadow: 0 0.75rem 1.5rem color-mix(in srgb, var(--c-shadow), transparent 82%);
 			}
 
 			:global(.comparison-selection-count) {
@@ -2361,8 +2351,9 @@ The AMM checkbox hides AMM pools and AMM-like vaults on listings with Filters.
 
 				.vault-comparison-selection {
 					display: grid;
+					min-height: 1.5rem;
 					place-items: center;
-					margin-top: 0.375rem;
+					margin-top: 0.125rem;
 					cursor: pointer;
 
 					input {

--- a/src/lib/top-vaults/TopVaultsTable.svelte
+++ b/src/lib/top-vaults/TopVaultsTable.svelte
@@ -18,7 +18,7 @@ The AMM checkbox hides AMM pools and AMM-like vaults on listings with Filters.
 	import type { TopVaults, VaultInfo } from './schemas';
 	import type { RiskRatingProvider } from './risk-rating-providers';
 	import type { ParamSchema } from '$lib/helpers/url-search-state';
-	import { onMount, tick, untrack } from 'svelte';
+	import { onMount, untrack } from 'svelte';
 	import { SvelteURL, SvelteURLSearchParams } from 'svelte/reactivity';
 	import { goto, replaceState } from '$app/navigation';
 	import { page } from '$app/state';
@@ -272,9 +272,7 @@ The AMM checkbox hides AMM pools and AMM-like vaults on listings with Filters.
 	});
 
 	let selectionLimitReached = $derived(selectedVaultIds.length >= MAX_SELECTED_VAULTS);
-	let comparisonTableElement = $state<HTMLTableElement>();
-	let comparisonActionElement = $state<HTMLDivElement>();
-	let comparisonActionTop = $state<number>();
+	let lastSelectedVaultId = $derived(selectedVaultIds.at(-1));
 	let comparisonHref = $derived.by(() => {
 		const searchParams = writeEquityComparisonState(new URLSearchParams(), {
 			vaultIds: selectedVaultIds,
@@ -313,50 +311,6 @@ The AMM checkbox hides AMM pools and AMM-like vaults on listings with Filters.
 	function preventUnavailableVaultSelection(event: KeyboardEvent, vaultId: string): void {
 		if (isVaultSelectionUnavailable(vaultId) && event.key === ' ') event.preventDefault();
 	}
-
-	/**
-	 * Keep the action immediately below the last visible selected row, while
-	 * clamping it beneath the sticky table heading and inside the viewport.
-	 */
-	function positionComparisonAction(): void {
-		if (!comparisonTableElement || !comparisonActionElement) return;
-
-		const selectedRows = comparisonTableElement.querySelectorAll<HTMLTableRowElement>('tbody tr.selected');
-		const lastSelectedRow = selectedRows.item(selectedRows.length - 1);
-		const headerBottom = comparisonTableElement.querySelector('thead th')?.getBoundingClientRect().bottom ?? 0;
-		const actionHeight = comparisonActionElement.getBoundingClientRect().height;
-		const gap = 8;
-		const minimumTop = Math.max(0, headerBottom) + gap;
-		const maximumTop = Math.max(minimumTop, window.innerHeight - actionHeight - 16);
-		const naturalTop = lastSelectedRow ? lastSelectedRow.getBoundingClientRect().bottom + gap : maximumTop;
-
-		comparisonActionTop = Math.min(Math.max(naturalTop, minimumTop), maximumTop);
-	}
-
-	$effect(() => {
-		if (selectedVaultIds.length === 0) {
-			comparisonActionTop = undefined;
-			return;
-		}
-
-		let disposed = false;
-		const updatePosition = () => {
-			if (!disposed) positionComparisonAction();
-		};
-		void tick().then(updatePosition);
-		window.addEventListener('scroll', updatePosition, { passive: true });
-		window.addEventListener('resize', updatePosition);
-		const resizeObserver = new ResizeObserver(updatePosition);
-		if (comparisonTableElement) resizeObserver.observe(comparisonTableElement);
-		if (comparisonActionElement) resizeObserver.observe(comparisonActionElement);
-
-		return () => {
-			disposed = true;
-			window.removeEventListener('scroll', updatePosition);
-			window.removeEventListener('resize', updatePosition);
-			resizeObserver.disconnect();
-		};
-	});
 
 	// --- Sort column registry (key → default direction) ---
 
@@ -1084,21 +1038,22 @@ The AMM checkbox hides AMM pools and AMM-like vaults on listings with Filters.
 {/snippet}
 
 {#snippet comparisonAction()}
-	<div
-		bind:this={comparisonActionElement}
-		class="compare-vaults-action"
-		data-testid="compare-vaults-action"
-		style:top={comparisonActionTop == null ? undefined : `${comparisonActionTop}px`}
-	>
-		<p id="vault-comparison-selection-status" role="status" class:sr-only={!selectionLimitReached}>
-			{selectionLimitReached ? `You can compare up to ${MAX_SELECTED_VAULTS} vaults.` : ''}
-		</p>
-		<Button href={comparisonHref} size="md" class="compare-vaults-button">
-			Compare vaults
-			<span class="comparison-selection-count" aria-hidden="true">{selectedVaultIds.length}</span>
-			<span class="sr-only">{selectedVaultIds.length} selected vault{selectedVaultIds.length === 1 ? '' : 's'}</span>
-		</Button>
-	</div>
+	<tr class="compare-vaults-action-row">
+		<td
+			class="compare-vaults-action"
+			data-testid="compare-vaults-action"
+			colspan={12 + selectedReturnColumns.length + (showChainCol ? 1 : 0) + (showProviderRiskRating ? 1 : 0)}
+		>
+			<p id="vault-comparison-selection-status" role="status" class:sr-only={!selectionLimitReached}>
+				{selectionLimitReached ? `You can compare up to ${MAX_SELECTED_VAULTS} vaults.` : ''}
+			</p>
+			<Button href={comparisonHref} size="md" class="compare-vaults-button">
+				Compare vaults
+				<span class="comparison-selection-count" aria-hidden="true">{selectedVaultIds.length}</span>
+				<span class="sr-only">{selectedVaultIds.length} selected vault{selectedVaultIds.length === 1 ? '' : 's'}</span>
+			</Button>
+		</td>
+	</tr>
 {/snippet}
 
 <div class="top-vaults-table">
@@ -1495,10 +1450,9 @@ The AMM checkbox hides AMM pools and AMM-like vaults on listings with Filters.
 		{/if}
 	</div>
 
-	<div class="table-wrapper" class:comparison-selection-active={allowVaultComparison && selectedVaultIds.length > 0}>
+	<div class="table-wrapper">
 		<!-- --table-width needed for proper tr.targetable styling  -->
 		<table
-			bind:this={comparisonTableElement}
 			bind:offsetWidth
 			style:--table-width="{offsetWidth}px"
 			class:loading
@@ -1717,7 +1671,13 @@ The AMM checkbox hides AMM pools and AMM-like vaults on listings with Filters.
 							<TargetableLink label="View {vault.name} details" href={resolveVaultDetails(vault)} class="row-link" />
 						</td>
 					</tr>
+					{#if allowVaultComparison && selectedVaultIds.length > 0 && vault.id === lastSelectedVaultId}
+						{@render comparisonAction()}
+					{/if}
 				{/each}
+				{#if allowVaultComparison && selectedVaultIds.length > 0 && !visibleVaults.some((vault) => vault.id === lastSelectedVaultId)}
+					{@render comparisonAction()}
+				{/if}
 				{#if hasMoreRows}
 					<tr class="load-more-sentinel" data-testid="load-more-sentinel">
 						<td colspan={12 + selectedReturnColumns.length + (showChainCol ? 1 : 0) + (showProviderRiskRating ? 1 : 0)}>
@@ -1731,10 +1691,6 @@ The AMM checkbox hides AMM pools and AMM-like vaults on listings with Filters.
 			</tbody>
 		</table>
 	</div>
-
-	{#if allowVaultComparison && selectedVaultIds.length > 0}
-		{@render comparisonAction()}
-	{/if}
 
 	{#if hiddenBlacklistedCount > 0 && !remoteHasMore}
 		<button
@@ -1754,14 +1710,18 @@ The AMM checkbox hides AMM pools and AMM-like vaults on listings with Filters.
 		display: grid;
 		gap: 1rem;
 
-		.compare-vaults-action {
-			position: fixed;
-			z-index: 20;
-			display: grid;
-			justify-items: start;
-			gap: var(--space-xs);
-			left: max(env(safe-area-inset-left), calc((100% - var(--SECTION-width, calc(100% - (2 * var(--space-lg))))) / 2));
-			padding-bottom: env(safe-area-inset-bottom);
+		.compare-vaults-action-row .compare-vaults-action {
+			position: sticky;
+			top: 3.75rem;
+			z-index: 2;
+			padding: var(--space-sm) var(--space-md);
+			background: var(--c-body) !important;
+			box-shadow: 0 0.5rem 1rem color-mix(in srgb, var(--c-shadow), transparent 88%);
+			text-align: left;
+
+			@media (--viewport-sm-down) {
+				top: 3.25rem;
+			}
 
 			p {
 				margin: 0;
@@ -2176,10 +2136,6 @@ The AMM checkbox hides AMM pools and AMM-like vaults on listings with Filters.
 
 		.table-wrapper {
 			width: 100%;
-
-			&.comparison-selection-active {
-				padding-bottom: calc(var(--space-lg) + 7rem);
-			}
 
 			/*
 				Setting overflow:auto breaks the sticky header, but is needed to allow horizontal scrolling

--- a/src/lib/top-vaults/TopVaultsTable.test.ts
+++ b/src/lib/top-vaults/TopVaultsTable.test.ts
@@ -1,4 +1,4 @@
-import { cleanup, render, screen } from '@testing-library/svelte';
+import { cleanup, fireEvent, render, screen } from '@testing-library/svelte';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { getChain } from '$lib/helpers/chain';
 import TopVaultsTable from './TopVaultsTable.svelte';
@@ -21,6 +21,15 @@ vi.mock('$lib/vault-protocol/helpers', () => ({
 
 function getRenderedVaultNames() {
 	return Array.from(document.querySelectorAll('tbody tr td.vault strong')).map((element) => element.textContent);
+}
+
+function getTopVaults(...vaults: ReturnType<typeof createTestVault>[]) {
+	return {
+		generated_at: '2026-07-30T11:30:40Z',
+		vaults,
+		core3_protocols: {},
+		curators: {}
+	};
 }
 
 describe('TopVaultsTable risk rating column', () => {
@@ -176,5 +185,76 @@ describe('TopVaultsTable risk rating column', () => {
 
 		expect(curatorLogo?.src).toBe('https://example.com/curator-logo.svg');
 		expect(protocolLogo?.src).toBe('https://example.com/protocol/aave.svg');
+	});
+});
+
+describe('TopVaultsTable comparison selection', () => {
+	it('selects vaults from the rank cell and builds the ordered comparison URL', async () => {
+		const firstVault = createTestVault('First comparison vault', {
+			address: '0x0000000000000000000000000000000000000001'
+		});
+		const secondVault = createTestVault('Second comparison vault', {
+			address: '0x0000000000000000000000000000000000000002'
+		});
+
+		render(TopVaultsTable, { props: { topVaults: getTopVaults(firstVault, secondVault) } });
+
+		const firstCheckbox = screen.getByRole('checkbox', { name: 'Select First comparison vault for comparison' });
+		const secondCheckbox = screen.getByRole('checkbox', { name: 'Select Second comparison vault for comparison' });
+		expect(firstCheckbox.closest('td')).toHaveClass('index');
+		expect(firstCheckbox.closest('label')).toHaveClass('targetable-above');
+
+		await fireEvent.click(secondCheckbox);
+		await fireEvent.click(firstCheckbox);
+
+		expect(secondCheckbox).toBeChecked();
+		expect(firstCheckbox).toBeChecked();
+		expect(firstCheckbox.closest('tr')).toHaveClass('selected');
+		expect(secondCheckbox.closest('tr')).toHaveClass('selected');
+
+		const compareActionContainer = screen.getByTestId('compare-vaults-action');
+		const compareAction = compareActionContainer.querySelector<HTMLAnchorElement>('a');
+		expect(compareAction).not.toBeNull();
+		expect(screen.getByRole('link', { name: 'Compare vaults 2 selected vaults' })).toBe(compareAction);
+		const searchParams = new URL(compareAction!.href).searchParams;
+		expect(searchParams.getAll('vault')).toEqual([secondVault.id, firstVault.id]);
+		expect(searchParams.get('period')).toBe('3M');
+		expect(searchParams.has('benchmark')).toBe(false);
+
+		await fireEvent.click(firstCheckbox);
+		await fireEvent.click(secondCheckbox);
+		expect(screen.queryByTestId('compare-vaults-action')).not.toBeInTheDocument();
+	});
+
+	it('keeps unchecked controls focusable but unavailable once the comparison limit is reached', async () => {
+		const vaults = Array.from({ length: 9 }, (_, index) =>
+			createTestVault(`Comparison vault ${index + 1}`, {
+				address: `0x${String(index + 1).padStart(40, '0')}`
+			})
+		);
+		render(TopVaultsTable, { props: { topVaults: getTopVaults(...vaults) } });
+
+		const checkboxes = screen.getAllByRole('checkbox');
+		for (const checkbox of checkboxes.slice(0, 8)) await fireEvent.click(checkbox);
+
+		const unavailableCheckbox = checkboxes[8];
+		expect(unavailableCheckbox).toHaveAttribute('aria-disabled', 'true');
+		expect(unavailableCheckbox).not.toBeDisabled();
+		expect(screen.getByRole('status')).toHaveTextContent('You can compare up to 8 vaults.');
+		expect(screen.getByRole('link', { name: 'Compare vaults 8 selected vaults' })).toBeInTheDocument();
+
+		await fireEvent.click(unavailableCheckbox);
+		expect(unavailableCheckbox).not.toBeChecked();
+		expect(screen.getByTestId('compare-vaults-action')).toHaveTextContent('8');
+	});
+
+	it('can disable comparison selection for embedded summary tables', () => {
+		const vault = createTestVault('Embedded comparison vault');
+		render(TopVaultsTable, {
+			props: { topVaults: getTopVaults(vault), allowVaultComparison: false }
+		});
+
+		expect(screen.queryByRole('checkbox', { name: /Select .* for comparison/ })).not.toBeInTheDocument();
+		expect(screen.queryByTestId('compare-vaults-action')).not.toBeInTheDocument();
 	});
 });

--- a/src/lib/top-vaults/TopVaultsTable.test.ts
+++ b/src/lib/top-vaults/TopVaultsTable.test.ts
@@ -32,6 +32,14 @@ function getTopVaults(...vaults: ReturnType<typeof createTestVault>[]) {
 	};
 }
 
+const completeNetFees = {
+	fee_mode: 'feeless',
+	management: null,
+	performance: null,
+	deposit: null,
+	withdraw: null
+} as const;
+
 describe('TopVaultsTable risk rating column', () => {
 	it('shows the blacklisted-vault reveal control when the server summary reports hidden vaults', () => {
 		const safeVault = createTestVault('Safe vault', { risk: 'Low' });
@@ -191,7 +199,8 @@ describe('TopVaultsTable risk rating column', () => {
 describe('TopVaultsTable comparison selection', () => {
 	it('selects vaults from the rank cell and builds the ordered comparison URL', async () => {
 		const firstVault = createTestVault('First comparison vault', {
-			address: '0x0000000000000000000000000000000000000001'
+			address: '0x0000000000000000000000000000000000000001',
+			net_fees: completeNetFees
 		});
 		const secondVault = createTestVault('Second comparison vault', {
 			address: '0x0000000000000000000000000000000000000002'
@@ -215,14 +224,18 @@ describe('TopVaultsTable comparison selection', () => {
 		const compareActionContainer = screen.getByTestId('compare-vaults-action');
 		const compareAction = compareActionContainer.querySelector<HTMLAnchorElement>('a');
 		expect(compareAction).not.toBeNull();
+		expect(compareActionContainer.closest('tr')?.previousElementSibling).toBe(firstCheckbox.closest('tr'));
+		expect(Number(compareActionContainer.getAttribute('colspan'))).toBe(document.querySelectorAll('thead th').length);
 		expect(screen.getByRole('link', { name: 'Compare vaults 2 selected vaults' })).toBe(compareAction);
 		const searchParams = new URL(compareAction!.href).searchParams;
 		expect(searchParams.getAll('vault')).toEqual([secondVault.id, firstVault.id]);
 		expect(searchParams.get('period')).toBe('3M');
+		expect(searchParams.get('return')).toBe('gross');
 		expect(searchParams.has('benchmark')).toBe(false);
 
-		await fireEvent.click(firstCheckbox);
 		await fireEvent.click(secondCheckbox);
+		expect(new URL(compareAction!.href).searchParams.get('return')).toBe('net');
+		await fireEvent.click(firstCheckbox);
 		expect(screen.queryByTestId('compare-vaults-action')).not.toBeInTheDocument();
 	});
 
@@ -234,7 +247,7 @@ describe('TopVaultsTable comparison selection', () => {
 		);
 		render(TopVaultsTable, { props: { topVaults: getTopVaults(...vaults) } });
 
-		const checkboxes = screen.getAllByRole('checkbox');
+		const checkboxes = screen.getAllByRole('checkbox', { name: /for comparison$/ });
 		for (const checkbox of checkboxes.slice(0, 8)) await fireEvent.click(checkbox);
 
 		const unavailableCheckbox = checkboxes[8];
@@ -246,6 +259,38 @@ describe('TopVaultsTable comparison selection', () => {
 		await fireEvent.click(unavailableCheckbox);
 		expect(unavailableCheckbox).not.toBeChecked();
 		expect(screen.getByTestId('compare-vaults-action')).toHaveTextContent('8');
+	});
+
+	it('resets selection only when the listing identity changes', async () => {
+		const vault = createTestVault('Listing identity vault', { net_fees: completeNetFees });
+		const topVaults = getTopVaults(vault);
+		const { rerender } = render(TopVaultsTable, {
+			props: { topVaults, listingKey: 'protocol', listingScope: 'first-protocol' }
+		});
+		const checkbox = screen.getByRole('checkbox', { name: 'Select Listing identity vault for comparison' });
+
+		await fireEvent.click(checkbox);
+		expect(
+			new URL(
+				screen.getByRole('link', { name: /Compare vaults/ }).getAttribute('href')!,
+				document.baseURI
+			).searchParams.get('return')
+		).toBe('net');
+
+		await rerender({ topVaults: getTopVaults(), listingKey: 'protocol', listingScope: 'first-protocol' });
+		expect(
+			new URL(
+				screen.getByRole('link', { name: /Compare vaults/ }).getAttribute('href')!,
+				document.baseURI
+			).searchParams.get('return')
+		).toBe('gross');
+
+		await rerender({ topVaults, listingKey: 'protocol', listingScope: 'first-protocol' });
+		expect(screen.getByRole('checkbox', { name: 'Select Listing identity vault for comparison' })).toBeChecked();
+
+		await rerender({ topVaults, listingKey: 'protocol', listingScope: 'second-protocol' });
+		expect(screen.getByRole('checkbox', { name: 'Select Listing identity vault for comparison' })).not.toBeChecked();
+		expect(screen.queryByTestId('compare-vaults-action')).not.toBeInTheDocument();
 	});
 
 	it('can disable comparison selection for embedded summary tables', () => {

--- a/src/routes/vaults/compare/+page.svelte
+++ b/src/routes/vaults/compare/+page.svelte
@@ -407,6 +407,7 @@ Compare selected vault equity curves and fixed market benchmarks on one indexed 
 				<h2 id="selected-comparison-heading">Selected vault comparison</h2>
 				<TopVaultsTable
 					topVaults={data.selectedTopVaults}
+					allowVaultComparison={false}
 					includeBlacklisted
 					defaultHideUnknown={0}
 					tvlTriggerLabel="Selected vaults"

--- a/tests/integration/vaults/equity-compare.test.ts
+++ b/tests/integration/vaults/equity-compare.test.ts
@@ -160,6 +160,8 @@ test.describe('vault equity curve comparison page', () => {
 		await expect(selectedVaults.locator('li')).toHaveCount(1);
 		await expect(selectedVaults).toContainText('Savings USDS');
 		await expect(page.getByRole('radio', { name: 'Net' })).toBeChecked();
+		await expect(page.locator('.selected-comparison-table').getByTestId('vault-comparison-checkbox')).toHaveCount(0);
+		await expect(page.locator('.selected-comparison-table').getByTestId('compare-vaults-action')).toHaveCount(0);
 		await expect(selectedVaults).toContainText('21.3% CAGR');
 		await expect(selectedVaults).toContainText('Since 2024-12-26');
 		await expect(page.getByRole('checkbox', { name: 'T-Bill' })).toBeChecked();

--- a/tests/integration/vaults/index.test.ts
+++ b/tests/integration/vaults/index.test.ts
@@ -242,24 +242,20 @@ async function expectLifetimeDataTooltip(
 }
 
 /**
- * Read the Compare vaults action position relative to the selected row and sticky table heading.
+ * Read the Compare vaults action row position relative to the sticky table heading.
  */
 async function getCompareActionPlacement(page: import('@playwright/test').Page) {
 	return page.evaluate(() => {
 		const action = document.querySelector<HTMLElement>('[data-testid="compare-vaults-action"]');
 		const table = document.querySelector<HTMLTableElement>('.table-wrapper table');
-		const selectedRows = table?.querySelectorAll<HTMLTableRowElement>('tbody tr.selected');
-		const lastSelectedRow = selectedRows?.item((selectedRows.length ?? 1) - 1);
+		const actionRow = action?.closest('tr');
+		const precedingRow = actionRow?.previousElementSibling;
 		const header = table?.querySelector('thead th');
-		if (!action || !lastSelectedRow || !header)
-			throw new Error('Expected comparison action, selected row, and table heading');
+		if (!action || !actionRow || !precedingRow || !header)
+			throw new Error('Expected comparison action row and table heading');
 
 		const actionBounds = action.getBoundingClientRect();
-		const rowBounds = lastSelectedRow.getBoundingClientRect();
 		const headerBounds = header.getBoundingClientRect();
-		const gap = 8;
-		const minimumTop = Math.max(0, headerBounds.bottom) + gap;
-		const maximumTop = Math.max(minimumTop, innerHeight - actionBounds.height - 16);
 
 		return {
 			position: getComputedStyle(action).position,
@@ -268,7 +264,7 @@ async function getCompareActionPlacement(page: import('@playwright/test').Page) 
 			actionLeft: actionBounds.left,
 			tableLeft: table.getBoundingClientRect().left,
 			headerBottom: headerBounds.bottom,
-			expectedTop: Math.min(Math.max(rowBounds.bottom + gap, minimumTop), maximumTop)
+			followsSelectedRow: precedingRow.classList.contains('selected')
 		};
 	});
 }
@@ -319,25 +315,20 @@ test.describe('vault index page', () => {
 			).not.toBe(unselectedBackground);
 
 			const action = page.getByTestId('compare-vaults-action');
+			await action.scrollIntoViewIfNeeded();
 			await expect(action).toBeVisible();
 			const actionLayout = await getCompareActionPlacement(page);
-			expect(actionLayout.position).toBe('fixed');
+			expect(actionLayout.position).toBe('sticky');
 			expect(Math.abs(actionLayout.actionLeft - actionLayout.tableLeft)).toBeLessThan(1);
 			expect(actionLayout.actionBottom).toBeLessThanOrEqual(viewport.height);
 			expect(actionLayout.actionTop).toBeGreaterThanOrEqual(0);
-			expect(Math.abs(actionLayout.actionTop - actionLayout.expectedTop)).toBeLessThan(2);
+			expect(actionLayout.followsSelectedRow).toBe(true);
 
 			await page.evaluate(() => window.scrollTo(0, document.documentElement.scrollHeight));
 			await expect(action).toBeVisible();
-			await expect
-				.poll(async () => {
-					const layout = await getCompareActionPlacement(page);
-					return Math.abs(layout.actionTop - layout.expectedTop);
-				})
-				.toBeLessThan(2);
 			const stickyActionLayout = await getCompareActionPlacement(page);
-			expect(stickyActionLayout.position).toBe('fixed');
-			expect(stickyActionLayout.actionTop).toBeGreaterThanOrEqual(stickyActionLayout.headerBottom + 7);
+			expect(stickyActionLayout.position).toBe('sticky');
+			expect(stickyActionLayout.actionTop).toBeGreaterThanOrEqual(stickyActionLayout.headerBottom);
 
 			await checkbox.click();
 			await expect(action).not.toBeVisible();
@@ -363,9 +354,9 @@ test.describe('vault index page', () => {
 		const action = page.getByTestId('compare-vaults-action');
 		await expect(action).toBeVisible();
 		const actionLayout = await getCompareActionPlacement(page);
-		expect(actionLayout.position).toBe('fixed');
+		expect(actionLayout.position).toBe('sticky');
 		expect(Math.abs(actionLayout.actionLeft - actionLayout.tableLeft)).toBeLessThan(1);
-		expect(Math.abs(actionLayout.actionTop - actionLayout.expectedTop)).toBeLessThan(2);
+		expect(actionLayout.followsSelectedRow).toBe(true);
 		const compareLink = action.getByRole('link', { name: /Compare vaults/ });
 		const destination = new URL((await compareLink.getAttribute('href'))!, page.url());
 		expect(destination.pathname).toBe('/vaults/compare');

--- a/tests/integration/vaults/index.test.ts
+++ b/tests/integration/vaults/index.test.ts
@@ -261,6 +261,87 @@ test.describe('vault index page', () => {
 		);
 	});
 
+	for (const viewport of [
+		{ name: 'tablet', width: 1024, height: 768 },
+		{ name: 'mobile', width: 375, height: 667 }
+	]) {
+		test(`selects vaults for comparison in the ${viewport.name} viewport`, async ({ page }) => {
+			await page.setViewportSize({ width: viewport.width, height: viewport.height });
+			await page.goto('/vaults');
+
+			const checkbox = page.getByTestId('vault-comparison-checkbox').first();
+			const row = checkbox.locator('xpath=ancestor::tr');
+			const unselectedBackground = await row
+				.locator('td')
+				.first()
+				.evaluate((cell) => getComputedStyle(cell).backgroundColor);
+			await expect(checkbox).toBeVisible();
+			await checkbox.click();
+			await expect(checkbox).toBeChecked();
+			await expect(row).toHaveClass(/selected/);
+			expect(
+				await row
+					.locator('td')
+					.first()
+					.evaluate((cell) => getComputedStyle(cell).backgroundColor)
+			).not.toBe(unselectedBackground);
+
+			const action = page.getByTestId('compare-vaults-action');
+			await expect(action).toBeVisible();
+			const actionLayout = await action.evaluate((element) => {
+				const actionBounds = element.getBoundingClientRect();
+				const tableWrapperBounds = document.querySelector('.table-wrapper')!.getBoundingClientRect();
+				return {
+					position: getComputedStyle(element).position,
+					actionAlignedWithTable: Math.abs(actionBounds.left - tableWrapperBounds.left) < 1,
+					actionFitsViewport:
+						actionBounds.left >= 0 && actionBounds.right <= innerWidth && actionBounds.bottom <= innerHeight
+				};
+			});
+			expect(actionLayout.position).toBe('fixed');
+			expect(actionLayout.actionAlignedWithTable).toBe(true);
+			expect(actionLayout.actionFitsViewport).toBe(true);
+
+			await page.evaluate(() => window.scrollBy(0, 800));
+			await expect(action).toBeVisible();
+			expect(await action.evaluate((element) => getComputedStyle(element).position)).toBe('fixed');
+
+			await checkbox.click();
+			await expect(action).not.toBeVisible();
+		});
+	}
+
+	test('compares the two highest-ranked vaults from the top of the list', async ({ page }) => {
+		await page.setViewportSize({ width: 1440, height: 900 });
+		await page.goto('/vaults');
+
+		const firstCheckbox = page.getByTestId('vault-comparison-checkbox').first();
+		const secondCheckbox = page.getByTestId('vault-comparison-checkbox').nth(1);
+		const firstRow = firstCheckbox.locator('xpath=ancestor::tr');
+		const secondRow = secondCheckbox.locator('xpath=ancestor::tr');
+		const firstVaultName = await firstRow.locator('td.vault strong').textContent();
+		const secondVaultName = await secondRow.locator('td.vault strong').textContent();
+
+		await firstCheckbox.click();
+		await secondCheckbox.click();
+		await expect(firstCheckbox).toBeChecked();
+		await expect(secondCheckbox).toBeChecked();
+
+		const action = page.getByTestId('compare-vaults-action');
+		await expect(action).toBeVisible();
+		const compareLink = action.getByRole('link', { name: /Compare vaults/ });
+		const destination = new URL((await compareLink.getAttribute('href'))!, page.url());
+		expect(destination.pathname).toBe('/vaults/compare');
+		expect(destination.searchParams.getAll('vault')).toHaveLength(2);
+		expect(destination.searchParams.get('period')).toBe('3M');
+
+		await compareLink.click();
+		await expect(page).toHaveURL(/\/vaults\/compare\?.*vault=.*vault=/);
+		const selectedVaults = page.getByRole('list', { name: 'Selected vaults' });
+		await expect(selectedVaults).toContainText(firstVaultName ?? '');
+		await expect(selectedVaults).toContainText(secondVaultName ?? '');
+	});
+
 	test('updates the ranking description when the table sort changes', async ({ page }) => {
 		await page.locator('th.tvl button').click();
 

--- a/tests/integration/vaults/index.test.ts
+++ b/tests/integration/vaults/index.test.ts
@@ -241,32 +241,17 @@ async function expectLifetimeDataTooltip(
 	await expect(popup).toContainText(`Days of data: ${totalDays}`);
 }
 
-/**
- * Read the Compare vaults action row position relative to the sticky table heading.
- */
-async function getCompareActionPlacement(page: import('@playwright/test').Page) {
-	return page.evaluate(() => {
-		const action = document.querySelector<HTMLElement>('[data-testid="compare-vaults-action"]');
-		const table = document.querySelector<HTMLTableElement>('.table-wrapper table');
-		const actionRow = action?.closest('tr');
-		const precedingRow = actionRow?.previousElementSibling;
-		const header = table?.querySelector('thead th');
-		if (!action || !actionRow || !precedingRow || !header)
-			throw new Error('Expected comparison action row and table heading');
+/** Verify that the comparison action occupies its own row after the latest selection. */
+async function expectCompareActionPlacement(page: import('@playwright/test').Page) {
+	const action = page.getByTestId('compare-vaults-action');
+	const actionRow = action.locator('xpath=ancestor::tr');
+	await expect(actionRow.locator('xpath=preceding-sibling::tr[1]')).toHaveClass(/selected/);
 
-		const actionBounds = action.getBoundingClientRect();
-		const headerBounds = header.getBoundingClientRect();
-
-		return {
-			position: getComputedStyle(action).position,
-			actionTop: actionBounds.top,
-			actionBottom: actionBounds.bottom,
-			actionLeft: actionBounds.left,
-			tableLeft: table.getBoundingClientRect().left,
-			headerBottom: headerBounds.bottom,
-			followsSelectedRow: precedingRow.classList.contains('selected')
-		};
-	});
+	const actionBounds = await action.boundingBox();
+	const tableBounds = await page.locator('.table-wrapper table').boundingBox();
+	expect(actionBounds).not.toBeNull();
+	expect(tableBounds).not.toBeNull();
+	expect(Math.abs(actionBounds!.x - tableBounds!.x)).toBeLessThan(1);
 }
 
 test.describe('vault index page', () => {
@@ -317,18 +302,8 @@ test.describe('vault index page', () => {
 			const action = page.getByTestId('compare-vaults-action');
 			await action.scrollIntoViewIfNeeded();
 			await expect(action).toBeVisible();
-			const actionLayout = await getCompareActionPlacement(page);
-			expect(actionLayout.position).toBe('sticky');
-			expect(Math.abs(actionLayout.actionLeft - actionLayout.tableLeft)).toBeLessThan(1);
-			expect(actionLayout.actionBottom).toBeLessThanOrEqual(viewport.height);
-			expect(actionLayout.actionTop).toBeGreaterThanOrEqual(0);
-			expect(actionLayout.followsSelectedRow).toBe(true);
-
-			await page.evaluate(() => window.scrollTo(0, document.documentElement.scrollHeight));
-			await expect(action).toBeVisible();
-			const stickyActionLayout = await getCompareActionPlacement(page);
-			expect(stickyActionLayout.position).toBe('sticky');
-			expect(stickyActionLayout.actionTop).toBeGreaterThanOrEqual(stickyActionLayout.headerBottom);
+			await expectCompareActionPlacement(page);
+			expect(await page.evaluate(() => document.documentElement.scrollWidth <= window.innerWidth)).toBe(true);
 
 			await checkbox.click();
 			await expect(action).not.toBeVisible();
@@ -336,7 +311,7 @@ test.describe('vault index page', () => {
 	}
 
 	test('compares the two highest-ranked vaults from the top of the list', async ({ page }) => {
-		await page.setViewportSize({ width: 1440, height: 900 });
+		await page.setViewportSize({ width: 1600, height: 900 });
 		await page.goto('/vaults');
 
 		const firstCheckbox = page.getByTestId('vault-comparison-checkbox').first();
@@ -353,18 +328,17 @@ test.describe('vault index page', () => {
 
 		const action = page.getByTestId('compare-vaults-action');
 		await expect(action).toBeVisible();
-		const actionLayout = await getCompareActionPlacement(page);
-		expect(actionLayout.position).toBe('sticky');
-		expect(Math.abs(actionLayout.actionLeft - actionLayout.tableLeft)).toBeLessThan(1);
-		expect(actionLayout.followsSelectedRow).toBe(true);
+		await expectCompareActionPlacement(page);
 		const compareLink = action.getByRole('link', { name: /Compare vaults/ });
 		const destination = new URL((await compareLink.getAttribute('href'))!, page.url());
 		expect(destination.pathname).toBe('/vaults/compare');
 		expect(destination.searchParams.getAll('vault')).toHaveLength(2);
 		expect(destination.searchParams.get('period')).toBe('3M');
+		expect(destination.searchParams.get('return')).toBe('gross');
 
 		await compareLink.click();
 		await expect(page).toHaveURL(/\/vaults\/compare\?.*vault=.*vault=/);
+		expect(new URL(page.url()).searchParams.get('return')).toBe(destination.searchParams.get('return'));
 		const selectedVaults = page.getByRole('list', { name: 'Selected vaults' });
 		await expect(selectedVaults).toContainText(firstVaultName ?? '');
 		await expect(selectedVaults).toContainText(secondVaultName ?? '');

--- a/tests/integration/vaults/index.test.ts
+++ b/tests/integration/vaults/index.test.ts
@@ -241,6 +241,38 @@ async function expectLifetimeDataTooltip(
 	await expect(popup).toContainText(`Days of data: ${totalDays}`);
 }
 
+/**
+ * Read the Compare vaults action position relative to the selected row and sticky table heading.
+ */
+async function getCompareActionPlacement(page: import('@playwright/test').Page) {
+	return page.evaluate(() => {
+		const action = document.querySelector<HTMLElement>('[data-testid="compare-vaults-action"]');
+		const table = document.querySelector<HTMLTableElement>('.table-wrapper table');
+		const selectedRows = table?.querySelectorAll<HTMLTableRowElement>('tbody tr.selected');
+		const lastSelectedRow = selectedRows?.item((selectedRows.length ?? 1) - 1);
+		const header = table?.querySelector('thead th');
+		if (!action || !lastSelectedRow || !header)
+			throw new Error('Expected comparison action, selected row, and table heading');
+
+		const actionBounds = action.getBoundingClientRect();
+		const rowBounds = lastSelectedRow.getBoundingClientRect();
+		const headerBounds = header.getBoundingClientRect();
+		const gap = 8;
+		const minimumTop = Math.max(0, headerBounds.bottom) + gap;
+		const maximumTop = Math.max(minimumTop, innerHeight - actionBounds.height - 16);
+
+		return {
+			position: getComputedStyle(action).position,
+			actionTop: actionBounds.top,
+			actionBottom: actionBounds.bottom,
+			actionLeft: actionBounds.left,
+			tableLeft: table.getBoundingClientRect().left,
+			headerBottom: headerBounds.bottom,
+			expectedTop: Math.min(Math.max(rowBounds.bottom + gap, minimumTop), maximumTop)
+		};
+	});
+}
+
 test.describe('vault index page', () => {
 	test.beforeEach(async ({ page }) => {
 		await page.goto('/vaults');
@@ -288,23 +320,24 @@ test.describe('vault index page', () => {
 
 			const action = page.getByTestId('compare-vaults-action');
 			await expect(action).toBeVisible();
-			const actionLayout = await action.evaluate((element) => {
-				const actionBounds = element.getBoundingClientRect();
-				const tableWrapperBounds = document.querySelector('.table-wrapper')!.getBoundingClientRect();
-				return {
-					position: getComputedStyle(element).position,
-					actionAlignedWithTable: Math.abs(actionBounds.left - tableWrapperBounds.left) < 1,
-					actionFitsViewport:
-						actionBounds.left >= 0 && actionBounds.right <= innerWidth && actionBounds.bottom <= innerHeight
-				};
-			});
+			const actionLayout = await getCompareActionPlacement(page);
 			expect(actionLayout.position).toBe('fixed');
-			expect(actionLayout.actionAlignedWithTable).toBe(true);
-			expect(actionLayout.actionFitsViewport).toBe(true);
+			expect(Math.abs(actionLayout.actionLeft - actionLayout.tableLeft)).toBeLessThan(1);
+			expect(actionLayout.actionBottom).toBeLessThanOrEqual(viewport.height);
+			expect(actionLayout.actionTop).toBeGreaterThanOrEqual(0);
+			expect(Math.abs(actionLayout.actionTop - actionLayout.expectedTop)).toBeLessThan(2);
 
-			await page.evaluate(() => window.scrollBy(0, 800));
+			await page.evaluate(() => window.scrollTo(0, document.documentElement.scrollHeight));
 			await expect(action).toBeVisible();
-			expect(await action.evaluate((element) => getComputedStyle(element).position)).toBe('fixed');
+			await expect
+				.poll(async () => {
+					const layout = await getCompareActionPlacement(page);
+					return Math.abs(layout.actionTop - layout.expectedTop);
+				})
+				.toBeLessThan(2);
+			const stickyActionLayout = await getCompareActionPlacement(page);
+			expect(stickyActionLayout.position).toBe('fixed');
+			expect(stickyActionLayout.actionTop).toBeGreaterThanOrEqual(stickyActionLayout.headerBottom + 7);
 
 			await checkbox.click();
 			await expect(action).not.toBeVisible();
@@ -329,6 +362,10 @@ test.describe('vault index page', () => {
 
 		const action = page.getByTestId('compare-vaults-action');
 		await expect(action).toBeVisible();
+		const actionLayout = await getCompareActionPlacement(page);
+		expect(actionLayout.position).toBe('fixed');
+		expect(Math.abs(actionLayout.actionLeft - actionLayout.tableLeft)).toBeLessThan(1);
+		expect(Math.abs(actionLayout.actionTop - actionLayout.expectedTop)).toBeLessThan(2);
 		const compareLink = action.getByRole('link', { name: /Compare vaults/ });
 		const destination = new URL((await compareLink.getAttribute('href'))!, page.url());
 		expect(destination.pathname).toBe('/vaults/compare');


### PR DESCRIPTION
## Why

Vault listings need a direct way to compare several candidates without manually finding each vault again on the comparison page. The selection and action must remain usable across desktop, tablet, and mobile layouts without covering table content.

## Lessons learnt

A comparison action that follows the latest selection belongs in its own table row and should scroll naturally with the listing. Comparison URLs must choose a return mode that every selected, currently loaded vault can support, while missing records require a conservative Gross fallback. Accessibility announcements must live outside the moving action row so they are not remounted on every selection.

## Summary

- Add accessible rank-column checkboxes for selecting and highlighting up to eight vaults.
- Render Compare vaults in a dedicated row after the most recently selected vault and prefill the comparison page in selection order.
- Preserve local selection across listing updates, reset it for a new listing identity, and select a compatible Gross or Net return mode.
- Update component and Playwright coverage, the implementation plan, theme guidance, and vault-listing documentation.
