### PR TITLE
feat: add vault table sort dropdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Weblog of stuff
 
+- Add a Sort dropdown to vault listing filters (2026-09-08)
 - Add vault comparison selection controls to public vault listings (2026-09-04)
 - Add Gross and Net fee-aware return modes to the multi-vault comparison chart (2026-09-04)
 - Show a "check your email for your API key" notice on the vault datasets page after a Creem checkout redirect (2026-09-03)

--- a/docs/theme.md
+++ b/docs/theme.md
@@ -144,6 +144,21 @@ Avoid these mistakes:
 - Do not use raw black or white where a semantic token exists.
 - Do not treat `--c-bullish` as a general-purpose brand colour for all controls.
 
+### Native select menus
+
+The closed `<select>` control is styled by the page, but its opened option menu is rendered by the browser and operating system. Some browser environments can combine a light native menu surface with the dark theme's inherited light option text, making unselected options unreadable.
+
+When a native select needs themed option-menu colours, explicitly set both properties on its options and scope the rule to that control:
+
+```css
+#control-id option {
+	background-color: var(--c-body);
+	color: var(--c-text);
+}
+```
+
+The semantic tokens keep this pairing readable in dark and light modes. Do not set only `color`, and do not use hard-coded black or white. Keep native selects where their browser-provided keyboard and assistive-technology behaviour is desirable; use a custom listbox only when the menu itself needs a fully controlled design.
+
 ## Typography
 
 Two typography layers are active.

--- a/docs/vault-listings.md
+++ b/docs/vault-listings.md
@@ -41,6 +41,16 @@ Each listing has a fixed definition (`top`, `chain`, `protocol`,
 `stablecoin`, `curator`, `tokenised-funds`, and the special listings). URL
 filters may narrow that definition but cannot change its base population.
 
+### Sorting
+
+The table headers and the **Display** group's **Sort** dropdown share the
+`sort` and `direction` URL state, so each control always reflects the other.
+Choosing a dropdown option applies that metric's normal ranking direction;
+selecting the active table header reverses it. Descending is the URL default,
+so a descending sort may omit `direction=desc` while remaining active. The
+dropdown only offers sortable columns currently visible in the table, including
+the selected return columns.
+
 ### Permissioned vault filter
 
 The Filters panel exposes the permissioned-vault control as **Private** inside

--- a/docs/vault-listings.md
+++ b/docs/vault-listings.md
@@ -44,12 +44,12 @@ filters may narrow that definition but cannot change its base population.
 ### Sorting
 
 The table headers and the **Display** group's **Sort** dropdown share the
-`sort` and `direction` URL state, so each control always reflects the other.
-Choosing a dropdown option applies that metric's normal ranking direction;
-selecting the active table header reverses it. Descending is the URL default,
-so a descending sort may omit `direction=desc` while remaining active. The
+`sort` and `direction` URL state. Choosing a dropdown option applies that
+metric's normal ranking direction; selecting the active table header reverses
+it. A route's configured default direction may be omitted from the URL. The
 dropdown only offers sortable columns currently visible in the table, including
-the selected return columns.
+the selected return columns; removing an active column falls back to sorting by
+vault name.
 
 ### Permissioned vault filter
 

--- a/src/lib/top-vaults/TopVaultsTable.svelte
+++ b/src/lib/top-vaults/TopVaultsTable.svelte
@@ -1849,6 +1849,16 @@ Set `allowVaultComparison={false}` for read-only or embedded tables.
 			min-width: 0;
 		}
 
