### PR TITLE
fix: align vault comparison returns per period

### DIFF
--- a/docs/chart-pages.md
+++ b/docs/chart-pages.md
@@ -58,13 +58,12 @@ series are unchanged by the return mode.
 The T-bill line uses FRED's DGS3MO 3-month constant-maturity Treasury market
 yield, quoted on an investment basis, as a cumulative-return approximation.
 
-The chart is labelled **Vault returns index**. The oldest selected vault starts
-at 100; each younger vault starts at the highest older curve that overlaps its
-first observation. A non-overlapping history starts at 100 and is marked in the
-legend. The 1M, 3M, 6M, 1Y, and Max controls drive both the visible range and
-the CAGR/Since values shown on selected-vault cards. T-bill, ETH, and BTC use
-fixed colours, while vaults receive stable, distinct colours for the current
-selection.
+The chart is labelled **Returns index**. Every displayed series is
+rebased to 100 at the beginning of the selected period; a vault without an
+observation at that boundary begins at its first plotted observation. The 1M,
+3M, 6M, 1Y, and Max controls drive both the visible range and the CAGR/Since
+values shown on selected-vault cards. T-bill, ETH, and BTC use fixed colours,
+while vaults receive stable, distinct colours for the current selection.
 
 ## Data flow
 

--- a/docs/chart-pages.md
+++ b/docs/chart-pages.md
@@ -58,12 +58,13 @@ series are unchanged by the return mode.
 The T-bill line uses FRED's DGS3MO 3-month constant-maturity Treasury market
 yield, quoted on an investment basis, as a cumulative-return approximation.
 
-The chart is labelled **Returns index**. Every displayed series is
-rebased to 100 at the beginning of the selected period; a vault without an
-observation at that boundary begins at its first plotted observation. The 1M,
-3M, 6M, 1Y, and Max controls drive both the visible range and the CAGR/Since
-values shown on selected-vault cards. T-bill, ETH, and BTC use fixed colours,
-while vaults receive stable, distinct colours for the current selection.
+The chart is labelled **Returns index**. The earliest vault in the selected
+period starts at 100. A vault with a shorter history joins at the highest older
+vault curve that overlaps its first observation; a non-overlapping history
+starts at 100. The 1M, 3M, 6M, 1Y, and Max controls drive both the visible
+range and the CAGR/Since values shown on selected-vault cards. T-bill, ETH, and
+BTC use fixed colours, while vaults receive stable, distinct colours for the
+current selection.
 
 ## Data flow
 

--- a/src/lib/top-vaults/equity-comparison/VaultEquityComparisonChart.svelte
+++ b/src/lib/top-vaults/equity-comparison/VaultEquityComparisonChart.svelte
@@ -28,6 +28,7 @@ on one TradingView lightweight-charts pane.
 	import { formatNumber } from '$lib/helpers/formatters';
 	import BenchmarkLogo from './BenchmarkLogo.svelte';
 	import { benchmarkComparisonColours } from './colours';
+	import { rebaseComparisonPoints, rebaseVisibleComparisonPoints } from './equity-curves';
 	import { getComparisonVisibleRange, getNetComparisonPoints } from './net-returns';
 	import type {
 		ComparisonBenchmark,
@@ -61,7 +62,6 @@ on one TradingView lightweight-charts pane.
 		colour: string;
 		indexValue: number;
 		benchmark?: ComparisonBenchmark;
-		discontinuous?: boolean;
 		feeEvent?: 'after-entry' | 'before-exit' | 'after-exit';
 	};
 
@@ -101,7 +101,8 @@ on one TradingView lightweight-charts pane.
 	function buildChartPoints(
 		series: ComparisonChartSeries | undefined,
 		timeSpan: TimeSpan,
-		kind: ChartPointMeta['kind']
+		kind: ChartPointMeta['kind'],
+		visibleRange: [number, number] | null
 	): ComparisonChartPoint[] {
 		if (!series) return [];
 		const timeBucket = timeSpan.timeBucket as ComparisonTimeBucket;
@@ -109,12 +110,8 @@ on one TradingView lightweight-charts pane.
 		const feeProfile = vaultById.get(series.id)?.feeProfile;
 		const points =
 			kind === 'vault' && returnMode === 'net' && feeProfile
-				? getNetComparisonPoints(
-						series.points[timeBucket],
-						feeProfile,
-						getComparisonVisibleRange(data?.range, timeSpan)
-					)
-				: series.points[timeBucket];
+				? rebaseComparisonPoints(getNetComparisonPoints(series.points[timeBucket], feeProfile, visibleRange))
+				: rebaseVisibleComparisonPoints(series.points[timeBucket], visibleRange);
 		const label = benchmark ? benchmarkLabels[benchmark] : (vaultById.get(series.id)?.name ?? series.id);
 		const colour = benchmark
 			? benchmarkComparisonColours[benchmark]
@@ -130,7 +127,6 @@ on one TradingView lightweight-charts pane.
 				colour,
 				indexValue: point.value,
 				benchmark,
-				discontinuous: series.discontinuous,
 				feeEvent: point.feeEvent
 			}
 		}));
