### PR TITLE
fix: add vault comparison tooltip

### DIFF
--- a/src/lib/top-vaults/TopVaultsTable.svelte
+++ b/src/lib/top-vaults/TopVaultsTable.svelte
@@ -1539,17 +1539,20 @@ Set `allowVaultComparison={false}` for read-only or embedded tables.
 						<!-- index cell is populated with row index via `rowNumber` CSS counter -->
 						<td class="index">
 							{#if allowVaultComparison}
-								<label class="vault-comparison-selection targetable-above">
-									<input
-										type="checkbox"
-										data-testid="vault-comparison-checkbox"
-										checked={isVaultSelected(vault.id)}
-										aria-disabled={isVaultSelectionUnavailable(vault.id)}
-										aria-describedby={selectionLimitReached ? 'vault-comparison-selection-status' : undefined}
-										onclick={(event) => toggleVaultComparisonSelection(event, vault.id)}
-									/>
-									<span class="sr-only">Select {vault.name} for comparison</span>
-								</label>
+								<Tooltip>
+									<label class="vault-comparison-selection targetable-above" slot="trigger">
+										<input
+											type="checkbox"
+											data-testid="vault-comparison-checkbox"
+											checked={isVaultSelected(vault.id)}
+											aria-disabled={isVaultSelectionUnavailable(vault.id)}
+											aria-describedby={selectionLimitReached ? 'vault-comparison-selection-status' : undefined}
+											onclick={(event) => toggleVaultComparisonSelection(event, vault.id)}
+										/>
+										<span class="sr-only">Select {vault.name} for comparison</span>
+									</label>
+									<svelte:fragment slot="popup">Choose vaults to compare against each other</svelte:fragment>
+								</Tooltip>
 							{/if}
 						</td>
 						{#if showChainCol}

--- a/src/lib/top-vaults/TopVaultsTable.test.ts
+++ b/src/lib/top-vaults/TopVaultsTable.test.ts
@@ -212,6 +212,9 @@ describe('TopVaultsTable comparison selection', () => {
 		const secondCheckbox = screen.getByRole('checkbox', { name: 'Select Second comparison vault for comparison' });
 		expect(firstCheckbox.closest('td')).toHaveClass('index');
 		expect(firstCheckbox.closest('label')).toHaveClass('targetable-above');
+		expect(firstCheckbox.closest('.tooltip')?.querySelector('.popup')).toHaveTextContent(
+			'Choose vaults to compare against each other'
+		);
 
 		await fireEvent.click(secondCheckbox);
 		await fireEvent.click(firstCheckbox);


### PR DESCRIPTION
## Why

The vault-comparison checkbox needs a concise explanation of its purpose.

## Lessons learnt

Use the shared tooltip component for interactive listing controls so mouse and keyboard users receive the same guidance.

## Summary

- Add a tooltip to each vault-comparison checkbox.
- Cover the tooltip copy in the table unit test.