+		/*
+		 * Native select menus are rendered by the browser. Give the Sort options an
+		 * explicit colour pair so browsers that use a light menu surface do not
+		 * combine it with the dark theme's inherited text colour.
+		 */
+		:global(#vault-sort option) {
+			background-color: var(--c-body);
+			color: var(--c-text);
+		}
+
 		.filter-section-heading {
 			width: 100%;
 			margin: 0;

--- a/src/lib/top-vaults/TopVaultsTable.svelte
+++ b/src/lib/top-vaults/TopVaultsTable.svelte
@@ -606,16 +606,21 @@ Set `allowVaultComparison={false}` for read-only or embedded tables.
 	let showProviderRiskRating = $derived(ratingProvider != null);
 	let showTechnicalRisk = $derived(ratingProvider == null);
 	let tableColumnCount = $derived(12 + selectedReturnColumns.length + (showChainCol ? 1 : 0));
-	let sortDropdownOptions = $derived.by(() =>
-		[
-			...(showChainCol ? ['chain'] : []),
-			'vault',
-			...(showProviderRiskRating ? ['provider_risk_rating'] : []),
-			...selectedReturnColumns.map((column) => column.id),
-			...standardSortColumnKeys,
-			...(showTechnicalRisk ? ['risk'] : [])
-		].map((key) => ({ key, label: sortColumnMap[key].label }))
-	);
+	let sortDropdownOptionKeys = $derived([
+		...(showChainCol ? ['chain'] : []),
+		'vault',
+		...(showProviderRiskRating ? ['provider_risk_rating'] : []),
+		...selectedReturnColumns.map((column) => column.id),
+		...standardSortColumnKeys,
+		...(showTechnicalRisk ? ['risk'] : [])
+	]);
+	let sortDropdownOptions = $derived(sortDropdownOptionKeys.map((key) => ({ key, label: sortColumnMap[key].label })));
+
+	// Keep every active sort represented by a visible table header and dropdown option.
+	$effect(() => {
+		if (sortDropdownOptionKeys.some((key) => key === sortOptions.key)) return;
+		updateSearchParams({ sort: 'vault', direction: sortColumnMap.vault.defaultDirection });
+	});
 
 	let offsetWidth = $state<number>();
 
@@ -914,8 +919,9 @@ Set `allowVaultComparison={false}` for read-only or embedded tables.
 		const nextReturns = serialiseReturnColumnSelection(nextSelection);
 		const canonicalSort = canonicaliseReturnSortKey(urlState.sort);
 
-		if (canonicalSort && !nextSelection.includes(canonicalSort) && nextSelection.length > 0) {
-			updateSearchParams({ returns: nextReturns, sort: nextSelection[0], direction: 'desc' });
+		if (canonicalSort && !nextSelection.includes(canonicalSort)) {
+			const sort = nextSelection[0] ?? 'vault';
+			updateSearchParams({ returns: nextReturns, sort, direction: sortColumnMap[sort].defaultDirection });
 			return;
 		}
 

--- a/src/lib/top-vaults/TopVaultsTable.svelte
+++ b/src/lib/top-vaults/TopVaultsTable.svelte
@@ -136,6 +136,11 @@ Set `allowVaultComparison={false}` for read-only or embedded tables.
 		direction: 'asc' | 'desc';
 	}
 
+	interface SortColumn {
+		defaultDirection: SortOptions['direction'];
+		label: string;
+	}
+
 	interface Props {
 		topVaults?: TopVaults;
 		chain?: Chain;
@@ -317,7 +322,7 @@ Set `allowVaultComparison={false}` for read-only or embedded tables.
 		selectedVaultIds = [...selectedVaultIds, vaultId];
 	}
 
-	// --- Sort column registry (key → default direction) ---
+	// --- Sort column registry ---
 
 	function getXerberusRiskRating(vault: VaultInfo): string {
 		const score = vault.xerberus?.score;
@@ -326,34 +331,48 @@ Set `allowVaultComparison={false}` for read-only or embedded tables.
 	}
 
 	const returnSortColumnMap = Object.fromEntries(
-		returnColumnDefinitions.map((definition) => [definition.id, { defaultDirection: definition.sortDirection }])
-	) as Record<ReturnColumnId, { defaultDirection: 'desc' }>;
+		returnColumnDefinitions.map((definition) => [
+			definition.id,
+			{ defaultDirection: definition.sortDirection, label: definition.label }
+		])
+	) as Record<ReturnColumnId, SortColumn>;
 
 	// The provider is a page-level configuration and does not change after the table mounts.