@@ -176,11 +172,12 @@ on one TradingView lightweight-charts pane.
 							{#if returnMode === 'net'}
 								Net estimates each vault's liquidation value after its known fees over the selected period. Management
 								fees use starting invested capital, while performance fees apply to positive profit at each point.
-								Internalised fees are already reflected in share prices. Benchmarks are unchanged. The oldest vault
-								starts at 100; younger vaults join at the highest overlapping curve.
+								Internalised fees are already reflected in share prices. Every series is rebased to 100 at the beginning
+								of the selected period, or its first plotted observation. Benchmarks are unchanged by the fee
+								calculation.
 							{:else}
-								Gross follows published vault share prices without additional investor-fee deductions. Benchmarks are
-								unchanged. The oldest vault starts at 100; younger vaults join at the highest overlapping curve.
+								Gross follows published vault share prices without additional investor-fee deductions. Every series is
+								rebased to 100 at the beginning of the selected period, or its first plotted observation.
 							{/if}
 						</svelte:fragment>
 					</Tooltip>
@@ -228,10 +225,11 @@ on one TradingView lightweight-charts pane.
 		{/snippet}
 
 		{#snippet series({ timeSpan })}
+			{@const visibleRange = getComparisonVisibleRange(data?.range, timeSpan)}
 			{#each vaults as vault (vault.id)}
 				<Series
 					type={LineSeries}
-					data={buildChartPoints(vaultSeriesById.get(vault.id), timeSpan, 'vault')}
+					data={buildChartPoints(vaultSeriesById.get(vault.id), timeSpan, 'vault', visibleRange)}
 					options={{
 						color: colours.get(vault.id),
 						lineWidth: 2,
@@ -245,7 +243,7 @@ on one TradingView lightweight-charts pane.
 			{#each enabledBenchmarks as benchmark (benchmark)}
 				<Series
 					type={LineSeries}
-					data={buildChartPoints(benchmarkSeriesById.get(benchmark), timeSpan, 'benchmark')}
+					data={buildChartPoints(benchmarkSeriesById.get(benchmark), timeSpan, 'benchmark', visibleRange)}
 					options={{
 						color: benchmarkComparisonColours[benchmark],
 						lineWidth: 2,
@@ -272,9 +270,7 @@ on one TradingView lightweight-charts pane.
 									<span class="swatch" aria-hidden="true"></span>
 								{/if}
 								<span class="tooltip-label" class:vault-name={row.kind === 'vault'}>
-									{row.label}{#if row.discontinuous}<small> · no overlap</small>{/if}{#if row.feeEvent}<small>
-											· {feeEventLabel(row.feeEvent)}</small
-										>{/if}
+									{row.label}{#if row.feeEvent}<small> · {feeEventLabel(row.feeEvent)}</small>{/if}
 								</span>
 								<strong>{formatNumber(row.indexValue, 1)}</strong>
 							</li>
@@ -289,7 +285,6 @@ on one TradingView lightweight-charts pane.
 				{#each vaults as vault (vault.id)}
 					<div class="legend-item" style:--series-colour={colours.get(vault.id)} title={vault.name}>
 						<span class="swatch" aria-hidden="true"></span><span class="vault-name">{vault.name}</span>
-						{#if vaultSeriesById.get(vault.id)?.discontinuous}<small>No overlap</small>{/if}
 					</div>
 				{/each}
 				{#each enabledBenchmarks as benchmark (benchmark)}

--- a/src/lib/top-vaults/equity-comparison/VaultEquityComparisonChart.svelte
+++ b/src/lib/top-vaults/equity-comparison/VaultEquityComparisonChart.svelte
@@ -28,10 +28,11 @@ on one TradingView lightweight-charts pane.
 	import { formatNumber } from '$lib/helpers/formatters';
 	import BenchmarkLogo from './BenchmarkLogo.svelte';
 	import { benchmarkComparisonColours } from './colours';
-	import { rebaseComparisonPoints, rebaseVisibleComparisonPoints } from './equity-curves';
+	import { alignVisibleVaultCurves, getVisibleComparisonPoints, rebaseComparisonPoints } from './equity-curves';
 	import { getComparisonVisibleRange, getNetComparisonPoints } from './net-returns';
 	import type {
 		ComparisonBenchmark,
+		ComparisonChartPoint,
 		ComparisonChartSeries,
 		ComparisonReturnMode,
 		ComparisonTimeBucket,
@@ -100,18 +101,11 @@ on one TradingView lightweight-charts pane.
 	};
 	function buildChartPoints(
 		series: ComparisonChartSeries | undefined,
-		timeSpan: TimeSpan,
 		kind: ChartPointMeta['kind'],
-		visibleRange: [number, number] | null
+		points: readonly ComparisonChartPoint[]
 	): ComparisonChartPoint[] {
 		if (!series) return [];
-		const timeBucket = timeSpan.timeBucket as ComparisonTimeBucket;
 		const benchmark = kind === 'benchmark' ? (series.id as ComparisonBenchmark) : undefined;
-		const feeProfile = vaultById.get(series.id)?.feeProfile;
-		const points =
-			kind === 'vault' && returnMode === 'net' && feeProfile
-				? rebaseComparisonPoints(getNetComparisonPoints(series.points[timeBucket], feeProfile, visibleRange))
-				: rebaseVisibleComparisonPoints(series.points[timeBucket], visibleRange);
 		const label = benchmark ? benchmarkLabels[benchmark] : (vaultById.get(series.id)?.name ?? series.id);
 		const colour = benchmark
 			? benchmarkComparisonColours[benchmark]
@@ -130,6 +124,20 @@ on one TradingView lightweight-charts pane.
 				feeEvent: point.feeEvent
 			}
 		}));
+	}
+
+	function getChartSeriesPoints(
+		series: ComparisonChartSeries | undefined,
+		timeSpan: TimeSpan,
+		kind: ChartPointMeta['kind'],
+		visibleRange: [number, number] | null
+	): ComparisonChartPoint[] {
+		if (!series) return [];
+		const points = series.points[timeSpan.timeBucket as ComparisonTimeBucket];
+		const feeProfile = vaultById.get(series.id)?.feeProfile;
+		return kind === 'vault' && returnMode === 'net' && feeProfile
+			? getNetComparisonPoints(points, feeProfile, visibleRange)
+			: getVisibleComparisonPoints(points, visibleRange);
 	}
 
 	function tooltipRows(points: unknown[]): ChartPointMeta[] {
@@ -172,12 +180,11 @@ on one TradingView lightweight-charts pane.
 							{#if returnMode === 'net'}
 								Net estimates each vault's liquidation value after its known fees over the selected period. Management
 								fees use starting invested capital, while performance fees apply to positive profit at each point.
-								Internalised fees are already reflected in share prices. Every series is rebased to 100 at the beginning
-								of the selected period, or its first plotted observation. Benchmarks are unchanged by the fee
-								calculation.
+								Internalised fees are already reflected in share prices. The earliest vault starts at 100; later vaults
+								join at the highest overlapping vault curve. Benchmarks are unchanged by the fee calculation.
 							{:else}
-								Gross follows published vault share prices without additional investor-fee deductions. Every series is
-								rebased to 100 at the beginning of the selected period, or its first plotted observation.
+								Gross follows published vault share prices without additional investor-fee deductions. The earliest
+								vault starts at 100; later vaults join at the highest overlapping vault curve.
 							{/if}
 						</svelte:fragment>
 					</Tooltip>
@@ -226,10 +233,18 @@ on one TradingView lightweight-charts pane.
 
 		{#snippet series({ timeSpan })}
 			{@const visibleRange = getComparisonVisibleRange(data?.range, timeSpan)}
-			{#each vaults as vault (vault.id)}
+			{@const vaultPoints = alignVisibleVaultCurves(
+				vaults.map((vault) => getChartSeriesPoints(vaultSeriesById.get(vault.id), timeSpan, 'vault', visibleRange))
+			)}
+			{@const benchmarkPoints = enabledBenchmarks.map((benchmark) =>
+				rebaseComparisonPoints(
+					getChartSeriesPoints(benchmarkSeriesById.get(benchmark), timeSpan, 'benchmark', visibleRange)
+				)
+			)}
+			{#each vaults as vault, index (vault.id)}
 				<Series
 					type={LineSeries}
-					data={buildChartPoints(vaultSeriesById.get(vault.id), timeSpan, 'vault', visibleRange)}
+					data={buildChartPoints(vaultSeriesById.get(vault.id), 'vault', vaultPoints[index])}
 					options={{
 						color: colours.get(vault.id),
 						lineWidth: 2,
@@ -240,10 +255,10 @@ on one TradingView lightweight-charts pane.
 				/>
 			{/each}
 
-			{#each enabledBenchmarks as benchmark (benchmark)}
+			{#each enabledBenchmarks as benchmark, index (benchmark)}
 				<Series
 					type={LineSeries}
-					data={buildChartPoints(benchmarkSeriesById.get(benchmark), timeSpan, 'benchmark', visibleRange)}
+					data={buildChartPoints(benchmarkSeriesById.get(benchmark), 'benchmark', benchmarkPoints[index])}
 					options={{
 						color: benchmarkComparisonColours[benchmark],
 						lineWidth: 2,

--- a/src/lib/top-vaults/equity-comparison/equity-curves.test.ts
+++ b/src/lib/top-vaults/equity-comparison/equity-curves.test.ts
@@ -1,9 +1,10 @@
 import { utcHour } from 'd3-time';
 import {
+	alignVisibleVaultCurves,
 	calculateComparisonPeriodMetrics,
+	getVisibleComparisonPoints,
 	indexPriceSeries,
 	rebaseComparisonPoints,
-	rebaseVisibleComparisonPoints,
 	resampleComparisonPoints
 } from './equity-curves';
 
@@ -53,9 +54,9 @@ describe('rebaseComparisonPoints', () => {
 		expect(rebaseComparisonPoints([{ time: 86_400, value: 0 }])).toEqual([]);
 	});
 
-	test('clips to the selected period before rebasing a younger vault', () => {
+	test('keeps only observations inside the selected range', () => {
 		expect(
-			rebaseVisibleComparisonPoints(
+			getVisibleComparisonPoints(
 				[
 					{ time: 1, value: 80 },
 					{ time: 3, value: 120 },
@@ -64,8 +65,46 @@ describe('rebaseComparisonPoints', () => {
 				[2, 4]
 			)
 		).toEqual([
-			{ time: 3, value: 100 },
-			{ time: 4, value: 125 }
+			{ time: 3, value: 120 },
+			{ time: 4, value: 150 }
+		]);
+	});
+});
+
+describe('alignVisibleVaultCurves', () => {
+	test('anchors a vault with shorter history to the highest overlapping curve', () => {
+		expect(
+			alignVisibleVaultCurves([
+				[
+					{ time: 1, value: 50 },
+					{ time: 2, value: 60 },
+					{ time: 3, value: 40 }
+				],
+				[
+					{ time: 1, value: 10 },
+					{ time: 2, value: 13 },
+					{ time: 3, value: 17 }
+				],
+				[
+					{ time: 2, value: 200 },
+					{ time: 3, value: 250 }
+				]
+			])
+		).toEqual([
+			[
+				{ time: 1, value: 100 },
+				{ time: 2, value: 120 },
+				{ time: 3, value: 80 }
+			],
+			[
+				{ time: 1, value: 100 },
+				{ time: 2, value: 130 },
+				{ time: 3, value: 170 }
+			],
+			[
+				{ time: 2, value: 130 },
+				{ time: 3, value: 162.5 }
+			]
 		]);
 	});
 });

--- a/src/lib/top-vaults/equity-comparison/equity-curves.test.ts
+++ b/src/lib/top-vaults/equity-comparison/equity-curves.test.ts
@@ -1,153 +1,88 @@
 import { utcHour } from 'd3-time';
 import {
-	alignVaultEquityCurves,
 	calculateComparisonPeriodMetrics,
-	indexBenchmarkPrices,
+	indexPriceSeries,
+	rebaseComparisonPoints,
+	rebaseVisibleComparisonPoints,
 	resampleComparisonPoints
 } from './equity-curves';
 
-describe('alignVaultEquityCurves', () => {
-	test('indexes the oldest vault to 100', () => {
-		const [vault] = alignVaultEquityCurves([
-			{
-				id: 'old',
-				points: [
-					[1, 2],
-					[2, 3]
-				]
-			}
+describe('indexPriceSeries', () => {
+	test('indexes a valid price series to 100', () => {
+		expect(
+			indexPriceSeries([
+				[1, 2],
+				[2, 3]
+			])
+		).toEqual([
+			{ time: 1, value: 100 },
+			{ time: 2, value: 150 }
 		]);
-		expect(vault.anchor).toBe(100);
-		expect(vault.points.map(({ value }) => value)).toEqual([100, 150]);
-	});
-
-	test('anchors a younger vault to the highest overlapping curve', () => {
-		const result = alignVaultEquityCurves([
-			{
-				id: 'lower',
-				points: [
-					[1, 1],
-					[3, 0.9],
-					[5, 1]
-				]
-			},
-			{
-				id: 'higher',
-				points: [
-					[1, 2],
-					[3, 3],
-					[5, 4]
-				]
-			},
-			{
-				id: 'young',
-				points: [
-					[4, 10],
-					[5, 12]
-				]
-			}
-		]);
-		const young = result.find(({ id }) => id === 'young')!;
-		expect(young.anchor).toBe(150);
-		expect(young.points[0].value).toBe(150);
-		expect(young.points[1].value).toBe(180);
-		expect(young.points[0].time).toBe(4);
-	});
-
-	test('aligns same-start cohorts without processing-order bias', () => {
-		const result = alignVaultEquityCurves([
-			{
-				id: 'first',
-				points: [
-					[1, 1],
-					[2, 2]
-				]
-			},
-			{
-				id: 'second',
-				points: [
-					[1, 5],
-					[2, 4]
-				]
-			}
-		]);
-		expect(result.map(({ anchor }) => anchor)).toEqual([100, 100]);
-	});
-
-	test('falls back to 100 for non-overlapping histories', () => {
-		const result = alignVaultEquityCurves([
-			{
-				id: 'finished',
-				points: [
-					[1, 1],
-					[2, 2]
-				]
-			},
-			{
-				id: 'later',
-				points: [
-					[4, 5],
-					[5, 6]
-				]
-			}
-		]);
-		expect(result[1]).toMatchObject({ anchor: 100, discontinuous: true });
 	});
 
 	test('sorts, de-duplicates, and removes invalid samples', () => {
-		const [vault] = alignVaultEquityCurves([
-			{
-				id: 'vault',
-				points: [
-					[2, 4],
-					[1, 2],
-					[2, 6],
-					[3, 0],
-					[4, Number.NaN]
-				]
-			}
-		]);
-		expect(vault.points.map(({ time, value }) => [time, value])).toEqual([
-			[1, 100],
-			[2, 300]
+		expect(
+			indexPriceSeries([
+				[2, 4],
+				[1, 2],
+				[2, 6],
+				[3, 0],
+				[4, Number.NaN]
+			])
+		).toEqual([
+			{ time: 1, value: 100 },
+			{ time: 2, value: 300 }
 		]);
 	});
 });
 
-describe('indexBenchmarkPrices', () => {
-	test('indexes valid market prices to the requested starting value', () => {
+describe('rebaseComparisonPoints', () => {
+	test('rebases the first visible observation to index 100 without losing fee markers', () => {
 		expect(
-			indexBenchmarkPrices(
+			rebaseComparisonPoints([
+				{ time: 86_400, value: 125, feeEvent: 'after-entry' },
+				{ time: 2 * 86_400, value: 150 }
+			])
+		).toEqual([
+			{ time: 86_400, value: 100, feeEvent: 'after-entry' },
+			{ time: 2 * 86_400, value: 120 }
+		]);
+	});
+
+	test('does not produce a return index from a non-positive starting value', () => {
+		expect(rebaseComparisonPoints([{ time: 86_400, value: 0 }])).toEqual([]);
+	});
+
+	test('clips to the selected period before rebasing a younger vault', () => {
+		expect(
+			rebaseVisibleComparisonPoints(
 				[
-					[1, 20],
-					[2, 25]
+					{ time: 1, value: 80 },
+					{ time: 3, value: 120 },
+					{ time: 4, value: 150 }
 				],
-				100
+				[2, 4]
 			)
 		).toEqual([
-			[1, 100],
-			[2, 125]
+			{ time: 3, value: 100 },
+			{ time: 4, value: 125 }
 		]);
 	});
 });
 
 describe('resampleComparisonPoints', () => {
 	test('prepares forward-filled chart points at the requested server-side interval', () => {
-		const [series] = alignVaultEquityCurves([
-			{
-				id: 'vault',
-				points: [
-					[0, 1],
-					[3 * 3_600, 1.1],
-					[8 * 3_600, 1.2]
-				]
-			}
-		]);
-
-		const points = resampleComparisonPoints(series.points, utcHour.every(4)!);
+		const points = resampleComparisonPoints(
+			[
+				{ time: 0, value: 100 },
+				{ time: 3 * 3_600, value: 110 },
+				{ time: 8 * 3_600, value: 120 }
+			],
+			utcHour.every(4)!
+		);
 		expect(points.map(({ time, value }) => [time, value])).toEqual([
 			[0, 100],
-			[4 * 3_600, 110.00000000000001],
+			[4 * 3_600, 110],
 			[8 * 3_600, 120]
 		]);
 	});

--- a/src/lib/top-vaults/equity-comparison/equity-curves.ts
+++ b/src/lib/top-vaults/equity-comparison/equity-curves.ts
@@ -4,135 +4,58 @@ import { TimeSpans } from '$lib/charts/time-span';
 import { annualizedReturn } from '$lib/helpers/financial';
 import {
 	comparisonTimeSpanKeys,
-	type AlignedEquityPoint,
-	type AlignedVaultSeries,
 	type ComparisonChartPoint,
 	type ComparisonPeriodMetrics,
 	type ComparisonTimeBucket,
-	type ComparisonTimeSpan,
-	type VaultPriceSeries
+	type ComparisonTimeSpan
 } from './types';
 
-interface PreparedSeries {
-	id: string;
-	selectionIndex: number;
-	points: [number, number][];
-}
-
-function prepareSeries(series: VaultPriceSeries, selectionIndex: number): PreparedSeries | null {
+/** Convert raw prices to a clean equity index beginning at 100. */
+export function indexPriceSeries(points: readonly [number, number][]): ComparisonChartPoint[] {
 	const pointsByTimestamp = new Map<number, number>();
 
-	for (const [timestamp, price] of series.points) {
+	for (const [timestamp, price] of points) {
 		if (!Number.isFinite(timestamp) || !Number.isFinite(price) || price <= 0) continue;
 		pointsByTimestamp.set(timestamp, price);
 	}
 
-	const points = [...pointsByTimestamp.entries()].sort(([left], [right]) => left - right);
-	return points.length ? { id: series.id, selectionIndex, points } : null;
+	const validPoints = [...pointsByTimestamp.entries()].sort(([left], [right]) => left - right);
+	const firstPrice = validPoints[0]?.[1];
+	if (!firstPrice) return [];
+
+	return validPoints.map(([time, price]) => ({ time, value: (price / firstPrice) * 100 }));
 }
 
-function valueAtOrBefore(points: AlignedEquityPoint[], timestamp: number): number | null {
-	let low = 0;
-	let high = points.length - 1;
-	let match = -1;
+/** Rebase a visible return series so its first plotted observation is index 100. */
+export function rebaseComparisonPoints(points: readonly ComparisonChartPoint[]): ComparisonChartPoint[] {
+	const startingValue = points[0]?.value;
+	if (!Number.isFinite(startingValue) || startingValue <= 0) return [];
 
-	while (low <= high) {
-		const middle = Math.floor((low + high) / 2);
-		if (points[middle].time <= timestamp) {
-			match = middle;
-			low = middle + 1;
-		} else {
-			high = middle - 1;
-		}
-	}
-
-	return match === -1 ? null : points[match].value;
+	return points.map((point) => ({ ...point, value: (point.value / startingValue) * 100 }));
 }
 
-function alignSeries(series: PreparedSeries, anchor: number, discontinuous: boolean): AlignedVaultSeries {
-	const firstPrice = series.points[0][1];
-	return {
-		id: series.id,
-		anchor,
-		discontinuous,
-		points: series.points.map(([time, rawPrice]) => ({
-			time,
-			value: (rawPrice / firstPrice) * anchor
-		}))
-	};
+/** Clip a series to its visible range and rebase its first plotted point to 100. */
+export function rebaseVisibleComparisonPoints(
+	points: readonly ComparisonChartPoint[],
+	visibleRange: [number, number] | null
+): ComparisonChartPoint[] {
+	if (!visibleRange) return [];
+	return rebaseComparisonPoints(points.filter(({ time }) => time >= visibleRange[0] && time <= visibleRange[1]));
 }
 
 /**
- * Convert raw vault prices to comparable indexed equity curves.
+ * Resample an indexed series on the server, forward-filling the latest point.
  *
- * The oldest cohort starts at 100. Each younger cohort starts at the highest
- * value among older curves which still cover its first timestamp.
- */
-export function alignVaultEquityCurves(series: readonly VaultPriceSeries[]): AlignedVaultSeries[] {
-	const prepared = series
-		.map(prepareSeries)
-		.filter((value): value is PreparedSeries => value !== null)
-		.sort((left, right) => left.points[0][0] - right.points[0][0] || left.selectionIndex - right.selectionIndex);
-
-	const alignedById = new Map<string, AlignedVaultSeries>();
-	let index = 0;
-
-	while (index < prepared.length) {
-		const cohortStart = prepared[index].points[0][0];
-		const cohort: PreparedSeries[] = [];
-		while (index < prepared.length && prepared[index].points[0][0] === cohortStart) {
-			cohort.push(prepared[index++]);
-		}
-
-		let anchor = 100;
-		let discontinuous = alignedById.size > 0;
-		if (alignedById.size > 0) {
-			const overlappingValues: number[] = [];
-			for (const older of alignedById.values()) {
-				const lastPoint = older.points.at(-1);
-				if (!lastPoint || lastPoint.time < cohortStart) continue;
-				const value = valueAtOrBefore(older.points, cohortStart);
-				if (value !== null) overlappingValues.push(value);
-			}
-
-			if (overlappingValues.length) {
-				anchor = Math.max(...overlappingValues);
-				discontinuous = false;
-			}
-		}
-
-		for (const member of cohort) alignedById.set(member.id, alignSeries(member, anchor, discontinuous));
-	}
-
-	return series.flatMap(({ id }) => {
-		const aligned = alignedById.get(id);
-		return aligned ? [aligned] : [];
-	});
-}
-
-/** Convert a market-price series to an equity index beginning at `startingValue`. */
-export function indexBenchmarkPrices(points: readonly [number, number][], startingValue = 100): [number, number][] {
-	const valid = points.filter(
-		(point): point is [number, number] => Number.isFinite(point[0]) && Number.isFinite(point[1]) && point[1] > 0
-	);
-	if (!valid.length || startingValue <= 0) return [];
-	const firstPrice = valid[0][1];
-	return valid.map(([timestamp, price]) => [timestamp, (price / firstPrice) * startingValue]);
-}
-
-/**
- * Resample an aligned series on the server, forward-filling the latest point.
- *
- * @param points Complete aligned history
+ * @param points Complete indexed history
  * @param interval Output time interval
  */
 export function resampleComparisonPoints(
-	points: readonly AlignedEquityPoint[],
+	points: readonly ComparisonChartPoint[],
 	interval: TimeInterval
 ): ComparisonChartPoint[] {
-	if (points.length < 2) return points.map(toComparisonChartPoint);
+	if (points.length < 2) return points.map((point) => ({ ...point }));
 
-	const result: ComparisonChartPoint[] = [toComparisonChartPoint(points[0])];
+	const result: ComparisonChartPoint[] = [{ ...points[0] }];
 	const lastMs = points.at(-1)!.time * 1000;
 	let sourceIndex = 0;
 	let current = interval.ceil(new Date(points[0].time * 1000));
@@ -141,12 +64,12 @@ export function resampleComparisonPoints(
 		const timestamp = current.getTime() / 1000;
 		while (sourceIndex < points.length - 1 && points[sourceIndex + 1].time <= timestamp) sourceIndex++;
 		const source = points[sourceIndex];
-		if (timestamp > result.at(-1)!.time) result.push({ ...toComparisonChartPoint(source), time: timestamp });
+		if (timestamp > result.at(-1)!.time) result.push({ ...source, time: timestamp });
 		current = interval.offset(current);
 	}
 
 	const lastPoint = points.at(-1)!;
-	if (lastPoint.time > result.at(-1)!.time) result.push(toComparisonChartPoint(lastPoint));
+	if (lastPoint.time > result.at(-1)!.time) result.push({ ...lastPoint });
 	return result;
 }
 
@@ -197,8 +120,4 @@ export function calculateComparisonPeriodMetrics(
 	}
 
 	return metrics;
-}
-
-function toComparisonChartPoint(point: AlignedEquityPoint): ComparisonChartPoint {
-	return { time: point.time, value: point.value };
 }

--- a/src/lib/top-vaults/equity-comparison/equity-curves.ts
+++ b/src/lib/top-vaults/equity-comparison/equity-curves.ts
@@ -34,13 +34,55 @@ export function rebaseComparisonPoints(points: readonly ComparisonChartPoint[]):
 	return points.map((point) => ({ ...point, value: (point.value / startingValue) * 100 }));
 }
 
-/** Clip a series to its visible range and rebase its first plotted point to 100. */
-export function rebaseVisibleComparisonPoints(
+/** Return the observations contained in a selected chart range. */
+export function getVisibleComparisonPoints(
 	points: readonly ComparisonChartPoint[],
 	visibleRange: [number, number] | null
 ): ComparisonChartPoint[] {
 	if (!visibleRange) return [];
-	return rebaseComparisonPoints(points.filter(({ time }) => time >= visibleRange[0] && time <= visibleRange[1]));
+	return points.filter(({ time }) => time >= visibleRange[0] && time <= visibleRange[1]);
+}
+
+/**
+ * Anchor later-starting vault curves to the highest older curve that overlaps
+ * their first visible observation. The earliest visible curve starts at 100.
+ */
+export function alignVisibleVaultCurves(
+	curves: readonly (readonly ComparisonChartPoint[])[]
+): ComparisonChartPoint[][] {
+	const prepared = curves
+		.map((points, index) => ({ index, points }))
+		.filter(({ points }) => {
+			const firstValue = points[0]?.value;
+			return Number.isFinite(firstValue) && firstValue > 0;
+		})
+		.sort((left, right) => left.points[0].time - right.points[0].time || left.index - right.index);
+	const alignedByIndex = new Map<number, ComparisonChartPoint[]>();
+	let index = 0;
+
+	while (index < prepared.length) {
+		const cohortStart = prepared[index].points[0].time;
+		const cohort: (typeof prepared)[number][] = [];
+		while (index < prepared.length && prepared[index].points[0].time === cohortStart) cohort.push(prepared[index++]);
+
+		const overlappingValues = [...alignedByIndex.values()].flatMap((points) => {
+			const lastPoint = points.at(-1);
+			if (!lastPoint || lastPoint.time < cohortStart) return [];
+			const value = valueAtOrBefore(points, cohortStart);
+			return value === null ? [] : [value];
+		});
+		const anchor = overlappingValues.length ? Math.max(...overlappingValues) : 100;
+
+		for (const curve of cohort) {
+			const startingValue = curve.points[0].value;
+			alignedByIndex.set(
+				curve.index,
+				curve.points.map((point) => ({ ...point, value: (point.value / startingValue) * anchor }))
+			);
+		}
+	}
+
+	return curves.map((_, index) => alignedByIndex.get(index) ?? []);
 }
 
 /**
@@ -71,6 +113,24 @@ export function resampleComparisonPoints(
 	const lastPoint = points.at(-1)!;
 	if (lastPoint.time > result.at(-1)!.time) result.push({ ...lastPoint });
 	return result;
+}
+
+function valueAtOrBefore(points: readonly ComparisonChartPoint[], timestamp: number): number | null {
+	let low = 0;
+	let high = points.length - 1;
+	let match = -1;
+
+	while (low <= high) {
+		const middle = Math.floor((low + high) / 2);
+		if (points[middle].time <= timestamp) {
+			match = middle;
+			low = middle + 1;
+		} else {
+			high = middle - 1;
+		}
+	}
+
+	return match === -1 ? null : points[match].value;
 }
 
 /**

--- a/src/lib/top-vaults/equity-comparison/types.ts
+++ b/src/lib/top-vaults/equity-comparison/types.ts
@@ -35,18 +35,6 @@ export interface VaultPriceSeries {
 	points: [timestamp: number, sharePrice: number][];
 }
 
-export interface AlignedEquityPoint {
-	time: number;
-	value: number;
-}
-
-export interface AlignedVaultSeries {
-	id: string;
-	anchor: number;
-	discontinuous: boolean;
-	points: AlignedEquityPoint[];
-}
-
 /** Server-prepared sampling resolutions used by the comparison chart controls. */
 export type ComparisonTimeBucket = '4h' | '1d';
 
@@ -67,7 +55,6 @@ export interface ComparisonChartPoint {
 
 export interface ComparisonChartSeries {
 	id: string;
-	discontinuous: boolean;
 	points: Record<ComparisonTimeBucket, ComparisonChartPoint[]>;
 	periodMetrics: Record<ComparisonTimeSpan, ComparisonPeriodMetrics>;
 }

--- a/src/routes/vaults/compare/chart-data/+server.ts
+++ b/src/routes/vaults/compare/chart-data/+server.ts
@@ -5,9 +5,8 @@ import { utcDay, utcHour } from 'd3-time';
 import { queryVaultPriceRows } from '$lib/server/top-vaults/vault-price-series';
 import { fetchCoinbaseBenchmarkCloses } from '$lib/top-vaults/coinbase';
 import {
-	alignVaultEquityCurves,
 	calculateComparisonPeriodMetrics,
-	indexBenchmarkPrices,
+	indexPriceSeries,
 	resampleComparisonPoints
 } from '$lib/top-vaults/equity-comparison/equity-curves';
 import {
@@ -16,8 +15,6 @@ import {
 	canonicaliseComparisonVaultIds
 } from '$lib/top-vaults/equity-comparison/state';
 import type {
-	AlignedEquityPoint,
-	AlignedVaultSeries,
 	ComparisonBenchmark,
 	ComparisonChartPoint,
 	ComparisonChartSeries,
@@ -33,6 +30,11 @@ const fourHours = utcHour.every(4)!;
 const compress = promisify(brotliCompress);
 type CachedResponse = { json: string; br: Uint8Array };
 const responseCache = new Map<string, { expiresAt: number; response: Promise<CachedResponse> }>();
+
+interface IndexedSeries {
+	id: string;
+	points: ComparisonChartPoint[];
+}
 
 const cacheHeaders = {
 	'cache-control': 'public, max-age=300',
@@ -122,12 +124,14 @@ async function buildComparisonChartResponse(
 		else missingVaultIds.push(vaultId);
 	}
 
-	const alignedSeries = alignVaultEquityCurves(rawSeries);
-	const starts = alignedSeries.flatMap(({ points }) => (points[0] ? [points[0].time] : []));
-	const ends = alignedSeries.flatMap(({ points }) => (points.at(-1) ? [points.at(-1)!.time] : []));
+	const indexedSeries = rawSeries
+		.map(({ id, points }) => ({ id, points: indexPriceSeries(points) }))
+		.filter((series) => series.points.length > 0);
+	const starts = indexedSeries.flatMap(({ points }) => (points[0] ? [points[0].time] : []));
+	const ends = indexedSeries.flatMap(({ points }) => (points.at(-1) ? [points.at(-1)!.time] : []));
 	const range: [number, number] | null = starts.length && ends.length ? [Math.min(...starts), Math.max(...ends)] : null;
 	const recentStart = range ? range[1] - RECENT_FOUR_HOUR_DAYS * 86_400 : 0;
-	const vaultSeries = range ? alignedSeries.map((series) => buildProcessedSeries(series, recentStart, range)) : [];
+	const vaultSeries = range ? indexedSeries.map((series) => buildProcessedSeries(series, recentStart, range)) : [];
 	const benchmarkSeries: ComparisonChartSeries[] = [];
 	const benchmarkErrors: Partial<Record<ComparisonBenchmark, string>> = {};
 
@@ -152,18 +156,17 @@ async function buildComparisonChartResponse(
 }
 
 function buildProcessedSeries(
-	series: AlignedVaultSeries,
+	series: IndexedSeries,
 	recentStart: number,
 	range: [number, number]
 ): ComparisonChartSeries {
-	const { id, points, discontinuous } = series;
+	const { id, points } = series;
 	const processedPoints = {
 		'4h': resampleComparisonPoints(points, fourHours).filter(({ time }) => time >= recentStart),
 		'1d': resampleComparisonPoints(points, utcDay)
 	};
 	return {
 		id,
-		discontinuous,
 		points: processedPoints,
 		periodMetrics: calculateComparisonPeriodMetrics(processedPoints, range)
 	};
@@ -190,7 +193,6 @@ async function buildBenchmarkSeries(
 		};
 		return {
 			id: benchmark,
-			discontinuous: false,
 			points,
 			periodMetrics: calculateComparisonPeriodMetrics(points, range)
 		};
@@ -203,12 +205,8 @@ async function buildBenchmarkSeries(
 		end,
 		false
 	);
-	const indexedPoints: AlignedEquityPoint[] = indexBenchmarkPrices(source).map(([time, value]) => ({ time, value }));
-	return buildProcessedSeries(
-		{ id: benchmark, anchor: 100, discontinuous: false, points: indexedPoints },
-		recentStart,
-		range
-	);
+	const indexedPoints = indexPriceSeries(source);
+	return buildProcessedSeries({ id: benchmark, points: indexedPoints }, recentStart, range);
 }
 
 function toBenchmarkPoint(time: number, value: number): ComparisonChartPoint {

--- a/tests/integration/vaults/equity-compare.test.ts
+++ b/tests/integration/vaults/equity-compare.test.ts
@@ -68,7 +68,6 @@ async function mockResponsiveChartData(page: Page) {
 			const points = responsiveChartPoints(index);
 			return {
 				id,
-				discontinuous: false,
 				points: { '4h': points, '1d': points },
 				periodMetrics: mockPeriodMetrics(index)
 			};
@@ -77,7 +76,6 @@ async function mockResponsiveChartData(page: Page) {
 			const points = responsiveChartPoints(0);
 			return {
 				id,
-				discontinuous: false,
 				points: { '4h': points, '1d': points },
 				periodMetrics: mockPeriodMetrics()
 			};
@@ -242,13 +240,11 @@ test.describe('vault equity curve comparison page', () => {
 					range: [1_735_689_600, 1_735_862_400],
 					vaultSeries: vaultIds.map((id, index) => ({
 						id,
-						discontinuous: false,
 						points: { '4h': pointsFor(index), '1d': pointsFor(index) },
 						periodMetrics: mockPeriodMetrics(index)
 					})),
 					benchmarkSeries: benchmarks.map((id) => ({
 						id,
-						discontinuous: false,
 						points: { '4h': pointsFor(0), '1d': pointsFor(0) },
 						periodMetrics: mockPeriodMetrics()
 					})),

--- a/tests/integration/vaults/equity-compare.test.ts
+++ b/tests/integration/vaults/equity-compare.test.ts
@@ -1,4 +1,4 @@
-import { expect, test, type APIRequestContext, type Page } from '@playwright/test';
+import { expect, test, type APIRequestContext, type Locator, type Page } from '@playwright/test';
 
 type SearchResult = {
 	name: string;
@@ -52,6 +52,36 @@ function mockPeriodMetrics(seriesIndex = 0) {
 		'1Y': { cagr: 0.21 + seriesIndex / 100, since: '2024-03-01' },
 		Max: { cagr: 0.25 + seriesIndex / 100, since: '2024-01-01' }
 	};
+}
+
+/** Build a daily indexed curve with a known start date and value progression. */
+function dailyChartPoints(start: number, length: number, startingValue: number, dailyIncrease: number) {
+	const day = 24 * 60 * 60;
+	return Array.from({ length }, (_, index) => ({
+		time: start + index * day,
+		value: startingValue + index * dailyIncrease
+	}));
+}
+
+/** Move the crosshair near a known point until the chart tooltip shows its date. */
+async function hoverChartDate(page: Page, chart: Locator, formattedDate: string, position: number) {
+	await chart.scrollIntoViewIfNeeded();
+	const bounds = await chart.boundingBox();
+	expect(bounds).toBeTruthy();
+	const tooltip = chart.locator('.chart-tooltip');
+	const heading = tooltip.locator('.tooltip-heading');
+	const expectedX = bounds!.x + bounds!.width * position;
+	const minimumX = Math.max(bounds!.x + 1, expectedX - 80);
+	const maximumX = Math.min(bounds!.x + bounds!.width - 1, expectedX + 80);
+	for (let x = minimumX; x <= maximumX; x += 2) {
+		await page.mouse.move(x, bounds!.y + bounds!.height / 2);
+		if (await heading.count()) {
+			const date = await heading.textContent();
+			if (date?.startsWith(formattedDate)) return tooltip;
+		}
+	}
+
+	throw new Error(`Could not show the chart tooltip for ${formattedDate}`);
 }
 
 /**
@@ -143,6 +173,77 @@ test.describe('vault equity curve comparison page', () => {
 		expect(await kingfisherMetrics.textContent()).not.toBe(netKingfisherMetrics);
 		expect(await gamiMetrics.textContent()).not.toBe(netGamiMetrics);
 		expect(chartRequests).toHaveLength(1);
+	});
+
+	test('anchors three vault curves when switching the selected return period', async ({ page, request }) => {
+		const vaults = await Promise.all([
+			findVaultId(request, 'Savings USDS', 'Savings USDS'),
+			findVaultId(request, 'The Kingfisher Vault', 'The Kingfisher Vault'),
+			findVaultId(request, 'Gami USDC', 'Gami USDC')
+		]);
+		const day = 24 * 60 * 60;
+		const rangeStart = Date.UTC(2025, 0, 1) / 1_000;
+		const rangeLength = 120;
+		const shorterHistoryStart = 99;
+		const firstVaultPoints = dailyChartPoints(rangeStart, rangeLength, 100, 1);
+		const secondVaultPoints = dailyChartPoints(rangeStart, rangeLength, 100, 2);
+		const thirdVaultPoints = dailyChartPoints(
+			rangeStart + shorterHistoryStart * day,
+			rangeLength - shorterHistoryStart,
+			50,
+			5
+		);
+
+		await page.route('**/vaults/compare/chart-data?*', async (route) => {
+			const requestedVaults = new URL(route.request().url()).searchParams.getAll('vault');
+			const pointsByVaultId = new Map([
+				[vaults[0], firstVaultPoints],
+				[vaults[1], secondVaultPoints],
+				[vaults[2], thirdVaultPoints]
+			]);
+			await route.fulfill({
+				contentType: 'application/json',
+				body: JSON.stringify({
+					range: [rangeStart, rangeStart + (rangeLength - 1) * day],
+					vaultSeries: requestedVaults.map((id, index) => {
+						const points = pointsByVaultId.get(id)!;
+						return {
+							id,
+							points: { '4h': points, '1d': points },
+							periodMetrics: mockPeriodMetrics(index)
+						};
+					}),
+					benchmarkSeries: [],
+					missingVaultIds: [],
+					benchmarkErrors: {}
+				})
+			});
+		});
+
+		const selection = new URLSearchParams();
+		for (const vaultId of vaults) selection.append('vault', vaultId);
+		selection.set('period', '3M');
+		selection.set('return', 'gross');
+		await page.goto(`/vaults/compare?${selection}`);
+
+		const chart = page.getByTestId('tv-chart');
+		await expect(chart.locator('canvas').first()).toBeVisible();
+		await expect(chart.locator('.loading')).toBeHidden();
+		const periodOptions = page.locator('.comparison-chart .segmented-control label');
+
+		// For 3M, the first two vaults begin on 31 January. On 10 April the
+		// second is higher (186.3), so the later third vault must begin there.
+		let tooltip = await hoverChartDate(page, chart, '10 Apr 2025', 69 / 89);
+		await expect(tooltip.locator('.tooltip-rows li strong')).toHaveText(['153.1', '186.3', '186.3']);
+
+		await periodOptions.filter({ hasText: '1M' }).click();
+		await expect(periodOptions.filter({ hasText: '1M' })).toHaveClass(/selected/);
+		await expect.poll(() => new URL(page.url()).searchParams.get('period')).toBe('1M');
+
+		// For 1M, the visible period starts on 1 April. The same later vault
+		// starts on 10 April at the higher curve's newly rebased value (106.4).
+		tooltip = await hoverChartDate(page, chart, '10 Apr 2025', 9 / 29);
+		await expect(tooltip.locator('.tooltip-rows li strong')).toHaveText(['104.7', '106.4', '106.4']);
 	});
 
 	test('selects Savings USDS and all benchmarks by default', async ({ page }) => {


### PR DESCRIPTION
## Why

Returns index values must reflect the selected period without suggesting that a vault with a shorter history was available at the period boundary.

## Lessons learnt

Period rebasing and joining shorter histories are separate concerns: establish the period window first, then anchor later-starting vaults against the displayed older curves.

## Summary

- Start the earliest visible vault at 100 for each selected period.
- Anchor later-starting vaults to the highest overlapping older vault curve, falling back to 100 when histories do not overlap.
- Rebase benchmarks independently for the selected period and simplify obsolete server-side lifetime alignment.
- Add a Playwright regression test that verifies three vaults across 3M and 1M selections through the rendered chart tooltip.