-	const providerSortColumnMap = untrack((): Record<string, { defaultDirection: 'asc' | 'desc' }> => {
+	const providerSortColumnMap = untrack((): Record<string, SortColumn> => {
 		if (!ratingProvider) return {};
 		return {
 			provider_risk_rating: {
-				defaultDirection: ratingProvider === 'xerberus' ? 'desc' : 'asc'
+				defaultDirection: ratingProvider === 'xerberus' ? 'desc' : 'asc',
+				label: 'Risk rating'
 			}
 		};
 	});
 
-	const sortColumnMap: Record<string, { defaultDirection: 'asc' | 'desc' }> = {
+	const sortColumnMap: Record<string, SortColumn> = {
 		...returnSortColumnMap,
-		chain: { defaultDirection: 'asc' },
-		vault: { defaultDirection: 'asc' },
-		three_months_sharpe: { defaultDirection: 'desc' },
-		three_months_volatility: { defaultDirection: 'asc' },
-		max_dd: { defaultDirection: 'desc' },
-		denomination: { defaultDirection: 'asc' },
-		tvl: { defaultDirection: 'desc' },
-		age: { defaultDirection: 'desc' },
-		fees: { defaultDirection: 'asc' },
-		lockup: { defaultDirection: 'asc' },
-		risk: { defaultDirection: 'asc' },
+		chain: { defaultDirection: 'asc', label: 'Chain' },
+		vault: { defaultDirection: 'asc', label: 'Vault' },
+		three_months_sharpe: { defaultDirection: 'desc', label: '3M Sharpe' },
+		three_months_volatility: { defaultDirection: 'asc', label: '3M volatility' },
+		max_dd: { defaultDirection: 'desc', label: 'Maximum drawdown' },
+		denomination: { defaultDirection: 'asc', label: 'Denomination' },
+		tvl: { defaultDirection: 'desc', label: 'TVL' },
+		age: { defaultDirection: 'desc', label: 'Age' },
+		fees: { defaultDirection: 'asc', label: 'Fees' },
+		lockup: { defaultDirection: 'asc', label: 'Deposit and delays' },
+		risk: { defaultDirection: 'asc', label: 'Protocol technical risk' },
 		...providerSortColumnMap
 	};
+	const standardSortColumnKeys = [
+		'three_months_sharpe',
+		'three_months_volatility',
+		'max_dd',
+		'denomination',
+		'tvl',
+		'age',
+		'fees',
+		'lockup'
+	] as const;
 
 	// --- URL search state schema ---
 
@@ -587,27 +606,16 @@ Set `allowVaultComparison={false}` for read-only or embedded tables.
 	let showProviderRiskRating = $derived(ratingProvider != null);
 	let showTechnicalRisk = $derived(ratingProvider == null);
 	let tableColumnCount = $derived(12 + selectedReturnColumns.length + (showChainCol ? 1 : 0));
-	let sortDropdownOptions = $derived.by(() => {
-		const options: Array<{ key: string; label: string }> = [];
-
-		if (showChainCol) options.push({ key: 'chain', label: 'Chain' });
-		options.push({ key: 'vault', label: 'Vault' });
-		if (showProviderRiskRating) options.push({ key: 'provider_risk_rating', label: 'Risk rating' });
-		options.push(
-			...selectedReturnColumns.map((column) => ({ key: column.id, label: column.label })),
-			{ key: 'three_months_sharpe', label: '3M Sharpe' },
-			{ key: 'three_months_volatility', label: '3M volatility' },
-			{ key: 'max_dd', label: 'Maximum drawdown' },
-			{ key: 'denomination', label: 'Denomination' },
-			{ key: 'tvl', label: 'TVL' },
-			{ key: 'age', label: 'Age' },
-			{ key: 'fees', label: 'Fees' },
-			{ key: 'lockup', label: 'Deposit and delays' }
-		);
-		if (showTechnicalRisk) options.push({ key: 'risk', label: 'Protocol technical risk' });
-
-		return options;
-	});
+	let sortDropdownOptions = $derived.by(() =>
+		[
+			...(showChainCol ? ['chain'] : []),
+			'vault',
+			...(showProviderRiskRating ? ['provider_risk_rating'] : []),
+			...selectedReturnColumns.map((column) => column.id),
+			...standardSortColumnKeys,
+			...(showTechnicalRisk ? ['risk'] : [])
+		].map((key) => ({ key, label: sortColumnMap[key].label }))
+	);
 
 	let offsetWidth = $state<number>();
 

--- a/src/lib/top-vaults/TopVaultsTable.svelte
+++ b/src/lib/top-vaults/TopVaultsTable.svelte
@@ -587,6 +587,27 @@ Set `allowVaultComparison={false}` for read-only or embedded tables.
 	let showProviderRiskRating = $derived(ratingProvider != null);
 	let showTechnicalRisk = $derived(ratingProvider == null);
 	let tableColumnCount = $derived(12 + selectedReturnColumns.length + (showChainCol ? 1 : 0));
+	let sortDropdownOptions = $derived.by(() => {
+		const options: Array<{ key: string; label: string }> = [];
+
+		if (showChainCol) options.push({ key: 'chain', label: 'Chain' });
+		options.push({ key: 'vault', label: 'Vault' });
+		if (showProviderRiskRating) options.push({ key: 'provider_risk_rating', label: 'Risk rating' });
+		options.push(
+			...selectedReturnColumns.map((column) => ({ key: column.id, label: column.label })),
+			{ key: 'three_months_sharpe', label: '3M Sharpe' },
+			{ key: 'three_months_volatility', label: '3M volatility' },
+			{ key: 'max_dd', label: 'Maximum drawdown' },
+			{ key: 'denomination', label: 'Denomination' },
+			{ key: 'tvl', label: 'TVL' },
+			{ key: 'age', label: 'Age' },
+			{ key: 'fees', label: 'Fees' },
+			{ key: 'lockup', label: 'Deposit and delays' }
+		);
+		if (showTechnicalRisk) options.push({ key: 'risk', label: 'Protocol technical risk' });
+
+		return options;
+	});
 
 	let offsetWidth = $state<number>();
 
@@ -873,6 +894,14 @@ Set `allowVaultComparison={false}` for read-only or embedded tables.
 		updateSearchParams({ sort: key, direction });
 	}
 
+	/** Select a table sort criterion using its default direction. */
+	function selectSort(event: Event) {
+		const key = (event.target as HTMLSelectElement).value;
+		const column = sortColumnMap[key];
+		if (!column) return;
+		updateSearchParams({ sort: key, direction: column.defaultDirection });
+	}
+
 	function updateReturnColumns(nextSelection: ReturnColumnId[]) {
 		const nextReturns = serialiseReturnColumnSelection(nextSelection);
 		const canonicalSort = canonicaliseReturnSortKey(urlState.sort);
@@ -1151,6 +1180,14 @@ Set `allowVaultComparison={false}` for read-only or embedded tables.
 								aria-labelledby="filter-group-display-heading"
 							>
 								<h3 class="filter-section-heading" id="filter-group-display-heading">Display</h3>
+								<div class="filter-group">
+									<label class="filter-label" for="vault-sort">Sort</label>
+									<Select id="vault-sort" value={sortOptions.key} data-testid="sort-select" onchange={selectSort}>
+										{#each sortDropdownOptions as option (option.key)}
+											<option value={option.key}>{option.label}</option>
+										{/each}
+									</Select>
+								</div>
 								<div class="filter-group">
 									<span class="filter-label">Columns</span>
 									<div class="tvl-dropdown" use:clickOutside={() => (returnsDropdownOpen = false)}>

--- a/src/lib/top-vaults/TopVaultsTable.svelte
+++ b/src/lib/top-vaults/TopVaultsTable.svelte
@@ -1996,7 +1996,33 @@ Set `allowVaultComparison={false}` for read-only or embedded tables.
 			}
 
 			.filter-section-display {
+				display: grid;
+				grid-template-columns: max-content minmax(0, 1fr);
+				align-items: center;
+				gap: 0.75rem 0.5rem;
 				padding-right: 1.5rem;
+
+				.filter-section-heading {
+					grid-column: 1 / -1;
+				}
+
+				.filter-group {
+					display: contents;
+
+					> .filter-label {
+						text-align: right;
+					}
+
+					> :global(.select),
+					> .tvl-dropdown {
+						width: 100%;
+						min-width: 0;
+					}
+
+					.tvl-trigger {
+						width: 100%;
+					}
+				}
 			}
 
 			.filter-section-hide {

--- a/src/lib/top-vaults/vault-sort-description.ts
+++ b/src/lib/top-vaults/vault-sort-description.ts
@@ -2,7 +2,7 @@ import { DEFAULT_RETURN_COLUMN_IDS, canonicaliseReturnSortKey, type ReturnColumn
 
 const returnSortDescriptions: Record<ReturnColumnId, string> = {
 	'1m-ann': 'one-month annualised returns',
-	'1m-abs': '30-day absolute returns',
+	'1m-abs': 'one-month absolute returns',
 	'3m-ann': 'three-month annualised returns',
 	'3m-abs': 'three-month absolute returns',
 	'6m-ann': 'six-month annualised returns',

--- a/src/lib/top-vaults/vault-sort-description.ts
+++ b/src/lib/top-vaults/vault-sort-description.ts
@@ -1,7 +1,7 @@
 import { DEFAULT_RETURN_COLUMN_IDS, canonicaliseReturnSortKey, type ReturnColumnId } from './return-columns';
 
 const returnSortDescriptions: Record<ReturnColumnId, string> = {
-	'1m-ann': '30-day returns',
+	'1m-ann': 'one-month annualised returns',
 	'1m-abs': '30-day absolute returns',
 	'3m-ann': 'three-month annualised returns',
 	'3m-abs': 'three-month absolute returns',

--- a/src/routes/vaults/+page.svelte
+++ b/src/routes/vaults/+page.svelte
@@ -14,9 +14,7 @@ Top stablecoin vault listing page.
 	const description = 'Stablecoin vault rankings by yield, risk, and other performance criteria.';
 	let pageUrl = $derived(new URL(page.url.pathname, page.url.origin).href);
 	let rankingDescription = $derived(getVaultSortDescription(page.url.searchParams.get('sort')));
-	let subtitle = $derived(
-		`The best-performing stablecoin vaults. Ranked by ${rankingDescription}. Table headers and filters offer more criteria.`
-	);
+	let subtitle = $derived(`The best-performing stablecoin vaults. Ranked by ${rankingDescription}.`);
 </script>
 
 <MetaTags

--- a/tests/integration/vaults/index.test.ts
+++ b/tests/integration/vaults/index.test.ts
@@ -271,7 +271,7 @@ test.describe('vault index page', () => {
 
 	test('describes the default return ranking', async ({ page }) => {
 		await expect(page.locator('.hero-banner .subtitle')).toHaveText(
-			'The best-performing stablecoin vaults. Ranked by 30-day returns.'
+			'The best-performing stablecoin vaults. Ranked by one-month annualised returns.'
 		);
 	});
 

--- a/tests/integration/vaults/index.test.ts
+++ b/tests/integration/vaults/index.test.ts
@@ -100,6 +100,7 @@ async function expectFilterControls(page: import('@playwright/test').Page) {
 	}
 
 	await expect(displayGroup.getByText('Columns', { exact: true })).toBeVisible();
+	await expect(displayGroup.getByLabel('Sort', { exact: true })).toBeVisible();
 	await expect(returnColumnsTrigger(page)).toBeVisible();
 	for (const label of ['Currently closed', 'Unknown protocols', 'AMM', 'Private']) {
 		await expect(hideGroup.getByLabel(label, { exact: true })).toBeVisible();
@@ -270,7 +271,7 @@ test.describe('vault index page', () => {
 
 	test('describes the default return ranking', async ({ page }) => {
 		await expect(page.locator('.hero-banner .subtitle')).toHaveText(
-			'The best-performing stablecoin vaults. Ranked by 30-day returns. Table headers and filters offer more criteria.'
+			'The best-performing stablecoin vaults. Ranked by 30-day returns.'
 		);
 	});
 
@@ -349,8 +350,38 @@ test.describe('vault index page', () => {
 
 		await expect(page).toHaveURL(/sort=tvl/);
 		await expect(page.locator('.hero-banner .subtitle')).toHaveText(
-			'The best-performing stablecoin vaults. Ranked by total value locked. Table headers and filters offer more criteria.'
+			'The best-performing stablecoin vaults. Ranked by total value locked.'
 		);
+	});
+
+	test('keeps the Sort dropdown synchronised with both directions of sortable table headers', async ({ page }) => {
+		await openFilters(page);
+		const sortSelect = filterGroup(page, 'display').getByLabel('Sort', { exact: true });
+		const tvlHeader = page.locator('th.tvl');
+		const vaultHeader = page.locator('th.vault');
+
+		await expect(sortSelect).toHaveValue('1m-ann');
+
+		// TVL sorts descending by default, then ascending after the header is clicked.
+		await sortSelect.selectOption('tvl');
+		await expect(page).toHaveURL(/sort=tvl/);
+		await expect(tvlHeader).toContainText('TVL USD');
+		await expect(tvlHeader.locator('.chevron-down')).toBeVisible();
+		await tvlHeader.getByRole('button').click();
+		await expect(page).toHaveURL(urlParamsMatch({ sort: 'tvl', direction: 'asc' }));
+		await expect(tvlHeader.locator('.chevron-up')).toBeVisible();
+
+		// Vault sorts ascending by default, then descending after the header is clicked.
+		await sortSelect.selectOption('vault');
+		await expect(page).toHaveURL(urlParamsMatch({ sort: 'vault', direction: 'asc' }));
+		await expect(sortSelect).toHaveValue('vault');
+		await expect(vaultHeader.locator('.chevron-up')).toBeVisible();
+
+		await vaultHeader.getByRole('button').click();
+		await expect(page).toHaveURL(/sort=vault/);
+		await expect(page).not.toHaveURL(/direction=/);
+		await expect(vaultHeader.locator('.chevron-down')).toBeVisible();
+		await expect(sortSelect).toHaveValue('vault');
 	});
 
 	test('shows lifetime data tooltip on the lifetime return cell', async ({ page }) => {

--- a/tests/integration/vaults/index.test.ts
+++ b/tests/integration/vaults/index.test.ts
@@ -371,17 +371,40 @@ test.describe('vault index page', () => {
 		await expect(page).toHaveURL(urlParamsMatch({ sort: 'tvl', direction: 'asc' }));
 		await expect(tvlHeader.locator('.chevron-up')).toBeVisible();
 
-		// Vault sorts ascending by default, then descending after the header is clicked.
-		await sortSelect.selectOption('vault');
+		// Selecting a different header updates the dropdown, then clicking it again reverses the direction.
+		await vaultHeader.getByRole('button').click();
 		await expect(page).toHaveURL(urlParamsMatch({ sort: 'vault', direction: 'asc' }));
 		await expect(sortSelect).toHaveValue('vault');
 		await expect(vaultHeader.locator('.chevron-up')).toBeVisible();
 
 		await vaultHeader.getByRole('button').click();
-		await expect(page).toHaveURL(/sort=vault/);
+		await expect(page).toHaveURL(urlParamsMatch({ sort: 'vault' }));
 		await expect(page).not.toHaveURL(/direction=/);
 		await expect(vaultHeader.locator('.chevron-down')).toBeVisible();
 		await expect(sortSelect).toHaveValue('vault');
+	});
+
+	test('falls back to vault sorting when no return columns are displayed', async ({ page }) => {
+		await openFilters(page);
+		const sortSelect = filterGroup(page, 'display').getByLabel('Sort', { exact: true });
+
+		for (const [label, selectedColumns] of [
+			['One month annualised', '3M ann., Lifetime abs'],
+			['Three months annualised', 'Lifetime abs'],
+			['Lifetime absolute', 'None']
+		]) {
+			const returnColumnsMenu = page.getByTestId('return-columns-menu');
+			if (!(await returnColumnsMenu.isVisible())) {
+				await returnColumnsTrigger(page).click();
+			}
+			await expect(returnColumnsMenu).toBeVisible();
+			await toggleReturnOption(page, label);
+			await expect(returnColumnsTrigger(page)).toContainText(selectedColumns);
+		}
+
+		await expect(page).toHaveURL(urlParamsMatch({ sort: 'vault', direction: 'asc' }));
+		await expect(sortSelect).toHaveValue('vault');
+		await expect(page.locator('th.vault .chevron-up')).toBeVisible();
 	});
 
 	test('shows lifetime data tooltip on the lifetime return cell', async ({ page }) => {


### PR DESCRIPTION
## Why

Vault listings could only be sorted from table headers, making the selected ranking less discoverable and harder to use on smaller screens.

## Lessons learnt

The URL is the source of truth for vault sort state, so each visible control must retain a valid, visible sort key as columns change.

## Summary

- Add and align a Display Sort dropdown with the vault table headers.
- Keep sort state valid when visible return columns change, and cover both directions across two columns.
- Remove redundant copy, correct return terminology, and document vault-listing sorting.